### PR TITLE
Remove index functions

### DIFF
--- a/include/samurai/boundary.hpp
+++ b/include/samurai/boundary.hpp
@@ -4,25 +4,6 @@
 
 namespace samurai
 {
-    /*template<class Vector>
-    inline unsigned int number_of_zeros(const Vector& v)
-    {
-        unsigned int n_zeros = 0;
-        for (std::size_t i=0; i<v.shape()[0]; ++i)
-        {
-            n_zeros += v[i] == 0 ? 1 : 0;
-        }
-        return n_zeros;
-    }
-
-    template<class Vector>
-    inline bool is_cartesian_direction(const Vector& v)
-    {
-        std::size_t dim = v.shape()[0];
-        auto n_zeros = number_of_zeros(v);
-        return (dim == 0 || n_zeros == dim-1);
-    }*/
-
     template <class Mesh, class Vector>
     auto in_boundary(const Mesh& mesh, std::size_t level, const Vector& direction)
     {
@@ -86,7 +67,7 @@ namespace samurai
         {
             if (!cells[level].empty())
             {
-                double h = 1./(1<<level);
+                double h = cell_length(level);
                 auto coeffs = get_coefficients(h);
                 for_each_interval_on_boundary(mesh, level, stencil, coeffs, std::forward<Func>(func));
             }
@@ -102,26 +83,6 @@ namespace samurai
             for_each_cell(mesh, mesh_interval.level, mesh_interval.i, mesh_interval.index, [&](auto& cell)
             {
                 func(cell, stencil_vector, out_coeff);
-            });
-        });
-    }
-
-    template <typename DesiredIndexType, class Mesh, std::size_t stencil_size, class GetCoeffsFunc, class Func>
-    void for_each_stencil_center_and_outside_ghost_indices(const Mesh& mesh, const Stencil<stencil_size, Mesh::dim>& stencil, GetCoeffsFunc&& get_coefficients, Func &&func)
-    {
-        for_each_level(mesh, [&](std::size_t level)
-        {
-            double h = cell_length(level);
-            auto coeffs = get_coefficients(h);
-
-            for_each_interval_on_boundary(mesh, level, stencil, coeffs,
-            [&] (const auto& mesh_interval, const auto& towards_bdry_ghost, double out_coeff)
-            {
-                for_each_stencil<DesiredIndexType>(mesh, mesh_interval, in_out_stencil<Mesh::dim>(towards_bdry_ghost), 
-                [&] (const std::array<DesiredIndexType, 2>& indices)
-                {
-                    func(indices, towards_bdry_ghost, out_coeff);
-                });
             });
         });
     }

--- a/include/samurai/indices.hpp
+++ b/include/samurai/indices.hpp
@@ -44,54 +44,8 @@ namespace samurai
         {
             coord[d] = 2*coord[d] + translation_vect[d];
         }
-
         return mesh.get_index(mesh_interval.level+1, coord);
     }
-
-
-    //
-    // Functions that return cell indices
-    //
-    template <typename DesiredIndexType, class Mesh, class Func>
-    inline void for_each_cell_index(const Mesh& mesh, const typename Mesh::mesh_interval_t& mesh_interval, Func &&f)
-    {
-        auto i_start = static_cast<DesiredIndexType>(get_index_start(mesh, mesh_interval));
-        for(DesiredIndexType ii=0; ii<static_cast<DesiredIndexType>(mesh_interval.i.size()); ++ii)
-        {
-            f(i_start + ii);
-        }
-    }
-
-    template <typename DesiredIndexType, class Mesh, class Func>
-    inline void for_each_cell_index(const Mesh& mesh, const typename Mesh::ca_type& set, Func &&f)
-    {
-        for_each_meshinterval(set, [&](const auto mesh_interval)//std::size_t level, const auto& i, const auto& index)
-        {
-            //typename Mesh::mesh_interval_t mesh_interval(level, i, index);
-            for_each_cell_index<DesiredIndexType>(mesh, mesh_interval, std::forward<Func>(f));
-        });
-    }
-
-    template <typename DesiredIndexType, class Mesh, class Func>
-    inline void for_each_cell_index(const Mesh& mesh, Func &&f)
-    {
-        using mesh_id_t = typename Mesh::mesh_id_t;
-        for_each_cell_index<DesiredIndexType>(mesh, mesh[mesh_id_t::cells], std::forward<Func>(f));
-    }
-
-    template <typename DesiredIndexType, class Mesh, class Subset, class Func>
-    inline void for_each_cell_index(const Mesh& mesh, std::size_t level, Subset& subset, Func &&f)
-    {
-        typename Mesh::mesh_interval_t mesh_interval(level);
-        subset([&](const auto& i, const auto& index)
-        {
-            mesh_interval.i = i;
-            mesh_interval.index = index;
-            for_each_cell_index<DesiredIndexType>(mesh, mesh_interval, std::forward<Func>(f));
-        });
-    }
-
-
 
     /**
      * Used to define the projection operator.
@@ -219,16 +173,5 @@ namespace samurai
 
             for_each_cell(mesh, set, std::forward<Func>(f));
         }
-    }
-
-    template <typename DesiredIndexType, class Mesh, class Func>
-    inline void for_each_outside_ghost_index(const Mesh& mesh, Func &&f)
-    {
-        using mesh_id_t = typename Mesh::mesh_id_t;
-        for_each_level(mesh, [&](std::size_t level, double)
-        {
-            auto boundary_ghosts = difference(mesh[mesh_id_t::cells_and_ghosts][level], mesh.domain()).on(level);
-            for_each_cell_index<DesiredIndexType>(mesh, level, boundary_ghosts, std::forward<Func>(f));
-        });
     }
 }

--- a/include/samurai/petsc/petsc_cell_based_scheme_assembly.hpp
+++ b/include/samurai/petsc/petsc_cell_based_scheme_assembly.hpp
@@ -106,9 +106,12 @@ namespace samurai { namespace petsc
             }
 
             // Apply the given coefficents on the given stencil
-            for_each_stencil<PetscInt>(mesh, _stencil, _get_coefficients,
-            [&] (const std::array<PetscInt, cfg::scheme_stencil_size>& indices, const std::array<double, cfg::scheme_stencil_size>& coeffs)
+            for_each_stencil(mesh, _stencil, _get_coefficients,
+            [&] (const auto& cells, const std::array<double, cfg::scheme_stencil_size>& coeffs)
             {
+                std::array<PetscInt, cfg::scheme_stencil_size> indices;
+                std::transform(cells.begin(), cells.end(), indices.begin(), [](auto& cell) { return cell.index; });
+
                 if constexpr(cfg::contiguous_indices_start > 0)
                 {
                     for (unsigned int i=0; i<cfg::contiguous_indices_start; ++i)

--- a/include/samurai/stencil.hpp
+++ b/include/samurai/stencil.hpp
@@ -154,8 +154,7 @@ namespace samurai
 
         for_each_level(mesh, [&](std::size_t level)
         {
-            double h = cell_length(level);
-            auto coeffs = get_coefficients(h);
+            auto coeffs = get_coefficients(cell_length(level));
 
             for_each_stencil(mesh, level, stencil_it,
             [&] (auto& cells)

--- a/include/samurai/stencil.hpp
+++ b/include/samurai/stencil.hpp
@@ -30,141 +30,9 @@ namespace samurai
         return -1;
     }
 
-
-
-
-    template<typename DesiredIndexType, std::size_t stencil_size, std::size_t dim>
-    class IteratorStencil_Indices
-    {
-    private:
-        const Stencil<stencil_size, dim> _stencil;
-        std::array<DesiredIndexType, stencil_size> _cell_indices;
-        std::array<int, stencil_size>  _origin_in_row;
-        unsigned int _origin_cell;
-
-    public:
-        IteratorStencil_Indices(const Stencil<stencil_size, dim>& stencil)
-        : _stencil(stencil)
-        {
-            int origin_index = find_stencil_origin(stencil);
-            assert(origin_index >= 0 && "the zero vector is required in the stencil definition.");
-            _origin_cell = static_cast<unsigned int>(origin_index);
-        }
-
-        template<class Mesh>
-        void init(const Mesh& mesh, const typename Mesh::mesh_interval_t& mesh_interval)
-        {
-            _cell_indices[_origin_cell] = static_cast<DesiredIndexType>(get_index_start(mesh, mesh_interval)); // origin of the stencil
-            for (unsigned int id = 0; id<stencil_size; ++id)
-            {
-                if (id == _origin_cell)
-                    continue;
-
-                auto d = xt::view(_stencil, id);
-
-                // We are on the same row as the stencil origin if d = {d[0], 0, ..., 0}
-                bool same_row = true;
-                for (std::size_t k=1; k<dim; ++k)
-                {
-                    if (d[k] != 0)
-                    {
-                        same_row = false;
-                        break;
-                    }
-                }
-
-                if (same_row) // same row as the stencil origin
-                {
-                    _cell_indices[id] = _cell_indices[_origin_cell] + d[0]; // translation on the row
-                }
-                else
-                {
-                    _cell_indices[id] = static_cast<DesiredIndexType>(get_index_start_translated(mesh, mesh_interval, d));
-                }
-            }
-        }
-
-        void move_next()
-        {
-            for (unsigned int cell = 0; cell < stencil_size; ++cell)
-            {
-                _cell_indices[cell]++;
-            }
-        }
-
-        std::array<DesiredIndexType, stencil_size>& indices()
-        {
-            return _cell_indices;
-        }
-    };
-
-
-
-
     
-
-    template <typename DesiredIndexType, class Mesh, std::size_t stencil_size, class Func>
-    inline void for_each_stencil(const Mesh& mesh, const typename Mesh::mesh_interval_t& mesh_interval, IteratorStencil_Indices<DesiredIndexType, stencil_size, Mesh::dim>& stencil_it, Func &&f)
-    {
-        stencil_it.init(mesh, mesh_interval);
-        f(stencil_it.indices());
-        for(DesiredIndexType ii=1; ii<static_cast<DesiredIndexType>(mesh_interval.i.size()); ++ii)
-        {
-            stencil_it.move_next();
-            f(stencil_it.indices());
-        }
-    }
-    
-    template <typename DesiredIndexType, class Mesh, std::size_t stencil_size, class Func>
-    inline void for_each_stencil(const Mesh& mesh, const typename Mesh::mesh_interval_t& mesh_interval, const Stencil<stencil_size, Mesh::dim>& stencil, Func &&f)
-    {
-        IteratorStencil_Indices<DesiredIndexType, stencil_size, Mesh::dim> stencil_it(stencil);
-        for_each_stencil(mesh, mesh_interval, stencil_it, std::forward<Func>(f));
-    }
-
-    template <typename DesiredIndexType, class Mesh, class Set, std::size_t stencil_size, class Func>
-    inline void for_each_stencil(const Mesh& mesh, const Set& set, std::size_t level, IteratorStencil_Indices<DesiredIndexType, stencil_size, Mesh::dim>& stencil_it, Func &&f)
-    {
-        typename Mesh::mesh_interval_t mesh_interval(level);
-        for_each_interval(set[level], [&](std::size_t /*level*/, const auto& i, const auto& index)
-        {
-            mesh_interval.i = i;
-            mesh_interval.index = index;
-            for_each_stencil<DesiredIndexType>(mesh, mesh_interval, stencil_it, std::forward<Func>(f));
-        });
-    }
-
-    template <typename DesiredIndexType, class Mesh, std::size_t stencil_size, class Func>
-    inline void for_each_stencil(const Mesh& mesh, std::size_t level, IteratorStencil_Indices<DesiredIndexType, stencil_size, Mesh::dim>& stencil_it, Func &&f)
-    {
-        using mesh_id_t = typename Mesh::mesh_id_t;
-        for_each_stencil<DesiredIndexType>(mesh, mesh[mesh_id_t::cells], level, stencil_it, std::forward<Func>(f));
-    }
-
-    template <typename DesiredIndexType, class Mesh, std::size_t stencil_size, class GetCoeffsFunc, class Func>
-    inline void for_each_stencil(const Mesh& mesh, Stencil<stencil_size, Mesh::dim>& stencil, GetCoeffsFunc&& get_coefficients, Func &&f)
-    {
-        IteratorStencil_Indices<DesiredIndexType, stencil_size, Mesh::dim> stencil_it(stencil);
-
-        for_each_level(mesh, [&](std::size_t level)
-        {
-            double h = cell_length(level);
-            auto coeffs = get_coefficients(h);
-
-            for_each_stencil<DesiredIndexType>(mesh, level, stencil_it,
-            [&] (const std::array<DesiredIndexType, stencil_size>& indices)
-            {
-                f(indices, coeffs);
-            });
-        });
-    }
-
-    
-
-
-
     template<class Mesh, std::size_t stencil_size>
-    class IteratorStencil_Cells
+    class IteratorStencil
     {
         static constexpr std::size_t dim = Mesh::dim;
         using coord_index_t = typename Mesh::config::interval_t::coord_index_t;
@@ -172,11 +40,10 @@ namespace samurai
     private:
         const Stencil<stencil_size, dim> _stencil;
         std::array<Cell, stencil_size> _cells;
-        std::array<int, stencil_size>  _origin_in_row;
         unsigned int _origin_cell;
 
     public:
-        IteratorStencil_Cells(const Stencil<stencil_size, dim>& stencil)
+        IteratorStencil(const Stencil<stencil_size, dim>& stencil)
         : _stencil(stencil)
         {
             int origin_index = find_stencil_origin(stencil);
@@ -186,7 +53,7 @@ namespace samurai
 
         void init(const Mesh& mesh, const typename Mesh::mesh_interval_t& mesh_interval)
         {
-            double length = 1./(1 << mesh_interval.level);
+            double length = cell_length(mesh_interval.level);
             for (Cell& cell : _cells)
             {
                 cell.level = mesh_interval.level;
@@ -241,8 +108,8 @@ namespace samurai
         {
             for (Cell& cell : _cells)
             {
-                cell.index++;
-                cell.indices[0]++;
+                cell.index++;      // increment cell index
+                cell.indices[0]++; // increment x-coordinate
             }
         }
 
@@ -253,48 +120,49 @@ namespace samurai
     };
 
     template <class Mesh, std::size_t stencil_size, class Func>
-    inline void for_each_stencil(const Mesh& mesh, const typename Mesh::mesh_interval_t& mesh_interval, IteratorStencil_Cells<Mesh, stencil_size>& stencil, Func &&f)
+    inline void for_each_stencil(const Mesh& mesh, const typename Mesh::mesh_interval_t& mesh_interval, IteratorStencil<Mesh, stencil_size>& stencil_it, Func &&f)
     {
-        stencil.init(mesh, mesh_interval);
-        f(stencil.cells());
-        for(std::size_t ii=1; ii<mesh_interval.i.size(); ++ii)
+        stencil_it.init(mesh, mesh_interval);
+        for(std::size_t ii=0; ii<mesh_interval.i.size(); ++ii)
         {
-            stencil.move_next();
-            f(stencil.cells());
+            f(stencil_it.cells());
+            stencil_it.move_next();
         }
     }
 
     template <class Mesh, std::size_t stencil_size, class Func>
-    inline void for_each_stencil(const Mesh& mesh, const typename Mesh::mesh_interval_t& mesh_interval, const Stencil<stencil_size, Mesh::dim>& stencil_shape, Func &&f)
+    inline void for_each_stencil(const Mesh& mesh, const typename Mesh::mesh_interval_t& mesh_interval, const Stencil<stencil_size, Mesh::dim>& stencil, Func &&f)
     {
-        IteratorStencil_Cells<Mesh, stencil_size> stencil(stencil_shape);
-        for_each_stencil(mesh, mesh_interval, stencil, std::forward<Func>(f));
+        IteratorStencil<Mesh, stencil_size> stencil_it(stencil);
+        for_each_stencil(mesh, mesh_interval, stencil_it, std::forward<Func>(f));
     }
 
-
-
-    template <std::size_t dim>
-    inline Stencil<2*dim, dim> cartesian_directions()
+    template <class Mesh, std::size_t stencil_size, class Func>
+    inline void for_each_stencil(const Mesh& mesh, std::size_t level, IteratorStencil<Mesh, stencil_size>& stencil_it, Func &&f)
     {
-        static_assert((dim >= 1 && dim <=3), "cartesian_directions() not implemented in this dimension");
+        using mesh_id_t = typename Mesh::mesh_id_t;
+        for_each_meshinterval(mesh[mesh_id_t::cells][level], [&](auto mesh_interval)
+        {
+            for_each_stencil(mesh, mesh_interval, stencil_it, std::forward<Func>(f));
+        });
+    }
 
-        // !!! The order is important: the opposite of a vector must be located 'dim' indices after.
-        if constexpr (dim == 1)
+    template <class Mesh, std::size_t stencil_size, class GetCoeffsFunc, class Func>
+    inline void for_each_stencil(const Mesh& mesh, const Stencil<stencil_size, Mesh::dim>& stencil, GetCoeffsFunc&& get_coefficients, Func &&f)
+    {
+        IteratorStencil<Mesh, stencil_size> stencil_it(stencil);
+
+        for_each_level(mesh, [&](std::size_t level)
         {
-            //                       left, right
-            return Stencil<1, 2>{{-1}, {1}};
-        }
-        else if constexpr (dim == 2)
-        {
-            //                        bottom,   right,  top,    left
-            return Stencil<2, 4>{{0, -1}, {1, 0}, {0, 1}, {-1, 0}};
-        }
-        else if constexpr (dim == 3)
-        {
-            //                         bottom,   front,   right,    top,     back,     left
-            return Stencil<3, 6>{{0,0,-1}, {0,1,0}, {1,0,0}, {0,0,1}, {0,-1,0}, {-1,0,0}};
-        }
-        return Stencil<dim, 2*dim>();
+            double h = cell_length(level);
+            auto coeffs = get_coefficients(h);
+
+            for_each_stencil(mesh, level, stencil_it,
+            [&] (auto& cells)
+            {
+                f(cells, coeffs);
+            });
+        });
     }
 
 
@@ -329,22 +197,12 @@ namespace samurai
         return Stencil<dim, 1+2*dim>();
     }
 
-
     template<std::size_t dim, class Vector>
-    Stencil<2, dim> out_in_stencil(const Vector& out_normal_vect)
+    Stencil<2, dim> in_out_stencil(const Vector& towards_out_from_in)
     {
         auto stencil_shape = Stencil<2, dim>();
         xt::view(stencil_shape, 0) = 0;
-        xt::view(stencil_shape, 1) = -out_normal_vect;
-        return stencil_shape;
-    }
-
-    template<std::size_t dim, class Vector>
-    Stencil<2, dim> in_out_stencil(const Vector& out_normal_vect)
-    {
-        auto stencil_shape = Stencil<2, dim>();
-        xt::view(stencil_shape, 0) = 0;
-        xt::view(stencil_shape, 1) = out_normal_vect;
+        xt::view(stencil_shape, 1) = towards_out_from_in;
         return stencil_shape;
     }
 }


### PR DESCRIPTION
The functions returning only cell indices are removed. The ones returning cells are used instead.