### PR TITLE
fix: add hdf5 dependency in cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,7 +85,7 @@ target_include_directories(samurai INTERFACE "$<BUILD_INTERFACE:${CMAKE_CURRENT_
   "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>")
 
 # Find dependencies:
-set(DEPENDENCIES_CONFIGURED xtensor HighFive pugixml fmt)
+set(DEPENDENCIES_CONFIGURED xtensor hdf5 HighFive pugixml fmt)
 
 if(${ENABLE_VCPKG})
   list(APPEND DEPENDENCIES_CONFIGURED hdf5)


### PR DESCRIPTION
`highfive` tries to find the target `hdf5::hdf5-static` when samurai is installed with `vcpkg`. Adding `hdf5` in the `find_package`fixes this issue.