### PR TITLE
feat: add Field_tuple

### DIFF
--- a/demos/FiniteVolume/level_set_from_scratch.cpp
+++ b/demos/FiniteVolume/level_set_from_scratch.cpp
@@ -367,7 +367,7 @@ bool update_mesh(Field& f, Field_u& u, Tag& tag)
 
     samurai::update_field(tag, f, u);
 
-    tag.mesh_ptr()->swap(new_mesh);
+    tag.mesh().swap(new_mesh);
     return false;
 }
 

--- a/demos/pablo/bubble_2d.cpp
+++ b/demos/pablo/bubble_2d.cpp
@@ -12,6 +12,7 @@
 
 #include <samurai/box.hpp>
 #include <samurai/cell_array.hpp>
+#include <samurai/cell_flag.hpp>
 #include <samurai/field.hpp>
 #include <samurai/hdf5.hpp>
 #include <samurai/subset/subset_op.hpp>

--- a/demos/tutorial/AMR_1D_Burgers/step_4/update_field.hpp
+++ b/demos/tutorial/AMR_1D_Burgers/step_4/update_field.hpp
@@ -71,6 +71,6 @@ void update_field(Field& f, const Tag& tag, Mesh& new_mesh)
             });
     }
 
-    f.mesh_ptr()->swap(new_mesh);
+    f.mesh().swap(new_mesh);
     std::swap(f.array(), new_f.array());
 }

--- a/include/samurai/field.hpp
+++ b/include/samurai/field.hpp
@@ -20,7 +20,6 @@
 #include "cell_array.hpp"
 #include "field_expression.hpp"
 #include "mesh_holder.hpp"
-#include "mr/operators.hpp"
 #include "numeric/gauss_legendre.hpp"
 
 namespace samurai
@@ -859,4 +858,46 @@ namespace samurai
     {
         return !(field1 == field2);
     }
+
+    template <class TField, class... TFields>
+    class Field_tuple
+    {
+      public:
+
+        using tuple_type                   = std::tuple<TField&, TFields&...>;
+        using tuple_type_without_ref       = std::tuple<TField, TFields...>;
+        static constexpr std::size_t nelem = detail::compute_size<TField, TFields...>();
+        using common_t                     = detail::common_type_t<TField, TFields...>;
+        using mesh_t                       = typename TField::mesh_t;
+        using mesh_id_t                    = typename mesh_t::mesh_id_t;
+
+        Field_tuple(TField& field, TFields&... fields)
+            : m_fields(field, fields...)
+        {
+        }
+
+        const auto& mesh() const
+        {
+            return std::get<0>(m_fields).mesh();
+        }
+
+        auto& mesh()
+        {
+            return std::get<0>(m_fields).mesh();
+        }
+
+        const auto& elements() const
+        {
+            return m_fields;
+        }
+
+        auto& elements()
+        {
+            return m_fields;
+        }
+
+      private:
+
+        tuple_type m_fields;
+    };
 } // namespace samurai

--- a/include/samurai/io/from_geometry.hpp
+++ b/include/samurai/io/from_geometry.hpp
@@ -6,6 +6,7 @@
 
 #include "../algorithm.hpp"
 #include "../cell_array.hpp"
+#include "../cell_flag.hpp"
 #include "../cell_list.hpp"
 #include "../field.hpp"
 #include "../graduation.hpp"

--- a/include/samurai/mesh_holder.hpp
+++ b/include/samurai/mesh_holder.hpp
@@ -66,17 +66,12 @@ namespace samurai
             return *p_mesh;
         }
 
-        const mesh_t* mesh_ptr() const
+        void change_mesh_ptr(mesh_t& mesh)
         {
-            return p_mesh;
+            p_mesh = &mesh;
         }
 
-        mesh_t* mesh_ptr()
-        {
-            return p_mesh;
-        }
-
-      private:
+      public:
 
         mesh_t* p_mesh = nullptr;
     };
@@ -114,16 +109,6 @@ namespace samurai
         mesh_t& mesh()
         {
             return m_mesh;
-        }
-
-        const mesh_t* mesh_ptr() const
-        {
-            return &m_mesh;
-        }
-
-        mesh_t* mesh_ptr()
-        {
-            return &m_mesh;
         }
 
       private:

--- a/include/samurai/mr/adapt.hpp
+++ b/include/samurai/mr/adapt.hpp
@@ -359,7 +359,6 @@ namespace samurai
         update_ghost_mr(old_fields);
         update_ghost_mr(other_fields...);
         return update_field_mr(m_tag, m_fields, old_fields, other_fields...);
-        return true;
     }
 
     template <class... TFields>

--- a/include/samurai/petsc/fv/FV_scheme_assembly.hpp
+++ b/include/samurai/petsc/fv/FV_scheme_assembly.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include "../../boundary.hpp"
+#include "../../numeric/prediction.hpp"
 #include "../../schemes/fv/FV_scheme.hpp"
 #include "../../schemes/fv/scheme_operators.hpp"
 #include "../matrix_assembly.hpp"

--- a/include/samurai/utils.hpp
+++ b/include/samurai/utils.hpp
@@ -171,6 +171,21 @@ namespace samurai
             return extract_mesh(std::get<Is>(t)...);
         }
 
+        template <class... T>
+        constexpr std::size_t compute_size()
+        {
+            return (0 + ... + T::size);
+        }
+
+        template <class... T>
+        struct common_type
+        {
+            using type = std::common_type_t<typename T::value_type...>;
+        };
+
+        template <class... T>
+        using common_type_t = typename common_type<T...>::type;
+
         template <class Head, class... Tail>
         auto& extract_mesh(Head&& h, Tail&&... t)
         {

--- a/test/test_field.cpp
+++ b/test/test_field.cpp
@@ -41,7 +41,7 @@ namespace samurai
         EXPECT_EQ(u.name(), u_const.name());
         EXPECT_EQ(u.array(), u_const.array());
         EXPECT_EQ(u.mesh(), u_const.mesh());
-        EXPECT_EQ(u.mesh_ptr(), u_const.mesh_ptr());
+        EXPECT_EQ(&(u.mesh()), &(u_const.mesh()));
 
         auto m              = holder(mesh);
         const auto u_const1 = make_field<double, 1>("uc", m);
@@ -64,7 +64,7 @@ namespace samurai
         EXPECT_EQ(u.name(), u_const.name());
         EXPECT_EQ(u.array(), u_const.array());
         EXPECT_EQ(u.mesh(), u_const.mesh());
-        EXPECT_EQ(u.mesh_ptr(), u_const.mesh_ptr());
+        EXPECT_EQ(&(u.mesh()), &(u_const.mesh()));
 
         auto m1             = holder(mesh1);
         auto m2             = holder(mesh2);

--- a/test/test_utils.cpp
+++ b/test/test_utils.cpp
@@ -21,4 +21,18 @@ namespace samurai
         static_assert(detail::is_field_function<decltype(5 + u)>::value);
         static_assert(detail::is_field_function<decltype(upwind(1, u))>::value);
     }
+
+    TEST(utils, compute_size)
+    {
+        Box<double, 1> box{{0}, {1}};
+        using Config = UniformConfig<1>;
+        auto mesh    = UniformMesh<Config>(box, 3);
+
+        auto u1 = make_field<int, 1>("u", mesh);
+        auto u2 = make_field<double, 3>("u", mesh);
+
+        static_assert(detail::compute_size<decltype(u1), decltype(u2)>() == 4);
+
+        static_assert(std::is_same<detail::common_type_t<decltype(u1), decltype(u2)>, double>::value);
+    }
 }


### PR DESCRIPTION
Field_tuple is used in the multiresolution process in order to compute the details from several fields.

Now, we can make 

```
auto MRadaptation = samurai::make_MRAdapt(u, v);
```

And the details will be computed using the two fields `u` and `v`.