### PR TITLE
fix: detail computation in MRAdapt

### DIFF
--- a/include/samurai/mr/adapt.hpp
+++ b/include/samurai/mr/adapt.hpp
@@ -70,7 +70,7 @@ namespace samurai
             using mesh_t                       = typename fields_t::mesh_t;
             static constexpr std::size_t nelem = fields_t::nelem;
             using common_t                     = typename fields_t::common_t;
-            using detail_t                     = Field<mesh_t, common_t, nelem, true>;
+            using detail_t                     = Field<mesh_t, common_t, nelem>;
         };
 
         template <class TField>

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -11,6 +11,7 @@ set(COMMON_BASE
 )
 
 set(SAMURAI_TESTS
+    test_adapt.cpp
     test_bc.cpp
     test_box.cpp
     test_cell.cpp

--- a/tests/test_adapt.cpp
+++ b/tests/test_adapt.cpp
@@ -1,0 +1,32 @@
+#include <gtest/gtest.h>
+
+#include <samurai/field.hpp>
+#include <samurai/mr/adapt.hpp>
+#include <samurai/mr/mesh.hpp>
+
+namespace samurai
+{
+
+    template <typename T>
+    class adapt_test : public ::testing::Test
+    {
+    };
+
+    using adapt_test_types = ::testing::
+        Types<std::integral_constant<std::size_t, 1>, std::integral_constant<std::size_t, 2>, std::integral_constant<std::size_t, 3>>;
+
+    TYPED_TEST_SUITE(adapt_test, adapt_test_types);
+
+    TYPED_TEST(adapt_test, mutliple_fields)
+    {
+        static constexpr std::size_t dim = TypeParam::value;
+        using config                     = MRConfig<dim>;
+        auto mesh                        = MRMesh<config>({xt::zeros<double>({dim}), xt::ones<double>({dim})}, 2, 4);
+        auto u_1                         = make_field<double, 1>("u_1", mesh);
+        auto u_2                         = make_field<double, 3, true>("u_2", mesh);
+        auto u_3                         = make_field<double, 2>("u_3", mesh);
+
+        auto adapt = make_MRAdapt(u_1, u_2, u_3);
+        adapt(1e-4, 2);
+    }
+}


### PR DESCRIPTION
## Description

This PR fixes the detail computation in the multi resolution process when several fields are used with different size.

## How has this been tested?

see tests/test_adapt.cpp

## Code of Conduct
By submitting this PR, you agree to follow our [Code of Conduct](https://github.com/hpc-maths/samurai/blob/master/docs/CODE_OF_CONDUCT.md)
- [x] I agree to follow this project's Code of Conduct
