### PR TITLE
fix: Fix operators for time integration

### DIFF
--- a/include/samurai/petsc/fv/FV_scheme_assembly.hpp
+++ b/include/samurai/petsc/fv/FV_scheme_assembly.hpp
@@ -666,7 +666,7 @@ namespace samurai
 
             void set_0_for_all_ghosts(Vec& b) const
             {
-                for (std::size_t level = mesh().min_level(); level <= mesh().max_level(); ++level)
+                for (std::size_t level = 0; level <= mesh().max_level(); ++level)
                 {
                     auto ghosts = difference(mesh()[mesh_id_t::reference][level], mesh()[mesh_id_t::cells][level]);
 

--- a/include/samurai/petsc/nonlinear_solver.hpp
+++ b/include/samurai/petsc/nonlinear_solver.hpp
@@ -169,7 +169,7 @@ namespace samurai
                                });
 
                 // Apply explicit scheme
-                // update_ghost_mr(x_field); // Necessary ?? Seems to work without it but seems risky
+                update_ghost_mr(x_field);
                 auto f_field = self->scheme()(x_field);
 
                 copy(f_field, f);

--- a/include/samurai/schemes/fv/cell_based/local_field.hpp
+++ b/include/samurai/schemes/fv/cell_based/local_field.hpp
@@ -30,7 +30,7 @@ namespace samurai
         {
         }
 
-        field_value_type& operator[](const cell_t& cell)
+        field_value_type& operator[]([[maybe_unused]] const cell_t& cell)
         {
             assert(cell.index == m_cell.index);
             return m_value;
@@ -62,7 +62,7 @@ namespace samurai
         {
         }
 
-        auto operator[](const cell_t& cell) const
+        auto operator[]([[maybe_unused]] const cell_t& cell) const
         {
             assert(cell.index == m_cell.index);
             return xt::view(m_container, xt::all());

--- a/include/samurai/schemes/fv/scheme_operators.hpp
+++ b/include/samurai/schemes/fv/scheme_operators.hpp
@@ -278,4 +278,16 @@ namespace samurai
         return sum_scheme;
     }
 
+    template <class... Operators>
+    OperatorSum<Operators...> operator*(double scalar, const OperatorSum<Operators...>& sum_scheme)
+    {
+        auto result = sum_scheme;
+        for_each(result.operators(),
+                 [&](auto& op)
+                 {
+                     op = scalar * op;
+                 });
+        return result;
+    }
+
 } // end namespace samurai


### PR DESCRIPTION
## Description
Fix problems that prevented the implementation of a high-order scheme in time:

- an algebraic operators between schemes has been added
- bugs in the global Newton solver have been fixed.

## How has this been tested?
Time scheme of order 2 in Nagumo.

## Code of Conduct
By submitting this PR, you agree to follow our [Code of Conduct](https://github.com/hpc-maths/samurai/blob/master/docs/CODE_OF_CONDUCT.md)
- [x] I agree to follow this project's Code of Conduct
