### PR TITLE
fix: cell array instead of cell xtensor for the stencil of non-linear cell-based schemes

### DIFF
--- a/include/samurai/schemes/fv/cell_based/cell_based_scheme_definition.hpp
+++ b/include/samurai/schemes/fv/cell_based/cell_based_scheme_definition.hpp
@@ -57,7 +57,7 @@ namespace samurai
 
         CellBasedSchemeDefinitionBase()
         {
-            if constexpr (cfg::scheme_stencil_size == 1 + 2 * dim * cfg::neighbourhood_width)
+            if constexpr (cfg::scheme_stencil_size == 1 + 2 * dim * cfg::neighbourhood_width && cfg::neighbourhood_width <= 2)
             {
                 stencil = samurai::star_stencil<dim, cfg::neighbourhood_width>();
             }
@@ -85,7 +85,7 @@ namespace samurai
         using cell_t                            = typename field_t::cell_t;
         static constexpr std::size_t field_size = field_t::size;
 
-        using stencil_cells_t = CollapsVector<cell_t, cfg::scheme_stencil_size>;
+        using stencil_cells_t = CollapsArray<cell_t, cfg::scheme_stencil_size>;
 
         using scheme_value_t = CollapsVector<field_value_type, cfg::output_field_size>;
         using scheme_func    = std::function<scheme_value_t(stencil_cells_t&, field_t&)>;

--- a/include/samurai/schemes/fv/utils.hpp
+++ b/include/samurai/schemes/fv/utils.hpp
@@ -44,6 +44,21 @@ namespace samurai
         {
             using Type = value_type;
         };
+
+        template <class T, std::size_t size>
+        struct FixedCollapsableArray
+        {
+            using Type = std::array<T, size>;
+        };
+
+        /**
+         * Template specialization: if size=1, then just the object
+         */
+        template <class T>
+        struct FixedCollapsableArray<T, 1>
+        {
+            using Type = T;
+        };
     }
 
     /**
@@ -57,6 +72,12 @@ namespace samurai
      */
     template <class value_type, std::size_t size>
     using CollapsVector = typename detail::FixedCollapsableVector<value_type, size>::Type;
+
+    /**
+     * Collapsable fixed size array: reduces to the object if size = 1.
+     */
+    template <class T, std::size_t size>
+    using CollapsArray = typename detail::FixedCollapsableArray<T, size>::Type;
 
     template <class matrix_type>
     matrix_type eye()


### PR DESCRIPTION
## Description
Using cell array instead of cell xtensor for the stencil of non-linear cell-based schemes.

## Related issue
Compilation issue when making a non-local cell-based scheme with a stencil.

## How has this been tested?
Tested in Nicolas Grenier's level-set code.

## Code of Conduct
By submitting this PR, you agree to follow our [Code of Conduct](https://github.com/hpc-maths/samurai/blob/master/docs/CODE_OF_CONDUCT.md)
- [x] I agree to follow this project's Code of Conduct
