### PR TITLE
fix: Fix flux-based schemes with unsymmetric stencil

### DIFF
--- a/demos/FiniteVolume/linear_convection.cpp
+++ b/demos/FiniteVolume/linear_convection.cpp
@@ -47,7 +47,7 @@ int main(int argc, char* argv[])
     using Box                        = samurai::Box<double, dim>;
     using point_t                    = typename Box::point_t;
 
-    std::cout << "------------------------- Burgers -------------------------" << std::endl;
+    std::cout << "------------------------- Linear convection -------------------------" << std::endl;
 
     //--------------------//
     // Program parameters //

--- a/include/samurai/interface.hpp
+++ b/include/samurai/interface.hpp
@@ -213,7 +213,7 @@ namespace samurai
         Stencil<1, dim> coarse_cell_stencil = center_only_stencil<dim>();
         auto coarse_it                      = make_stencil_iterator(mesh, coarse_cell_stencil);
 
-        Stencil<comput_stencil_size, dim> minus_comput_stencil = -xt::flip(comput_stencil, 0);
+        Stencil<comput_stencil_size, dim> minus_comput_stencil = comput_stencil - direction;
         Vector minus_direction                                 = -direction;
         int minus_direction_index_int                          = find(minus_comput_stencil, minus_direction);
         auto minus_direction_index                             = static_cast<std::size_t>(minus_direction_index_int);
@@ -323,7 +323,7 @@ namespace samurai
                                                           Func&& f)
     {
         Vector opposite_direction                        = -direction;
-        decltype(comput_stencil) opposite_comput_stencil = -xt::flip(comput_stencil, 0);
+        decltype(comput_stencil) opposite_comput_stencil = comput_stencil - direction;
         for_each_boundary_interface___direction(mesh, level, opposite_direction, opposite_comput_stencil, std::forward<Func>(f));
     }
 


### PR DESCRIPTION
## Description
When computing the flux on the boundary in the opposite direction, the stencil was wrong.
The 'flip(stencil)' instruction is replaced with 'stencil - direction'.

## Related issue
The flux-based schemes didn't work when the stencil was unsymmetric.

## How has this been tested?
It was tested on the Lax-Wendroff scheme in N. Grenier's code.

## Code of Conduct
By submitting this PR, you agree to follow our [Code of Conduct](https://github.com/hpc-maths/samurai/blob/master/docs/CODE_OF_CONDUCT.md)
- [x] I agree to follow this project's Code of Conduct
