### PR TITLE
feat: Non-conservative fluxes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
       - name: cppcheck installation
         shell: bash -el {0}
         run: |
-          conda install -y cppcheck=2.7.5 cxx-compiler
+          conda install -y cppcheck=2.12.1 cxx-compiler
 
       - name: Configure
         shell: bash -el {0}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
       - name: cppcheck installation
         shell: bash -el {0}
         run: |
-          conda install -y cppcheck cxx-compiler
+          conda install -y cppcheck=2.7.5 cxx-compiler
 
       - name: Configure
         shell: bash -el {0}

--- a/docs/source/reference/finite_volume_schemes.rst
+++ b/docs/source/reference/finite_volume_schemes.rst
@@ -147,19 +147,19 @@ The corresponding stencils are configured by
     samurai::FluxDefinition<cfg> my_flux;
 
     // x-direction
-    my_flux[0].stencil       = {{-1,0}, {0,0}, {1,0}, {2,0}};
-    my_flux[0].flux_function = my_flux_function_x;
+    my_flux[0].stencil = {{-1,0}, {0,0}, {1,0}, {2,0}};
+    my_flux[0].cons_flux_function = my_flux_function_x;
     // y-direction
-    my_flux[1].stencil       = {{0,-1}, {0,0}, {0,1}, {0,2}};
-    my_flux[1].flux_function = my_flux_function_y;
+    my_flux[1].stencil = {{0,-1}, {0,0}, {0,1}, {0,2}};
+    my_flux[1].cons_flux_function = my_flux_function_y;
 
 Note that one stencil and associated flux function must be defined for each positive Cartesian direction.
 The set of cells captured by the stencil will be passed as argument of the flux function in the form of a cell array, arranged according the order chosen in the configured stencil:
 
 .. code-block:: c++
 
-    my_flux[0].stencil       = {{-1,0}, {0,0}, {1,0}, {2,0}};
-    my_flux[0].flux_function = [](auto& cells, ...)
+    my_flux[0].stencil = {{-1,0}, {0,0}, {1,0}, {2,0}};
+    my_flux[0].cons_flux_function = [](auto& cells, ...)
         {
             auto& L2 = cells[0]; // {-1,0}
             auto& L1 = cells[1]; // { 0,0}
@@ -172,8 +172,8 @@ Configuring it explicitly yields
 
 .. code-block:: c++
 
-    my_flux[0].stencil       = {{0,0}, {1,0}}; // default value
-    my_flux[0].flux_function = [](auto& cells, ...)
+    my_flux[0].stencil = {{0,0}, {1,0}}; // default value
+    my_flux[0].cons_flux_function = [](auto& cells, ...)
         {
             auto& L = cells[0]; // {0,0}
             auto& R = cells[1]; // {1,0}
@@ -193,8 +193,8 @@ The flux function must be defined for each positive Cartesian direction. Here in
 .. code-block:: c++
 
     samurai::FluxDefinition<cfg> my_flux;
-    my_flux[0].flux_function = my_flux_function_x; // flux in the x-direction
-    my_flux[1].flux_function = my_flux_function_y; // flux in the y-direction
+    my_flux[0].cons_flux_function = my_flux_function_x; // flux in the x-direction
+    my_flux[1].cons_flux_function = my_flux_function_y; // flux in the y-direction
 
 In this generic code, the flux functions remain abstract:
 their signatures actually depend on the :code:`SchemeType` declared in :code:`cfg`, and are described in the next sections.
@@ -210,7 +210,7 @@ If the flux functions only differ by the direction index, you can write an :math
             {
                 static constexpr int d = decltype(integral_constant_d)::value; // get the static direction index
 
-                my_flux[d].flux_function = my_flux_function_d;
+                my_flux[d].cons_flux_function = my_flux_function_d;
             });
 
 If the flux function is strictly identical for all directions, you can simply pass it into the constructor:
@@ -509,7 +509,7 @@ In 2D, they write:
 
     samurai::FluxDefinition<cfg> flux;
 
-    flux[x].flux_function = [](double h)
+    flux[x].cons_flux_function = [](double h)
     {
         static constexpr std::size_t L = 0;
         static constexpr std::size_t R = 1;
@@ -523,7 +523,7 @@ In 2D, they write:
         return c;
     };
 
-    flux[y].flux_function = [](double h)
+    flux[y].cons_flux_function = [](double h)
     {
         static constexpr std::size_t B = 0;
         static constexpr std::size_t T = 1;
@@ -551,7 +551,7 @@ This code can be compacted into the :math:`n`-dimensional code
         {
             static constexpr int d = decltype(integral_constant_d)::value; // direction index
 
-            flux[d].flux_function = [](double h)
+            flux[d].cons_flux_function = [](double h)
             {
                 static constexpr std::size_t L = 0;
                 static constexpr std::size_t R = 1;
@@ -650,7 +650,7 @@ The following code corresponds directly to the :math:`n`-dimensional version:
         {
             static constexpr int d = decltype(integral_constant_d)::value;
 
-            flux[d].flux_function = [](double)
+            flux[d].cons_flux_function = [](double)
             {
                 static constexpr std::size_t L = 0;
                 static constexpr std::size_t R = 1;
@@ -800,7 +800,7 @@ The construction of the operator now reads
         {
             static constexpr int d = decltype(integral_constant_d)::value;
 
-            upwind[d].flux_function = [&](const auto& cells)
+            upwind[d].cons_flux_function = [&](const auto& cells)
             {
                 static constexpr std::size_t L = 0;
                 static constexpr std::size_t R = 1;
@@ -892,7 +892,7 @@ The associated code yields
                 return f_v;
             };
 
-            f_h[d].flux_function = [f](auto& cells, Field& u)
+            f_h[d].cons_flux_function = [f](auto& cells, Field& u)
             {
                 auto& L = cells[0];
                 auto& R = cells[1];
@@ -973,7 +973,7 @@ We choose the upwind scheme, and implement:
     samurai::FluxDefinition<cfg> upwind_f;
 
     // x-direction
-    upwind_f[0].flux_function = [f_x](auto& cells, Field& u)
+    upwind_f[0].cons_flux_function = [f_x](auto& cells, Field& u)
     {
         auto& L = cells[0]; // left
         auto& R = cells[1]; // right
@@ -981,7 +981,7 @@ We choose the upwind scheme, and implement:
     };
 
     // y-direction
-    upwind_f[1].flux_function = [f_y](auto& cells, Field& u)
+    upwind_f[1].cons_flux_function = [f_y](auto& cells, Field& u)
     {
         auto& B = cells[0]; // bottom
         auto& T = cells[1]; // top
@@ -1011,7 +1011,7 @@ where :math:`u_d` is the :math:`d`-th component of :math:`\mathbf{u}`, the code 
                 return u(d) * u;
             };
 
-            upwind_f[d].flux_function = [f_d](auto& cells, Field& u)
+            upwind_f[d].cons_flux_function = [f_d](auto& cells, Field& u)
             {
                 auto& L = cells[0];
                 auto& R = cells[1];
@@ -1040,7 +1040,7 @@ In a conservative scheme, the respective contributions of :math:`F` on :math:`V_
 
 and flux :math:`\mathcal{F}_h(u_h)_{|F}` is computed only once and used for both contributions.
 
-Now, the contributions of a non-conservative scheme reads
+Now, the contributions of a non-conservative scheme read
 
 .. math::
 
@@ -1049,19 +1049,10 @@ Now, the contributions of a non-conservative scheme reads
 
 where we do not necessarily have :math:`\mathcal{F}_h^-(u_h)_{|F} = -\mathcal{F}_h^+(u_h)_{|F}`.
 
-Implementation-wise, conservative schemes are implemented as a particular case of non-conservative ones, where :math:`\mathcal{F}_h^+(u_h)_{|F} = \mathcal{F}_h(u_h)_{|F}` and  :math:`\mathcal{F}_h^-(u_h)_{|F} = -\mathcal{F}_h(u_h)_{|F}`.
-As a consequence, the preceding sections allow you to implement :math:`\mathcal{F}_h^+(u_h)_{|F}`. Only :math:`\mathcal{F}_h^-(u_h)_{|F}` remains.
-This is done via the data member :code:`opposite_flux_function`:
-
-.. code::
-
-    samurai::FluxDefinition<cfg> my_flux;
-
-    my_flux[0].flux_function          = ...;
-    my_flux[0].opposite_flux_function = ...;
-
+Implementation-wise, while conservative schemes implement :math:`\mathcal{F}_h(u_h)_{|F}` through :code:`cons_flux_function`,
+non-conservative ones return both values of :math:`\mathcal{F}_h^+(u_h)_{|F}` and :math:`\mathcal{F}_h^-(u_h)_{|F}` through :code:`flux_function`.
 So far, only non-linear schemes are possible.
-The signature of the flux functions are
+The signature is the same as :code:`flux_function`, except that it returns two values instead of one:
 
 .. code::
 
@@ -1069,21 +1060,29 @@ The signature of the flux functions are
 
     my_flux[0].flux_function = [](auto& cells, Field& u)
                                {
-                                   ...
-                               };
-    my_flux[0].opposite_flux_function = [](auto& flux_value, auto& cells, Field& u)
-                               {
-                                   ...
+                                   samurai::FluxValuePair<cfg> flux;
+                                   flux[0] = ...; // left --> right (direction '+')
+                                   flux[1] = ...; // right --> left (direction '-')
+                                   return flux;
                                };
 
-The argument :code:`flux_value` holds the return value of the function :code:`flux_function` on the same face.
-As an exemple, here is how a conservative scheme can be emulated as a non-conservative one:
+Alternatively, you can also write
 
 .. code::
 
-    my_flux[0].opposite_flux_function = [](auto& flux_value, auto& cells, Field& u)
+    my_flux[0].flux_function = [](auto& cells, Field& u) -> samurai::FluxValuePair<cfg>
                                {
-                                   return -flux_value;
+                                   samurai::FluxValue<cfg> fluxLR = ...; // left --> right (direction '+')
+                                   samurai::FluxValue<cfg> fluxRL = ...; // right --> left (direction '-')
+                                   return {fluxLR, fluxRL};
                                };
 
-Note also that in both flux functions, the stencil cells are given in the same order.
+For instance, conservativity can be enforced by
+
+.. code::
+
+    my_flux[0].flux_function = [](auto& cells, Field& u) -> samurai::FluxValuePair<cfg>
+                               {
+                                   samurai::FluxValue<cfg> flux = ...;
+                                   return {flux, -flux};
+                               };

--- a/include/samurai/schemes/fv/flux_based/flux_based_scheme__lin_het.hpp
+++ b/include/samurai/schemes/fv/flux_based/flux_based_scheme__lin_het.hpp
@@ -97,7 +97,7 @@ namespace samurai
                         flux_def.stencil,
                         [&](auto& interface_cells, auto& comput_cells)
                         {
-                            auto flux_coeffs                               = flux_def.flux_function(comput_cells);
+                            auto flux_coeffs                               = flux_def.cons_flux_function(comput_cells);
                             auto left_cell_contrib                         = contribution(flux_coeffs, h, h);
                             decltype(left_cell_contrib) right_cell_contrib = -left_cell_contrib;
                             apply_coeffs(interface_cells, comput_cells, left_cell_contrib, right_cell_contrib);
@@ -122,7 +122,7 @@ namespace samurai
                             flux_def.stencil,
                             [&](auto& interface_cells, auto& comput_cells)
                             {
-                                auto flux_coeffs                        = flux_def.flux_function(comput_cells);
+                                auto flux_coeffs                        = flux_def.cons_flux_function(comput_cells);
                                 decltype(flux_coeffs) minus_flux_coeffs = -flux_coeffs;
                                 auto left_cell_contrib                  = contribution(flux_coeffs, h_lp1, h_l);
                                 auto right_cell_contrib                 = contribution(minus_flux_coeffs, h_lp1, h_lp1);
@@ -141,7 +141,7 @@ namespace samurai
                             flux_def.stencil,
                             [&](auto& interface_cells, auto& comput_cells)
                             {
-                                auto flux_coeffs                        = flux_def.flux_function(comput_cells);
+                                auto flux_coeffs                        = flux_def.cons_flux_function(comput_cells);
                                 decltype(flux_coeffs) minus_flux_coeffs = -flux_coeffs;
                                 auto left_cell_contrib                  = contribution(flux_coeffs, h_lp1, h_lp1);
                                 auto right_cell_contrib                 = contribution(minus_flux_coeffs, h_lp1, h_l);
@@ -174,7 +174,7 @@ namespace samurai
                                                                            flux_def.stencil,
                                                                            [&](auto& cell, auto& comput_cells)
                                                                            {
-                                                                               auto flux_coeffs  = flux_def.flux_function(comput_cells);
+                                                                               auto flux_coeffs = flux_def.cons_flux_function(comput_cells);
                                                                                auto cell_contrib = contribution(flux_coeffs, h, h);
                                                                                apply_coeffs(cell, comput_cells, cell_contrib);
                                                                            });
@@ -187,7 +187,7 @@ namespace samurai
                                        flux_def.stencil,
                                        [&](auto& cell, auto& comput_cells)
                                        {
-                                           auto flux_coeffs                        = flux_def.flux_function(comput_cells);
+                                           auto flux_coeffs                        = flux_def.cons_flux_function(comput_cells);
                                            decltype(flux_coeffs) minus_flux_coeffs = -flux_coeffs;
                                            auto cell_contrib                       = contribution(minus_flux_coeffs, h, h);
                                            apply_coeffs(cell, comput_cells, cell_contrib);

--- a/include/samurai/schemes/fv/flux_based/flux_based_scheme__lin_hom.hpp
+++ b/include/samurai/schemes/fv/flux_based/flux_based_scheme__lin_hom.hpp
@@ -89,7 +89,7 @@ namespace samurai
                 for (std::size_t level = min_level; level <= max_level; ++level)
                 {
                     auto h           = cell_length(level);
-                    auto flux_coeffs = flux_def.flux_function(h);
+                    auto flux_coeffs = flux_def.cons_flux_function(h);
 
                     auto left_cell_coeffs                        = contribution(flux_coeffs, h, h);
                     decltype(left_cell_coeffs) right_cell_coeffs = -left_cell_coeffs;
@@ -110,7 +110,7 @@ namespace samurai
                 {
                     auto h_l                                = cell_length(level);
                     auto h_lp1                              = cell_length(level + 1);
-                    auto flux_coeffs                        = flux_def.flux_function(h_lp1); // flux computed at level l+1
+                    auto flux_coeffs                        = flux_def.cons_flux_function(h_lp1); // flux computed at level l+1
                     decltype(flux_coeffs) minus_flux_coeffs = -flux_coeffs;
 
                     //         |__|   l+1
@@ -169,7 +169,7 @@ namespace samurai
                                    auto h = cell_length(level);
 
                                    // Boundary in direction
-                                   auto flux_coeffs = flux_def.flux_function(h);
+                                   auto flux_coeffs = flux_def.cons_flux_function(h);
                                    auto cell_coeffs = contribution(flux_coeffs, h, h);
                                    for_each_boundary_interface___direction(mesh,
                                                                            level,

--- a/include/samurai/schemes/fv/flux_based/flux_definition.hpp
+++ b/include/samurai/schemes/fv/flux_based/flux_definition.hpp
@@ -69,13 +69,18 @@ namespace samurai
 
         using stencil_cells_t = std::array<cell_t, cfg::stencil_size>;
 
-        using flux_value_t = xt::xtensor_fixed<field_value_type, xt::xshape<cfg::output_field_size>>;
-        using flux_func    = std::function<flux_value_t(stencil_cells_t&, field_t&)>;
+        using flux_value_t       = xt::xtensor_fixed<field_value_type, xt::xshape<cfg::output_field_size>>;
+        using flux_func          = std::function<flux_value_t(stencil_cells_t&, field_t&)>;
+        using opposite_flux_func = std::function<flux_value_t(flux_value_t&, stencil_cells_t&, field_t&)>;
 
         // using flux_jac_t         = CollapsMatrix<field_value_type, cfg::output_field_size, field_size>;
         // using flux_jacobian_func = std::function<flux_jac_t(stencil_cells_t&, field_t&)>;
 
-        flux_func flux_function = nullptr;
+        flux_func flux_function                   = nullptr;
+        opposite_flux_func opposite_flux_function = [](auto& flux_value, auto&, auto&) -> flux_value_t
+        {
+            return -flux_value;
+        };
 
         // flux_jacobian_func flux_jac_function = nullptr;
 

--- a/include/samurai/schemes/fv/operators/convection_FV__lin.hpp
+++ b/include/samurai/schemes/fv/operators/convection_FV__lin.hpp
@@ -8,7 +8,7 @@ namespace samurai
     using VelocityVector = xt::xtensor_fixed<double, xt::xshape<dim>>;
 
     template <class Field>
-    auto make_convection(const VelocityVector<Field::dim> velocity)
+    auto make_convection(const VelocityVector<Field::dim>& velocity)
     {
         // static_assert(Field::size == 1, "The field type for the gradient operator must be a scalar field.");
 
@@ -31,7 +31,7 @@ namespace samurai
 
                 if (velocity(d) >= 0) // use the left values
                 {
-                    upwind[d].flux_function = [&](double)
+                    upwind[d].cons_flux_function = [&](double)
                     {
                         // Return type: 2 matrices (left, right) of size output_field_size x field_size.
                         // In this case, of size field_size x field_size.
@@ -53,7 +53,7 @@ namespace samurai
                 }
                 else // use the right values
                 {
-                    upwind[d].flux_function = [&](double)
+                    upwind[d].cons_flux_function = [&](double)
                     {
                         FluxStencilCoeffs<cfg> coeffs;
                         if constexpr (output_field_size == 1)
@@ -98,7 +98,7 @@ namespace samurai
                 static constexpr std::size_t left  = 0;
                 static constexpr std::size_t right = 1;
 
-                upwind[d].flux_function = [&](const auto& cells)
+                upwind[d].cons_flux_function = [&](const auto& cells)
                 {
                     // Return type: 2 matrices (left, right) of size output_field_size x field_size.
                     // In this case, of size field_size x field_size.

--- a/include/samurai/schemes/fv/operators/convection_FV__nonlin.hpp
+++ b/include/samurai/schemes/fv/operators/convection_FV__nonlin.hpp
@@ -72,7 +72,7 @@ namespace samurai
 
                             FluxDefinition<cfg> upwind_f;
                             // x-direction
-                            upwind_f[0].flux_function = [f_x](auto& cells, Field& v)
+                            upwind_f[0].cons_flux_function = [f_x](auto& cells, Field& v)
                             {
                                 static constexpr std::size_t x = 0;
                                 auto& left                     = cells[0];
@@ -80,7 +80,7 @@ namespace samurai
                                 return v[left](x) >= 0 ? f_x(v[left]) : f_x(v[right]);
                             };
                             // y-direction
-                            upwind_f[1].flux_function = [f_y](auto& cells, Field& v)
+                            upwind_f[1].cons_flux_function = [f_y](auto& cells, Field& v)
                             {
                                 static constexpr std::size_t y = 1;
                                 auto& bottom                   = cells[0];
@@ -121,7 +121,7 @@ namespace samurai
 
                             FluxDefinition<cfg> upwind_f;
                             // x-direction
-                            upwind_f[0].flux_function = [f_x](auto& cells, Field& v)
+                            upwind_f[0].cons_flux_function = [f_x](auto& cells, Field& v)
                             {
                                 static constexpr std::size_t x = 0;
                                 auto& left                     = cells[0];
@@ -129,7 +129,7 @@ namespace samurai
                                 return v[left](x) >= 0 ? f_x(v[left]) : f_x(v[right]);
                             };
                             // y-direction
-                            upwind_f[1].flux_function = [f_y](auto& cells, Field& v)
+                            upwind_f[1].cons_flux_function = [f_y](auto& cells, Field& v)
                             {
                                 static constexpr std::size_t y = 1;
                                 auto& front                    = cells[0];
@@ -137,7 +137,7 @@ namespace samurai
                                 return v[front](y) >= 0 ? f_y(v[front]) : f_y(v[back]);
                             };
                             // z-direction
-                            upwind_f[2].flux_function = [f_z](auto& cells, Field& v)
+                            upwind_f[2].cons_flux_function = [f_z](auto& cells, Field& v)
                             {
                                 static constexpr std::size_t z = 2;
                                 auto& bottom                   = cells[0];
@@ -171,7 +171,7 @@ namespace samurai
                         // return f_v;
                     };
 
-                    upwind_f[d].flux_function = [f](auto& cells, Field& field)
+                    upwind_f[d].cons_flux_function = [f](auto& cells, Field& field)
                     {
                         auto& left  = cells[0];
                         auto& right = cells[1];

--- a/include/samurai/schemes/fv/operators/diffusion_FV.hpp
+++ b/include/samurai/schemes/fv/operators/diffusion_FV.hpp
@@ -145,7 +145,7 @@ namespace samurai
             {
                 static constexpr int d = decltype(integral_constant_d)::value;
 
-                K_grad[d].flux_function = [K](double h)
+                K_grad[d].cons_flux_function = [K](double h)
                 {
                     static constexpr std::size_t left  = 0;
                     static constexpr std::size_t right = 1;
@@ -220,7 +220,7 @@ namespace samurai
             {
                 static constexpr int d = decltype(integral_constant_d)::value;
 
-                K_grad[d].flux_function = [&](const auto& cells)
+                K_grad[d].cons_flux_function = [&](const auto& cells)
                 {
                     static constexpr std::size_t left  = 0;
                     static constexpr std::size_t right = 1;

--- a/include/samurai/schemes/fv/operators/divergence_FV.hpp
+++ b/include/samurai/schemes/fv/operators/divergence_FV.hpp
@@ -22,7 +22,7 @@ namespace samurai
             {
                 static constexpr int d = decltype(integral_constant_d)::value;
 
-                average_coeffs[d].flux_function = [](double)
+                average_coeffs[d].cons_flux_function = [](double)
                 {
                     static constexpr std::size_t left  = 0;
                     static constexpr std::size_t right = 1;

--- a/include/samurai/schemes/fv/operators/gradient_FV.hpp
+++ b/include/samurai/schemes/fv/operators/gradient_FV.hpp
@@ -21,7 +21,7 @@ namespace samurai
             {
                 static constexpr int d = decltype(integral_constant_d)::value;
 
-                average_coeffs[d].flux_function = [](double)
+                average_coeffs[d].cons_flux_function = [](double)
                 {
                     static constexpr std::size_t left  = 0;
                     static constexpr std::size_t right = 1;


### PR DESCRIPTION
## Description
Member 'flux_function' is renamed as 'cons_flux_function', expressing that the flux is conservative.
A new member 'flux_function' for non-conservative fluxes has been added. This function takes the same arguments, but must return two fluxes instead of one (one for the flux in the positive direction, one for the flux in the negative direction).

## Related issue

## How has this been tested?
Demo Burgers and file convection_FV__nonlin.hpp.

## Code of Conduct
By submitting this PR, you agree to follow our [Code of Conduct](https://github.com/hpc-maths/samurai/blob/master/docs/CODE_OF_CONDUCT.md)
- [x] I agree to follow this project's Code of Conduct
