### PR TITLE
feat: additional initial value parameter to make_field 

### DIFF
--- a/include/samurai/field.hpp
+++ b/include/samurai/field.hpp
@@ -8,6 +8,7 @@
 #include <array>
 #include <memory>
 #include <stdexcept>
+#include <type_traits>
 
 #include <fmt/format.h>
 
@@ -769,11 +770,27 @@ namespace samurai
         return field_t(name, mesh);
     }
 
+    template <class value_t, std::size_t size, bool SOA = false, class mesh_t>
+    auto make_field(std::string name, mesh_t& mesh, value_t init_value)
+    {
+        using field_t = Field<mesh_t, value_t, size, SOA>;
+        auto field    = field_t(name, mesh);
+        field.fill(init_value);
+        return field;
+    }
+
     template <std::size_t size, bool SOA = false, class mesh_t>
     auto make_field(std::string name, mesh_t& mesh)
     {
         using default_value_t = double;
         return make_field<default_value_t, size, SOA>(name, mesh);
+    }
+
+    template <std::size_t size, bool SOA = false, class mesh_t>
+    auto make_field(std::string name, mesh_t& mesh, double init_value)
+    {
+        using default_value_t = double;
+        return make_field<default_value_t, size, SOA>(name, mesh, init_value);
     }
 
     /**
@@ -809,7 +826,12 @@ namespace samurai
      * @param name Name of the returned Field.
      * @param f Continuous function.
      */
-    template <class value_t, std::size_t size, bool SOA = false, class mesh_t, class Func>
+    template <class value_t,
+              std::size_t size,
+              bool SOA = false,
+              class mesh_t,
+              class Func,
+              typename = std::enable_if_t<std::is_invocable_v<Func, typename Cell<mesh_t::dim, typename mesh_t::interval_t>::coords_t>>>
     auto make_field(std::string name, mesh_t& mesh, Func&& f)
     {
         auto field = make_field<value_t, size, SOA, mesh_t>(name, mesh);
@@ -823,7 +845,11 @@ namespace samurai
         return field;
     }
 
-    template <std::size_t size, bool SOA = false, class mesh_t, class Func>
+    template <std::size_t size,
+              bool SOA = false,
+              class mesh_t,
+              class Func,
+              typename = std::enable_if_t<std::is_invocable_v<Func, typename Cell<mesh_t::dim, typename mesh_t::interval_t>::coords_t>>>
     auto make_field(std::string name, mesh_t& mesh, Func&& f)
     {
         using default_value_t = double;

--- a/tests/test_field.cpp
+++ b/tests/test_field.cpp
@@ -35,7 +35,7 @@ namespace samurai
         Box<double, 1> box{{0}, {1}};
         using Config       = UniformConfig<1>;
         auto mesh          = UniformMesh<Config>(box, 3);
-        const auto u_const = make_field<double, 1>("uc", mesh);
+        const auto u_const = make_field<double, 1>("uc", mesh, 1.);
 
         auto u = u_const;
         EXPECT_EQ(u.name(), u_const.name());
@@ -44,7 +44,7 @@ namespace samurai
         EXPECT_EQ(&(u.mesh()), &(u_const.mesh()));
 
         auto m              = holder(mesh);
-        const auto u_const1 = make_field<double, 1>("uc", m);
+        const auto u_const1 = make_field<double, 1>("uc", m, 1.);
         auto u1             = u_const1;
         EXPECT_EQ(u1.name(), u_const1.name());
         EXPECT_EQ(u1.array(), u_const1.array());


### PR DESCRIPTION
 <!-- Thank you for your contribution to samurai! -->

<!-- Please check the following before submitting your PR -->
- [x] I have installed [pre-commit](https://pre-commit.com/) locally and use it to validate my commits.
- [x] The PR title follows the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) convention.
      Available tags: 'build', 'chore', 'ci', 'docs', 'feat', 'fix', 'perf', 'refactor', 'revert', 'style', 'test'
- [ ] This new PR is documented.
- [x] This new PR is tested.

## Description
`make_field` now accepts an additional parameter (when no initialisation function is given) that is used to fill the newly created field.

## Related issue
It allows to easily create a default initialized field stored in a constant variable. It is related to an issue in `test_field.cpp` where such constant fields were left uninitialised leading to potential test failure.
 
## How has this been tested?
It is tested in the `copy_from_const` test of `test_field.cpp`.

## Code of Conduct
By submitting this PR, you agree to follow our [Code of Conduct](https://github.com/hpc-maths/samurai/blob/master/docs/CODE_OF_CONDUCT.md)
- [x] I agree to follow this project's Code of Conduct
