### PR TITLE
fix: fixing (almost) all warnings triggered when compiling tests & demos

### DIFF
--- a/demos/FiniteVolume/lid_driven_cavity.cpp
+++ b/demos/FiniteVolume/lid_driven_cavity.cpp
@@ -166,7 +166,7 @@ int main(int argc, char* argv[])
     // where v = velocity
     //       p = pressure
 
-    auto mesh = Mesh(box, static_cast<std::size_t>(min_level), static_cast<std::size_t>(max_level));
+    auto mesh = Mesh(box, min_level, max_level);
 
     // Fields for the Navier-Stokes equations
     auto velocity     = samurai::make_field<dim, is_soa>("velocity", mesh);
@@ -242,7 +242,7 @@ int main(int argc, char* argv[])
     //               d(i)/dt + conv(i) = 0,       where conv(i) = v.grad(i).
 
     // 2nd mesh
-    auto mesh2 = Mesh(box, static_cast<std::size_t>(min_level), static_cast<std::size_t>(max_level));
+    auto mesh2 = Mesh(box, min_level, max_level);
 
     // Ink data fields
     auto ink     = samurai::make_field<1, is_soa>("ink", mesh2);

--- a/demos/FiniteVolume/stencil_field.hpp
+++ b/demos/FiniteVolume/stencil_field.hpp
@@ -25,7 +25,7 @@ namespace samurai
 
             if (level == max_level)
             {
-                double dx = this->dx();
+                double dx_ = this->dx();
                 // // First order one sided
                 // auto dxp = (phi(level, i + 1, j) - phi(level, i    , j))/dx;
                 // auto dxm = (phi(level, i    , j) - phi(level, i - 1, j))/dx;
@@ -34,11 +34,11 @@ namespace samurai
                 // auto dym = (phi(level, i, j    ) - phi(level, i, j - 1))/dx;
 
                 // // Second-order one sided
-                auto dxp = 1. / dx * (.5 * phi(level, i - 2, j) - 2. * phi(level, i - 1, j) + 1.5 * phi(level, i, j));
-                auto dxm = 1. / dx * (-.5 * phi(level, i + 2, j) + 2. * phi(level, i + 1, j) - 1.5 * phi(level, i, j));
+                auto dxp = 1. / dx_ * (.5 * phi(level, i - 2, j) - 2. * phi(level, i - 1, j) + 1.5 * phi(level, i, j));
+                auto dxm = 1. / dx_ * (-.5 * phi(level, i + 2, j) + 2. * phi(level, i + 1, j) - 1.5 * phi(level, i, j));
 
-                auto dyp = 1. / dx * (.5 * phi(level, i, j - 2) - 2. * phi(level, i, j - 1) + 1.5 * phi(level, i, j));
-                auto dym = 1. / dx * (-.5 * phi(level, i, j + 2) + 2. * phi(level, i, j + 1) - 1.5 * phi(level, i, j));
+                auto dyp = 1. / dx_ * (.5 * phi(level, i, j - 2) - 2. * phi(level, i, j - 1) + 1.5 * phi(level, i, j));
+                auto dym = 1. / dx_ * (-.5 * phi(level, i, j + 2) + 2. * phi(level, i, j + 1) - 1.5 * phi(level, i, j));
 
                 auto pos_part = [](auto& a)
                 {

--- a/demos/FiniteVolume/stokes_2d.cpp
+++ b/demos/FiniteVolume/stokes_2d.cpp
@@ -209,7 +209,7 @@ int main(int argc, char* argv[])
     PetscOptionsSetValue(NULL, "-options_left", "off"); // disable warning for unused options
 
     auto box  = samurai::Box<double, dim>({0, 0}, {1, 1});
-    auto mesh = Mesh(box, static_cast<std::size_t>(min_level), static_cast<std::size_t>(max_level));
+    auto mesh = Mesh(box, min_level, max_level);
 
     //--------------------//
     // Stationary problem //

--- a/demos/multigrid/main.cpp
+++ b/demos/multigrid/main.cpp
@@ -103,7 +103,7 @@ template <class Mesh>
     min_level = level - 1;
     max_level = level;
 
-    int i = static_cast<int>(1 << min_level);
+    int i = 1 << min_level;
 
     cl_type cl;
     if constexpr (Mesh::dim == 1)

--- a/include/samurai/field.hpp
+++ b/include/samurai/field.hpp
@@ -809,7 +809,7 @@ namespace samurai
                       [&](const auto& cell)
                       {
                           const double& h = cell.length;
-                          field[cell]     = gl.quadrature<size>(cell, f) / pow(h, mesh_t::dim);
+                          field[cell]     = gl.template quadrature<size>(cell, f) / pow(h, mesh_t::dim);
                       });
         return field;
     }

--- a/include/samurai/graduation.hpp
+++ b/include/samurai/graduation.hpp
@@ -81,9 +81,9 @@ namespace samurai
                                       if (tag[itag])
                                       {
                                           static_nested_loop<dim - 1, 0, 2>(
-                                              [&](auto stencil)
+                                              [&](auto s)
                                               {
-                                                  auto index = 2 * index_yz + stencil;
+                                                  auto index = 2 * index_yz + s;
                                                   cl[level + 1][index].add_interval({2 * i, 2 * i + 2});
                                               });
                                       }

--- a/include/samurai/mr/mesh.hpp
+++ b/include/samurai/mr/mesh.hpp
@@ -251,9 +251,9 @@ namespace samurai
                 [&](const auto& interval, const auto& index_yz)
                 {
                     static_nested_loop<dim - 1, 0, 2>(
-                        [&](auto stencil)
+                        [&](auto s)
                         {
-                            lcl[(index_yz << 1) + stencil].add_interval(interval << 1);
+                            lcl[(index_yz << 1) + s].add_interval(interval << 1);
                         });
                     lcl_proj[index_yz].add_interval(interval);
                 });

--- a/include/samurai/petsc/fv/FV_scheme_assembly.hpp
+++ b/include/samurai/petsc/fv/FV_scheme_assembly.hpp
@@ -107,7 +107,7 @@ namespace samurai
 
                 for_each_projection_ghost_and_children_cells<std::size_t>(
                     mesh(),
-                    [&](auto, std::size_t ghost, const std::array<std::size_t, number_of_children>& children)
+                    [&](auto, std::size_t ghost, const std::array<std::size_t, static_cast<std::size_t>(number_of_children)>& children)
                     {
                         CellLinearCombination linear_comb;
                         for (auto child : children)
@@ -771,7 +771,7 @@ namespace samurai
 
                     for_each_projection_ghost_and_children_cells<PetscInt>(
                         mesh(),
-                        [&](auto level, PetscInt ghost, const std::array<PetscInt, number_of_children>& children)
+                        [&](auto level, PetscInt ghost, const std::array<PetscInt, static_cast<std::size_t>(number_of_children)>& children)
                         {
                             double h       = cell_length(level);
                             double scaling = 1. / (h * h);

--- a/include/samurai/petsc/fv/cell_based_scheme_assembly.hpp
+++ b/include/samurai/petsc/fv/cell_based_scheme_assembly.hpp
@@ -43,8 +43,8 @@ namespace samurai
             using stencil_t         = Stencil<scheme_stencil_size, dim>;
             using get_coeffs_func_t = std::function<std::array<local_matrix_t, scheme_stencil_size>(double)>;
 
-            explicit Assembly(const Scheme& scheme)
-                : base_class(scheme)
+            explicit Assembly(const Scheme& s)
+                : base_class(s)
             {
             }
 

--- a/include/samurai/petsc/fv/flux_based_scheme_assembly.hpp
+++ b/include/samurai/petsc/fv/flux_based_scheme_assembly.hpp
@@ -41,8 +41,8 @@ namespace samurai
             static constexpr std::size_t output_field_size = cfg_t::output_field_size;
             static constexpr std::size_t stencil_size      = cfg_t::stencil_size;
 
-            explicit Assembly(const Scheme& scheme)
-                : base_class(scheme)
+            explicit Assembly(const Scheme& s)
+                : base_class(s)
             {
                 set_current_insert_mode(ADD_VALUES);
             }
@@ -73,44 +73,47 @@ namespace samurai
                                             auto it_ghost = this->m_ghost_recursion.find(comput_cells[c].index);
                                             if (it_ghost == this->m_ghost_recursion.end())
                                             {
-                                                nnz[static_cast<std::size_t>(this->row_index(interface_cells[0], field_i))] += field_size;
-                                                nnz[static_cast<std::size_t>(this->row_index(interface_cells[1], field_i))] += field_size;
+                                                nnz[static_cast<std::size_t>(
+                                                    this->row_index(interface_cells[0], field_i))] += static_cast<PetscInt>(field_size);
+                                                nnz[static_cast<std::size_t>(
+                                                    this->row_index(interface_cells[1], field_i))] += static_cast<PetscInt>(field_size);
                                             }
                                             else
                                             {
                                                 auto& linear_comb = it_ghost->second;
-                                                nnz[static_cast<std::size_t>(this->row_index(interface_cells[0], field_i))] += linear_comb.size()
-                                                                                                                             * field_size;
-                                                nnz[static_cast<std::size_t>(this->row_index(interface_cells[1], field_i))] += linear_comb.size()
-                                                                                                                             * field_size;
+                                                nnz[static_cast<std::size_t>(this->row_index(interface_cells[0], field_i))] += static_cast<PetscInt>(
+                                                    linear_comb.size() * field_size);
+                                                nnz[static_cast<std::size_t>(this->row_index(interface_cells[1], field_i))] += static_cast<PetscInt>(
+                                                    linear_comb.size() * field_size);
                                             }
                                         }
                                     }
                                     else
                                     {
-                                        nnz[static_cast<std::size_t>(this->row_index(interface_cells[0], field_i))] += stencil_size
-                                                                                                                     * field_size;
-                                        nnz[static_cast<std::size_t>(this->row_index(interface_cells[1], field_i))] += stencil_size
-                                                                                                                     * field_size;
+                                        nnz[static_cast<std::size_t>(this->row_index(interface_cells[0], field_i))] += static_cast<PetscInt>(
+                                            stencil_size * field_size);
+                                        nnz[static_cast<std::size_t>(this->row_index(interface_cells[1], field_i))] += static_cast<PetscInt>(
+                                            stencil_size * field_size);
                                     }
                                 }
                             }
                         });
 
-                    for_each_boundary_interface(mesh(),
-                                                flux_def[d].direction,
-                                                flux_def[d].stencil,
-                                                [&](auto& cell, auto&)
-                                                {
-                                                    for (unsigned int field_i = 0; field_i < output_field_size; ++field_i)
-                                                    {
-                                                        for (unsigned int field_j = 0; field_j < field_size; ++field_j)
-                                                        {
-                                                            nnz[static_cast<std::size_t>(this->row_index(cell, field_i))] += stencil_size
-                                                                                                                           * field_size;
-                                                        }
-                                                    }
-                                                });
+                    for_each_boundary_interface(
+                        mesh(),
+                        flux_def[d].direction,
+                        flux_def[d].stencil,
+                        [&](auto& cell, auto&)
+                        {
+                            for (unsigned int field_i = 0; field_i < output_field_size; ++field_i)
+                            {
+                                for (unsigned int field_j = 0; field_j < field_size; ++field_j)
+                                {
+                                    nnz[static_cast<std::size_t>(this->row_index(cell, field_i))] += static_cast<PetscInt>(stencil_size
+                                                                                                                           * field_size);
+                                }
+                            }
+                        });
                 }
             }
 

--- a/include/samurai/schemes/fv/cell_based/explicit_cell_based_scheme.hpp
+++ b/include/samurai/schemes/fv/cell_based/explicit_cell_based_scheme.hpp
@@ -27,8 +27,8 @@ namespace samurai
 
       public:
 
-        explicit Explicit(const scheme_t& scheme)
-            : base_class(scheme)
+        explicit Explicit(const scheme_t& s)
+            : base_class(s)
         {
         }
 
@@ -73,8 +73,8 @@ namespace samurai
 
       public:
 
-        explicit Explicit(const scheme_t& scheme)
-            : base_class(scheme)
+        explicit Explicit(const scheme_t& s)
+            : base_class(s)
         {
         }
 

--- a/include/samurai/schemes/fv/flux_based/explicit_flux_based_scheme.hpp
+++ b/include/samurai/schemes/fv/flux_based/explicit_flux_based_scheme.hpp
@@ -28,8 +28,8 @@ namespace samurai
 
       public:
 
-        explicit Explicit(const scheme_t& scheme)
-            : base_class(scheme)
+        explicit Explicit(const scheme_t& s)
+            : base_class(s)
         {
         }
 
@@ -106,8 +106,8 @@ namespace samurai
 
       public:
 
-        explicit Explicit(const scheme_t& scheme)
-            : base_class(scheme)
+        explicit Explicit(const scheme_t& s)
+            : base_class(s)
         {
         }
 

--- a/include/samurai/schemes/fv/flux_based/flux_based_scheme__lin_het.hpp
+++ b/include/samurai/schemes/fv/flux_based/flux_based_scheme__lin_het.hpp
@@ -18,7 +18,8 @@ namespace samurai
         using base_class::dim;
         using base_class::field_size;
         using base_class::output_field_size;
-        using mesh_t = typename base_class::mesh_t;
+        using typename base_class::mesh_id_t;
+        using typename base_class::mesh_t;
 
         using cfg_t      = cfg;
         using bdry_cfg_t = bdry_cfg;
@@ -76,8 +77,6 @@ namespace samurai
         template <class Func>
         void for_each_interior_interface(const mesh_t& mesh, Func&& apply_coeffs) const
         {
-            using mesh_id_t = typename mesh_t::mesh_id_t;
-
             auto min_level = mesh[mesh_id_t::cells].min_level();
             auto max_level = mesh[mesh_id_t::cells].max_level();
 

--- a/include/samurai/schemes/fv/flux_based/flux_based_scheme__lin_hom.hpp
+++ b/include/samurai/schemes/fv/flux_based/flux_based_scheme__lin_hom.hpp
@@ -18,7 +18,8 @@ namespace samurai
         using base_class::dim;
         using base_class::field_size;
         using base_class::output_field_size;
-        using mesh_t = typename base_class::mesh_t;
+        using typename base_class::mesh_id_t;
+        using typename base_class::mesh_t;
 
         using cfg_t      = cfg;
         using bdry_cfg_t = bdry_cfg;
@@ -76,8 +77,6 @@ namespace samurai
         template <class Func>
         void for_each_interior_interface(const mesh_t& mesh, Func&& apply_coeffs) const
         {
-            using mesh_id_t = typename mesh_t::mesh_id_t;
-
             auto min_level = mesh[mesh_id_t::cells].min_level();
             auto max_level = mesh[mesh_id_t::cells].max_level();
 

--- a/include/samurai/schemes/fv/flux_based/flux_based_scheme__nonlin.hpp
+++ b/include/samurai/schemes/fv/flux_based/flux_based_scheme__nonlin.hpp
@@ -19,8 +19,9 @@ namespace samurai
         using base_class::field_size;
         using base_class::output_field_size;
 
-        using input_field_t = typename base_class::input_field_t;
-        using mesh_t        = typename base_class::mesh_t;
+        using typename base_class::input_field_t;
+        using typename base_class::mesh_id_t;
+        using typename base_class::mesh_t;
 
         using cfg_t      = cfg;
         using bdry_cfg_t = bdry_cfg;
@@ -75,8 +76,6 @@ namespace samurai
         template <class Func>
         void for_each_interior_interface(input_field_t& field, Func&& apply_contrib) const
         {
-            using mesh_id_t = typename mesh_t::mesh_id_t;
-
             auto& mesh = field.mesh();
 
             auto min_level = mesh[mesh_id_t::cells].min_level();

--- a/tests/test_adapt.cpp
+++ b/tests/test_adapt.cpp
@@ -15,7 +15,7 @@ namespace samurai
     using adapt_test_types = ::testing::
         Types<std::integral_constant<std::size_t, 1>, std::integral_constant<std::size_t, 2>, std::integral_constant<std::size_t, 3>>;
 
-    TYPED_TEST_SUITE(adapt_test, adapt_test_types);
+    TYPED_TEST_SUITE(adapt_test, adapt_test_types, );
 
     TYPED_TEST(adapt_test, mutliple_fields)
     {

--- a/tests/test_periodic.cpp
+++ b/tests/test_periodic.cpp
@@ -18,7 +18,7 @@ namespace samurai
     using dim_test_types = ::testing::
         Types<std::integral_constant<std::size_t, 1>, std::integral_constant<std::size_t, 2>, std::integral_constant<std::size_t, 3>>;
 
-    TYPED_TEST_SUITE(dim_test, dim_test_types);
+    TYPED_TEST_SUITE(dim_test, dim_test_types, );
 
     template <class Mesh>
     auto init(Mesh& mesh)


### PR DESCRIPTION
- [x] I have installed [pre-commit](https://pre-commit.com/) locally and use it to validate my commits.
- [x] The PR title follows the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) convention.
      Available tags: 'build', 'chore', 'ci', 'docs', 'feat', 'fix', 'perf', 'refactor', 'revert', 'style', 'test'
- [x] This new PR is tested.

## Description
Trying to fix as many warnings as possible with little change to the code: renaming variable, fixing type alias or adding new one, remove useless cast, ...

Tested with GCC 11.4, 12.3 and LLVM 14.0.

## Related issue
None

## How has this been tested?
Launching the already existing tests.

## Code of Conduct
By submitting this PR, you agree to follow our [Code of Conduct](https://github.com/hpc-maths/samurai/blob/master/docs/CODE_OF_CONDUCT.md)
- [x] I agree to follow this project's Code of Conduct
