### PR TITLE
feat: collapsable flux value in non-linear flux-based schemes

### DIFF
--- a/docs/source/reference/finite_volume_schemes.rst
+++ b/docs/source/reference/finite_volume_schemes.rst
@@ -843,7 +843,8 @@ The flux function is
         return flux_value;
     };
 
-Here, the :code:`FluxValue<cfg>` is an array-like structure of size :code:`output_field_size` (defined in :code:`cfg`).
+Here, :code:`FluxValue<cfg>` is an array-like structure of size :code:`cfg::output_field_size`.
+If :code:`cfg::output_field_size = 1`, it collapses to a simple scalar.
 
 .. warning::
 

--- a/include/samurai/schemes/fv/flux_based/flux_based_scheme__nonlin.hpp
+++ b/include/samurai/schemes/fv/flux_based/flux_based_scheme__nonlin.hpp
@@ -19,6 +19,7 @@ namespace samurai
         using base_class::field_size;
         using base_class::output_field_size;
 
+        using typename base_class::field_value_type;
         using typename base_class::input_field_t;
         using typename base_class::mesh_id_t;
         using typename base_class::mesh_t;
@@ -58,9 +59,9 @@ namespace samurai
             return (face_measure / cell_measure) * flux_value;
         }
 
-        inline double flux_value_cmpnent(const flux_value_t& flux_value, [[maybe_unused]] std::size_t field_i) const
+        inline field_value_type flux_value_cmpnent(const flux_value_t& flux_value, [[maybe_unused]] std::size_t field_i) const
         {
-            if constexpr (output_field_size == 1 && std::is_same_v<flux_value_t, double>)
+            if constexpr (output_field_size == 1)
             {
                 return flux_value;
             }

--- a/include/samurai/schemes/fv/flux_based/flux_definition.hpp
+++ b/include/samurai/schemes/fv/flux_based/flux_definition.hpp
@@ -69,7 +69,7 @@ namespace samurai
 
         using stencil_cells_t = std::array<cell_t, cfg::stencil_size>;
 
-        using flux_value_t      = xt::xtensor_fixed<field_value_type, xt::xshape<cfg::output_field_size>>;
+        using flux_value_t      = CollapsVector<field_value_type, cfg::output_field_size>;
         using flux_value_pair_t = xt::xtensor_fixed<flux_value_t, xt::xshape<2>>;
         using flux_func         = std::function<flux_value_pair_t(stencil_cells_t&, const field_t&)>; // non-conservative
         using cons_flux_func    = std::function<flux_value_t(stencil_cells_t&, const field_t&)>;      // conservative


### PR DESCRIPTION
## Description
In non-linear flux-based schemes, the type ```FluxValue<cfg>``` was an xtensor of size ```cfg::output_field_size```. It now collapses to a simple scalar type when ```cfg::output_field_size = 1```.

## Related issue
The user had to add ```[0]``` to read the value.

## How has this been tested?
Burgers demo with field_size = 1.

## Code of Conduct
By submitting this PR, you agree to follow our [Code of Conduct](https://github.com/hpc-maths/samurai/blob/master/docs/CODE_OF_CONDUCT.md)
- [x] I agree to follow this project's Code of Conduct
