### PR TITLE
feat: add dim in field_operator_base

### DIFF
--- a/demos/FiniteVolume/AMR_Burgers_Hat.cpp
+++ b/demos/FiniteVolume/AMR_Burgers_Hat.cpp
@@ -126,9 +126,10 @@ void save(const fs::path& path, const std::string& filename, const Field& u, con
 template <class Field>
 void flux_correction(Field& phi_np1, const Field& phi_n, double dt)
 {
-    using mesh_t     = typename Field::mesh_t;
-    using mesh_id_t  = typename mesh_t::mesh_id_t;
-    using interval_t = typename mesh_t::interval_t;
+    using mesh_t                     = typename Field::mesh_t;
+    static constexpr std::size_t dim = Field::dim;
+    using mesh_id_t                  = typename mesh_t::mesh_id_t;
+    using interval_t                 = typename mesh_t::interval_t;
 
     auto mesh                   = phi_np1.mesh();
     const std::size_t min_level = mesh[mesh_id_t::cells].min_level();
@@ -151,8 +152,8 @@ void flux_correction(Field& phi_np1, const Field& phi_n, double dt)
             {
                 phi_np1(level, i) = phi_np1(level, i)
                                   + dt / dx_loc
-                                        * (samurai::upwind_Burgers_op<interval_t>(level, i).right_flux(phi_n, dx / dt)
-                                           - samurai::upwind_Burgers_op<interval_t>(level + 1, 2 * i + 1).right_flux(phi_n, dx / dt));
+                                        * (samurai::upwind_Burgers_op<dim, interval_t>(level, i).right_flux(phi_n, dx / dt)
+                                           - samurai::upwind_Burgers_op<dim, interval_t>(level + 1, 2 * i + 1).right_flux(phi_n, dx / dt));
             });
 
         stencil          = {1};
@@ -165,8 +166,8 @@ void flux_correction(Field& phi_np1, const Field& phi_n, double dt)
             {
                 phi_np1(level, i) = phi_np1(level, i)
                                   - dt / dx_loc
-                                        * (samurai::upwind_Burgers_op<interval_t>(level, i).left_flux(phi_n, dx / dt)
-                                           - samurai::upwind_Burgers_op<interval_t>(level + 1, 2 * i).left_flux(phi_n, dx / dt));
+                                        * (samurai::upwind_Burgers_op<dim, interval_t>(level, i).left_flux(phi_n, dx / dt)
+                                           - samurai::upwind_Burgers_op<dim, interval_t>(level + 1, 2 * i).left_flux(phi_n, dx / dt));
             });
     }
 }

--- a/demos/FiniteVolume/advection_1d.cpp
+++ b/demos/FiniteVolume/advection_1d.cpp
@@ -67,8 +67,8 @@ void flux_correction(double dt, double a, const Field& u, Field& unp1)
 
                 unp1(level, i) = unp1(level, i)
                                - dt / dx
-                                     * (-samurai::upwind_op<interval_t>(level, i).right_flux(a, u)
-                                        + samurai::upwind_op<interval_t>(level + 1, 2 * i + 1).right_flux(a, u));
+                                     * (-samurai::upwind_op<dim, interval_t>(level, i).right_flux(a, u)
+                                        + samurai::upwind_op<dim, interval_t>(level + 1, 2 * i + 1).right_flux(a, u));
             });
 
         stencil = {{1}};
@@ -84,8 +84,8 @@ void flux_correction(double dt, double a, const Field& u, Field& unp1)
 
                 unp1(level, i) = unp1(level, i)
                                - dt / dx
-                                     * (samurai::upwind_op<interval_t>(level, i).left_flux(a, u)
-                                        - samurai::upwind_op<interval_t>(level + 1, 2 * i).left_flux(a, u));
+                                     * (samurai::upwind_op<dim, interval_t>(level, i).left_flux(a, u)
+                                        - samurai::upwind_op<dim, interval_t>(level + 1, 2 * i).left_flux(a, u));
             });
     }
 }

--- a/demos/FiniteVolume/advection_2d.cpp
+++ b/demos/FiniteVolume/advection_2d.cpp
@@ -76,9 +76,9 @@ void flux_correction(double dt, const std::array<double, 2>& a, const Field& u, 
 
                 unp1(level, i, j) = unp1(level, i, j)
                                   + dt / dx
-                                        * (samurai::upwind_op<interval_t>(level, i, j).right_flux(a, u)
-                                           - .5 * samurai::upwind_op<interval_t>(level + 1, 2 * i + 1, 2 * j).right_flux(a, u)
-                                           - .5 * samurai::upwind_op<interval_t>(level + 1, 2 * i + 1, 2 * j + 1).right_flux(a, u));
+                                        * (samurai::upwind_op<dim, interval_t>(level, i, j).right_flux(a, u)
+                                           - .5 * samurai::upwind_op<dim, interval_t>(level + 1, 2 * i + 1, 2 * j).right_flux(a, u)
+                                           - .5 * samurai::upwind_op<dim, interval_t>(level + 1, 2 * i + 1, 2 * j + 1).right_flux(a, u));
             });
 
         stencil = {
@@ -97,9 +97,9 @@ void flux_correction(double dt, const std::array<double, 2>& a, const Field& u, 
 
                 unp1(level, i, j) = unp1(level, i, j)
                                   - dt / dx
-                                        * (samurai::upwind_op<interval_t>(level, i, j).left_flux(a, u)
-                                           - .5 * samurai::upwind_op<interval_t>(level + 1, 2 * i, 2 * j).left_flux(a, u)
-                                           - .5 * samurai::upwind_op<interval_t>(level + 1, 2 * i, 2 * j + 1).left_flux(a, u));
+                                        * (samurai::upwind_op<dim, interval_t>(level, i, j).left_flux(a, u)
+                                           - .5 * samurai::upwind_op<dim, interval_t>(level + 1, 2 * i, 2 * j).left_flux(a, u)
+                                           - .5 * samurai::upwind_op<dim, interval_t>(level + 1, 2 * i, 2 * j + 1).left_flux(a, u));
             });
 
         stencil = {
@@ -117,9 +117,9 @@ void flux_correction(double dt, const std::array<double, 2>& a, const Field& u, 
 
                 unp1(level, i, j) = unp1(level, i, j)
                                   + dt / dx
-                                        * (samurai::upwind_op<interval_t>(level, i, j).up_flux(a, u)
-                                           - .5 * samurai::upwind_op<interval_t>(level + 1, 2 * i, 2 * j + 1).up_flux(a, u)
-                                           - .5 * samurai::upwind_op<interval_t>(level + 1, 2 * i + 1, 2 * j + 1).up_flux(a, u));
+                                        * (samurai::upwind_op<dim, interval_t>(level, i, j).up_flux(a, u)
+                                           - .5 * samurai::upwind_op<dim, interval_t>(level + 1, 2 * i, 2 * j + 1).up_flux(a, u)
+                                           - .5 * samurai::upwind_op<dim, interval_t>(level + 1, 2 * i + 1, 2 * j + 1).up_flux(a, u));
             });
 
         stencil = {
@@ -138,9 +138,9 @@ void flux_correction(double dt, const std::array<double, 2>& a, const Field& u, 
 
                 unp1(level, i, j) = unp1(level, i, j)
                                   - dt / dx
-                                        * (samurai::upwind_op<interval_t>(level, i, j).down_flux(a, u)
-                                           - .5 * samurai::upwind_op<interval_t>(level + 1, 2 * i, 2 * j).down_flux(a, u)
-                                           - .5 * samurai::upwind_op<interval_t>(level + 1, 2 * i + 1, 2 * j).down_flux(a, u));
+                                        * (samurai::upwind_op<dim, interval_t>(level, i, j).down_flux(a, u)
+                                           - .5 * samurai::upwind_op<dim, interval_t>(level + 1, 2 * i, 2 * j).down_flux(a, u)
+                                           - .5 * samurai::upwind_op<dim, interval_t>(level + 1, 2 * i + 1, 2 * j).down_flux(a, u));
             });
     }
 }

--- a/demos/FiniteVolume/advection_2d_user_bc.cpp
+++ b/demos/FiniteVolume/advection_2d_user_bc.cpp
@@ -89,9 +89,9 @@ void flux_correction(double dt, const std::array<double, 2>& a, const Field& u, 
 
                 unp1(level, i, j) = unp1(level, i, j)
                                   + dt / dx
-                                        * (samurai::upwind_op<interval_t>(level, i, j).right_flux(a, u)
-                                           - .5 * samurai::upwind_op<interval_t>(level + 1, 2 * i + 1, 2 * j).right_flux(a, u)
-                                           - .5 * samurai::upwind_op<interval_t>(level + 1, 2 * i + 1, 2 * j + 1).right_flux(a, u));
+                                        * (samurai::upwind_op<dim, interval_t>(level, i, j).right_flux(a, u)
+                                           - .5 * samurai::upwind_op<dim, interval_t>(level + 1, 2 * i + 1, 2 * j).right_flux(a, u)
+                                           - .5 * samurai::upwind_op<dim, interval_t>(level + 1, 2 * i + 1, 2 * j + 1).right_flux(a, u));
             });
 
         stencil = {
@@ -110,9 +110,9 @@ void flux_correction(double dt, const std::array<double, 2>& a, const Field& u, 
 
                 unp1(level, i, j) = unp1(level, i, j)
                                   - dt / dx
-                                        * (samurai::upwind_op<interval_t>(level, i, j).left_flux(a, u)
-                                           - .5 * samurai::upwind_op<interval_t>(level + 1, 2 * i, 2 * j).left_flux(a, u)
-                                           - .5 * samurai::upwind_op<interval_t>(level + 1, 2 * i, 2 * j + 1).left_flux(a, u));
+                                        * (samurai::upwind_op<dim, interval_t>(level, i, j).left_flux(a, u)
+                                           - .5 * samurai::upwind_op<dim, interval_t>(level + 1, 2 * i, 2 * j).left_flux(a, u)
+                                           - .5 * samurai::upwind_op<dim, interval_t>(level + 1, 2 * i, 2 * j + 1).left_flux(a, u));
             });
 
         stencil = {
@@ -130,9 +130,9 @@ void flux_correction(double dt, const std::array<double, 2>& a, const Field& u, 
 
                 unp1(level, i, j) = unp1(level, i, j)
                                   + dt / dx
-                                        * (samurai::upwind_op<interval_t>(level, i, j).up_flux(a, u)
-                                           - .5 * samurai::upwind_op<interval_t>(level + 1, 2 * i, 2 * j + 1).up_flux(a, u)
-                                           - .5 * samurai::upwind_op<interval_t>(level + 1, 2 * i + 1, 2 * j + 1).up_flux(a, u));
+                                        * (samurai::upwind_op<dim, interval_t>(level, i, j).up_flux(a, u)
+                                           - .5 * samurai::upwind_op<dim, interval_t>(level + 1, 2 * i, 2 * j + 1).up_flux(a, u)
+                                           - .5 * samurai::upwind_op<dim, interval_t>(level + 1, 2 * i + 1, 2 * j + 1).up_flux(a, u));
             });
 
         stencil = {
@@ -151,9 +151,9 @@ void flux_correction(double dt, const std::array<double, 2>& a, const Field& u, 
 
                 unp1(level, i, j) = unp1(level, i, j)
                                   - dt / dx
-                                        * (samurai::upwind_op<interval_t>(level, i, j).down_flux(a, u)
-                                           - .5 * samurai::upwind_op<interval_t>(level + 1, 2 * i, 2 * j).down_flux(a, u)
-                                           - .5 * samurai::upwind_op<interval_t>(level + 1, 2 * i + 1, 2 * j).down_flux(a, u));
+                                        * (samurai::upwind_op<dim, interval_t>(level, i, j).down_flux(a, u)
+                                           - .5 * samurai::upwind_op<dim, interval_t>(level + 1, 2 * i, 2 * j).down_flux(a, u)
+                                           - .5 * samurai::upwind_op<dim, interval_t>(level + 1, 2 * i + 1, 2 * j).down_flux(a, u));
             });
     }
 }

--- a/demos/FiniteVolume/level_set.cpp
+++ b/demos/FiniteVolume/level_set.cpp
@@ -121,11 +121,12 @@ void AMR_criteria(const Field& f, Tag& tag)
 template <class Field, class Field_u>
 void flux_correction(Field& phi_np1, const Field& phi_n, const Field_u& u, double dt)
 {
-    using mesh_t     = typename Field::mesh_t;
-    using mesh_id_t  = typename mesh_t::mesh_id_t;
-    using interval_t = typename mesh_t::interval_t;
+    using mesh_t              = typename Field::mesh_t;
+    using mesh_id_t           = typename mesh_t::mesh_id_t;
+    using interval_t          = typename mesh_t::interval_t;
+    constexpr std::size_t dim = Field::dim;
 
-    auto mesh                   = phi_np1.mesh();
+    auto& mesh                  = phi_np1.mesh();
     const std::size_t min_level = mesh[mesh_id_t::cells].min_level();
     const std::size_t max_level = mesh[mesh_id_t::cells].max_level();
     for (std::size_t level = min_level; level < max_level; ++level)
@@ -146,13 +147,14 @@ void flux_correction(Field& phi_np1, const Field& phi_n, const Field_u& u, doubl
                 auto j          = index[0];
                 const double dx = samurai::cell_length(level);
 
-                phi_np1(level,
-                        i,
-                        j) = phi_np1(level, i, j)
-                           + dt / dx
-                                 * (samurai::upwind_variable_op<interval_t>(level, i, j).right_flux(u, phi_n, dt)
-                                    - .5 * samurai::upwind_variable_op<interval_t>(level + 1, 2 * i + 1, 2 * j).right_flux(u, phi_n, dt)
-                                    - .5 * samurai::upwind_variable_op<interval_t>(level + 1, 2 * i + 1, 2 * j + 1).right_flux(u, phi_n, dt));
+                phi_np1(
+                    level,
+                    i,
+                    j) = phi_np1(level, i, j)
+                       + dt / dx
+                             * (samurai::upwind_variable_op<dim, interval_t>(level, i, j).right_flux(u, phi_n, dt)
+                                - .5 * samurai::upwind_variable_op<dim, interval_t>(level + 1, 2 * i + 1, 2 * j).right_flux(u, phi_n, dt)
+                                - .5 * samurai::upwind_variable_op<dim, interval_t>(level + 1, 2 * i + 1, 2 * j + 1).right_flux(u, phi_n, dt));
             });
 
         stencil = {
@@ -173,9 +175,9 @@ void flux_correction(Field& phi_np1, const Field& phi_n, const Field_u& u, doubl
                         i,
                         j) = phi_np1(level, i, j)
                            - dt / dx
-                                 * (samurai::upwind_variable_op<interval_t>(level, i, j).left_flux(u, phi_n, dt)
-                                    - .5 * samurai::upwind_variable_op<interval_t>(level + 1, 2 * i, 2 * j).left_flux(u, phi_n, dt)
-                                    - .5 * samurai::upwind_variable_op<interval_t>(level + 1, 2 * i, 2 * j + 1).left_flux(u, phi_n, dt));
+                                 * (samurai::upwind_variable_op<dim, interval_t>(level, i, j).left_flux(u, phi_n, dt)
+                                    - .5 * samurai::upwind_variable_op<dim, interval_t>(level + 1, 2 * i, 2 * j).left_flux(u, phi_n, dt)
+                                    - .5 * samurai::upwind_variable_op<dim, interval_t>(level + 1, 2 * i, 2 * j + 1).left_flux(u, phi_n, dt));
             });
 
         stencil = {
@@ -191,13 +193,14 @@ void flux_correction(Field& phi_np1, const Field& phi_n, const Field_u& u, doubl
                 auto j          = index[0];
                 const double dx = samurai::cell_length(level);
 
-                phi_np1(level,
-                        i,
-                        j) = phi_np1(level, i, j)
-                           + dt / dx
-                                 * (samurai::upwind_variable_op<interval_t>(level, i, j).up_flux(u, phi_n, dt)
-                                    - .5 * samurai::upwind_variable_op<interval_t>(level + 1, 2 * i, 2 * j + 1).up_flux(u, phi_n, dt)
-                                    - .5 * samurai::upwind_variable_op<interval_t>(level + 1, 2 * i + 1, 2 * j + 1).up_flux(u, phi_n, dt));
+                phi_np1(
+                    level,
+                    i,
+                    j) = phi_np1(level, i, j)
+                       + dt / dx
+                             * (samurai::upwind_variable_op<dim, interval_t>(level, i, j).up_flux(u, phi_n, dt)
+                                - .5 * samurai::upwind_variable_op<dim, interval_t>(level + 1, 2 * i, 2 * j + 1).up_flux(u, phi_n, dt)
+                                - .5 * samurai::upwind_variable_op<dim, interval_t>(level + 1, 2 * i + 1, 2 * j + 1).up_flux(u, phi_n, dt));
             });
 
         stencil = {
@@ -218,9 +221,9 @@ void flux_correction(Field& phi_np1, const Field& phi_n, const Field_u& u, doubl
                         i,
                         j) = phi_np1(level, i, j)
                            - dt / dx
-                                 * (samurai::upwind_variable_op<interval_t>(level, i, j).down_flux(u, phi_n, dt)
-                                    - .5 * samurai::upwind_variable_op<interval_t>(level + 1, 2 * i, 2 * j).down_flux(u, phi_n, dt)
-                                    - .5 * samurai::upwind_variable_op<interval_t>(level + 1, 2 * i + 1, 2 * j).down_flux(u, phi_n, dt));
+                                 * (samurai::upwind_variable_op<dim, interval_t>(level, i, j).down_flux(u, phi_n, dt)
+                                    - .5 * samurai::upwind_variable_op<dim, interval_t>(level + 1, 2 * i, 2 * j).down_flux(u, phi_n, dt)
+                                    - .5 * samurai::upwind_variable_op<dim, interval_t>(level + 1, 2 * i + 1, 2 * j).down_flux(u, phi_n, dt));
             });
     }
 }

--- a/demos/FiniteVolume/level_set_from_scratch.cpp
+++ b/demos/FiniteVolume/level_set_from_scratch.cpp
@@ -115,8 +115,8 @@ class AMRMesh : public samurai::Mesh_base<AMRMesh<Config>, Config>
     }
 };
 
-template <class TInterval>
-class projection_op_ : public samurai::field_operator_base<TInterval>
+template <std::size_t dim, class TInterval>
+class projection_op_ : public samurai::field_operator_base<dim, TInterval>
 {
   public:
 
@@ -456,13 +456,14 @@ void flux_correction(Field& phi_np1, const Field& phi_n, const Field_u& u, doubl
                 auto j          = index[0];
                 const double dx = samurai::cell_length(level);
 
-                phi_np1(level,
-                        i,
-                        j) = phi_np1(level, i, j)
-                           + dt / dx
-                                 * (samurai::upwind_variable_op<interval_t>(level, i, j).right_flux(u, phi_n, dt)
-                                    - .5 * samurai::upwind_variable_op<interval_t>(level + 1, 2 * i + 1, 2 * j).right_flux(u, phi_n, dt)
-                                    - .5 * samurai::upwind_variable_op<interval_t>(level + 1, 2 * i + 1, 2 * j + 1).right_flux(u, phi_n, dt));
+                phi_np1(
+                    level,
+                    i,
+                    j) = phi_np1(level, i, j)
+                       + dt / dx
+                             * (samurai::upwind_variable_op<dim, interval_t>(level, i, j).right_flux(u, phi_n, dt)
+                                - .5 * samurai::upwind_variable_op<dim, interval_t>(level + 1, 2 * i + 1, 2 * j).right_flux(u, phi_n, dt)
+                                - .5 * samurai::upwind_variable_op<dim, interval_t>(level + 1, 2 * i + 1, 2 * j + 1).right_flux(u, phi_n, dt));
             });
 
         stencil = {
@@ -483,9 +484,9 @@ void flux_correction(Field& phi_np1, const Field& phi_n, const Field_u& u, doubl
                         i,
                         j) = phi_np1(level, i, j)
                            - dt / dx
-                                 * (samurai::upwind_variable_op<interval_t>(level, i, j).left_flux(u, phi_n, dt)
-                                    - .5 * samurai::upwind_variable_op<interval_t>(level + 1, 2 * i, 2 * j).left_flux(u, phi_n, dt)
-                                    - .5 * samurai::upwind_variable_op<interval_t>(level + 1, 2 * i, 2 * j + 1).left_flux(u, phi_n, dt));
+                                 * (samurai::upwind_variable_op<dim, interval_t>(level, i, j).left_flux(u, phi_n, dt)
+                                    - .5 * samurai::upwind_variable_op<dim, interval_t>(level + 1, 2 * i, 2 * j).left_flux(u, phi_n, dt)
+                                    - .5 * samurai::upwind_variable_op<dim, interval_t>(level + 1, 2 * i, 2 * j + 1).left_flux(u, phi_n, dt));
             });
 
         stencil = {
@@ -501,13 +502,14 @@ void flux_correction(Field& phi_np1, const Field& phi_n, const Field_u& u, doubl
                 auto j          = index[0];
                 const double dx = samurai::cell_length(level);
 
-                phi_np1(level,
-                        i,
-                        j) = phi_np1(level, i, j)
-                           + dt / dx
-                                 * (samurai::upwind_variable_op<interval_t>(level, i, j).up_flux(u, phi_n, dt)
-                                    - .5 * samurai::upwind_variable_op<interval_t>(level + 1, 2 * i, 2 * j + 1).up_flux(u, phi_n, dt)
-                                    - .5 * samurai::upwind_variable_op<interval_t>(level + 1, 2 * i + 1, 2 * j + 1).up_flux(u, phi_n, dt));
+                phi_np1(
+                    level,
+                    i,
+                    j) = phi_np1(level, i, j)
+                       + dt / dx
+                             * (samurai::upwind_variable_op<dim, interval_t>(level, i, j).up_flux(u, phi_n, dt)
+                                - .5 * samurai::upwind_variable_op<dim, interval_t>(level + 1, 2 * i, 2 * j + 1).up_flux(u, phi_n, dt)
+                                - .5 * samurai::upwind_variable_op<dim, interval_t>(level + 1, 2 * i + 1, 2 * j + 1).up_flux(u, phi_n, dt));
             });
 
         stencil = {
@@ -528,9 +530,9 @@ void flux_correction(Field& phi_np1, const Field& phi_n, const Field_u& u, doubl
                         i,
                         j) = phi_np1(level, i, j)
                            - dt / dx
-                                 * (samurai::upwind_variable_op<interval_t>(level, i, j).down_flux(u, phi_n, dt)
-                                    - .5 * samurai::upwind_variable_op<interval_t>(level + 1, 2 * i, 2 * j).down_flux(u, phi_n, dt)
-                                    - .5 * samurai::upwind_variable_op<interval_t>(level + 1, 2 * i + 1, 2 * j).down_flux(u, phi_n, dt));
+                                 * (samurai::upwind_variable_op<dim, interval_t>(level, i, j).down_flux(u, phi_n, dt)
+                                    - .5 * samurai::upwind_variable_op<dim, interval_t>(level + 1, 2 * i, 2 * j).down_flux(u, phi_n, dt)
+                                    - .5 * samurai::upwind_variable_op<dim, interval_t>(level + 1, 2 * i + 1, 2 * j).down_flux(u, phi_n, dt));
             });
     }
 }

--- a/demos/FiniteVolume/scalar_burgers_2d.cpp
+++ b/demos/FiniteVolume/scalar_burgers_2d.cpp
@@ -86,9 +86,9 @@ void flux_correction(double dt, const std::array<double, 2>& k, const Field& u, 
                      i,
                      j) = unp1(level, i, j)
                         + dt / dx
-                              * (samurai::upwind_scalar_burgers_op<interval_t>(level, i, j).right_flux(k, u)
-                                 - 0.5 * samurai::upwind_scalar_burgers_op<interval_t>(level + 1, 2 * i + 1, 2 * j).right_flux(k, u)
-                                 - 0.5 * samurai::upwind_scalar_burgers_op<interval_t>(level + 1, 2 * i + 1, 2 * j + 1).right_flux(k, u));
+                              * (samurai::upwind_scalar_burgers_op<dim, interval_t>(level, i, j).right_flux(k, u)
+                                 - 0.5 * samurai::upwind_scalar_burgers_op<dim, interval_t>(level + 1, 2 * i + 1, 2 * j).right_flux(k, u)
+                                 - 0.5 * samurai::upwind_scalar_burgers_op<dim, interval_t>(level + 1, 2 * i + 1, 2 * j + 1).right_flux(k, u));
             });
 
         stencil = {
@@ -105,11 +105,13 @@ void flux_correction(double dt, const std::array<double, 2>& k, const Field& u, 
                 auto j          = index[0];
                 const double dx = samurai::cell_length(level);
 
-                unp1(level, i, j) = unp1(level, i, j)
-                                  - dt / dx
-                                        * (samurai::upwind_scalar_burgers_op<interval_t>(level, i, j).left_flux(k, u)
-                                           - 0.5 * samurai::upwind_scalar_burgers_op<interval_t>(level + 1, 2 * i, 2 * j).left_flux(k, u)
-                                           - 0.5 * samurai::upwind_scalar_burgers_op<interval_t>(level + 1, 2 * i, 2 * j + 1).left_flux(k, u));
+                unp1(level,
+                     i,
+                     j) = unp1(level, i, j)
+                        - dt / dx
+                              * (samurai::upwind_scalar_burgers_op<dim, interval_t>(level, i, j).left_flux(k, u)
+                                 - 0.5 * samurai::upwind_scalar_burgers_op<dim, interval_t>(level + 1, 2 * i, 2 * j).left_flux(k, u)
+                                 - 0.5 * samurai::upwind_scalar_burgers_op<dim, interval_t>(level + 1, 2 * i, 2 * j + 1).left_flux(k, u));
             });
 
         stencil = {
@@ -129,9 +131,9 @@ void flux_correction(double dt, const std::array<double, 2>& k, const Field& u, 
                      i,
                      j) = unp1(level, i, j)
                         + dt / dx
-                              * (samurai::upwind_scalar_burgers_op<interval_t>(level, i, j).up_flux(k, u)
-                                 - 0.5 * samurai::upwind_scalar_burgers_op<interval_t>(level + 1, 2 * i, 2 * j + 1).up_flux(k, u)
-                                 - 0.5 * samurai::upwind_scalar_burgers_op<interval_t>(level + 1, 2 * i + 1, 2 * j + 1).up_flux(k, u));
+                              * (samurai::upwind_scalar_burgers_op<dim, interval_t>(level, i, j).up_flux(k, u)
+                                 - 0.5 * samurai::upwind_scalar_burgers_op<dim, interval_t>(level + 1, 2 * i, 2 * j + 1).up_flux(k, u)
+                                 - 0.5 * samurai::upwind_scalar_burgers_op<dim, interval_t>(level + 1, 2 * i + 1, 2 * j + 1).up_flux(k, u));
             });
 
         stencil = {
@@ -148,11 +150,13 @@ void flux_correction(double dt, const std::array<double, 2>& k, const Field& u, 
                 auto j          = index[0];
                 const double dx = samurai::cell_length(level);
 
-                unp1(level, i, j) = unp1(level, i, j)
-                                  - dt / dx
-                                        * (samurai::upwind_scalar_burgers_op<interval_t>(level, i, j).down_flux(k, u)
-                                           - 0.5 * samurai::upwind_scalar_burgers_op<interval_t>(level + 1, 2 * i, 2 * j).down_flux(k, u)
-                                           - 0.5 * samurai::upwind_scalar_burgers_op<interval_t>(level + 1, 2 * i + 1, 2 * j).down_flux(k, u));
+                unp1(level,
+                     i,
+                     j) = unp1(level, i, j)
+                        - dt / dx
+                              * (samurai::upwind_scalar_burgers_op<dim, interval_t>(level, i, j).down_flux(k, u)
+                                 - 0.5 * samurai::upwind_scalar_burgers_op<dim, interval_t>(level + 1, 2 * i, 2 * j).down_flux(k, u)
+                                 - 0.5 * samurai::upwind_scalar_burgers_op<dim, interval_t>(level + 1, 2 * i + 1, 2 * j).down_flux(k, u));
             });
     }
 }

--- a/demos/FiniteVolume/stencil_field.hpp
+++ b/demos/FiniteVolume/stencil_field.hpp
@@ -8,9 +8,9 @@
 
 namespace samurai
 {
-    template <class TInterval>
-    class H_wrap_op : public field_operator_base<TInterval>,
-                      public field_expression<H_wrap_op<TInterval>>
+    template <std::size_t dim, class TInterval>
+    class H_wrap_op : public field_operator_base<dim, TInterval>,
+                      public field_expression<H_wrap_op<dim, TInterval>>
     {
       public:
 
@@ -82,9 +82,9 @@ namespace samurai
      * upwind operator for the scalar advection equation with variable velocity
      *******************/
 
-    template <class TInterval>
-    class upwind_variable_op : public field_operator_base<TInterval>,
-                               public finite_volume<upwind_variable_op<TInterval>>
+    template <std::size_t dim, class TInterval>
+    class upwind_variable_op : public field_operator_base<dim, TInterval>,
+                               public finite_volume<upwind_variable_op<dim, TInterval>>
     {
       public:
 
@@ -242,9 +242,9 @@ namespace samurai
         return make_field_operator_function<upwind_variable_op>(std::forward<CT>(e)...);
     }
 
-    template <class TInterval>
-    class upwind_Burgers_op : public field_operator_base<TInterval>,
-                              public finite_volume<upwind_Burgers_op<TInterval>>
+    template <std::size_t dim, class TInterval>
+    class upwind_Burgers_op : public field_operator_base<dim, TInterval>,
+                              public finite_volume<upwind_Burgers_op<dim, TInterval>>
     {
       public:
 

--- a/demos/LBM/boundary_conditions.hpp
+++ b/demos/LBM/boundary_conditions.hpp
@@ -9,8 +9,8 @@
 #include <samurai/operators_base.hpp>
 #include <samurai/subset/subset_op.hpp>
 
-template <class TInterval>
-class update_boundary_D2Q4_flat_op : public samurai::field_operator_base<TInterval>
+template <std::size_t dim, class TInterval>
+class update_boundary_D2Q4_flat_op : public samurai::field_operator_base<dim, TInterval>
 {
   public:
 
@@ -35,8 +35,8 @@ inline auto update_boundary_D2Q4_flat(T&& field, stencil_t&& stencil)
     return samurai::make_field_operator_function<update_boundary_D2Q4_flat_op>(std::forward<T>(field), std::forward<stencil_t>(stencil));
 }
 
-template <class TInterval>
-class update_boundary_D2Q4_linear_op : public samurai::field_operator_base<TInterval>
+template <std::size_t dim, class TInterval>
+class update_boundary_D2Q4_linear_op : public samurai::field_operator_base<dim, TInterval>
 {
   public:
 

--- a/demos/tutorial/set_operator.cpp
+++ b/demos/tutorial/set_operator.cpp
@@ -11,8 +11,8 @@
 #include <samurai/samurai.hpp>
 #include <samurai/subset/subset_op.hpp>
 
-template <class TInterval>
-class projection_op : public samurai::field_operator_base<TInterval>
+template <std::size_t dim, class TInterval>
+class projection_op : public samurai::field_operator_base<dim, TInterval>
 {
   public:
 

--- a/include/samurai/algorithm/graduation.hpp
+++ b/include/samurai/algorithm/graduation.hpp
@@ -17,8 +17,8 @@ namespace samurai
     // graduate operator //
     ///////////////////////
 
-    template <class TInterval>
-    class graduate_op : public field_operator_base<TInterval>
+    template <std::size_t dim, class TInterval>
+    class graduate_op : public field_operator_base<dim, TInterval>
     {
       public:
 

--- a/include/samurai/algorithm/utils.hpp
+++ b/include/samurai/algorithm/utils.hpp
@@ -17,8 +17,8 @@ namespace samurai
     // copy operator //
     ///////////////////
 
-    template <class TInterval>
-    class copy_op : public field_operator_base<TInterval>
+    template <std::size_t dim, class TInterval>
+    class copy_op : public field_operator_base<dim, TInterval>
     {
       public:
 
@@ -53,8 +53,8 @@ namespace samurai
     // tag_to_keep operator //
     //////////////////////////
 
-    template <class TInterval>
-    class tag_to_keep_op : public field_operator_base<TInterval>
+    template <std::size_t dim, class TInterval>
+    class tag_to_keep_op : public field_operator_base<dim, TInterval>
     {
       public:
 
@@ -143,8 +143,8 @@ namespace samurai
     // keep_children_together operator //
     /////////////////////////////////////
 
-    template <class TInterval>
-    class keep_children_together_op : public field_operator_base<TInterval>
+    template <std::size_t dim, class TInterval>
+    class keep_children_together_op : public field_operator_base<dim, TInterval>
     {
       public:
 

--- a/include/samurai/mr/criteria.hpp
+++ b/include/samurai/mr/criteria.hpp
@@ -13,8 +13,8 @@
 namespace samurai
 {
 
-    template <class TInterval>
-    class to_coarsen_mr_op : public field_operator_base<TInterval>
+    template <std::size_t dim, class TInterval>
+    class to_coarsen_mr_op : public field_operator_base<dim, TInterval>
     {
       public:
 
@@ -185,8 +185,8 @@ namespace samurai
 
     // Uses the details in the way suggested in
     // the paper by Bihari && Harten [1997]
-    template <class TInterval>
-    class to_coarsen_mr_BH_op : public field_operator_base<TInterval>
+    template <std::size_t dim, class TInterval>
+    class to_coarsen_mr_BH_op : public field_operator_base<dim, TInterval>
     {
       public:
 
@@ -262,8 +262,8 @@ namespace samurai
         return make_field_operator_function<to_coarsen_mr_BH_op>(std::forward<CT>(e)...);
     }
 
-    template <class TInterval>
-    class to_refine_mr_op : public field_operator_base<TInterval>
+    template <std::size_t dim, class TInterval>
+    class to_refine_mr_op : public field_operator_base<dim, TInterval>
     {
       public:
 
@@ -438,8 +438,8 @@ namespace samurai
         return make_field_operator_function<to_refine_mr_op>(std::forward<CT>(e)...);
     }
 
-    template <class TInterval>
-    class to_refine_mr_BH_op : public field_operator_base<TInterval>
+    template <std::size_t dim, class TInterval>
+    class to_refine_mr_BH_op : public field_operator_base<dim, TInterval>
     {
       public:
 
@@ -514,8 +514,8 @@ namespace samurai
         return make_field_operator_function<to_refine_mr_BH_op>(std::forward<CT>(e)...);
     }
 
-    template <class TInterval>
-    class max_detail_mr_op : public field_operator_base<TInterval>
+    template <std::size_t dim, class TInterval>
+    class max_detail_mr_op : public field_operator_base<dim, TInterval>
     {
       public:
 

--- a/include/samurai/mr/operators.hpp
+++ b/include/samurai/mr/operators.hpp
@@ -273,611 +273,647 @@ namespace samurai
             auto src_shape  = field(level + 1, 2 * i).shape();
             if (xt::same_shape(dest_shape, src_shape))
             {
-    template <std::size_t dim, class TInterval>
-    class compute_detail_on_tuple_op : public field_operator_base<dim, TInterval>
-    {
-      public:
-
-        INIT_OPERATOR(compute_detail_on_tuple_op)
-
-        template <class Ranges, class T1, class T2>
-        inline void compute_detail_impl(Dim<3>, std::size_t index, const Ranges& ranges, T1& detail, const T2& field) const
-        {
-            static constexpr std::size_t order = T1::mesh_t::config::prediction_order;
-            auto qs_i                          = Qs_i<order>(field, level, i, j, k);
-            auto qs_j                          = Qs_j<order>(field, level, i, j, k);
-            auto qs_k                          = Qs_k<order>(field, level, i, j, k);
-            auto qs_ij                         = Qs_ij<order>(field, level, i, j, k);
-            auto qs_ik                         = Qs_ik<order>(field, level, i, j, k);
-            auto qs_jk                         = Qs_jk<order>(field, level, i, j, k);
-            auto qs_ijk                        = Qs_ijk<order>(field, level, i, j, k);
-
-            auto dest_shape = detail(ranges[index], ranges[index + 1], level + 1, 2 * i, 2 * j, 2 * k).shape();
-            auto src_shape  = field(level + 1, 2 * i, 2 * j, 2 * k).shape();
-            if (xt::same_shape(dest_shape, src_shape))
-            {
-                detail(ranges[index], ranges[index + 1], level + 1, 2 * i, 2 * j, 2 * k) = field(level + 1, 2 * i, 2 * j, 2 * k)
-                                                                                         - (field(level, i, j, k) + qs_i + qs_j + qs_k
-                                                                                            - qs_ij - qs_ik - qs_jk + qs_ijk);
-
-                detail(ranges[index], ranges[index + 1], level + 1, 2 * i + 1, 2 * j, 2 * k) = field(level + 1, 2 * i + 1, 2 * j, 2 * k)
-                                                                                             - (field(level, i, j, k) - qs_i + qs_j + qs_k
-                                                                                                + qs_ij + qs_ik - qs_jk - qs_ijk);
-
-                detail(ranges[index], ranges[index + 1], level + 1, 2 * i, 2 * j + 1, 2 * k) = field(level + 1, 2 * i, 2 * j + 1, 2 * k)
-                                                                                             - (field(level, i, j, k) + qs_i - qs_j + qs_k
-                                                                                                + qs_ij - qs_ik + qs_jk - qs_ijk);
-
-                detail(ranges[index], ranges[index + 1], level + 1, 2 * i + 1, 2 * j + 1, 2 * k) = field(level + 1, 2 * i + 1, 2 * j + 1, 2 * k)
-                                                                                                 - (field(level, i, j, k) - qs_i - qs_j
-                                                                                                    + qs_k - qs_ij + qs_ik + qs_jk + qs_ijk);
-
-                detail(ranges[index], ranges[index + 1], level + 1, 2 * i, 2 * j, 2 * k + 1) = field(level + 1, 2 * i, 2 * j, 2 * k + 1)
-                                                                                             - (field(level, i, j, k) + qs_i + qs_j - qs_k
-                                                                                                - qs_ij + qs_ik + qs_jk - qs_ijk);
-
-                detail(ranges[index], ranges[index + 1], level + 1, 2 * i + 1, 2 * j, 2 * k + 1) = field(level + 1, 2 * i + 1, 2 * j, 2 * k + 1)
-                                                                                                 - (field(level, i, j, k) - qs_i + qs_j
-                                                                                                    - qs_k + qs_ij - qs_ik + qs_jk + qs_ijk);
-                detail(ranges[index], ranges[index + 1], level + 1, 2 * i, 2 * j + 1, 2 * k + 1) = field(level + 1, 2 * i, 2 * j + 1, 2 * k + 1)
-                                                                                                 - (field(level, i, j, k) + qs_i - qs_j
-                                                                                                    - qs_k + qs_ij + qs_ik - qs_jk + qs_ijk);
-
-                detail(ranges[index],
-                       ranges[index + 1],
-                       level + 1,
-                       2 * i + 1,
-                       2 * j + 1,
-                       2 * k + 1) = field(level + 1, 2 * i + 1, 2 * j + 1, 2 * k + 1)
-                                  - (field(level, i, j, k) - qs_i - qs_j - qs_k - qs_ij - qs_ik - qs_jk - qs_ijk);
-            }
-            else
-            {
-                detail(ranges[index], ranges[index + 1], level + 1, 2 * i, 2 * j, 2 * k) = xt::transpose(
-                    field(level + 1, 2 * i, 2 * j, 2 * k) - (field(level, i, j, k) + qs_i + qs_j + qs_k - qs_ij - qs_ik - qs_jk + qs_ijk));
-
-                detail(ranges[index], ranges[index + 1], level + 1, 2 * i + 1, 2 * j, 2 * k) = xt::transpose(
-                    field(level + 1, 2 * i + 1, 2 * j, 2 * k) - (field(level, i, j, k) - qs_i + qs_j + qs_k + qs_ij + qs_ik - qs_jk - qs_ijk));
-
-                detail(ranges[index], ranges[index + 1], level + 1, 2 * i, 2 * j + 1, 2 * k) = xt::transpose(
-                    field(level + 1, 2 * i, 2 * j + 1, 2 * k) - (field(level, i, j, k) + qs_i - qs_j + qs_k + qs_ij - qs_ik + qs_jk - qs_ijk));
-
-                detail(ranges[index], ranges[index + 1], level + 1, 2 * i + 1, 2 * j + 1, 2 * k) = xt::transpose(
-                    field(level + 1, 2 * i + 1, 2 * j + 1, 2 * k)
-                    - (field(level, i, j, k) - qs_i - qs_j + qs_k - qs_ij + qs_ik + qs_jk + qs_ijk));
-
-                detail(ranges[index], ranges[index + 1], level + 1, 2 * i, 2 * j, 2 * k + 1) = xt::transpose(
-                    field(level + 1, 2 * i, 2 * j, 2 * k + 1) - (field(level, i, j, k) + qs_i + qs_j - qs_k - qs_ij + qs_ik + qs_jk - qs_ijk));
-
-                detail(ranges[index], ranges[index + 1], level + 1, 2 * i + 1, 2 * j, 2 * k + 1) = xt::transpose(
-                    field(level + 1, 2 * i + 1, 2 * j, 2 * k + 1)
-                    - (field(level, i, j, k) - qs_i + qs_j - qs_k + qs_ij - qs_ik + qs_jk + qs_ijk));
-                detail(ranges[index], ranges[index + 1], level + 1, 2 * i, 2 * j + 1, 2 * k + 1) = xt::transpose(
-                    field(level + 1, 2 * i, 2 * j + 1, 2 * k + 1)
-                    - (field(level, i, j, k) + qs_i - qs_j - qs_k + qs_ij + qs_ik - qs_jk + qs_ijk));
-
-                detail(ranges[index], ranges[index + 1], level + 1, 2 * i + 1, 2 * j + 1, 2 * k + 1) = xt::transpose(
-                    field(level + 1, 2 * i + 1, 2 * j + 1, 2 * k + 1)
-                    - (field(level, i, j, k) - qs_i - qs_j - qs_k - qs_ij - qs_ik - qs_jk - qs_ijk));
-            }
-        }
-
-        template <std::size_t dim, class T1, class T2, std::size_t... Is>
-        inline void compute_detail_impl(Dim<dim>, T1& detail, const T2& fields, std::index_sequence<Is...>) const
-        {
-            std::array<std::size_t, std::tuple_size_v<T2> + 1> ranges;
-            ranges[0]         = 0;
-            std::size_t index = 1;
-            (
-                [&]()
+                template <std::size_t dim, class TInterval>
+                class compute_detail_on_tuple_op : public field_operator_base<dim, TInterval>
                 {
-                    ranges[index] = ranges[index - 1] + std::get<Is>(fields).size;
-                    ++index;
-                }(),
-                ...);
-            (compute_detail_impl(Dim<dim>(), Is, ranges, detail, std::get<Is>(fields)), ...);
-        }
+                  public:
 
-        template <std::size_t dim, class T1, class T2>
-        inline void operator()(Dim<dim>, T1& detail, const T2& fields) const
-        {
-            compute_detail_impl(Dim<dim>(), detail, fields.elements(), std::make_index_sequence<std::tuple_size_v<typename T2::tuple_type>>{});
-        }
-    };
+                    INIT_OPERATOR(compute_detail_on_tuple_op)
 
-    template <class Field, class... T>
-    inline auto compute_detail(Field& detail, const Field_tuple<T...>& fields)
-    {
-        return make_field_operator_function<compute_detail_on_tuple_op>(detail, fields);
-    }
-
-    /*******************************
-     * compute max detail operator *
-     *******************************/
-
-    template <std::size_t dim, class TInterval>
-    class compute_max_detail_op : public field_operator_base<dim, TInterval>
-    {
-      public:
-
-        INIT_OPERATOR(compute_max_detail_op)
-
-        template <class T, class U>
-        inline void operator()(Dim<1>, const U& detail, T& max_detail) const
-        {
-            auto ii       = 2 * i;
-            ii.step       = 1;
-            auto max_view = xt::view(max_detail, level + 1);
-
-            max_view = xt::maximum(max_view, xt::amax(xt::abs(detail(level + 1, ii)), {0}));
-        }
-
-        template <class T, class U>
-        inline void operator()(Dim<2>, const U& detail, T& max_detail) const
-        {
-            auto ii       = 2 * i;
-            ii.step       = 1;
-            auto max_view = xt::view(max_detail, level + 1);
-
-            max_view = xt::maximum(
-                max_view,
-                xt::amax(xt::maximum(xt::abs(detail(level + 1, ii, 2 * j)), xt::abs(detail(level + 1, ii, 2 * j + 1))), {0}));
-        }
-
-        template <class T, class U>
-        inline void operator()(Dim<3>, const U& detail, T& max_detail) const
-        {
-            auto ii       = 2 * i;
-            ii.step       = 1;
-            auto max_view = xt::view(max_detail, level + 1);
-
-            max_view = xt::maximum(max_view,
-                                   xt::amax(xt::maximum(xt::maximum(xt::abs(detail(level + 1, ii, 2 * j, 2 * k)),
-                                                                    xt::abs(detail(level + 1, ii, 2 * j + 1, 2 * k))),
-                                                        xt::maximum(xt::abs(detail(level + 1, ii, 2 * j, 2 * k + 1)),
-                                                                    xt::abs(detail(level + 1, ii, 2 * j + 1, 2 * k + 1)))),
-                                            {0}));
-        }
-    };
-
-    template <class T, class U>
-    inline auto compute_max_detail(U&& detail, T&& max_detail)
-    {
-        return make_field_operator_function<compute_max_detail_op>(std::forward<U>(detail), std::forward<T>(max_detail));
-    }
-
-    /*******************************
-     * compute max detail operator *
-     *******************************/
-
-    template <std::size_t dim, class TInterval>
-    class compute_max_detail_op_ : public field_operator_base<dim, TInterval>
-    {
-      public:
-
-        INIT_OPERATOR(compute_max_detail_op_)
-
-        template <class T, class U>
-        inline void operator()(Dim<1>, const U& detail, T& max_detail) const
-        {
-            max_detail[level] = std::max(max_detail[level], xt::amax(xt::abs(detail(level, i)))[0]);
-        }
-
-        template <class T, class U>
-        inline void operator()(Dim<2>, const U& detail, T& max_detail) const
-        {
-            max_detail[level] = std::max(max_detail[level], xt::amax(xt::abs(detail(level, i, j)))[0]);
-        }
-
-        template <class T, class U>
-        inline void operator()(Dim<3>, const U& detail, T& max_detail) const
-        {
-            max_detail[level] = std::max(max_detail[level], xt::amax(xt::abs(detail(level, i, j, k)))[0]);
-        }
-    };
-
-    template <class T, class U>
-    inline auto compute_max_detail_(U&& detail, T&& max_detail)
-    {
-        return make_field_operator_function<compute_max_detail_op_>(std::forward<U>(detail), std::forward<T>(max_detail));
-    }
-
-    /***********************
-     * to_coarsen operator *
-     ***********************/
-
-    template <std::size_t dim, class TInterval>
-    class to_coarsen_op : public field_operator_base<dim, TInterval>
-    {
-      public:
-
-        INIT_OPERATOR(to_coarsen_op)
-
-        template <class T, class U, class V>
-        inline void operator()(Dim<1>, T& keep, const U& detail, double eps) const
-        {
-            auto mask = xt::abs(detail(level + 1, 2 * i)) < eps;
-            // auto mask = (.5 *
-            //              (xt::abs(detail(level + 1, 2 * i)) +
-            //               xt::abs(detail(level + 1, 2 * i + 1))) /
-            //              max_detail[level + 1]) < eps;
-
-            for (coord_index_t ii = 0; ii < 2; ++ii)
-            {
-                xt::masked_view(keep(level + 1, 2 * i + ii), mask) = static_cast<int>(CellFlag::coarsen);
-            }
-        }
-
-        template <class T, class U, class V>
-        inline void operator()(Dim<2>, T& keep, const U& detail, double eps) const
-        {
-            auto mask = xt::abs(detail(level + 1, 2 * i, 2 * j)) < eps;
-
-            // auto mask = (0.25 *
-            //              (xt::abs(detail(level + 1, 2 * i, 2 * j)) +
-            //               xt::abs(detail(level + 1, 2 * i + 1, 2 * j)) +
-            //               xt::abs(detail(level + 1, 2 * i, 2 * j + 1)) +
-            //               xt::abs(detail(level + 1, 2 * i + 1, 2 * j + 1))) /
-            //              max_detail[level + 1]) < eps;
-
-            for (coord_index_t jj = 0; jj < 2; ++jj)
-            {
-                for (coord_index_t ii = 0; ii < 2; ++ii)
-                {
-                    xt::masked_view(keep(level + 1, 2 * i + ii, 2 * j + jj), mask) = static_cast<int>(CellFlag::coarsen);
-                }
-            }
-        }
-
-        template <class T, class U, class V>
-        inline void operator()(Dim<3>, T& keep, const U& detail, double eps) const
-        {
-            auto mask = xt::abs(detail(level + 1, 2 * i, 2 * j, 2 * k)) < eps;
-
-            for (coord_index_t kk = 0; kk < 2; ++kk)
-            {
-                for (coord_index_t jj = 0; jj < 2; ++jj)
-                {
-                    for (coord_index_t ii = 0; ii < 2; ++ii)
+                    template <class Ranges, class T1, class T2>
+                    inline void compute_detail_impl(Dim<3>, std::size_t index, const Ranges& ranges, T1& detail, const T2& field) const
                     {
-                        xt::masked_view(keep(level + 1, 2 * i + ii, 2 * j + jj, 2 * k + kk), mask) = static_cast<int>(CellFlag::coarsen);
+                        static constexpr std::size_t order = T1::mesh_t::config::prediction_order;
+                        auto qs_i                          = Qs_i<order>(field, level, i, j, k);
+                        auto qs_j                          = Qs_j<order>(field, level, i, j, k);
+                        auto qs_k                          = Qs_k<order>(field, level, i, j, k);
+                        auto qs_ij                         = Qs_ij<order>(field, level, i, j, k);
+                        auto qs_ik                         = Qs_ik<order>(field, level, i, j, k);
+                        auto qs_jk                         = Qs_jk<order>(field, level, i, j, k);
+                        auto qs_ijk                        = Qs_ijk<order>(field, level, i, j, k);
+
+                        auto dest_shape = detail(ranges[index], ranges[index + 1], level + 1, 2 * i, 2 * j, 2 * k).shape();
+                        auto src_shape  = field(level + 1, 2 * i, 2 * j, 2 * k).shape();
+                        if (xt::same_shape(dest_shape, src_shape))
+                        {
+                            detail(ranges[index], ranges[index + 1], level + 1, 2 * i, 2 * j, 2 * k) = field(level + 1, 2 * i, 2 * j, 2 * k)
+                                                                                                     - (field(level, i, j, k) + qs_i + qs_j
+                                                                                                        + qs_k - qs_ij - qs_ik - qs_jk
+                                                                                                        + qs_ijk);
+
+                            detail(ranges[index],
+                                   ranges[index + 1],
+                                   level + 1,
+                                   2 * i + 1,
+                                   2 * j,
+                                   2 * k) = field(level + 1, 2 * i + 1, 2 * j, 2 * k)
+                                          - (field(level, i, j, k) - qs_i + qs_j + qs_k + qs_ij + qs_ik - qs_jk - qs_ijk);
+
+                            detail(ranges[index],
+                                   ranges[index + 1],
+                                   level + 1,
+                                   2 * i,
+                                   2 * j + 1,
+                                   2 * k) = field(level + 1, 2 * i, 2 * j + 1, 2 * k)
+                                          - (field(level, i, j, k) + qs_i - qs_j + qs_k + qs_ij - qs_ik + qs_jk - qs_ijk);
+
+                            detail(ranges[index],
+                                   ranges[index + 1],
+                                   level + 1,
+                                   2 * i + 1,
+                                   2 * j + 1,
+                                   2 * k) = field(level + 1, 2 * i + 1, 2 * j + 1, 2 * k)
+                                          - (field(level, i, j, k) - qs_i - qs_j + qs_k - qs_ij + qs_ik + qs_jk + qs_ijk);
+
+                            detail(ranges[index],
+                                   ranges[index + 1],
+                                   level + 1,
+                                   2 * i,
+                                   2 * j,
+                                   2 * k + 1) = field(level + 1, 2 * i, 2 * j, 2 * k + 1)
+                                              - (field(level, i, j, k) + qs_i + qs_j - qs_k - qs_ij + qs_ik + qs_jk - qs_ijk);
+
+                            detail(ranges[index],
+                                   ranges[index + 1],
+                                   level + 1,
+                                   2 * i + 1,
+                                   2 * j,
+                                   2 * k + 1) = field(level + 1, 2 * i + 1, 2 * j, 2 * k + 1)
+                                              - (field(level, i, j, k) - qs_i + qs_j - qs_k + qs_ij - qs_ik + qs_jk + qs_ijk);
+                            detail(ranges[index],
+                                   ranges[index + 1],
+                                   level + 1,
+                                   2 * i,
+                                   2 * j + 1,
+                                   2 * k + 1) = field(level + 1, 2 * i, 2 * j + 1, 2 * k + 1)
+                                              - (field(level, i, j, k) + qs_i - qs_j - qs_k + qs_ij + qs_ik - qs_jk + qs_ijk);
+
+                            detail(ranges[index],
+                                   ranges[index + 1],
+                                   level + 1,
+                                   2 * i + 1,
+                                   2 * j + 1,
+                                   2 * k + 1) = field(level + 1, 2 * i + 1, 2 * j + 1, 2 * k + 1)
+                                              - (field(level, i, j, k) - qs_i - qs_j - qs_k - qs_ij - qs_ik - qs_jk - qs_ijk);
+                        }
+                        else
+                        {
+                            detail(ranges[index], ranges[index + 1], level + 1, 2 * i, 2 * j, 2 * k) = xt::transpose(
+                                field(level + 1, 2 * i, 2 * j, 2 * k)
+                                - (field(level, i, j, k) + qs_i + qs_j + qs_k - qs_ij - qs_ik - qs_jk + qs_ijk));
+
+                            detail(ranges[index], ranges[index + 1], level + 1, 2 * i + 1, 2 * j, 2 * k) = xt::transpose(
+                                field(level + 1, 2 * i + 1, 2 * j, 2 * k)
+                                - (field(level, i, j, k) - qs_i + qs_j + qs_k + qs_ij + qs_ik - qs_jk - qs_ijk));
+
+                            detail(ranges[index], ranges[index + 1], level + 1, 2 * i, 2 * j + 1, 2 * k) = xt::transpose(
+                                field(level + 1, 2 * i, 2 * j + 1, 2 * k)
+                                - (field(level, i, j, k) + qs_i - qs_j + qs_k + qs_ij - qs_ik + qs_jk - qs_ijk));
+
+                            detail(ranges[index], ranges[index + 1], level + 1, 2 * i + 1, 2 * j + 1, 2 * k) = xt::transpose(
+                                field(level + 1, 2 * i + 1, 2 * j + 1, 2 * k)
+                                - (field(level, i, j, k) - qs_i - qs_j + qs_k - qs_ij + qs_ik + qs_jk + qs_ijk));
+
+                            detail(ranges[index], ranges[index + 1], level + 1, 2 * i, 2 * j, 2 * k + 1) = xt::transpose(
+                                field(level + 1, 2 * i, 2 * j, 2 * k + 1)
+                                - (field(level, i, j, k) + qs_i + qs_j - qs_k - qs_ij + qs_ik + qs_jk - qs_ijk));
+
+                            detail(ranges[index], ranges[index + 1], level + 1, 2 * i + 1, 2 * j, 2 * k + 1) = xt::transpose(
+                                field(level + 1, 2 * i + 1, 2 * j, 2 * k + 1)
+                                - (field(level, i, j, k) - qs_i + qs_j - qs_k + qs_ij - qs_ik + qs_jk + qs_ijk));
+                            detail(ranges[index], ranges[index + 1], level + 1, 2 * i, 2 * j + 1, 2 * k + 1) = xt::transpose(
+                                field(level + 1, 2 * i, 2 * j + 1, 2 * k + 1)
+                                - (field(level, i, j, k) + qs_i - qs_j - qs_k + qs_ij + qs_ik - qs_jk + qs_ijk));
+
+                            detail(ranges[index], ranges[index + 1], level + 1, 2 * i + 1, 2 * j + 1, 2 * k + 1) = xt::transpose(
+                                field(level + 1, 2 * i + 1, 2 * j + 1, 2 * k + 1)
+                                - (field(level, i, j, k) - qs_i - qs_j - qs_k - qs_ij - qs_ik - qs_jk - qs_ijk));
+                        }
                     }
-                }
-            }
-        }
-    };
 
-    template <class... CT>
-    inline auto to_coarsen(CT&&... e)
-    {
-        return make_field_operator_function<to_coarsen_op>(std::forward<CT>(e)...);
-    }
-
-    /*************************
-     * refine_ghost operator *
-     *************************/
-
-    template <std::size_t dim, class TInterval>
-    class refine_ghost_op : public field_operator_base<dim, TInterval>
-    {
-      public:
-
-        INIT_OPERATOR(refine_ghost_op)
-
-        template <class T>
-        inline void operator()(Dim<1>, T& flag) const
-        {
-            auto mask                                 = flag(level + 1, i) & static_cast<int>(CellFlag::keep);
-            xt::masked_view(flag(level, i / 2), mask) = static_cast<int>(CellFlag::refine);
-        }
-
-        template <class T>
-        inline void operator()(Dim<2>, T& flag) const
-        {
-            auto mask                                        = flag(level + 1, i, j) & static_cast<int>(CellFlag::keep);
-            xt::masked_view(flag(level, i / 2, j / 2), mask) = static_cast<int>(CellFlag::refine);
-        }
-
-        template <class T>
-        inline void operator()(Dim<3>, T& flag) const
-        {
-            auto mask                                               = flag(level + 1, i, j, k) & static_cast<int>(CellFlag::keep);
-            xt::masked_view(flag(level, i / 2, j / 2, k / 2), mask) = static_cast<int>(CellFlag::refine);
-        }
-    };
-
-    template <class... CT>
-    inline auto refine_ghost(CT&&... e)
-    {
-        return make_field_operator_function<refine_ghost_op>(std::forward<CT>(e)...);
-    }
-
-    /********************
-     * enlarge operator *
-     ********************/
-
-    template <std::size_t dim, class TInterval>
-    class enlarge_op : public field_operator_base<dim, TInterval>
-    {
-      public:
-
-        INIT_OPERATOR(enlarge_op)
-
-        template <class T>
-        inline void operator()(Dim<1>, T& cell_flag) const
-        {
-            auto keep_mask = cell_flag(level, i) & static_cast<int>(CellFlag::keep);
-
-            for (int ii = -1; ii < 2; ++ii)
-            {
-                xt::masked_view(cell_flag(level, i + ii), keep_mask) |= static_cast<int>(CellFlag::enlarge);
-            }
-        }
-
-        template <class T>
-        inline void operator()(Dim<2>, T& cell_flag) const
-        {
-            auto keep_mask = cell_flag(level, i, j) & static_cast<int>(CellFlag::keep);
-
-            for (int jj = -1; jj < 2; ++jj)
-            {
-                for (int ii = -1; ii < 2; ++ii)
-                {
-                    xt::masked_view(cell_flag(level, i + ii, j + jj), keep_mask) |= static_cast<int>(CellFlag::enlarge);
-                }
-            }
-        }
-
-        template <class T>
-        inline void operator()(Dim<3>, T& cell_flag) const
-        {
-            auto keep_mask = cell_flag(level, i, j, k) & static_cast<int>(CellFlag::keep);
-
-            for (int kk = -1; kk < 2; ++kk)
-            {
-                for (int jj = -1; jj < 2; ++jj)
-                {
-                    for (int ii = -1; ii < 2; ++ii)
+                    template <std::size_t dim, class T1, class T2, std::size_t... Is>
+                    inline void compute_detail_impl(Dim<dim>, T1& detail, const T2& fields, std::index_sequence<Is...>) const
                     {
-                        xt::masked_view(cell_flag(level, i + ii, j + jj, k + kk), keep_mask) |= static_cast<int>(CellFlag::enlarge);
+                        std::array<std::size_t, std::tuple_size_v<T2> + 1> ranges;
+                        ranges[0]         = 0;
+                        std::size_t index = 1;
+                        (
+                            [&]()
+                            {
+                                ranges[index] = ranges[index - 1] + std::get<Is>(fields).size;
+                                ++index;
+                            }(),
+                            ...);
+                        (compute_detail_impl(Dim<dim>(), Is, ranges, detail, std::get<Is>(fields)), ...);
                     }
-                }
-            }
-        }
-    };
 
-    template <class... CT>
-    inline auto enlarge(CT&&... e)
-    {
-        return make_field_operator_function<enlarge_op>(std::forward<CT>(e)...);
-    }
-
-    /*******************************
-     * keep_around_refine operator *
-     *******************************/
-
-    template <std::size_t dim, class TInterval>
-    class keep_around_refine_op : public field_operator_base<dim, TInterval>
-    {
-      public:
-
-        INIT_OPERATOR(keep_around_refine_op)
-
-        template <class T>
-        inline void operator()(Dim<1>, T& cell_flag) const
-        {
-            auto refine_mask = cell_flag(level, i) & static_cast<int>(CellFlag::refine);
-
-            for (int ii = -1; ii < 2; ++ii)
-            {
-                xt::masked_view(cell_flag(level, i + ii), refine_mask) |= static_cast<int>(CellFlag::keep);
-            }
-        }
-
-        template <class T>
-        inline void operator()(Dim<2>, T& cell_flag) const
-        {
-            auto refine_mask = cell_flag(level, i, j) & static_cast<int>(CellFlag::refine);
-
-            for (int jj = -1; jj < 2; ++jj)
-            {
-                for (int ii = -1; ii < 2; ++ii)
-                {
-                    xt::masked_view(cell_flag(level, i + ii, j + jj), refine_mask) |= static_cast<int>(CellFlag::keep);
-                }
-            }
-        }
-
-        template <class T>
-        inline void operator()(Dim<3>, T& cell_flag) const
-        {
-            auto refine_mask = cell_flag(level, i, j, k) & static_cast<int>(CellFlag::refine);
-
-            for (int kk = -1; kk < 2; ++kk)
-            {
-                for (int jj = -1; jj < 2; ++jj)
-                {
-                    for (int ii = -1; ii < 2; ++ii)
+                    template <std::size_t dim, class T1, class T2>
+                    inline void operator()(Dim<dim>, T1& detail, const T2& fields) const
                     {
-                        xt::masked_view(cell_flag(level, i + ii, j + jj, k + kk), refine_mask) |= static_cast<int>(CellFlag::keep);
+                        compute_detail_impl(Dim<dim>(),
+                                            detail,
+                                            fields.elements(),
+                                            std::make_index_sequence<std::tuple_size_v<typename T2::tuple_type>>{});
                     }
-                }
-            }
-        }
-    };
+                };
 
-    template <class... CT>
-    inline auto keep_around_refine(CT&&... e)
-    {
-        return make_field_operator_function<keep_around_refine_op>(std::forward<CT>(e)...);
-    }
-
-    /***********************
-     * apply_expr operator *
-     ***********************/
-
-    template <std::size_t dim, class TInterval>
-    class apply_expr_op : public field_operator_base<dim, TInterval>
-    {
-      public:
-
-        INIT_OPERATOR(apply_expr_op)
-
-        template <class T, class E>
-        inline void operator()(Dim<1>, T& field, const field_expression<E>& e) const
-        {
-            field(level, i) = e.derived_cast()(level, i);
-        }
-
-        template <class T, class E>
-        inline void operator()(Dim<2>, T& field, const field_expression<E>& e) const
-        {
-            field(level, i, j) = e.derived_cast()(level, i, j);
-        }
-
-        template <class T, class E>
-        inline void operator()(Dim<3>, T& field, const field_expression<E>& e) const
-        {
-            field(level, i, j, k) = e.derived_cast()(level, i, j, k);
-        }
-    };
-
-    template <class... CT>
-    inline auto apply_expr(CT&&... e)
-    {
-        return make_field_operator_function<apply_expr_op>(std::forward<CT>(e)...);
-    }
-
-    /*******************
-     * extend operator *
-     *******************/
-    template <std::size_t dim, class TInterval>
-    class extend_op : public field_operator_base<dim, TInterval>
-    {
-      public:
-
-        INIT_OPERATOR(extend_op)
-
-        template <class T>
-        inline void operator()(Dim<1>, T& tag) const
-        {
-            auto refine_mask = tag(level, i) & static_cast<int>(samurai::CellFlag::refine);
-
-            const int added_cells = 1; // 1 by default
-
-            for (int ii = -added_cells; ii < added_cells + 1; ++ii)
-            {
-                xt::masked_view(tag(level, i + ii), refine_mask) |= static_cast<int>(samurai::CellFlag::keep);
-            }
-        }
-
-        template <class T>
-        inline void operator()(Dim<2>, T& tag) const
-        {
-            auto refine_mask = tag(level, i, j) & static_cast<int>(samurai::CellFlag::refine);
-
-            for (int jj = -1; jj < 2; ++jj)
-            {
-                for (int ii = -1; ii < 2; ++ii)
+                template <class Field, class... T>
+                inline auto compute_detail(Field & detail, const Field_tuple<T...>& fields)
                 {
-                    xt::masked_view(tag(level, i + ii, j + jj), refine_mask) |= static_cast<int>(samurai::CellFlag::keep);
+                    return make_field_operator_function<compute_detail_on_tuple_op>(detail, fields);
                 }
-            }
-        }
 
-        template <class T>
-        inline void operator()(Dim<3>, T& tag) const
-        {
-            auto refine_mask = tag(level, i, j, k) & static_cast<int>(samurai::CellFlag::refine);
+                /*******************************
+                 * compute max detail operator *
+                 *******************************/
 
-            for (int kk = -1; kk < 2; ++kk)
-            {
-                for (int jj = -1; jj < 2; ++jj)
+                template <std::size_t dim, class TInterval>
+                class compute_max_detail_op : public field_operator_base<dim, TInterval>
                 {
-                    for (int ii = -1; ii < 2; ++ii)
+                  public:
+
+                    INIT_OPERATOR(compute_max_detail_op)
+
+                    template <class T, class U>
+                    inline void operator()(Dim<1>, const U& detail, T& max_detail) const
                     {
-                        xt::masked_view(tag(level, i + ii, j + jj, k + kk), refine_mask) |= static_cast<int>(samurai::CellFlag::keep);
+                        auto ii       = 2 * i;
+                        ii.step       = 1;
+                        auto max_view = xt::view(max_detail, level + 1);
+
+                        max_view = xt::maximum(max_view, xt::amax(xt::abs(detail(level + 1, ii)), {0}));
                     }
+
+                    template <class T, class U>
+                    inline void operator()(Dim<2>, const U& detail, T& max_detail) const
+                    {
+                        auto ii       = 2 * i;
+                        ii.step       = 1;
+                        auto max_view = xt::view(max_detail, level + 1);
+
+                        max_view = xt::maximum(
+                            max_view,
+                            xt::amax(xt::maximum(xt::abs(detail(level + 1, ii, 2 * j)), xt::abs(detail(level + 1, ii, 2 * j + 1))), {0}));
+                    }
+
+                    template <class T, class U>
+                    inline void operator()(Dim<3>, const U& detail, T& max_detail) const
+                    {
+                        auto ii       = 2 * i;
+                        ii.step       = 1;
+                        auto max_view = xt::view(max_detail, level + 1);
+
+                        max_view = xt::maximum(max_view,
+                                               xt::amax(xt::maximum(xt::maximum(xt::abs(detail(level + 1, ii, 2 * j, 2 * k)),
+                                                                                xt::abs(detail(level + 1, ii, 2 * j + 1, 2 * k))),
+                                                                    xt::maximum(xt::abs(detail(level + 1, ii, 2 * j, 2 * k + 1)),
+                                                                                xt::abs(detail(level + 1, ii, 2 * j + 1, 2 * k + 1)))),
+                                                        {0}));
+                    }
+                };
+
+                template <class T, class U>
+                inline auto compute_max_detail(U && detail, T && max_detail)
+                {
+                    return make_field_operator_function<compute_max_detail_op>(std::forward<U>(detail), std::forward<T>(max_detail));
                 }
-            }
-        }
-    };
 
-    template <class... CT>
-    inline auto extend(CT&&... e)
-    {
-        return make_field_operator_function<extend_op>(std::forward<CT>(e)...);
-    }
+                /*******************************
+                 * compute max detail operator *
+                 *******************************/
 
-    /****************************
-     * make_graduation operator *
-     ****************************/
+                template <std::size_t dim, class TInterval>
+                class compute_max_detail_op_ : public field_operator_base<dim, TInterval>
+                {
+                  public:
 
-    template <std::size_t dim, class TInterval>
-    class make_graduation_op : public field_operator_base<dim, TInterval>
-    {
-      public:
+                    INIT_OPERATOR(compute_max_detail_op_)
 
-        INIT_OPERATOR(make_graduation_op)
+                    template <class T, class U>
+                    inline void operator()(Dim<1>, const U& detail, T& max_detail) const
+                    {
+                        max_detail[level] = std::max(max_detail[level], xt::amax(xt::abs(detail(level, i)))[0]);
+                    }
 
-        template <class T>
-        inline void operator()(Dim<1>, T& tag) const
-        {
-            auto i_even = i.even_elements();
-            if (i_even.is_valid())
-            {
-                auto mask = tag(level, i_even) & static_cast<int>(CellFlag::keep);
-                xt::masked_view(tag(level - 1, i_even >> 1), mask) |= static_cast<int>(CellFlag::refine);
-            }
+                    template <class T, class U>
+                    inline void operator()(Dim<2>, const U& detail, T& max_detail) const
+                    {
+                        max_detail[level] = std::max(max_detail[level], xt::amax(xt::abs(detail(level, i, j)))[0]);
+                    }
 
-            auto i_odd = i.odd_elements();
-            if (i_odd.is_valid())
-            {
-                auto mask = tag(level, i_odd) & static_cast<int>(CellFlag::keep);
-                xt::masked_view(tag(level - 1, i_odd >> 1), mask) |= static_cast<int>(CellFlag::refine);
-            }
-        }
+                    template <class T, class U>
+                    inline void operator()(Dim<3>, const U& detail, T& max_detail) const
+                    {
+                        max_detail[level] = std::max(max_detail[level], xt::amax(xt::abs(detail(level, i, j, k)))[0]);
+                    }
+                };
 
-        template <class T>
-        inline void operator()(Dim<2>, T& tag) const
-        {
-            auto i_even = i.even_elements();
-            if (i_even.is_valid())
-            {
-                auto mask = tag(level, i_even, j) & static_cast<int>(CellFlag::keep);
-                xt::masked_view(tag(level - 1, i_even >> 1, j >> 1), mask) |= static_cast<int>(CellFlag::refine);
-            }
+                template <class T, class U>
+                inline auto compute_max_detail_(U && detail, T && max_detail)
+                {
+                    return make_field_operator_function<compute_max_detail_op_>(std::forward<U>(detail), std::forward<T>(max_detail));
+                }
 
-            auto i_odd = i.odd_elements();
-            if (i_odd.is_valid())
-            {
-                auto mask = tag(level, i_odd, j) & static_cast<int>(CellFlag::keep);
-                xt::masked_view(tag(level - 1, i_odd >> 1, j >> 1), mask) |= static_cast<int>(CellFlag::refine);
-            }
-        }
+                /***********************
+                 * to_coarsen operator *
+                 ***********************/
 
-        template <class T>
-        inline void operator()(Dim<3>, T& tag) const
-        {
-            auto i_even = i.even_elements();
-            if (i_even.is_valid())
-            {
-                auto mask = tag(level, i_even, j, k) & static_cast<int>(CellFlag::keep);
-                xt::masked_view(tag(level - 1, i_even >> 1, j >> 1, k >> 1), mask) |= static_cast<int>(CellFlag::refine);
-            }
+                template <std::size_t dim, class TInterval>
+                class to_coarsen_op : public field_operator_base<dim, TInterval>
+                {
+                  public:
 
-            auto i_odd = i.odd_elements();
-            if (i_odd.is_valid())
-            {
-                auto mask = tag(level, i_odd, j, k) & static_cast<int>(CellFlag::keep);
-                xt::masked_view(tag(level - 1, i_odd >> 1, j >> 1, k >> 1), mask) |= static_cast<int>(CellFlag::refine);
-            }
-        }
-    };
+                    INIT_OPERATOR(to_coarsen_op)
 
-    template <class... CT>
-    inline auto make_graduation(CT&&... e)
-    {
-        return make_field_operator_function<make_graduation_op>(std::forward<CT>(e)...);
-    }
-} // namespace samurai
+                    template <class T, class U, class V>
+                    inline void operator()(Dim<1>, T& keep, const U& detail, double eps) const
+                    {
+                        auto mask = xt::abs(detail(level + 1, 2 * i)) < eps;
+                        // auto mask = (.5 *
+                        //              (xt::abs(detail(level + 1, 2 * i)) +
+                        //               xt::abs(detail(level + 1, 2 * i + 1))) /
+                        //              max_detail[level + 1]) < eps;
+
+                        for (coord_index_t ii = 0; ii < 2; ++ii)
+                        {
+                            xt::masked_view(keep(level + 1, 2 * i + ii), mask) = static_cast<int>(CellFlag::coarsen);
+                        }
+                    }
+
+                    template <class T, class U, class V>
+                    inline void operator()(Dim<2>, T& keep, const U& detail, double eps) const
+                    {
+                        auto mask = xt::abs(detail(level + 1, 2 * i, 2 * j)) < eps;
+
+                        // auto mask = (0.25 *
+                        //              (xt::abs(detail(level + 1, 2 * i, 2 * j)) +
+                        //               xt::abs(detail(level + 1, 2 * i + 1, 2 * j)) +
+                        //               xt::abs(detail(level + 1, 2 * i, 2 * j + 1)) +
+                        //               xt::abs(detail(level + 1, 2 * i + 1, 2 * j + 1))) /
+                        //              max_detail[level + 1]) < eps;
+
+                        for (coord_index_t jj = 0; jj < 2; ++jj)
+                        {
+                            for (coord_index_t ii = 0; ii < 2; ++ii)
+                            {
+                                xt::masked_view(keep(level + 1, 2 * i + ii, 2 * j + jj), mask) = static_cast<int>(CellFlag::coarsen);
+                            }
+                        }
+                    }
+
+                    template <class T, class U, class V>
+                    inline void operator()(Dim<3>, T& keep, const U& detail, double eps) const
+                    {
+                        auto mask = xt::abs(detail(level + 1, 2 * i, 2 * j, 2 * k)) < eps;
+
+                        for (coord_index_t kk = 0; kk < 2; ++kk)
+                        {
+                            for (coord_index_t jj = 0; jj < 2; ++jj)
+                            {
+                                for (coord_index_t ii = 0; ii < 2; ++ii)
+                                {
+                                    xt::masked_view(keep(level + 1, 2 * i + ii, 2 * j + jj, 2 * k + kk),
+                                                    mask) = static_cast<int>(CellFlag::coarsen);
+                                }
+                            }
+                        }
+                    }
+                };
+
+                template <class... CT>
+                inline auto to_coarsen(CT && ... e)
+                {
+                    return make_field_operator_function<to_coarsen_op>(std::forward<CT>(e)...);
+                }
+
+                /*************************
+                 * refine_ghost operator *
+                 *************************/
+
+                template <std::size_t dim, class TInterval>
+                class refine_ghost_op : public field_operator_base<dim, TInterval>
+                {
+                  public:
+
+                    INIT_OPERATOR(refine_ghost_op)
+
+                    template <class T>
+                    inline void operator()(Dim<1>, T& flag) const
+                    {
+                        auto mask                                 = flag(level + 1, i) & static_cast<int>(CellFlag::keep);
+                        xt::masked_view(flag(level, i / 2), mask) = static_cast<int>(CellFlag::refine);
+                    }
+
+                    template <class T>
+                    inline void operator()(Dim<2>, T& flag) const
+                    {
+                        auto mask                                        = flag(level + 1, i, j) & static_cast<int>(CellFlag::keep);
+                        xt::masked_view(flag(level, i / 2, j / 2), mask) = static_cast<int>(CellFlag::refine);
+                    }
+
+                    template <class T>
+                    inline void operator()(Dim<3>, T& flag) const
+                    {
+                        auto mask = flag(level + 1, i, j, k) & static_cast<int>(CellFlag::keep);
+                        xt::masked_view(flag(level, i / 2, j / 2, k / 2), mask) = static_cast<int>(CellFlag::refine);
+                    }
+                };
+
+                template <class... CT>
+                inline auto refine_ghost(CT && ... e)
+                {
+                    return make_field_operator_function<refine_ghost_op>(std::forward<CT>(e)...);
+                }
+
+                /********************
+                 * enlarge operator *
+                 ********************/
+
+                template <std::size_t dim, class TInterval>
+                class enlarge_op : public field_operator_base<dim, TInterval>
+                {
+                  public:
+
+                    INIT_OPERATOR(enlarge_op)
+
+                    template <class T>
+                    inline void operator()(Dim<1>, T& cell_flag) const
+                    {
+                        auto keep_mask = cell_flag(level, i) & static_cast<int>(CellFlag::keep);
+
+                        for (int ii = -1; ii < 2; ++ii)
+                        {
+                            xt::masked_view(cell_flag(level, i + ii), keep_mask) |= static_cast<int>(CellFlag::enlarge);
+                        }
+                    }
+
+                    template <class T>
+                    inline void operator()(Dim<2>, T& cell_flag) const
+                    {
+                        auto keep_mask = cell_flag(level, i, j) & static_cast<int>(CellFlag::keep);
+
+                        for (int jj = -1; jj < 2; ++jj)
+                        {
+                            for (int ii = -1; ii < 2; ++ii)
+                            {
+                                xt::masked_view(cell_flag(level, i + ii, j + jj), keep_mask) |= static_cast<int>(CellFlag::enlarge);
+                            }
+                        }
+                    }
+
+                    template <class T>
+                    inline void operator()(Dim<3>, T& cell_flag) const
+                    {
+                        auto keep_mask = cell_flag(level, i, j, k) & static_cast<int>(CellFlag::keep);
+
+                        for (int kk = -1; kk < 2; ++kk)
+                        {
+                            for (int jj = -1; jj < 2; ++jj)
+                            {
+                                for (int ii = -1; ii < 2; ++ii)
+                                {
+                                    xt::masked_view(cell_flag(level, i + ii, j + jj, k + kk),
+                                                    keep_mask) |= static_cast<int>(CellFlag::enlarge);
+                                }
+                            }
+                        }
+                    }
+                };
+
+                template <class... CT>
+                inline auto enlarge(CT && ... e)
+                {
+                    return make_field_operator_function<enlarge_op>(std::forward<CT>(e)...);
+                }
+
+                /*******************************
+                 * keep_around_refine operator *
+                 *******************************/
+
+                template <std::size_t dim, class TInterval>
+                class keep_around_refine_op : public field_operator_base<dim, TInterval>
+                {
+                  public:
+
+                    INIT_OPERATOR(keep_around_refine_op)
+
+                    template <class T>
+                    inline void operator()(Dim<1>, T& cell_flag) const
+                    {
+                        auto refine_mask = cell_flag(level, i) & static_cast<int>(CellFlag::refine);
+
+                        for (int ii = -1; ii < 2; ++ii)
+                        {
+                            xt::masked_view(cell_flag(level, i + ii), refine_mask) |= static_cast<int>(CellFlag::keep);
+                        }
+                    }
+
+                    template <class T>
+                    inline void operator()(Dim<2>, T& cell_flag) const
+                    {
+                        auto refine_mask = cell_flag(level, i, j) & static_cast<int>(CellFlag::refine);
+
+                        for (int jj = -1; jj < 2; ++jj)
+                        {
+                            for (int ii = -1; ii < 2; ++ii)
+                            {
+                                xt::masked_view(cell_flag(level, i + ii, j + jj), refine_mask) |= static_cast<int>(CellFlag::keep);
+                            }
+                        }
+                    }
+
+                    template <class T>
+                    inline void operator()(Dim<3>, T& cell_flag) const
+                    {
+                        auto refine_mask = cell_flag(level, i, j, k) & static_cast<int>(CellFlag::refine);
+
+                        for (int kk = -1; kk < 2; ++kk)
+                        {
+                            for (int jj = -1; jj < 2; ++jj)
+                            {
+                                for (int ii = -1; ii < 2; ++ii)
+                                {
+                                    xt::masked_view(cell_flag(level, i + ii, j + jj, k + kk),
+                                                    refine_mask) |= static_cast<int>(CellFlag::keep);
+                                }
+                            }
+                        }
+                    }
+                };
+
+                template <class... CT>
+                inline auto keep_around_refine(CT && ... e)
+                {
+                    return make_field_operator_function<keep_around_refine_op>(std::forward<CT>(e)...);
+                }
+
+                /***********************
+                 * apply_expr operator *
+                 ***********************/
+
+                template <std::size_t dim, class TInterval>
+                class apply_expr_op : public field_operator_base<dim, TInterval>
+                {
+                  public:
+
+                    INIT_OPERATOR(apply_expr_op)
+
+                    template <class T, class E>
+                    inline void operator()(Dim<1>, T& field, const field_expression<E>& e) const
+                    {
+                        field(level, i) = e.derived_cast()(level, i);
+                    }
+
+                    template <class T, class E>
+                    inline void operator()(Dim<2>, T& field, const field_expression<E>& e) const
+                    {
+                        field(level, i, j) = e.derived_cast()(level, i, j);
+                    }
+
+                    template <class T, class E>
+                    inline void operator()(Dim<3>, T& field, const field_expression<E>& e) const
+                    {
+                        field(level, i, j, k) = e.derived_cast()(level, i, j, k);
+                    }
+                };
+
+                template <class... CT>
+                inline auto apply_expr(CT && ... e)
+                {
+                    return make_field_operator_function<apply_expr_op>(std::forward<CT>(e)...);
+                }
+
+                /*******************
+                 * extend operator *
+                 *******************/
+                template <std::size_t dim, class TInterval>
+                class extend_op : public field_operator_base<dim, TInterval>
+                {
+                  public:
+
+                    INIT_OPERATOR(extend_op)
+
+                    template <class T>
+                    inline void operator()(Dim<1>, T& tag) const
+                    {
+                        auto refine_mask = tag(level, i) & static_cast<int>(samurai::CellFlag::refine);
+
+                        const int added_cells = 1; // 1 by default
+
+                        for (int ii = -added_cells; ii < added_cells + 1; ++ii)
+                        {
+                            xt::masked_view(tag(level, i + ii), refine_mask) |= static_cast<int>(samurai::CellFlag::keep);
+                        }
+                    }
+
+                    template <class T>
+                    inline void operator()(Dim<2>, T& tag) const
+                    {
+                        auto refine_mask = tag(level, i, j) & static_cast<int>(samurai::CellFlag::refine);
+
+                        for (int jj = -1; jj < 2; ++jj)
+                        {
+                            for (int ii = -1; ii < 2; ++ii)
+                            {
+                                xt::masked_view(tag(level, i + ii, j + jj), refine_mask) |= static_cast<int>(samurai::CellFlag::keep);
+                            }
+                        }
+                    }
+
+                    template <class T>
+                    inline void operator()(Dim<3>, T& tag) const
+                    {
+                        auto refine_mask = tag(level, i, j, k) & static_cast<int>(samurai::CellFlag::refine);
+
+                        for (int kk = -1; kk < 2; ++kk)
+                        {
+                            for (int jj = -1; jj < 2; ++jj)
+                            {
+                                for (int ii = -1; ii < 2; ++ii)
+                                {
+                                    xt::masked_view(tag(level, i + ii, j + jj, k + kk),
+                                                    refine_mask) |= static_cast<int>(samurai::CellFlag::keep);
+                                }
+                            }
+                        }
+                    }
+                };
+
+                template <class... CT>
+                inline auto extend(CT && ... e)
+                {
+                    return make_field_operator_function<extend_op>(std::forward<CT>(e)...);
+                }
+
+                /****************************
+                 * make_graduation operator *
+                 ****************************/
+
+                template <std::size_t dim, class TInterval>
+                class make_graduation_op : public field_operator_base<dim, TInterval>
+                {
+                  public:
+
+                    INIT_OPERATOR(make_graduation_op)
+
+                    template <class T>
+                    inline void operator()(Dim<1>, T& tag) const
+                    {
+                        auto i_even = i.even_elements();
+                        if (i_even.is_valid())
+                        {
+                            auto mask = tag(level, i_even) & static_cast<int>(CellFlag::keep);
+                            xt::masked_view(tag(level - 1, i_even >> 1), mask) |= static_cast<int>(CellFlag::refine);
+                        }
+
+                        auto i_odd = i.odd_elements();
+                        if (i_odd.is_valid())
+                        {
+                            auto mask = tag(level, i_odd) & static_cast<int>(CellFlag::keep);
+                            xt::masked_view(tag(level - 1, i_odd >> 1), mask) |= static_cast<int>(CellFlag::refine);
+                        }
+                    }
+
+                    template <class T>
+                    inline void operator()(Dim<2>, T& tag) const
+                    {
+                        auto i_even = i.even_elements();
+                        if (i_even.is_valid())
+                        {
+                            auto mask = tag(level, i_even, j) & static_cast<int>(CellFlag::keep);
+                            xt::masked_view(tag(level - 1, i_even >> 1, j >> 1), mask) |= static_cast<int>(CellFlag::refine);
+                        }
+
+                        auto i_odd = i.odd_elements();
+                        if (i_odd.is_valid())
+                        {
+                            auto mask = tag(level, i_odd, j) & static_cast<int>(CellFlag::keep);
+                            xt::masked_view(tag(level - 1, i_odd >> 1, j >> 1), mask) |= static_cast<int>(CellFlag::refine);
+                        }
+                    }
+
+                    template <class T>
+                    inline void operator()(Dim<3>, T& tag) const
+                    {
+                        auto i_even = i.even_elements();
+                        if (i_even.is_valid())
+                        {
+                            auto mask = tag(level, i_even, j, k) & static_cast<int>(CellFlag::keep);
+                            xt::masked_view(tag(level - 1, i_even >> 1, j >> 1, k >> 1), mask) |= static_cast<int>(CellFlag::refine);
+                        }
+
+                        auto i_odd = i.odd_elements();
+                        if (i_odd.is_valid())
+                        {
+                            auto mask = tag(level, i_odd, j, k) & static_cast<int>(CellFlag::keep);
+                            xt::masked_view(tag(level - 1, i_odd >> 1, j >> 1, k >> 1), mask) |= static_cast<int>(CellFlag::refine);
+                        }
+                    }
+                };
+
+                template <class... CT>
+                inline auto make_graduation(CT && ... e)
+                {
+                    return make_field_operator_function<make_graduation_op>(std::forward<CT>(e)...);
+                }
+            } // namespace samurai

--- a/include/samurai/mr/operators.hpp
+++ b/include/samurai/mr/operators.hpp
@@ -273,56 +273,12 @@ namespace samurai
             auto src_shape  = field(level + 1, 2 * i).shape();
             if (xt::same_shape(dest_shape, src_shape))
             {
-                detail(ranges[index], ranges[index + 1], level + 1, 2 * i)     = field(level + 1, 2 * i) - (field(level, i) + qs_i);
-                detail(ranges[index], ranges[index + 1], level + 1, 2 * i + 1) = field(level + 1, 2 * i + 1) - (field(level, i) - qs_i);
-            }
-            else
-            {
-                detail(ranges[index], ranges[index + 1], level + 1, 2 * i) = xt::transpose(field(level + 1, 2 * i) - (field(level, i) + qs_i));
-                detail(ranges[index], ranges[index + 1], level + 1, 2 * i + 1) = xt::transpose(field(level + 1, 2 * i + 1)
-                                                                                               - (field(level, i) - qs_i));
-            }
-        }
+    template <std::size_t dim, class TInterval>
+    class compute_detail_on_tuple_op : public field_operator_base<dim, TInterval>
+    {
+      public:
 
-        template <class Ranges, class T1, class T2>
-        inline void compute_detail_impl(Dim<2>, std::size_t index, const Ranges& ranges, T1& detail, const T2& field) const
-        {
-            static constexpr std::size_t order = T1::mesh_t::config::prediction_order;
-            auto qs_i                          = Qs_i<order>(field, level, i, j);
-            auto qs_j                          = Qs_j<order>(field, level, i, j);
-            auto qs_ij                         = Qs_ij<order>(field, level, i, j);
-
-            auto dest_shape = detail(ranges[index], ranges[index + 1], level + 1, 2 * i, 2 * j).shape();
-            auto src_shape  = field(level + 1, 2 * i, 2 * j).shape();
-            if (xt::same_shape(dest_shape, src_shape))
-            {
-                detail(ranges[index], ranges[index + 1], level + 1, 2 * i, 2 * j) = field(level + 1, 2 * i, 2 * j)
-                                                                                  - (field(level, i, j) + qs_i + qs_j - qs_ij);
-
-                detail(ranges[index], ranges[index + 1], level + 1, 2 * i + 1, 2 * j) = field(level + 1, 2 * i + 1, 2 * j)
-                                                                                      - (field(level, i, j) - qs_i + qs_j + qs_ij);
-
-                detail(ranges[index], ranges[index + 1], level + 1, 2 * i, 2 * j + 1) = field(level + 1, 2 * i, 2 * j + 1)
-                                                                                      - (field(level, i, j) + qs_i - qs_j + qs_ij);
-
-                detail(ranges[index], ranges[index + 1], level + 1, 2 * i + 1, 2 * j + 1) = field(level + 1, 2 * i + 1, 2 * j + 1)
-                                                                                          - (field(level, i, j) - qs_i - qs_j - qs_ij);
-            }
-            else
-            {
-                detail(ranges[index], ranges[index + 1], level + 1, 2 * i, 2 * j) = xt::transpose(
-                    field(level + 1, 2 * i, 2 * j) - (field(level, i, j) + qs_i + qs_j - qs_ij));
-
-                detail(ranges[index], ranges[index + 1], level + 1, 2 * i + 1, 2 * j) = xt::transpose(
-                    field(level + 1, 2 * i + 1, 2 * j) - (field(level, i, j) - qs_i + qs_j + qs_ij));
-
-                detail(ranges[index], ranges[index + 1], level + 1, 2 * i, 2 * j + 1) = xt::transpose(
-                    field(level + 1, 2 * i, 2 * j + 1) - (field(level, i, j) + qs_i - qs_j + qs_ij));
-
-                detail(ranges[index], ranges[index + 1], level + 1, 2 * i + 1, 2 * j + 1) = xt::transpose(
-                    field(level + 1, 2 * i + 1, 2 * j + 1) - (field(level, i, j) - qs_i - qs_j - qs_ij));
-            }
-        }
+        INIT_OPERATOR(compute_detail_on_tuple_op)
 
         template <class Ranges, class T1, class T2>
         inline void compute_detail_impl(Dim<3>, std::size_t index, const Ranges& ranges, T1& detail, const T2& field) const

--- a/include/samurai/mr/operators.hpp
+++ b/include/samurai/mr/operators.hpp
@@ -406,7 +406,7 @@ namespace samurai
             }
         }
 
-        template <std::size_t dim, class T1, class T2, std::size_t... Is>
+        template <class T1, class T2, std::size_t... Is>
         inline void compute_detail_impl(Dim<dim>, T1& detail, const T2& fields, std::index_sequence<Is...>) const
         {
             std::array<std::size_t, std::tuple_size_v<T2> + 1> ranges;
@@ -422,7 +422,7 @@ namespace samurai
             (compute_detail_impl(Dim<dim>(), Is, ranges, detail, std::get<Is>(fields)), ...);
         }
 
-        template <std::size_t dim, class T1, class T2>
+        template <class T1, class T2>
         inline void operator()(Dim<dim>, T1& detail, const T2& fields) const
         {
             compute_detail_impl(Dim<dim>(), detail, fields.elements(), std::make_index_sequence<std::tuple_size_v<typename T2::tuple_type>>{});

--- a/include/samurai/mr/operators.hpp
+++ b/include/samurai/mr/operators.hpp
@@ -256,8 +256,8 @@ namespace samurai
         return make_field_operator_function<compute_detail_op>(std::forward<T>(detail), std::forward<T>(field));
     }
 
-    template <class TInterval>
-    class compute_detail_on_tuple_op : public field_operator_base<TInterval>
+    template <std::size_t dim, class TInterval>
+    class compute_detail_on_tuple_op : public field_operator_base<dim, TInterval>
     {
       public:
 
@@ -273,647 +273,655 @@ namespace samurai
             auto src_shape  = field(level + 1, 2 * i).shape();
             if (xt::same_shape(dest_shape, src_shape))
             {
-                template <std::size_t dim, class TInterval>
-                class compute_detail_on_tuple_op : public field_operator_base<dim, TInterval>
+                detail(ranges[index], ranges[index + 1], level + 1, 2 * i)     = field(level + 1, 2 * i) - (field(level, i) + qs_i);
+                detail(ranges[index], ranges[index + 1], level + 1, 2 * i + 1) = field(level + 1, 2 * i + 1) - (field(level, i) - qs_i);
+            }
+            else
+            {
+                detail(ranges[index], ranges[index + 1], level + 1, 2 * i) = xt::transpose(field(level + 1, 2 * i) - (field(level, i) + qs_i));
+                detail(ranges[index], ranges[index + 1], level + 1, 2 * i + 1) = xt::transpose(field(level + 1, 2 * i + 1)
+                                                                                               - (field(level, i) - qs_i));
+            }
+        }
+
+        template <class Ranges, class T1, class T2>
+        inline void compute_detail_impl(Dim<2>, std::size_t index, const Ranges& ranges, T1& detail, const T2& field) const
+        {
+            static constexpr std::size_t order = T1::mesh_t::config::prediction_order;
+            auto qs_i                          = Qs_i<order>(field, level, i, j);
+            auto qs_j                          = Qs_j<order>(field, level, i, j);
+            auto qs_ij                         = Qs_ij<order>(field, level, i, j);
+
+            auto dest_shape = detail(ranges[index], ranges[index + 1], level + 1, 2 * i, 2 * j).shape();
+            auto src_shape  = field(level + 1, 2 * i, 2 * j).shape();
+            if (xt::same_shape(dest_shape, src_shape))
+            {
+                detail(ranges[index], ranges[index + 1], level + 1, 2 * i, 2 * j) = field(level + 1, 2 * i, 2 * j)
+                                                                                  - (field(level, i, j) + qs_i + qs_j - qs_ij);
+
+                detail(ranges[index], ranges[index + 1], level + 1, 2 * i + 1, 2 * j) = field(level + 1, 2 * i + 1, 2 * j)
+                                                                                      - (field(level, i, j) - qs_i + qs_j + qs_ij);
+
+                detail(ranges[index], ranges[index + 1], level + 1, 2 * i, 2 * j + 1) = field(level + 1, 2 * i, 2 * j + 1)
+                                                                                      - (field(level, i, j) + qs_i - qs_j + qs_ij);
+
+                detail(ranges[index], ranges[index + 1], level + 1, 2 * i + 1, 2 * j + 1) = field(level + 1, 2 * i + 1, 2 * j + 1)
+                                                                                          - (field(level, i, j) - qs_i - qs_j - qs_ij);
+            }
+            else
+            {
+                detail(ranges[index], ranges[index + 1], level + 1, 2 * i, 2 * j) = xt::transpose(
+                    field(level + 1, 2 * i, 2 * j) - (field(level, i, j) + qs_i + qs_j - qs_ij));
+
+                detail(ranges[index], ranges[index + 1], level + 1, 2 * i + 1, 2 * j) = xt::transpose(
+                    field(level + 1, 2 * i + 1, 2 * j) - (field(level, i, j) - qs_i + qs_j + qs_ij));
+
+                detail(ranges[index], ranges[index + 1], level + 1, 2 * i, 2 * j + 1) = xt::transpose(
+                    field(level + 1, 2 * i, 2 * j + 1) - (field(level, i, j) + qs_i - qs_j + qs_ij));
+
+                detail(ranges[index], ranges[index + 1], level + 1, 2 * i + 1, 2 * j + 1) = xt::transpose(
+                    field(level + 1, 2 * i + 1, 2 * j + 1) - (field(level, i, j) - qs_i - qs_j - qs_ij));
+            }
+        }
+
+        template <class Ranges, class T1, class T2>
+        inline void compute_detail_impl(Dim<3>, std::size_t index, const Ranges& ranges, T1& detail, const T2& field) const
+        {
+            static constexpr std::size_t order = T1::mesh_t::config::prediction_order;
+            auto qs_i                          = Qs_i<order>(field, level, i, j, k);
+            auto qs_j                          = Qs_j<order>(field, level, i, j, k);
+            auto qs_k                          = Qs_k<order>(field, level, i, j, k);
+            auto qs_ij                         = Qs_ij<order>(field, level, i, j, k);
+            auto qs_ik                         = Qs_ik<order>(field, level, i, j, k);
+            auto qs_jk                         = Qs_jk<order>(field, level, i, j, k);
+            auto qs_ijk                        = Qs_ijk<order>(field, level, i, j, k);
+
+            auto dest_shape = detail(ranges[index], ranges[index + 1], level + 1, 2 * i, 2 * j, 2 * k).shape();
+            auto src_shape  = field(level + 1, 2 * i, 2 * j, 2 * k).shape();
+            if (xt::same_shape(dest_shape, src_shape))
+            {
+                detail(ranges[index], ranges[index + 1], level + 1, 2 * i, 2 * j, 2 * k) = field(level + 1, 2 * i, 2 * j, 2 * k)
+                                                                                         - (field(level, i, j, k) + qs_i + qs_j + qs_k
+                                                                                            - qs_ij - qs_ik - qs_jk + qs_ijk);
+
+                detail(ranges[index], ranges[index + 1], level + 1, 2 * i + 1, 2 * j, 2 * k) = field(level + 1, 2 * i + 1, 2 * j, 2 * k)
+                                                                                             - (field(level, i, j, k) - qs_i + qs_j + qs_k
+                                                                                                + qs_ij + qs_ik - qs_jk - qs_ijk);
+
+                detail(ranges[index], ranges[index + 1], level + 1, 2 * i, 2 * j + 1, 2 * k) = field(level + 1, 2 * i, 2 * j + 1, 2 * k)
+                                                                                             - (field(level, i, j, k) + qs_i - qs_j + qs_k
+                                                                                                + qs_ij - qs_ik + qs_jk - qs_ijk);
+
+                detail(ranges[index], ranges[index + 1], level + 1, 2 * i + 1, 2 * j + 1, 2 * k) = field(level + 1, 2 * i + 1, 2 * j + 1, 2 * k)
+                                                                                                 - (field(level, i, j, k) - qs_i - qs_j
+                                                                                                    + qs_k - qs_ij + qs_ik + qs_jk + qs_ijk);
+
+                detail(ranges[index], ranges[index + 1], level + 1, 2 * i, 2 * j, 2 * k + 1) = field(level + 1, 2 * i, 2 * j, 2 * k + 1)
+                                                                                             - (field(level, i, j, k) + qs_i + qs_j - qs_k
+                                                                                                - qs_ij + qs_ik + qs_jk - qs_ijk);
+
+                detail(ranges[index], ranges[index + 1], level + 1, 2 * i + 1, 2 * j, 2 * k + 1) = field(level + 1, 2 * i + 1, 2 * j, 2 * k + 1)
+                                                                                                 - (field(level, i, j, k) - qs_i + qs_j
+                                                                                                    - qs_k + qs_ij - qs_ik + qs_jk + qs_ijk);
+                detail(ranges[index], ranges[index + 1], level + 1, 2 * i, 2 * j + 1, 2 * k + 1) = field(level + 1, 2 * i, 2 * j + 1, 2 * k + 1)
+                                                                                                 - (field(level, i, j, k) + qs_i - qs_j
+                                                                                                    - qs_k + qs_ij + qs_ik - qs_jk + qs_ijk);
+
+                detail(ranges[index],
+                       ranges[index + 1],
+                       level + 1,
+                       2 * i + 1,
+                       2 * j + 1,
+                       2 * k + 1) = field(level + 1, 2 * i + 1, 2 * j + 1, 2 * k + 1)
+                                  - (field(level, i, j, k) - qs_i - qs_j - qs_k - qs_ij - qs_ik - qs_jk - qs_ijk);
+            }
+            else
+            {
+                detail(ranges[index], ranges[index + 1], level + 1, 2 * i, 2 * j, 2 * k) = xt::transpose(
+                    field(level + 1, 2 * i, 2 * j, 2 * k) - (field(level, i, j, k) + qs_i + qs_j + qs_k - qs_ij - qs_ik - qs_jk + qs_ijk));
+
+                detail(ranges[index], ranges[index + 1], level + 1, 2 * i + 1, 2 * j, 2 * k) = xt::transpose(
+                    field(level + 1, 2 * i + 1, 2 * j, 2 * k) - (field(level, i, j, k) - qs_i + qs_j + qs_k + qs_ij + qs_ik - qs_jk - qs_ijk));
+
+                detail(ranges[index], ranges[index + 1], level + 1, 2 * i, 2 * j + 1, 2 * k) = xt::transpose(
+                    field(level + 1, 2 * i, 2 * j + 1, 2 * k) - (field(level, i, j, k) + qs_i - qs_j + qs_k + qs_ij - qs_ik + qs_jk - qs_ijk));
+
+                detail(ranges[index], ranges[index + 1], level + 1, 2 * i + 1, 2 * j + 1, 2 * k) = xt::transpose(
+                    field(level + 1, 2 * i + 1, 2 * j + 1, 2 * k)
+                    - (field(level, i, j, k) - qs_i - qs_j + qs_k - qs_ij + qs_ik + qs_jk + qs_ijk));
+
+                detail(ranges[index], ranges[index + 1], level + 1, 2 * i, 2 * j, 2 * k + 1) = xt::transpose(
+                    field(level + 1, 2 * i, 2 * j, 2 * k + 1) - (field(level, i, j, k) + qs_i + qs_j - qs_k - qs_ij + qs_ik + qs_jk - qs_ijk));
+
+                detail(ranges[index], ranges[index + 1], level + 1, 2 * i + 1, 2 * j, 2 * k + 1) = xt::transpose(
+                    field(level + 1, 2 * i + 1, 2 * j, 2 * k + 1)
+                    - (field(level, i, j, k) - qs_i + qs_j - qs_k + qs_ij - qs_ik + qs_jk + qs_ijk));
+                detail(ranges[index], ranges[index + 1], level + 1, 2 * i, 2 * j + 1, 2 * k + 1) = xt::transpose(
+                    field(level + 1, 2 * i, 2 * j + 1, 2 * k + 1)
+                    - (field(level, i, j, k) + qs_i - qs_j - qs_k + qs_ij + qs_ik - qs_jk + qs_ijk));
+
+                detail(ranges[index], ranges[index + 1], level + 1, 2 * i + 1, 2 * j + 1, 2 * k + 1) = xt::transpose(
+                    field(level + 1, 2 * i + 1, 2 * j + 1, 2 * k + 1)
+                    - (field(level, i, j, k) - qs_i - qs_j - qs_k - qs_ij - qs_ik - qs_jk - qs_ijk));
+            }
+        }
+
+        template <std::size_t dim, class T1, class T2, std::size_t... Is>
+        inline void compute_detail_impl(Dim<dim>, T1& detail, const T2& fields, std::index_sequence<Is...>) const
+        {
+            std::array<std::size_t, std::tuple_size_v<T2> + 1> ranges;
+            ranges[0]         = 0;
+            std::size_t index = 1;
+            (
+                [&]()
                 {
-                  public:
+                    ranges[index] = ranges[index - 1] + std::get<Is>(fields).size;
+                    ++index;
+                }(),
+                ...);
+            (compute_detail_impl(Dim<dim>(), Is, ranges, detail, std::get<Is>(fields)), ...);
+        }
 
-                    INIT_OPERATOR(compute_detail_on_tuple_op)
+        template <std::size_t dim, class T1, class T2>
+        inline void operator()(Dim<dim>, T1& detail, const T2& fields) const
+        {
+            compute_detail_impl(Dim<dim>(), detail, fields.elements(), std::make_index_sequence<std::tuple_size_v<typename T2::tuple_type>>{});
+        }
+    };
 
-                    template <class Ranges, class T1, class T2>
-                    inline void compute_detail_impl(Dim<3>, std::size_t index, const Ranges& ranges, T1& detail, const T2& field) const
-                    {
-                        static constexpr std::size_t order = T1::mesh_t::config::prediction_order;
-                        auto qs_i                          = Qs_i<order>(field, level, i, j, k);
-                        auto qs_j                          = Qs_j<order>(field, level, i, j, k);
-                        auto qs_k                          = Qs_k<order>(field, level, i, j, k);
-                        auto qs_ij                         = Qs_ij<order>(field, level, i, j, k);
-                        auto qs_ik                         = Qs_ik<order>(field, level, i, j, k);
-                        auto qs_jk                         = Qs_jk<order>(field, level, i, j, k);
-                        auto qs_ijk                        = Qs_ijk<order>(field, level, i, j, k);
+    template <class Field, class... T>
+    inline auto compute_detail(Field& detail, const Field_tuple<T...>& fields)
+    {
+        return make_field_operator_function<compute_detail_on_tuple_op>(detail, fields);
+    }
 
-                        auto dest_shape = detail(ranges[index], ranges[index + 1], level + 1, 2 * i, 2 * j, 2 * k).shape();
-                        auto src_shape  = field(level + 1, 2 * i, 2 * j, 2 * k).shape();
-                        if (xt::same_shape(dest_shape, src_shape))
-                        {
-                            detail(ranges[index], ranges[index + 1], level + 1, 2 * i, 2 * j, 2 * k) = field(level + 1, 2 * i, 2 * j, 2 * k)
-                                                                                                     - (field(level, i, j, k) + qs_i + qs_j
-                                                                                                        + qs_k - qs_ij - qs_ik - qs_jk
-                                                                                                        + qs_ijk);
+    /*******************************
+     * compute max detail operator *
+     *******************************/
 
-                            detail(ranges[index],
-                                   ranges[index + 1],
-                                   level + 1,
-                                   2 * i + 1,
-                                   2 * j,
-                                   2 * k) = field(level + 1, 2 * i + 1, 2 * j, 2 * k)
-                                          - (field(level, i, j, k) - qs_i + qs_j + qs_k + qs_ij + qs_ik - qs_jk - qs_ijk);
+    template <std::size_t dim, class TInterval>
+    class compute_max_detail_op : public field_operator_base<dim, TInterval>
+    {
+      public:
 
-                            detail(ranges[index],
-                                   ranges[index + 1],
-                                   level + 1,
-                                   2 * i,
-                                   2 * j + 1,
-                                   2 * k) = field(level + 1, 2 * i, 2 * j + 1, 2 * k)
-                                          - (field(level, i, j, k) + qs_i - qs_j + qs_k + qs_ij - qs_ik + qs_jk - qs_ijk);
+        INIT_OPERATOR(compute_max_detail_op)
 
-                            detail(ranges[index],
-                                   ranges[index + 1],
-                                   level + 1,
-                                   2 * i + 1,
-                                   2 * j + 1,
-                                   2 * k) = field(level + 1, 2 * i + 1, 2 * j + 1, 2 * k)
-                                          - (field(level, i, j, k) - qs_i - qs_j + qs_k - qs_ij + qs_ik + qs_jk + qs_ijk);
+        template <class T, class U>
+        inline void operator()(Dim<1>, const U& detail, T& max_detail) const
+        {
+            auto ii       = 2 * i;
+            ii.step       = 1;
+            auto max_view = xt::view(max_detail, level + 1);
 
-                            detail(ranges[index],
-                                   ranges[index + 1],
-                                   level + 1,
-                                   2 * i,
-                                   2 * j,
-                                   2 * k + 1) = field(level + 1, 2 * i, 2 * j, 2 * k + 1)
-                                              - (field(level, i, j, k) + qs_i + qs_j - qs_k - qs_ij + qs_ik + qs_jk - qs_ijk);
+            max_view = xt::maximum(max_view, xt::amax(xt::abs(detail(level + 1, ii)), {0}));
+        }
 
-                            detail(ranges[index],
-                                   ranges[index + 1],
-                                   level + 1,
-                                   2 * i + 1,
-                                   2 * j,
-                                   2 * k + 1) = field(level + 1, 2 * i + 1, 2 * j, 2 * k + 1)
-                                              - (field(level, i, j, k) - qs_i + qs_j - qs_k + qs_ij - qs_ik + qs_jk + qs_ijk);
-                            detail(ranges[index],
-                                   ranges[index + 1],
-                                   level + 1,
-                                   2 * i,
-                                   2 * j + 1,
-                                   2 * k + 1) = field(level + 1, 2 * i, 2 * j + 1, 2 * k + 1)
-                                              - (field(level, i, j, k) + qs_i - qs_j - qs_k + qs_ij + qs_ik - qs_jk + qs_ijk);
+        template <class T, class U>
+        inline void operator()(Dim<2>, const U& detail, T& max_detail) const
+        {
+            auto ii       = 2 * i;
+            ii.step       = 1;
+            auto max_view = xt::view(max_detail, level + 1);
 
-                            detail(ranges[index],
-                                   ranges[index + 1],
-                                   level + 1,
-                                   2 * i + 1,
-                                   2 * j + 1,
-                                   2 * k + 1) = field(level + 1, 2 * i + 1, 2 * j + 1, 2 * k + 1)
-                                              - (field(level, i, j, k) - qs_i - qs_j - qs_k - qs_ij - qs_ik - qs_jk - qs_ijk);
-                        }
-                        else
-                        {
-                            detail(ranges[index], ranges[index + 1], level + 1, 2 * i, 2 * j, 2 * k) = xt::transpose(
-                                field(level + 1, 2 * i, 2 * j, 2 * k)
-                                - (field(level, i, j, k) + qs_i + qs_j + qs_k - qs_ij - qs_ik - qs_jk + qs_ijk));
+            max_view = xt::maximum(
+                max_view,
+                xt::amax(xt::maximum(xt::abs(detail(level + 1, ii, 2 * j)), xt::abs(detail(level + 1, ii, 2 * j + 1))), {0}));
+        }
 
-                            detail(ranges[index], ranges[index + 1], level + 1, 2 * i + 1, 2 * j, 2 * k) = xt::transpose(
-                                field(level + 1, 2 * i + 1, 2 * j, 2 * k)
-                                - (field(level, i, j, k) - qs_i + qs_j + qs_k + qs_ij + qs_ik - qs_jk - qs_ijk));
+        template <class T, class U>
+        inline void operator()(Dim<3>, const U& detail, T& max_detail) const
+        {
+            auto ii       = 2 * i;
+            ii.step       = 1;
+            auto max_view = xt::view(max_detail, level + 1);
 
-                            detail(ranges[index], ranges[index + 1], level + 1, 2 * i, 2 * j + 1, 2 * k) = xt::transpose(
-                                field(level + 1, 2 * i, 2 * j + 1, 2 * k)
-                                - (field(level, i, j, k) + qs_i - qs_j + qs_k + qs_ij - qs_ik + qs_jk - qs_ijk));
+            max_view = xt::maximum(max_view,
+                                   xt::amax(xt::maximum(xt::maximum(xt::abs(detail(level + 1, ii, 2 * j, 2 * k)),
+                                                                    xt::abs(detail(level + 1, ii, 2 * j + 1, 2 * k))),
+                                                        xt::maximum(xt::abs(detail(level + 1, ii, 2 * j, 2 * k + 1)),
+                                                                    xt::abs(detail(level + 1, ii, 2 * j + 1, 2 * k + 1)))),
+                                            {0}));
+        }
+    };
 
-                            detail(ranges[index], ranges[index + 1], level + 1, 2 * i + 1, 2 * j + 1, 2 * k) = xt::transpose(
-                                field(level + 1, 2 * i + 1, 2 * j + 1, 2 * k)
-                                - (field(level, i, j, k) - qs_i - qs_j + qs_k - qs_ij + qs_ik + qs_jk + qs_ijk));
+    template <class T, class U>
+    inline auto compute_max_detail(U&& detail, T&& max_detail)
+    {
+        return make_field_operator_function<compute_max_detail_op>(std::forward<U>(detail), std::forward<T>(max_detail));
+    }
 
-                            detail(ranges[index], ranges[index + 1], level + 1, 2 * i, 2 * j, 2 * k + 1) = xt::transpose(
-                                field(level + 1, 2 * i, 2 * j, 2 * k + 1)
-                                - (field(level, i, j, k) + qs_i + qs_j - qs_k - qs_ij + qs_ik + qs_jk - qs_ijk));
+    /*******************************
+     * compute max detail operator *
+     *******************************/
 
-                            detail(ranges[index], ranges[index + 1], level + 1, 2 * i + 1, 2 * j, 2 * k + 1) = xt::transpose(
-                                field(level + 1, 2 * i + 1, 2 * j, 2 * k + 1)
-                                - (field(level, i, j, k) - qs_i + qs_j - qs_k + qs_ij - qs_ik + qs_jk + qs_ijk));
-                            detail(ranges[index], ranges[index + 1], level + 1, 2 * i, 2 * j + 1, 2 * k + 1) = xt::transpose(
-                                field(level + 1, 2 * i, 2 * j + 1, 2 * k + 1)
-                                - (field(level, i, j, k) + qs_i - qs_j - qs_k + qs_ij + qs_ik - qs_jk + qs_ijk));
+    template <std::size_t dim, class TInterval>
+    class compute_max_detail_op_ : public field_operator_base<dim, TInterval>
+    {
+      public:
 
-                            detail(ranges[index], ranges[index + 1], level + 1, 2 * i + 1, 2 * j + 1, 2 * k + 1) = xt::transpose(
-                                field(level + 1, 2 * i + 1, 2 * j + 1, 2 * k + 1)
-                                - (field(level, i, j, k) - qs_i - qs_j - qs_k - qs_ij - qs_ik - qs_jk - qs_ijk));
-                        }
-                    }
+        INIT_OPERATOR(compute_max_detail_op_)
 
-                    template <std::size_t dim, class T1, class T2, std::size_t... Is>
-                    inline void compute_detail_impl(Dim<dim>, T1& detail, const T2& fields, std::index_sequence<Is...>) const
-                    {
-                        std::array<std::size_t, std::tuple_size_v<T2> + 1> ranges;
-                        ranges[0]         = 0;
-                        std::size_t index = 1;
-                        (
-                            [&]()
-                            {
-                                ranges[index] = ranges[index - 1] + std::get<Is>(fields).size;
-                                ++index;
-                            }(),
-                            ...);
-                        (compute_detail_impl(Dim<dim>(), Is, ranges, detail, std::get<Is>(fields)), ...);
-                    }
+        template <class T, class U>
+        inline void operator()(Dim<1>, const U& detail, T& max_detail) const
+        {
+            max_detail[level] = std::max(max_detail[level], xt::amax(xt::abs(detail(level, i)))[0]);
+        }
 
-                    template <std::size_t dim, class T1, class T2>
-                    inline void operator()(Dim<dim>, T1& detail, const T2& fields) const
-                    {
-                        compute_detail_impl(Dim<dim>(),
-                                            detail,
-                                            fields.elements(),
-                                            std::make_index_sequence<std::tuple_size_v<typename T2::tuple_type>>{});
-                    }
-                };
+        template <class T, class U>
+        inline void operator()(Dim<2>, const U& detail, T& max_detail) const
+        {
+            max_detail[level] = std::max(max_detail[level], xt::amax(xt::abs(detail(level, i, j)))[0]);
+        }
 
-                template <class Field, class... T>
-                inline auto compute_detail(Field & detail, const Field_tuple<T...>& fields)
+        template <class T, class U>
+        inline void operator()(Dim<3>, const U& detail, T& max_detail) const
+        {
+            max_detail[level] = std::max(max_detail[level], xt::amax(xt::abs(detail(level, i, j, k)))[0]);
+        }
+    };
+
+    template <class T, class U>
+    inline auto compute_max_detail_(U&& detail, T&& max_detail)
+    {
+        return make_field_operator_function<compute_max_detail_op_>(std::forward<U>(detail), std::forward<T>(max_detail));
+    }
+
+    /***********************
+     * to_coarsen operator *
+     ***********************/
+
+    template <std::size_t dim, class TInterval>
+    class to_coarsen_op : public field_operator_base<dim, TInterval>
+    {
+      public:
+
+        INIT_OPERATOR(to_coarsen_op)
+
+        template <class T, class U, class V>
+        inline void operator()(Dim<1>, T& keep, const U& detail, double eps) const
+        {
+            auto mask = xt::abs(detail(level + 1, 2 * i)) < eps;
+            // auto mask = (.5 *
+            //              (xt::abs(detail(level + 1, 2 * i)) +
+            //               xt::abs(detail(level + 1, 2 * i + 1))) /
+            //              max_detail[level + 1]) < eps;
+
+            for (coord_index_t ii = 0; ii < 2; ++ii)
+            {
+                xt::masked_view(keep(level + 1, 2 * i + ii), mask) = static_cast<int>(CellFlag::coarsen);
+            }
+        }
+
+        template <class T, class U, class V>
+        inline void operator()(Dim<2>, T& keep, const U& detail, double eps) const
+        {
+            auto mask = xt::abs(detail(level + 1, 2 * i, 2 * j)) < eps;
+
+            // auto mask = (0.25 *
+            //              (xt::abs(detail(level + 1, 2 * i, 2 * j)) +
+            //               xt::abs(detail(level + 1, 2 * i + 1, 2 * j)) +
+            //               xt::abs(detail(level + 1, 2 * i, 2 * j + 1)) +
+            //               xt::abs(detail(level + 1, 2 * i + 1, 2 * j + 1))) /
+            //              max_detail[level + 1]) < eps;
+
+            for (coord_index_t jj = 0; jj < 2; ++jj)
+            {
+                for (coord_index_t ii = 0; ii < 2; ++ii)
                 {
-                    return make_field_operator_function<compute_detail_on_tuple_op>(detail, fields);
+                    xt::masked_view(keep(level + 1, 2 * i + ii, 2 * j + jj), mask) = static_cast<int>(CellFlag::coarsen);
                 }
+            }
+        }
 
-                /*******************************
-                 * compute max detail operator *
-                 *******************************/
+        template <class T, class U, class V>
+        inline void operator()(Dim<3>, T& keep, const U& detail, double eps) const
+        {
+            auto mask = xt::abs(detail(level + 1, 2 * i, 2 * j, 2 * k)) < eps;
 
-                template <std::size_t dim, class TInterval>
-                class compute_max_detail_op : public field_operator_base<dim, TInterval>
+            for (coord_index_t kk = 0; kk < 2; ++kk)
+            {
+                for (coord_index_t jj = 0; jj < 2; ++jj)
                 {
-                  public:
-
-                    INIT_OPERATOR(compute_max_detail_op)
-
-                    template <class T, class U>
-                    inline void operator()(Dim<1>, const U& detail, T& max_detail) const
+                    for (coord_index_t ii = 0; ii < 2; ++ii)
                     {
-                        auto ii       = 2 * i;
-                        ii.step       = 1;
-                        auto max_view = xt::view(max_detail, level + 1);
-
-                        max_view = xt::maximum(max_view, xt::amax(xt::abs(detail(level + 1, ii)), {0}));
+                        xt::masked_view(keep(level + 1, 2 * i + ii, 2 * j + jj, 2 * k + kk), mask) = static_cast<int>(CellFlag::coarsen);
                     }
-
-                    template <class T, class U>
-                    inline void operator()(Dim<2>, const U& detail, T& max_detail) const
-                    {
-                        auto ii       = 2 * i;
-                        ii.step       = 1;
-                        auto max_view = xt::view(max_detail, level + 1);
-
-                        max_view = xt::maximum(
-                            max_view,
-                            xt::amax(xt::maximum(xt::abs(detail(level + 1, ii, 2 * j)), xt::abs(detail(level + 1, ii, 2 * j + 1))), {0}));
-                    }
-
-                    template <class T, class U>
-                    inline void operator()(Dim<3>, const U& detail, T& max_detail) const
-                    {
-                        auto ii       = 2 * i;
-                        ii.step       = 1;
-                        auto max_view = xt::view(max_detail, level + 1);
-
-                        max_view = xt::maximum(max_view,
-                                               xt::amax(xt::maximum(xt::maximum(xt::abs(detail(level + 1, ii, 2 * j, 2 * k)),
-                                                                                xt::abs(detail(level + 1, ii, 2 * j + 1, 2 * k))),
-                                                                    xt::maximum(xt::abs(detail(level + 1, ii, 2 * j, 2 * k + 1)),
-                                                                                xt::abs(detail(level + 1, ii, 2 * j + 1, 2 * k + 1)))),
-                                                        {0}));
-                    }
-                };
-
-                template <class T, class U>
-                inline auto compute_max_detail(U && detail, T && max_detail)
-                {
-                    return make_field_operator_function<compute_max_detail_op>(std::forward<U>(detail), std::forward<T>(max_detail));
                 }
+            }
+        }
+    };
 
-                /*******************************
-                 * compute max detail operator *
-                 *******************************/
+    template <class... CT>
+    inline auto to_coarsen(CT&&... e)
+    {
+        return make_field_operator_function<to_coarsen_op>(std::forward<CT>(e)...);
+    }
 
-                template <std::size_t dim, class TInterval>
-                class compute_max_detail_op_ : public field_operator_base<dim, TInterval>
+    /*************************
+     * refine_ghost operator *
+     *************************/
+
+    template <std::size_t dim, class TInterval>
+    class refine_ghost_op : public field_operator_base<dim, TInterval>
+    {
+      public:
+
+        INIT_OPERATOR(refine_ghost_op)
+
+        template <class T>
+        inline void operator()(Dim<1>, T& flag) const
+        {
+            auto mask                                 = flag(level + 1, i) & static_cast<int>(CellFlag::keep);
+            xt::masked_view(flag(level, i / 2), mask) = static_cast<int>(CellFlag::refine);
+        }
+
+        template <class T>
+        inline void operator()(Dim<2>, T& flag) const
+        {
+            auto mask                                        = flag(level + 1, i, j) & static_cast<int>(CellFlag::keep);
+            xt::masked_view(flag(level, i / 2, j / 2), mask) = static_cast<int>(CellFlag::refine);
+        }
+
+        template <class T>
+        inline void operator()(Dim<3>, T& flag) const
+        {
+            auto mask                                               = flag(level + 1, i, j, k) & static_cast<int>(CellFlag::keep);
+            xt::masked_view(flag(level, i / 2, j / 2, k / 2), mask) = static_cast<int>(CellFlag::refine);
+        }
+    };
+
+    template <class... CT>
+    inline auto refine_ghost(CT&&... e)
+    {
+        return make_field_operator_function<refine_ghost_op>(std::forward<CT>(e)...);
+    }
+
+    /********************
+     * enlarge operator *
+     ********************/
+
+    template <std::size_t dim, class TInterval>
+    class enlarge_op : public field_operator_base<dim, TInterval>
+    {
+      public:
+
+        INIT_OPERATOR(enlarge_op)
+
+        template <class T>
+        inline void operator()(Dim<1>, T& cell_flag) const
+        {
+            auto keep_mask = cell_flag(level, i) & static_cast<int>(CellFlag::keep);
+
+            for (int ii = -1; ii < 2; ++ii)
+            {
+                xt::masked_view(cell_flag(level, i + ii), keep_mask) |= static_cast<int>(CellFlag::enlarge);
+            }
+        }
+
+        template <class T>
+        inline void operator()(Dim<2>, T& cell_flag) const
+        {
+            auto keep_mask = cell_flag(level, i, j) & static_cast<int>(CellFlag::keep);
+
+            for (int jj = -1; jj < 2; ++jj)
+            {
+                for (int ii = -1; ii < 2; ++ii)
                 {
-                  public:
-
-                    INIT_OPERATOR(compute_max_detail_op_)
-
-                    template <class T, class U>
-                    inline void operator()(Dim<1>, const U& detail, T& max_detail) const
-                    {
-                        max_detail[level] = std::max(max_detail[level], xt::amax(xt::abs(detail(level, i)))[0]);
-                    }
-
-                    template <class T, class U>
-                    inline void operator()(Dim<2>, const U& detail, T& max_detail) const
-                    {
-                        max_detail[level] = std::max(max_detail[level], xt::amax(xt::abs(detail(level, i, j)))[0]);
-                    }
-
-                    template <class T, class U>
-                    inline void operator()(Dim<3>, const U& detail, T& max_detail) const
-                    {
-                        max_detail[level] = std::max(max_detail[level], xt::amax(xt::abs(detail(level, i, j, k)))[0]);
-                    }
-                };
-
-                template <class T, class U>
-                inline auto compute_max_detail_(U && detail, T && max_detail)
-                {
-                    return make_field_operator_function<compute_max_detail_op_>(std::forward<U>(detail), std::forward<T>(max_detail));
+                    xt::masked_view(cell_flag(level, i + ii, j + jj), keep_mask) |= static_cast<int>(CellFlag::enlarge);
                 }
+            }
+        }
 
-                /***********************
-                 * to_coarsen operator *
-                 ***********************/
+        template <class T>
+        inline void operator()(Dim<3>, T& cell_flag) const
+        {
+            auto keep_mask = cell_flag(level, i, j, k) & static_cast<int>(CellFlag::keep);
 
-                template <std::size_t dim, class TInterval>
-                class to_coarsen_op : public field_operator_base<dim, TInterval>
+            for (int kk = -1; kk < 2; ++kk)
+            {
+                for (int jj = -1; jj < 2; ++jj)
                 {
-                  public:
-
-                    INIT_OPERATOR(to_coarsen_op)
-
-                    template <class T, class U, class V>
-                    inline void operator()(Dim<1>, T& keep, const U& detail, double eps) const
+                    for (int ii = -1; ii < 2; ++ii)
                     {
-                        auto mask = xt::abs(detail(level + 1, 2 * i)) < eps;
-                        // auto mask = (.5 *
-                        //              (xt::abs(detail(level + 1, 2 * i)) +
-                        //               xt::abs(detail(level + 1, 2 * i + 1))) /
-                        //              max_detail[level + 1]) < eps;
-
-                        for (coord_index_t ii = 0; ii < 2; ++ii)
-                        {
-                            xt::masked_view(keep(level + 1, 2 * i + ii), mask) = static_cast<int>(CellFlag::coarsen);
-                        }
+                        xt::masked_view(cell_flag(level, i + ii, j + jj, k + kk), keep_mask) |= static_cast<int>(CellFlag::enlarge);
                     }
-
-                    template <class T, class U, class V>
-                    inline void operator()(Dim<2>, T& keep, const U& detail, double eps) const
-                    {
-                        auto mask = xt::abs(detail(level + 1, 2 * i, 2 * j)) < eps;
-
-                        // auto mask = (0.25 *
-                        //              (xt::abs(detail(level + 1, 2 * i, 2 * j)) +
-                        //               xt::abs(detail(level + 1, 2 * i + 1, 2 * j)) +
-                        //               xt::abs(detail(level + 1, 2 * i, 2 * j + 1)) +
-                        //               xt::abs(detail(level + 1, 2 * i + 1, 2 * j + 1))) /
-                        //              max_detail[level + 1]) < eps;
-
-                        for (coord_index_t jj = 0; jj < 2; ++jj)
-                        {
-                            for (coord_index_t ii = 0; ii < 2; ++ii)
-                            {
-                                xt::masked_view(keep(level + 1, 2 * i + ii, 2 * j + jj), mask) = static_cast<int>(CellFlag::coarsen);
-                            }
-                        }
-                    }
-
-                    template <class T, class U, class V>
-                    inline void operator()(Dim<3>, T& keep, const U& detail, double eps) const
-                    {
-                        auto mask = xt::abs(detail(level + 1, 2 * i, 2 * j, 2 * k)) < eps;
-
-                        for (coord_index_t kk = 0; kk < 2; ++kk)
-                        {
-                            for (coord_index_t jj = 0; jj < 2; ++jj)
-                            {
-                                for (coord_index_t ii = 0; ii < 2; ++ii)
-                                {
-                                    xt::masked_view(keep(level + 1, 2 * i + ii, 2 * j + jj, 2 * k + kk),
-                                                    mask) = static_cast<int>(CellFlag::coarsen);
-                                }
-                            }
-                        }
-                    }
-                };
-
-                template <class... CT>
-                inline auto to_coarsen(CT && ... e)
-                {
-                    return make_field_operator_function<to_coarsen_op>(std::forward<CT>(e)...);
                 }
+            }
+        }
+    };
 
-                /*************************
-                 * refine_ghost operator *
-                 *************************/
+    template <class... CT>
+    inline auto enlarge(CT&&... e)
+    {
+        return make_field_operator_function<enlarge_op>(std::forward<CT>(e)...);
+    }
 
-                template <std::size_t dim, class TInterval>
-                class refine_ghost_op : public field_operator_base<dim, TInterval>
+    /*******************************
+     * keep_around_refine operator *
+     *******************************/
+
+    template <std::size_t dim, class TInterval>
+    class keep_around_refine_op : public field_operator_base<dim, TInterval>
+    {
+      public:
+
+        INIT_OPERATOR(keep_around_refine_op)
+
+        template <class T>
+        inline void operator()(Dim<1>, T& cell_flag) const
+        {
+            auto refine_mask = cell_flag(level, i) & static_cast<int>(CellFlag::refine);
+
+            for (int ii = -1; ii < 2; ++ii)
+            {
+                xt::masked_view(cell_flag(level, i + ii), refine_mask) |= static_cast<int>(CellFlag::keep);
+            }
+        }
+
+        template <class T>
+        inline void operator()(Dim<2>, T& cell_flag) const
+        {
+            auto refine_mask = cell_flag(level, i, j) & static_cast<int>(CellFlag::refine);
+
+            for (int jj = -1; jj < 2; ++jj)
+            {
+                for (int ii = -1; ii < 2; ++ii)
                 {
-                  public:
-
-                    INIT_OPERATOR(refine_ghost_op)
-
-                    template <class T>
-                    inline void operator()(Dim<1>, T& flag) const
-                    {
-                        auto mask                                 = flag(level + 1, i) & static_cast<int>(CellFlag::keep);
-                        xt::masked_view(flag(level, i / 2), mask) = static_cast<int>(CellFlag::refine);
-                    }
-
-                    template <class T>
-                    inline void operator()(Dim<2>, T& flag) const
-                    {
-                        auto mask                                        = flag(level + 1, i, j) & static_cast<int>(CellFlag::keep);
-                        xt::masked_view(flag(level, i / 2, j / 2), mask) = static_cast<int>(CellFlag::refine);
-                    }
-
-                    template <class T>
-                    inline void operator()(Dim<3>, T& flag) const
-                    {
-                        auto mask = flag(level + 1, i, j, k) & static_cast<int>(CellFlag::keep);
-                        xt::masked_view(flag(level, i / 2, j / 2, k / 2), mask) = static_cast<int>(CellFlag::refine);
-                    }
-                };
-
-                template <class... CT>
-                inline auto refine_ghost(CT && ... e)
-                {
-                    return make_field_operator_function<refine_ghost_op>(std::forward<CT>(e)...);
+                    xt::masked_view(cell_flag(level, i + ii, j + jj), refine_mask) |= static_cast<int>(CellFlag::keep);
                 }
+            }
+        }
 
-                /********************
-                 * enlarge operator *
-                 ********************/
+        template <class T>
+        inline void operator()(Dim<3>, T& cell_flag) const
+        {
+            auto refine_mask = cell_flag(level, i, j, k) & static_cast<int>(CellFlag::refine);
 
-                template <std::size_t dim, class TInterval>
-                class enlarge_op : public field_operator_base<dim, TInterval>
+            for (int kk = -1; kk < 2; ++kk)
+            {
+                for (int jj = -1; jj < 2; ++jj)
                 {
-                  public:
-
-                    INIT_OPERATOR(enlarge_op)
-
-                    template <class T>
-                    inline void operator()(Dim<1>, T& cell_flag) const
+                    for (int ii = -1; ii < 2; ++ii)
                     {
-                        auto keep_mask = cell_flag(level, i) & static_cast<int>(CellFlag::keep);
-
-                        for (int ii = -1; ii < 2; ++ii)
-                        {
-                            xt::masked_view(cell_flag(level, i + ii), keep_mask) |= static_cast<int>(CellFlag::enlarge);
-                        }
+                        xt::masked_view(cell_flag(level, i + ii, j + jj, k + kk), refine_mask) |= static_cast<int>(CellFlag::keep);
                     }
-
-                    template <class T>
-                    inline void operator()(Dim<2>, T& cell_flag) const
-                    {
-                        auto keep_mask = cell_flag(level, i, j) & static_cast<int>(CellFlag::keep);
-
-                        for (int jj = -1; jj < 2; ++jj)
-                        {
-                            for (int ii = -1; ii < 2; ++ii)
-                            {
-                                xt::masked_view(cell_flag(level, i + ii, j + jj), keep_mask) |= static_cast<int>(CellFlag::enlarge);
-                            }
-                        }
-                    }
-
-                    template <class T>
-                    inline void operator()(Dim<3>, T& cell_flag) const
-                    {
-                        auto keep_mask = cell_flag(level, i, j, k) & static_cast<int>(CellFlag::keep);
-
-                        for (int kk = -1; kk < 2; ++kk)
-                        {
-                            for (int jj = -1; jj < 2; ++jj)
-                            {
-                                for (int ii = -1; ii < 2; ++ii)
-                                {
-                                    xt::masked_view(cell_flag(level, i + ii, j + jj, k + kk),
-                                                    keep_mask) |= static_cast<int>(CellFlag::enlarge);
-                                }
-                            }
-                        }
-                    }
-                };
-
-                template <class... CT>
-                inline auto enlarge(CT && ... e)
-                {
-                    return make_field_operator_function<enlarge_op>(std::forward<CT>(e)...);
                 }
+            }
+        }
+    };
 
-                /*******************************
-                 * keep_around_refine operator *
-                 *******************************/
+    template <class... CT>
+    inline auto keep_around_refine(CT&&... e)
+    {
+        return make_field_operator_function<keep_around_refine_op>(std::forward<CT>(e)...);
+    }
 
-                template <std::size_t dim, class TInterval>
-                class keep_around_refine_op : public field_operator_base<dim, TInterval>
+    /***********************
+     * apply_expr operator *
+     ***********************/
+
+    template <std::size_t dim, class TInterval>
+    class apply_expr_op : public field_operator_base<dim, TInterval>
+    {
+      public:
+
+        INIT_OPERATOR(apply_expr_op)
+
+        template <class T, class E>
+        inline void operator()(Dim<1>, T& field, const field_expression<E>& e) const
+        {
+            field(level, i) = e.derived_cast()(level, i);
+        }
+
+        template <class T, class E>
+        inline void operator()(Dim<2>, T& field, const field_expression<E>& e) const
+        {
+            field(level, i, j) = e.derived_cast()(level, i, j);
+        }
+
+        template <class T, class E>
+        inline void operator()(Dim<3>, T& field, const field_expression<E>& e) const
+        {
+            field(level, i, j, k) = e.derived_cast()(level, i, j, k);
+        }
+    };
+
+    template <class... CT>
+    inline auto apply_expr(CT&&... e)
+    {
+        return make_field_operator_function<apply_expr_op>(std::forward<CT>(e)...);
+    }
+
+    /*******************
+     * extend operator *
+     *******************/
+    template <std::size_t dim, class TInterval>
+    class extend_op : public field_operator_base<dim, TInterval>
+    {
+      public:
+
+        INIT_OPERATOR(extend_op)
+
+        template <class T>
+        inline void operator()(Dim<1>, T& tag) const
+        {
+            auto refine_mask = tag(level, i) & static_cast<int>(samurai::CellFlag::refine);
+
+            const int added_cells = 1; // 1 by default
+
+            for (int ii = -added_cells; ii < added_cells + 1; ++ii)
+            {
+                xt::masked_view(tag(level, i + ii), refine_mask) |= static_cast<int>(samurai::CellFlag::keep);
+            }
+        }
+
+        template <class T>
+        inline void operator()(Dim<2>, T& tag) const
+        {
+            auto refine_mask = tag(level, i, j) & static_cast<int>(samurai::CellFlag::refine);
+
+            for (int jj = -1; jj < 2; ++jj)
+            {
+                for (int ii = -1; ii < 2; ++ii)
                 {
-                  public:
-
-                    INIT_OPERATOR(keep_around_refine_op)
-
-                    template <class T>
-                    inline void operator()(Dim<1>, T& cell_flag) const
-                    {
-                        auto refine_mask = cell_flag(level, i) & static_cast<int>(CellFlag::refine);
-
-                        for (int ii = -1; ii < 2; ++ii)
-                        {
-                            xt::masked_view(cell_flag(level, i + ii), refine_mask) |= static_cast<int>(CellFlag::keep);
-                        }
-                    }
-
-                    template <class T>
-                    inline void operator()(Dim<2>, T& cell_flag) const
-                    {
-                        auto refine_mask = cell_flag(level, i, j) & static_cast<int>(CellFlag::refine);
-
-                        for (int jj = -1; jj < 2; ++jj)
-                        {
-                            for (int ii = -1; ii < 2; ++ii)
-                            {
-                                xt::masked_view(cell_flag(level, i + ii, j + jj), refine_mask) |= static_cast<int>(CellFlag::keep);
-                            }
-                        }
-                    }
-
-                    template <class T>
-                    inline void operator()(Dim<3>, T& cell_flag) const
-                    {
-                        auto refine_mask = cell_flag(level, i, j, k) & static_cast<int>(CellFlag::refine);
-
-                        for (int kk = -1; kk < 2; ++kk)
-                        {
-                            for (int jj = -1; jj < 2; ++jj)
-                            {
-                                for (int ii = -1; ii < 2; ++ii)
-                                {
-                                    xt::masked_view(cell_flag(level, i + ii, j + jj, k + kk),
-                                                    refine_mask) |= static_cast<int>(CellFlag::keep);
-                                }
-                            }
-                        }
-                    }
-                };
-
-                template <class... CT>
-                inline auto keep_around_refine(CT && ... e)
-                {
-                    return make_field_operator_function<keep_around_refine_op>(std::forward<CT>(e)...);
+                    xt::masked_view(tag(level, i + ii, j + jj), refine_mask) |= static_cast<int>(samurai::CellFlag::keep);
                 }
+            }
+        }
 
-                /***********************
-                 * apply_expr operator *
-                 ***********************/
+        template <class T>
+        inline void operator()(Dim<3>, T& tag) const
+        {
+            auto refine_mask = tag(level, i, j, k) & static_cast<int>(samurai::CellFlag::refine);
 
-                template <std::size_t dim, class TInterval>
-                class apply_expr_op : public field_operator_base<dim, TInterval>
+            for (int kk = -1; kk < 2; ++kk)
+            {
+                for (int jj = -1; jj < 2; ++jj)
                 {
-                  public:
-
-                    INIT_OPERATOR(apply_expr_op)
-
-                    template <class T, class E>
-                    inline void operator()(Dim<1>, T& field, const field_expression<E>& e) const
+                    for (int ii = -1; ii < 2; ++ii)
                     {
-                        field(level, i) = e.derived_cast()(level, i);
+                        xt::masked_view(tag(level, i + ii, j + jj, k + kk), refine_mask) |= static_cast<int>(samurai::CellFlag::keep);
                     }
-
-                    template <class T, class E>
-                    inline void operator()(Dim<2>, T& field, const field_expression<E>& e) const
-                    {
-                        field(level, i, j) = e.derived_cast()(level, i, j);
-                    }
-
-                    template <class T, class E>
-                    inline void operator()(Dim<3>, T& field, const field_expression<E>& e) const
-                    {
-                        field(level, i, j, k) = e.derived_cast()(level, i, j, k);
-                    }
-                };
-
-                template <class... CT>
-                inline auto apply_expr(CT && ... e)
-                {
-                    return make_field_operator_function<apply_expr_op>(std::forward<CT>(e)...);
                 }
+            }
+        }
+    };
 
-                /*******************
-                 * extend operator *
-                 *******************/
-                template <std::size_t dim, class TInterval>
-                class extend_op : public field_operator_base<dim, TInterval>
-                {
-                  public:
+    template <class... CT>
+    inline auto extend(CT&&... e)
+    {
+        return make_field_operator_function<extend_op>(std::forward<CT>(e)...);
+    }
 
-                    INIT_OPERATOR(extend_op)
+    /****************************
+     * make_graduation operator *
+     ****************************/
 
-                    template <class T>
-                    inline void operator()(Dim<1>, T& tag) const
-                    {
-                        auto refine_mask = tag(level, i) & static_cast<int>(samurai::CellFlag::refine);
+    template <std::size_t dim, class TInterval>
+    class make_graduation_op : public field_operator_base<dim, TInterval>
+    {
+      public:
 
-                        const int added_cells = 1; // 1 by default
+        INIT_OPERATOR(make_graduation_op)
 
-                        for (int ii = -added_cells; ii < added_cells + 1; ++ii)
-                        {
-                            xt::masked_view(tag(level, i + ii), refine_mask) |= static_cast<int>(samurai::CellFlag::keep);
-                        }
-                    }
+        template <class T>
+        inline void operator()(Dim<1>, T& tag) const
+        {
+            auto i_even = i.even_elements();
+            if (i_even.is_valid())
+            {
+                auto mask = tag(level, i_even) & static_cast<int>(CellFlag::keep);
+                xt::masked_view(tag(level - 1, i_even >> 1), mask) |= static_cast<int>(CellFlag::refine);
+            }
 
-                    template <class T>
-                    inline void operator()(Dim<2>, T& tag) const
-                    {
-                        auto refine_mask = tag(level, i, j) & static_cast<int>(samurai::CellFlag::refine);
+            auto i_odd = i.odd_elements();
+            if (i_odd.is_valid())
+            {
+                auto mask = tag(level, i_odd) & static_cast<int>(CellFlag::keep);
+                xt::masked_view(tag(level - 1, i_odd >> 1), mask) |= static_cast<int>(CellFlag::refine);
+            }
+        }
 
-                        for (int jj = -1; jj < 2; ++jj)
-                        {
-                            for (int ii = -1; ii < 2; ++ii)
-                            {
-                                xt::masked_view(tag(level, i + ii, j + jj), refine_mask) |= static_cast<int>(samurai::CellFlag::keep);
-                            }
-                        }
-                    }
+        template <class T>
+        inline void operator()(Dim<2>, T& tag) const
+        {
+            auto i_even = i.even_elements();
+            if (i_even.is_valid())
+            {
+                auto mask = tag(level, i_even, j) & static_cast<int>(CellFlag::keep);
+                xt::masked_view(tag(level - 1, i_even >> 1, j >> 1), mask) |= static_cast<int>(CellFlag::refine);
+            }
 
-                    template <class T>
-                    inline void operator()(Dim<3>, T& tag) const
-                    {
-                        auto refine_mask = tag(level, i, j, k) & static_cast<int>(samurai::CellFlag::refine);
+            auto i_odd = i.odd_elements();
+            if (i_odd.is_valid())
+            {
+                auto mask = tag(level, i_odd, j) & static_cast<int>(CellFlag::keep);
+                xt::masked_view(tag(level - 1, i_odd >> 1, j >> 1), mask) |= static_cast<int>(CellFlag::refine);
+            }
+        }
 
-                        for (int kk = -1; kk < 2; ++kk)
-                        {
-                            for (int jj = -1; jj < 2; ++jj)
-                            {
-                                for (int ii = -1; ii < 2; ++ii)
-                                {
-                                    xt::masked_view(tag(level, i + ii, j + jj, k + kk),
-                                                    refine_mask) |= static_cast<int>(samurai::CellFlag::keep);
-                                }
-                            }
-                        }
-                    }
-                };
+        template <class T>
+        inline void operator()(Dim<3>, T& tag) const
+        {
+            auto i_even = i.even_elements();
+            if (i_even.is_valid())
+            {
+                auto mask = tag(level, i_even, j, k) & static_cast<int>(CellFlag::keep);
+                xt::masked_view(tag(level - 1, i_even >> 1, j >> 1, k >> 1), mask) |= static_cast<int>(CellFlag::refine);
+            }
 
-                template <class... CT>
-                inline auto extend(CT && ... e)
-                {
-                    return make_field_operator_function<extend_op>(std::forward<CT>(e)...);
-                }
+            auto i_odd = i.odd_elements();
+            if (i_odd.is_valid())
+            {
+                auto mask = tag(level, i_odd, j, k) & static_cast<int>(CellFlag::keep);
+                xt::masked_view(tag(level - 1, i_odd >> 1, j >> 1, k >> 1), mask) |= static_cast<int>(CellFlag::refine);
+            }
+        }
+    };
 
-                /****************************
-                 * make_graduation operator *
-                 ****************************/
-
-                template <std::size_t dim, class TInterval>
-                class make_graduation_op : public field_operator_base<dim, TInterval>
-                {
-                  public:
-
-                    INIT_OPERATOR(make_graduation_op)
-
-                    template <class T>
-                    inline void operator()(Dim<1>, T& tag) const
-                    {
-                        auto i_even = i.even_elements();
-                        if (i_even.is_valid())
-                        {
-                            auto mask = tag(level, i_even) & static_cast<int>(CellFlag::keep);
-                            xt::masked_view(tag(level - 1, i_even >> 1), mask) |= static_cast<int>(CellFlag::refine);
-                        }
-
-                        auto i_odd = i.odd_elements();
-                        if (i_odd.is_valid())
-                        {
-                            auto mask = tag(level, i_odd) & static_cast<int>(CellFlag::keep);
-                            xt::masked_view(tag(level - 1, i_odd >> 1), mask) |= static_cast<int>(CellFlag::refine);
-                        }
-                    }
-
-                    template <class T>
-                    inline void operator()(Dim<2>, T& tag) const
-                    {
-                        auto i_even = i.even_elements();
-                        if (i_even.is_valid())
-                        {
-                            auto mask = tag(level, i_even, j) & static_cast<int>(CellFlag::keep);
-                            xt::masked_view(tag(level - 1, i_even >> 1, j >> 1), mask) |= static_cast<int>(CellFlag::refine);
-                        }
-
-                        auto i_odd = i.odd_elements();
-                        if (i_odd.is_valid())
-                        {
-                            auto mask = tag(level, i_odd, j) & static_cast<int>(CellFlag::keep);
-                            xt::masked_view(tag(level - 1, i_odd >> 1, j >> 1), mask) |= static_cast<int>(CellFlag::refine);
-                        }
-                    }
-
-                    template <class T>
-                    inline void operator()(Dim<3>, T& tag) const
-                    {
-                        auto i_even = i.even_elements();
-                        if (i_even.is_valid())
-                        {
-                            auto mask = tag(level, i_even, j, k) & static_cast<int>(CellFlag::keep);
-                            xt::masked_view(tag(level - 1, i_even >> 1, j >> 1, k >> 1), mask) |= static_cast<int>(CellFlag::refine);
-                        }
-
-                        auto i_odd = i.odd_elements();
-                        if (i_odd.is_valid())
-                        {
-                            auto mask = tag(level, i_odd, j, k) & static_cast<int>(CellFlag::keep);
-                            xt::masked_view(tag(level - 1, i_odd >> 1, j >> 1, k >> 1), mask) |= static_cast<int>(CellFlag::refine);
-                        }
-                    }
-                };
-
-                template <class... CT>
-                inline auto make_graduation(CT && ... e)
-                {
-                    return make_field_operator_function<make_graduation_op>(std::forward<CT>(e)...);
-                }
-            } // namespace samurai
+    template <class... CT>
+    inline auto make_graduation(CT&&... e)
+    {
+        return make_field_operator_function<make_graduation_op>(std::forward<CT>(e)...);
+    }
+} // namespace samurai

--- a/include/samurai/mr/operators.hpp
+++ b/include/samurai/mr/operators.hpp
@@ -19,8 +19,8 @@ namespace samurai
      * maximum operator *
      ********************/
 
-    template <class TInterval>
-    class maximum_op : public field_operator_base<TInterval>
+    template <std::size_t dim, class TInterval>
+    class maximum_op : public field_operator_base<dim, TInterval>
     {
       public:
 
@@ -126,8 +126,8 @@ namespace samurai
      * balance_2to1 operator *
      ****************$$$$$$$$*/
 
-    template <class TInterval>
-    class balance_2to1_op : public field_operator_base<TInterval>
+    template <std::size_t dim, class TInterval>
+    class balance_2to1_op : public field_operator_base<dim, TInterval>
     {
       public:
 
@@ -163,8 +163,8 @@ namespace samurai
      * compute detail operator *
      ***************************/
 
-    template <class TInterval>
-    class compute_detail_op : public field_operator_base<TInterval>
+    template <std::size_t dim, class TInterval>
+    class compute_detail_op : public field_operator_base<dim, TInterval>
     {
       public:
 
@@ -439,8 +439,8 @@ namespace samurai
      * compute max detail operator *
      *******************************/
 
-    template <class TInterval>
-    class compute_max_detail_op : public field_operator_base<TInterval>
+    template <std::size_t dim, class TInterval>
+    class compute_max_detail_op : public field_operator_base<dim, TInterval>
     {
       public:
 
@@ -494,8 +494,8 @@ namespace samurai
      * compute max detail operator *
      *******************************/
 
-    template <class TInterval>
-    class compute_max_detail_op_ : public field_operator_base<TInterval>
+    template <std::size_t dim, class TInterval>
+    class compute_max_detail_op_ : public field_operator_base<dim, TInterval>
     {
       public:
 
@@ -530,8 +530,8 @@ namespace samurai
      * to_coarsen operator *
      ***********************/
 
-    template <class TInterval>
-    class to_coarsen_op : public field_operator_base<TInterval>
+    template <std::size_t dim, class TInterval>
+    class to_coarsen_op : public field_operator_base<dim, TInterval>
     {
       public:
 
@@ -601,8 +601,8 @@ namespace samurai
      * refine_ghost operator *
      *************************/
 
-    template <class TInterval>
-    class refine_ghost_op : public field_operator_base<TInterval>
+    template <std::size_t dim, class TInterval>
+    class refine_ghost_op : public field_operator_base<dim, TInterval>
     {
       public:
 
@@ -640,8 +640,8 @@ namespace samurai
      * enlarge operator *
      ********************/
 
-    template <class TInterval>
-    class enlarge_op : public field_operator_base<TInterval>
+    template <std::size_t dim, class TInterval>
+    class enlarge_op : public field_operator_base<dim, TInterval>
     {
       public:
 
@@ -700,8 +700,8 @@ namespace samurai
      * keep_around_refine operator *
      *******************************/
 
-    template <class TInterval>
-    class keep_around_refine_op : public field_operator_base<TInterval>
+    template <std::size_t dim, class TInterval>
+    class keep_around_refine_op : public field_operator_base<dim, TInterval>
     {
       public:
 
@@ -760,8 +760,8 @@ namespace samurai
      * apply_expr operator *
      ***********************/
 
-    template <class TInterval>
-    class apply_expr_op : public field_operator_base<TInterval>
+    template <std::size_t dim, class TInterval>
+    class apply_expr_op : public field_operator_base<dim, TInterval>
     {
       public:
 
@@ -795,8 +795,8 @@ namespace samurai
     /*******************
      * extend operator *
      *******************/
-    template <class TInterval>
-    class extend_op : public field_operator_base<TInterval>
+    template <std::size_t dim, class TInterval>
+    class extend_op : public field_operator_base<dim, TInterval>
     {
       public:
 
@@ -857,8 +857,8 @@ namespace samurai
      * make_graduation operator *
      ****************************/
 
-    template <class TInterval>
-    class make_graduation_op : public field_operator_base<TInterval>
+    template <std::size_t dim, class TInterval>
+    class make_graduation_op : public field_operator_base<dim, TInterval>
     {
       public:
 

--- a/include/samurai/numeric/prediction.hpp
+++ b/include/samurai/numeric/prediction.hpp
@@ -313,8 +313,8 @@ namespace samurai
     // prediction operator //
     /////////////////////////
 
-    template <class TInterval>
-    class prediction_op : public field_operator_base<TInterval>
+    template <std::size_t dim, class TInterval>
+    class prediction_op : public field_operator_base<dim, TInterval>
     {
       public:
 
@@ -363,13 +363,13 @@ namespace samurai
         operator()(Dim<3>, T1& dest, const T2& src, std::integral_constant<std::size_t, order>, std::integral_constant<bool, false>) const;
     };
 
-    template <class TInterval>
+    template <std::size_t dim, class TInterval>
     template <class T1, class T2>
-    inline void prediction_op<TInterval>::operator()(Dim<1>,
-                                                     T1& dest,
-                                                     const T2& src,
-                                                     std::integral_constant<std::size_t, 0>,
-                                                     std::integral_constant<bool, true>) const
+    inline void prediction_op<dim, TInterval>::operator()(Dim<1>,
+                                                          T1& dest,
+                                                          const T2& src,
+                                                          std::integral_constant<std::size_t, 0>,
+                                                          std::integral_constant<bool, true>) const
     {
         auto ii = i << 1;
         ii.step = 2;
@@ -378,13 +378,13 @@ namespace samurai
         dest(level + 1, ii + 1) = src(level, i);
     }
 
-    template <class TInterval>
+    template <std::size_t dim, class TInterval>
     template <class T1, class T2>
-    inline void prediction_op<TInterval>::operator()(Dim<1>,
-                                                     T1& dest,
-                                                     const T2& src,
-                                                     std::integral_constant<std::size_t, 0>,
-                                                     std::integral_constant<bool, false>) const
+    inline void prediction_op<dim, TInterval>::operator()(Dim<1>,
+                                                          T1& dest,
+                                                          const T2& src,
+                                                          std::integral_constant<std::size_t, 0>,
+                                                          std::integral_constant<bool, false>) const
     {
         auto even_i = i.even_elements();
         if (even_i.is_valid())
@@ -401,13 +401,13 @@ namespace samurai
         }
     }
 
-    template <class TInterval>
+    template <std::size_t dim, class TInterval>
     template <class T1, class T2, std::size_t order>
-    inline void prediction_op<TInterval>::operator()(Dim<1>,
-                                                     T1& dest,
-                                                     const T2& src,
-                                                     std::integral_constant<std::size_t, order>,
-                                                     std::integral_constant<bool, true>) const
+    inline void prediction_op<dim, TInterval>::operator()(Dim<1>,
+                                                          T1& dest,
+                                                          const T2& src,
+                                                          std::integral_constant<std::size_t, order>,
+                                                          std::integral_constant<bool, true>) const
     {
         auto ii = i << 1;
         ii.step = 2;
@@ -418,13 +418,13 @@ namespace samurai
         dest(level + 1, ii + 1) = src(level, i) - qs_i;
     }
 
-    template <class TInterval>
+    template <std::size_t dim, class TInterval>
     template <class T1, class T2, std::size_t order>
-    inline void prediction_op<TInterval>::operator()(Dim<1>,
-                                                     T1& dest,
-                                                     const T2& src,
-                                                     std::integral_constant<std::size_t, order>,
-                                                     std::integral_constant<bool, false>) const
+    inline void prediction_op<dim, TInterval>::operator()(Dim<1>,
+                                                          T1& dest,
+                                                          const T2& src,
+                                                          std::integral_constant<std::size_t, order>,
+                                                          std::integral_constant<bool, false>) const
     {
         auto qs_i = Qs_i<order>(src, level - 1, i >> 1);
 
@@ -445,13 +445,13 @@ namespace samurai
         }
     }
 
-    template <class TInterval>
+    template <std::size_t dim, class TInterval>
     template <class T1, class T2>
-    inline void prediction_op<TInterval>::operator()(Dim<2>,
-                                                     T1& dest,
-                                                     const T2& src,
-                                                     std::integral_constant<std::size_t, 0>,
-                                                     std::integral_constant<bool, true>) const
+    inline void prediction_op<dim, TInterval>::operator()(Dim<2>,
+                                                          T1& dest,
+                                                          const T2& src,
+                                                          std::integral_constant<std::size_t, 0>,
+                                                          std::integral_constant<bool, true>) const
     {
         auto ii = i << 1;
         ii.step = 2;
@@ -464,13 +464,13 @@ namespace samurai
         dest(level + 1, ii + 1, jj + 1) = src(level, i, j);
     }
 
-    template <class TInterval>
+    template <std::size_t dim, class TInterval>
     template <class T1, class T2>
-    inline void prediction_op<TInterval>::operator()(Dim<2>,
-                                                     T1& dest,
-                                                     const T2& src,
-                                                     std::integral_constant<std::size_t, 0>,
-                                                     std::integral_constant<bool, false>) const
+    inline void prediction_op<dim, TInterval>::operator()(Dim<2>,
+                                                          T1& dest,
+                                                          const T2& src,
+                                                          std::integral_constant<std::size_t, 0>,
+                                                          std::integral_constant<bool, false>) const
     {
         if (j & 1)
         {
@@ -506,13 +506,13 @@ namespace samurai
         }
     }
 
-    template <class TInterval>
+    template <std::size_t dim, class TInterval>
     template <class T1, class T2, std::size_t order>
-    inline void prediction_op<TInterval>::operator()(Dim<2>,
-                                                     T1& dest,
-                                                     const T2& src,
-                                                     std::integral_constant<std::size_t, order>,
-                                                     std::integral_constant<bool, true>) const
+    inline void prediction_op<dim, TInterval>::operator()(Dim<2>,
+                                                          T1& dest,
+                                                          const T2& src,
+                                                          std::integral_constant<std::size_t, order>,
+                                                          std::integral_constant<bool, true>) const
     {
         auto ii = i << 1;
         ii.step = 2;
@@ -529,13 +529,13 @@ namespace samurai
         dest(level + 1, ii + 1, jj + 1) = src(level, i, j) - qs_i - qs_j - qs_ij;
     }
 
-    template <class TInterval>
+    template <std::size_t dim, class TInterval>
     template <class T1, class T2, std::size_t order>
-    inline void prediction_op<TInterval>::operator()(Dim<2>,
-                                                     T1& dest,
-                                                     const T2& src,
-                                                     std::integral_constant<std::size_t, order>,
-                                                     std::integral_constant<bool, false>) const
+    inline void prediction_op<dim, TInterval>::operator()(Dim<2>,
+                                                          T1& dest,
+                                                          const T2& src,
+                                                          std::integral_constant<std::size_t, order>,
+                                                          std::integral_constant<bool, false>) const
     {
         auto qs_i  = Qs_i<order>(src, level - 1, i >> 1, j >> 1);
         auto qs_j  = Qs_j<order>(src, level - 1, i >> 1, j >> 1);
@@ -629,13 +629,13 @@ namespace samurai
         }
     }
 
-    template <class TInterval>
+    template <std::size_t dim, class TInterval>
     template <class T1, class T2>
-    inline void prediction_op<TInterval>::operator()(Dim<3>,
-                                                     T1& dest,
-                                                     const T2& src,
-                                                     std::integral_constant<std::size_t, 0>,
-                                                     std::integral_constant<bool, true>) const
+    inline void prediction_op<dim, TInterval>::operator()(Dim<3>,
+                                                          T1& dest,
+                                                          const T2& src,
+                                                          std::integral_constant<std::size_t, 0>,
+                                                          std::integral_constant<bool, true>) const
     {
         auto ii = i << 1;
         ii.step = 2;
@@ -653,13 +653,13 @@ namespace samurai
         dest(level + 1, ii + 1, jj + 1, kk + 1) = src(level, i, j, k);
     }
 
-    template <class TInterval>
+    template <std::size_t dim, class TInterval>
     template <class T1, class T2>
-    inline void prediction_op<TInterval>::operator()(Dim<3>,
-                                                     T1& dest,
-                                                     const T2& src,
-                                                     std::integral_constant<std::size_t, 0>,
-                                                     std::integral_constant<bool, false>) const
+    inline void prediction_op<dim, TInterval>::operator()(Dim<3>,
+                                                          T1& dest,
+                                                          const T2& src,
+                                                          std::integral_constant<std::size_t, 0>,
+                                                          std::integral_constant<bool, false>) const
     {
         auto even_i = i.even_elements();
         if (even_i.is_valid())
@@ -676,13 +676,13 @@ namespace samurai
         }
     }
 
-    template <class TInterval>
+    template <std::size_t dim, class TInterval>
     template <class T1, class T2, std::size_t order>
-    inline void prediction_op<TInterval>::operator()(Dim<3>,
-                                                     T1& dest,
-                                                     const T2& src,
-                                                     std::integral_constant<std::size_t, order>,
-                                                     std::integral_constant<bool, true>) const
+    inline void prediction_op<dim, TInterval>::operator()(Dim<3>,
+                                                          T1& dest,
+                                                          const T2& src,
+                                                          std::integral_constant<std::size_t, order>,
+                                                          std::integral_constant<bool, true>) const
     {
         auto ii = i << 1;
         ii.step = 2;
@@ -708,13 +708,13 @@ namespace samurai
         dest(level + 1, ii + 1, jj + 1, kk + 1) = src(level, i, j, k) - qs_i - qs_j - qs_k - qs_ij - qs_ik - qs_jk - qs_ijk;
     }
 
-    template <class TInterval>
+    template <std::size_t dim, class TInterval>
     template <class T1, class T2, std::size_t order>
-    inline void prediction_op<TInterval>::operator()(Dim<3>,
-                                                     T1& dest,
-                                                     const T2& src,
-                                                     std::integral_constant<std::size_t, order>,
-                                                     std::integral_constant<bool, false>) const
+    inline void prediction_op<dim, TInterval>::operator()(Dim<3>,
+                                                          T1& dest,
+                                                          const T2& src,
+                                                          std::integral_constant<std::size_t, order>,
+                                                          std::integral_constant<bool, false>) const
     {
         auto qs_i   = Qs_i<order>(src, level - 1, i >> 1, j >> 1, k >> 1);
         auto qs_j   = Qs_j<order>(src, level - 1, i >> 1, j >> 1, k >> 1);
@@ -860,8 +860,8 @@ namespace samurai
         }
     }
 
-    template <class TInterval>
-    class variadic_prediction_op : public field_operator_base<TInterval>
+    template <std::size_t dim, class TInterval>
+    class variadic_prediction_op : public field_operator_base<dim, TInterval>
     {
       public:
 
@@ -879,7 +879,7 @@ namespace samurai
                                Head& source,
                                Tail&... sources) const
         {
-            prediction_op<interval_t>(level, i)(Dim<1>{}, source, source, o, dest);
+            prediction_op<dim, interval_t>(level, i)(Dim<1>{}, source, source, o, dest);
             this->operator()(Dim<1>{}, o, dest, sources...);
         }
 
@@ -890,7 +890,7 @@ namespace samurai
                                Head& source,
                                Tail&... sources) const
         {
-            prediction_op<interval_t>(level, i, j)(Dim<2>{}, source, source, o, dest);
+            prediction_op<dim, interval_t>(level, i, j)(Dim<2>{}, source, source, o, dest);
             this->operator()(Dim<2>{}, o, dest, sources...);
         }
 
@@ -901,7 +901,7 @@ namespace samurai
                                Head& source,
                                Tail&... sources) const
         {
-            prediction_op<interval_t>(level, i, j, k)(Dim<3>{}, source, source, o, dest);
+            prediction_op<dim, interval_t>(level, i, j, k)(Dim<3>{}, source, source, o, dest);
             this->operator()(Dim<3>{}, o, dest, sources...);
         }
     };

--- a/include/samurai/numeric/projection.hpp
+++ b/include/samurai/numeric/projection.hpp
@@ -12,8 +12,8 @@ namespace samurai
     // projection operator //
     /////////////////////////
 
-    template <class TInterval>
-    class projection_op_ : public field_operator_base<TInterval>
+    template <std::size_t dim, class TInterval>
+    class projection_op_ : public field_operator_base<dim, TInterval>
     {
       public:
 
@@ -44,8 +44,8 @@ namespace samurai
         }
     };
 
-    template <class TInterval>
-    class variadic_projection_op_ : public field_operator_base<TInterval>
+    template <std::size_t dim, class TInterval>
+    class variadic_projection_op_ : public field_operator_base<dim, TInterval>
     {
       public:
 
@@ -59,21 +59,21 @@ namespace samurai
         template <class Head, class... Tail>
         inline void operator()(Dim<1>, Head& source, Tail&... sources) const
         {
-            projection_op_<interval_t>(level, i)(Dim<1>{}, source, source);
+            projection_op_<dim, interval_t>(level, i)(Dim<1>{}, source, source);
             this->operator()(Dim<1>{}, sources...);
         }
 
         template <class Head, class... Tail>
         inline void operator()(Dim<2>, Head& source, Tail&... sources) const
         {
-            projection_op_<interval_t>(level, i, j)(Dim<2>{}, source, source);
+            projection_op_<dim, interval_t>(level, i, j)(Dim<2>{}, source, source);
             this->operator()(Dim<2>{}, sources...);
         }
 
         template <class Head, class... Tail>
         inline void operator()(Dim<3>, Head& source, Tail&... sources) const
         {
-            projection_op_<interval_t>(level, i, j, k)(Dim<3>{}, source, source);
+            projection_op_<dim, interval_t>(level, i, j, k)(Dim<3>{}, source, source);
             this->operator()(Dim<3>{}, sources...);
         }
     };

--- a/include/samurai/reconstruction.hpp
+++ b/include/samurai/reconstruction.hpp
@@ -284,8 +284,8 @@ namespace samurai
         return iter->second;
     }
 
-    template <class TInterval>
-    class reconstruction_op_ : public field_operator_base<TInterval>
+    template <std::size_t dim, class TInterval>
+    class reconstruction_op_ : public field_operator_base<dim, TInterval>
     {
       public:
 

--- a/include/samurai/stencil_field.hpp
+++ b/include/samurai/stencil_field.hpp
@@ -76,9 +76,9 @@ namespace samurai
      * upwind operator *
      *******************/
 
-    template <class TInterval>
-    class upwind_op : public field_operator_base<TInterval>,
-                      public finite_volume<upwind_op<TInterval>>
+    template <std::size_t dim, class TInterval>
+    class upwind_op : public field_operator_base<dim, TInterval>,
+                      public finite_volume<upwind_op<dim, TInterval>>
     {
       public:
 
@@ -177,9 +177,9 @@ namespace samurai
     /*******************
      * upwind operator for the scalar Burgers equation *
      *******************/
-    template <class TInterval>
-    class upwind_scalar_burgers_op : public field_operator_base<TInterval>,
-                                     public finite_volume<upwind_scalar_burgers_op<TInterval>>
+    template <std::size_t dim, class TInterval>
+    class upwind_scalar_burgers_op : public field_operator_base<dim, TInterval>,
+                                     public finite_volume<upwind_scalar_burgers_op<dim, TInterval>>
     {
       public:
 

--- a/include/samurai/utils.hpp
+++ b/include/samurai/utils.hpp
@@ -67,7 +67,7 @@ namespace samurai
     template <class F, class... CT>
     class field_function;
 
-    template <template <class T> class OP, class... CT>
+    template <template <std::size_t dim, class T> class OP, class... CT>
     class field_operator_function;
 
     namespace detail
@@ -198,7 +198,7 @@ namespace samurai
         {
         };
 
-        template <template <class T> class OP, class... CT>
+        template <template <std::size_t dim, class T> class OP, class... CT>
         struct is_field_function<field_operator_function<OP, CT...>> : std::true_type
         {
         };


### PR DESCRIPTION
## Description

`field_operator_base` allows to build operators using the indices `i`, `j`, `k`, ... as in this example

```
template <class TInterval>
class projection_op_ : public field_operator_base<TInterval>
{
  public:

    INIT_OPERATOR(projection_op_)

    template <class T1, class T2>
    inline void operator()(Dim<1>, T1& dest, const T2& src) const
    {
        dest(level, i) = .5 * (src(level + 1, 2 * i) + src(level + 1, 2 * i + 1));
    }
}
``` 

The indices are built into the macro `INIT_OPERATOR`. Sometimes, the operator is independent of the dimension and can be written as

```
dest(level, i, index) = ...
```

where `index` is an array where `j`, `k`, ... are stored. To build the array into the macro, we have to give the dimension of the problem. 

This PR adds the dimension as a template argument in the `field_operator_base` class.

## Code of Conduct
By submitting this PR, you agree to follow our [Code of Conduct](https://github.com/hpc-maths/samurai/blob/master/docs/CODE_OF_CONDUCT.md)
- [x] I agree to follow this project's Code of Conduct
