### PR TITLE
fix: right shift on interval

### DIFF
--- a/include/samurai/interval.hpp
+++ b/include/samurai/interval.hpp
@@ -178,11 +178,12 @@ namespace samurai
     template <class TValue, class TIndex>
     inline auto Interval<TValue, TIndex>::operator>>=(std::size_t i) -> Interval&
     {
-        bool add_one = (start != end);
-        bool end_odd = (end & 1);
+        bool add_one    = (start != end);
+        bool end_odd    = (end & 1);
+        bool end_iszero = (end == 0);
         start >>= i;
         end >>= i;
-        if (end_odd || (start == end && add_one))
+        if (end_odd || (start == end && add_one) || (!end_iszero && end == 0))
         {
             ++end;
         }

--- a/tests/test_interval.cpp
+++ b/tests/test_interval.cpp
@@ -70,6 +70,39 @@ namespace samurai
         EXPECT_EQ(i1.step, 1);
     }
 
+    TEST(interval, right_shift)
+    {
+        using interval_t = Interval<int, int>;
+        interval_t out;
+
+        interval_t i{0, 9};
+
+        out = i >> 1;
+        EXPECT_EQ(out.start, 0);
+        EXPECT_EQ(out.end, 5);
+
+        out = i >> 2;
+        EXPECT_EQ(out.start, 0);
+        EXPECT_EQ(out.end, 3);
+
+        out = i >> 20;
+        EXPECT_EQ(out.start, 0);
+        EXPECT_EQ(out.end, 1);
+
+        i   = {-9, 2};
+        out = i >> 1;
+        EXPECT_EQ(out.start, -5);
+        EXPECT_EQ(out.end, 1);
+
+        out = i >> 2;
+        EXPECT_EQ(out.start, -3);
+        EXPECT_EQ(out.end, 1);
+
+        out = i >> 10;
+        EXPECT_EQ(out.start, -1);
+        EXPECT_EQ(out.end, 1);
+    }
+
     TEST(interval, ostream)
     {
         Interval<int, int> i{0, 3, 0};


### PR DESCRIPTION
## Description

Fix the right shift on interval.

## Related issue

When the interval is for example $[-9, 2[$ and we make a right shift, the output can be wrong if we go to 0. The initial interval must always be included in the output interval after the shift.

Before this PR we had

$[-9,  2[ >> 2 = [-3, 0[$

And now

$[-9,  2[ >> 2 = [-3, 1[$

## How has this been tested?

We have added some tests in the `test_interval.cpp` file

## Code of Conduct
By submitting this PR, you agree to follow our [Code of Conduct](https://github.com/hpc-maths/samurai/blob/master/docs/CODE_OF_CONDUCT.md)
- [x ] I agree to follow this project's Code of Conduct
