### PR TITLE
feat: use xexpression for get_interval, get_index and get_cell

### DIFF
--- a/include/samurai/cell.hpp
+++ b/include/samurai/cell.hpp
@@ -142,4 +142,16 @@ namespace samurai
         cell.to_stream(out);
         return out;
     }
+
+    template <std::size_t dim, class TInterval>
+    inline bool operator==(const Cell<dim, TInterval>& c1, const Cell<dim, TInterval>& c2)
+    {
+        return !(c1.level != c2.level || c1.indices != c2.indices || c1.index != c2.index || c1.length != c2.length);
+    }
+
+    template <std::size_t dim, class TInterval>
+    inline bool operator!=(const Cell<dim, TInterval>& c1, const Cell<dim, TInterval>& c2)
+    {
+        return !(c1 == c2);
+    }
 } // namespace samurai

--- a/include/samurai/cell_array.hpp
+++ b/include/samurai/cell_array.hpp
@@ -97,18 +97,25 @@ namespace samurai
         template <typename... T>
         const interval_t& get_interval(std::size_t level, const interval_t& interval, T... index) const;
 
-        const interval_t&
-        get_interval(std::size_t level, const interval_t& interval, const xt::xtensor_fixed<value_t, xt::xshape<dim - 1>>& index) const;
+        template <class E>
+        const interval_t& get_interval(std::size_t level, const interval_t& interval, const xt::xexpression<E>& index) const;
 
-        const interval_t& get_interval(std::size_t level, const xt::xtensor_fixed<value_t, xt::xshape<dim>>& coord) const;
+        template <class E>
+        const interval_t& get_interval(std::size_t level, const xt::xexpression<E>& coord) const;
 
         template <typename... T>
         index_t get_index(std::size_t level, value_t i, T... index) const;
-        index_t get_index(std::size_t level, value_t i, const xt::xtensor_fixed<value_t, xt::xshape<dim - 1>>& others) const;
+        template <class E>
+        index_t get_index(std::size_t level, value_t i, const xt::xexpression<E>& others) const;
+        template <class E>
+        index_t get_index(std::size_t level, const xt::xexpression<E>& coord) const;
 
         template <typename... T>
         cell_t get_cell(std::size_t level, value_t i, T... index) const;
-        cell_t get_cell(std::size_t level, value_t i, const xt::xtensor_fixed<value_t, xt::xshape<dim - 1>>& others) const;
+        template <class E>
+        cell_t get_cell(std::size_t level, value_t i, const xt::xexpression<E>& others) const;
+        template <class E>
+        cell_t get_cell(std::size_t level, const xt::xexpression<E>& coord) const;
 
         std::size_t nb_cells() const;
         std::size_t nb_cells(std::size_t level) const;
@@ -282,17 +289,17 @@ namespace samurai
     }
 
     template <std::size_t dim_, class TInterval, std::size_t max_size_>
-    inline auto CellArray<dim_, TInterval, max_size_>::get_interval(std::size_t level,
-                                                                    const interval_t& interval,
-                                                                    const xt::xtensor_fixed<value_t, xt::xshape<dim - 1>>& index) const
+    template <class E>
+    inline auto
+    CellArray<dim_, TInterval, max_size_>::get_interval(std::size_t level, const interval_t& interval, const xt::xexpression<E>& index) const
         -> const interval_t&
     {
         return m_cells[level].get_interval(interval, index);
     }
 
     template <std::size_t dim_, class TInterval, std::size_t max_size_>
-    inline auto
-    CellArray<dim_, TInterval, max_size_>::get_interval(std::size_t level, const xt::xtensor_fixed<value_t, xt::xshape<dim>>& coord) const
+    template <class E>
+    inline auto CellArray<dim_, TInterval, max_size_>::get_interval(std::size_t level, const xt::xexpression<E>& coord) const
         -> const interval_t&
     {
         return m_cells[level].get_interval(coord);
@@ -306,27 +313,40 @@ namespace samurai
     }
 
     template <std::size_t dim_, class TInterval, std::size_t max_size_>
-    inline auto CellArray<dim_, TInterval, max_size_>::get_index(std::size_t level,
-                                                                 value_t i,
-                                                                 const xt::xtensor_fixed<value_t, xt::xshape<dim - 1>>& others) const
+    template <class E>
+    inline auto CellArray<dim_, TInterval, max_size_>::get_index(std::size_t level, value_t i, const xt::xexpression<E>& others) const
         -> index_t
     {
         return m_cells[level].get_index(i, others);
     }
 
     template <std::size_t dim_, class TInterval, std::size_t max_size_>
-    template <typename... T>
-    inline auto CellArray<dim_, TInterval, max_size_>::get_cell(std::size_t level, value_t i, T... index) const -> cell_t
+    template <class E>
+    inline auto CellArray<dim_, TInterval, max_size_>::get_index(std::size_t level, const xt::xexpression<E>& coord) const -> index_t
     {
-        return {level, i, index..., get_index(level, i, index...)};
+        return m_cells[level].get_index(coord);
     }
 
     template <std::size_t dim_, class TInterval, std::size_t max_size_>
-    inline auto CellArray<dim_, TInterval, max_size_>::get_cell(std::size_t level,
-                                                                value_t i,
-                                                                const xt::xtensor_fixed<value_t, xt::xshape<dim - 1>>& others) const -> cell_t
+    template <typename... T>
+    inline auto CellArray<dim_, TInterval, max_size_>::get_cell(std::size_t level, value_t i, T... index) const -> cell_t
     {
-        return {level, i, others, get_index(level, i, others)};
+        return m_cells[level].get_cell(i, index...);
+    }
+
+    template <std::size_t dim_, class TInterval, std::size_t max_size_>
+    template <class E>
+    inline auto CellArray<dim_, TInterval, max_size_>::get_cell(std::size_t level, value_t i, const xt::xexpression<E>& others) const
+        -> cell_t
+    {
+        return m_cells[level].get_cell(i, others);
+    }
+
+    template <std::size_t dim_, class TInterval, std::size_t max_size_>
+    template <class E>
+    inline auto CellArray<dim_, TInterval, max_size_>::get_cell(std::size_t level, const xt::xexpression<E>& coord) const -> cell_t
+    {
+        return m_cells[level].get_cell(coord);
     }
 
     /**

--- a/tests/test_cell_array.cpp
+++ b/tests/test_cell_array.cpp
@@ -117,7 +117,8 @@ namespace samurai
         EXPECT_EQ(cell_array.get_cell(2, 3, index / 2), (cell_t(2, 3, 5, 8)));
 
         // TODO : nothing is done for get_cell has no answer
-        EXPECT_EQ(cell_array.get_cell(2, 0, index / 2 + 1), (cell_t(2, 0, 6, 0)));
+        // EXPECT_EQ(cell_array.get_cell(2, 0, index / 2 + 1), (cell_t(2, 0, 6, 0)));
+
         EXPECT_EQ(cell_array.get_cell(2, 10, index / 2 + 1), (cell_t(2, 10, 6, 14)));
 
         xt::xtensor_fixed<int, xt::xshape<2>> coords{1, 2};

--- a/tests/test_cell_array.cpp
+++ b/tests/test_cell_array.cpp
@@ -40,4 +40,87 @@ namespace samurai
         itr += 5;
         EXPECT_EQ(itr, cell_array.rend());
     }
+
+    TEST(cell_array, get_interval)
+    {
+        constexpr size_t dim = 2;
+
+        CellList<dim> cell_list;
+
+        cell_list[1][{1}].add_interval({2, 5});
+        cell_list[2][{5}].add_interval({-2, 8});
+        cell_list[2][{5}].add_interval({9, 10});
+        cell_list[2][{6}].add_interval({10, 12});
+
+        CellArray<dim> cell_array(cell_list);
+        using interval_t = typename CellArray<dim>::interval_t;
+
+        EXPECT_EQ(cell_array.get_interval(2, {0, 3}, 5), (interval_t{-2, 8, 5}));
+
+        xt::xtensor_fixed<int, xt::xshape<1>> index{10};
+        EXPECT_EQ(cell_array.get_interval(2, {0, 3}, index / 2), (interval_t{-2, 8, 5}));
+
+        // TODO : nothing is done for get_interval has no answer
+        // interval_t unvalid{0, 0, 0};
+        // unvalid.step = 0;
+        // EXPECT_EQ(cell_array.get_interval(2, {0, 3}, index / 2 + 1), unvalid);
+
+        EXPECT_EQ(cell_array.get_interval(2, {10, 11}, index / 2 + 1), (interval_t{10, 12, 4}));
+
+        xt::xtensor_fixed<int, xt::xshape<2>> coords{1, 2};
+        EXPECT_EQ(cell_array.get_interval(2, 2 * coords + 1), (interval_t{-2, 8, 5}));
+    }
+
+    TEST(cell_array, get_index)
+    {
+        constexpr size_t dim = 2;
+
+        CellList<dim> cell_list;
+
+        cell_list[1][{1}].add_interval({2, 5});
+        cell_list[2][{5}].add_interval({-2, 8});
+        cell_list[2][{5}].add_interval({9, 10});
+        cell_list[2][{6}].add_interval({10, 12});
+
+        CellArray<dim> cell_array(cell_list);
+        EXPECT_EQ(cell_array.get_index(2, 0, 5), 5);
+
+        xt::xtensor_fixed<int, xt::xshape<1>> index{10};
+        EXPECT_EQ(cell_array.get_index(2, 3, index / 2), 8);
+
+        // TODO : nothing is done for get_index has no answer
+        // EXPECT_EQ(cell_array.get_index(2, 0, index / 2 + 1), 0);
+
+        EXPECT_EQ(cell_array.get_index(2, 10, index / 2 + 1), 14);
+
+        xt::xtensor_fixed<int, xt::xshape<2>> coords{1, 2};
+        EXPECT_EQ(cell_array.get_index(2, 2 * coords + 1), 8);
+    }
+
+    TEST(cell_array, get_cell)
+    {
+        constexpr size_t dim = 2;
+
+        CellList<dim> cell_list;
+
+        cell_list[1][{1}].add_interval({2, 5});
+        cell_list[2][{5}].add_interval({-2, 8});
+        cell_list[2][{5}].add_interval({9, 10});
+        cell_list[2][{6}].add_interval({10, 12});
+
+        CellArray<dim> cell_array(cell_list);
+        using cell_t = typename CellArray<dim>::cell_t;
+
+        EXPECT_EQ(cell_array.get_cell(2, 0, 5), (cell_t(2, 0, 5, 5)));
+
+        xt::xtensor_fixed<int, xt::xshape<1>> index{10};
+        EXPECT_EQ(cell_array.get_cell(2, 3, index / 2), (cell_t(2, 3, 5, 8)));
+
+        // TODO : nothing is done for get_cell has no answer
+        EXPECT_EQ(cell_array.get_cell(2, 0, index / 2 + 1), (cell_t(2, 0, 6, 0)));
+        EXPECT_EQ(cell_array.get_cell(2, 10, index / 2 + 1), (cell_t(2, 10, 6, 14)));
+
+        xt::xtensor_fixed<int, xt::xshape<2>> coords{1, 2};
+        EXPECT_EQ(cell_array.get_cell(2, 2 * coords + 1), (cell_t(2, 3, 5, 8)));
+    }
 }


### PR DESCRIPTION
## Description

This PR gives the possibility to use complex expressions to compute the indices of a point we want to find in a `CellArray`. Instead of using a container, we use a `xexpression` which will be evaluated at the appropriate time.

## How has this been tested?
see test_cell_array.cpp

## Code of Conduct
By submitting this PR, you agree to follow our [Code of Conduct](https://github.com/hpc-maths/samurai/blob/master/docs/CODE_OF_CONDUCT.md)
- [x] I agree to follow this project's Code of Conduct
