### PR TITLE
fix: simplifies, fixes and documents left and right shift of Interval

### DIFF
--- a/tests/test_interval.cpp
+++ b/tests/test_interval.cpp
@@ -1,3 +1,5 @@
+#include <map>
+
 #include <gtest/gtest.h>
 
 #include <xtensor/xarray.hpp>
@@ -72,9 +74,72 @@ namespace samurai
 
     TEST(interval, right_shift)
     {
-        using interval_t = Interval<int, int>;
-        interval_t out;
+        // Expected mapping of an interval's start when applying a right shift of 1 (to be checked manually)
+        const std::map<int, int> start_rshift{
+            {-6, -3},
+            {-5, -3},
+            {-4, -2},
+            {-3, -2},
+            {-2, -1},
+            {-1, -1},
+            {0,  0 },
+            {1,  0 },
+            {2,  1 },
+            {3,  1 },
+            {4,  2 },
+            {5,  2 },
+            {6,  3 }
+        };
 
+        // Expected mapping of an interval's end when applying a right shift of 1 (to be checked manually)
+        const std::map<int, int> end_rshift{
+            {-6, -3},
+            {-5, -2},
+            {-4, -2},
+            {-3, -1},
+            {-2, -1},
+            {-1, 0 },
+            {0,  0 },
+            {1,  1 },
+            {2,  1 },
+            {3,  2 },
+            {4,  2 },
+            {5,  3 },
+            {6,  3 }
+        };
+
+        using interval_t = Interval<int, int>;
+
+        // Greedy check of all possible intervals within [-6, 6]
+        for (int start = -6; start < 6; ++start)
+        {
+            for (int end = start + 1; end <= 6; ++end)
+            {
+                interval_t i{start, end};
+                for (std::size_t shift : {0u, 1u, 2u, 10u})
+                {
+                    // Computing resulting start & end (shifting by n is equivalent to n shift of 1)
+                    int rstart = start;
+                    for (std::size_t s = 0; s < shift; ++s)
+                    {
+                        rstart = start_rshift.at(rstart);
+                    }
+                    int rend = end;
+                    for (std::size_t s = 0; s < shift; ++s)
+                    {
+                        rend = end_rshift.at(rend);
+                    }
+
+                    // Checking shifted interval
+                    interval_t out = i >> shift;
+                    EXPECT_EQ(out.start, rstart) << " for [" << start << "," << end << "[ >> " << shift;
+                    EXPECT_EQ(out.end, rend) << " for [" << start << "," << end << "[ >> " << shift;
+                }
+            }
+        }
+
+        // Keeping old tests (in case of...)
+        interval_t out;
         interval_t i{0, 9};
 
         out = i >> 1;
@@ -101,6 +166,34 @@ namespace samurai
         out = i >> 10;
         EXPECT_EQ(out.start, -1);
         EXPECT_EQ(out.end, 1);
+    }
+
+    TEST(interval, left_shift)
+    {
+        // The expected mapping of an interval's start & end when applying a left shift of s
+        // is simply a ---> a * 2^s = a << s
+
+        using interval_t = Interval<int, int>;
+
+        // Greedy check of all possible intervals within [-6, 6]
+        for (int start = -6; start < 6; ++start)
+        {
+            for (int end = start + 1; end <= 6; ++end)
+            {
+                interval_t i{start, end};
+                for (std::size_t shift : {0u, 1u, 2u, 10u})
+                {
+                    // Computing resulting start & end (simply `a << shift` for left shift)
+                    int rstart = start << shift;
+                    int rend   = end << shift;
+
+                    // Checking shifted interval
+                    interval_t out = i << shift;
+                    EXPECT_EQ(out.start, rstart) << " for [" << start << "," << end << "[ << " << shift;
+                    EXPECT_EQ(out.end, rend) << " for [" << start << "," << end << "[ << " << shift;
+                }
+            }
+        }
     }
 
     TEST(interval, ostream)


### PR DESCRIPTION
- [x] I have installed [pre-commit](https://pre-commit.com/) locally and use it to validate my commits.
- [x] The PR title follows the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) convention.
      Available tags: 'build', 'chore', 'ci', 'docs', 'feat', 'fix', 'perf', 'refactor', 'revert', 'style', 'test'
- [x] This new PR is documented.
- [x] This new PR is tested.

## Description
There was some issues with current implementation of right shift of an `Interval`:
- it was complicated with many checks,
- the result was wrong for right shift of 0 and 2 steps (and probably more).

This PR adds a more thorough test of `Interval`'s left and right shift and implements a new formula for the right shift that is consistent with previous behaviour for unitary step and fixes the others steps.
 
The formula is explained and justified in the documentation.

## How has this been tested?
Thorough test in `test_interval.cpp`.

## Code of Conduct
By submitting this PR, you agree to follow our [Code of Conduct](https://github.com/hpc-maths/samurai/blob/master/docs/CODE_OF_CONDUCT.md)
- [x] I agree to follow this project's Code of Conduct
