### PR TITLE
feat: check for NaN in the computations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -136,11 +136,16 @@ OPTION(BUILD_BENCHMARKS "samurai benchmark suite" OFF)
 OPTION(BUILD_DEMOS "samurai build all demos" OFF)
 OPTION(BUILD_TESTS "samurai test suite" OFF)
 OPTION(WITH_STATS "samurai mesh stats" OFF)
+option(SAMURAI_CHECK_NAN "Check NaN in computations" OFF)
 
 if(WITH_STATS)
   find_package(nlohmann_json REQUIRED)
   target_link_libraries(samurai INTERFACE nlohmann_json::nlohmann_json)
   target_compile_definitions(samurai INTERFACE WITH_STATS)
+endif()
+
+if(SAMURAI_CHECK_NAN)
+  target_compile_definitions(samurai INTERFACE SAMURAI_CHECK_NAN)
 endif()
 
 if(BUILD_BENCHMARKS)

--- a/include/samurai/algorithm/update.hpp
+++ b/include/samurai/algorithm/update.hpp
@@ -705,7 +705,11 @@ namespace samurai
             constexpr std::size_t pred_order = Field::mesh_t::config::prediction_order;
 
             Field new_field("new_f", new_mesh);
+#ifdef SAMURAI_CHECK_NAN
+            new_field.fill(std::nan(""));
+#else
             new_field.fill(0);
+#endif
 
             auto& mesh = field.mesh();
 
@@ -737,7 +741,11 @@ namespace samurai
             constexpr std::size_t pred_order = Field::mesh_t::config::prediction_order;
 
             Field new_field("new_f", new_mesh);
+#ifdef SAMURAI_CHECK_NAN
+            new_field.fill(std::nan(""));
+#else
             new_field.fill(0);
+#endif
 
             auto& mesh     = field.mesh();
             auto& old_mesh = old_field.mesh();

--- a/include/samurai/bc.hpp
+++ b/include/samurai/bc.hpp
@@ -976,7 +976,8 @@ namespace samurai
                 {
                     if (std::isnan(field_value(u, cells[c], field_i)))
                     {
-                        std::cout << "NaN detected when applying polynomial extrapolation on the outer ghosts: " << cells[c] << std::endl;
+                        std::cerr << "NaN detected when applying polynomial extrapolation on the outer ghosts: " << cells[c] << std::endl;
+                        assert(false);
                     }
                 }
             }

--- a/include/samurai/bc.hpp
+++ b/include/samurai/bc.hpp
@@ -969,6 +969,19 @@ namespace samurai
 
             const auto& ghost = cells[stencil_size_ - 1];
 
+#ifdef SAMURAI_CHECK_NAN
+            for (std::size_t field_i = 0; field_i < Field::size; field_i++)
+            {
+                for (std::size_t c = 0; c < stencil_size_ - 1; ++c)
+                {
+                    if (std::isnan(field_value(u, cells[c], field_i)))
+                    {
+                        std::cout << "NaN detected when applying polynomial extrapolation on the outer ghosts: " << cells[c] << std::endl;
+                    }
+                }
+            }
+#endif
+
             // Last coefficient of the polynomial
             if constexpr (stencil_size_ == 2)
             {

--- a/include/samurai/field.hpp
+++ b/include/samurai/field.hpp
@@ -127,7 +127,7 @@ namespace samurai
                 {
                     if (std::isnan(this->derived_cast().m_data[static_cast<std::size_t>(i)]))
                     {
-                        std::cout << "READ NaN at level " << level << ", " << interval << std::endl;
+                        std::cerr << "READ NaN at level " << level << ", " << interval << std::endl;
                         break;
                     }
                 }
@@ -207,7 +207,7 @@ namespace samurai
                 {
                     if (std::isnan(this->derived_cast().m_data[static_cast<std::size_t>(i)]))
                     {
-                        std::cout << "READ NaN at level " << level << ", " << interval << std::endl;
+                        std::cerr << "READ NaN at level " << level << ", " << interval << std::endl;
                         break;
                     }
                 }

--- a/include/samurai/field.hpp
+++ b/include/samurai/field.hpp
@@ -121,6 +121,17 @@ namespace samurai
             inline auto operator()(const std::size_t level, const interval_t& interval, const T... index) const
             {
                 auto interval_tmp = this->derived_cast().get_interval("READ", level, interval, index...);
+#ifdef SAMURAI_CHECK_NAN
+                for (decltype(interval_tmp.index) i = interval_tmp.index + interval.start; i < interval_tmp.index + interval.end;
+                     i += interval.step)
+                {
+                    if (std::isnan(this->derived_cast().m_data[static_cast<std::size_t>(i)]))
+                    {
+                        std::cout << "READ NaN at level " << level << ", " << interval << std::endl;
+                        break;
+                    }
+                }
+#endif
                 return xt::view(this->derived_cast().m_data,
                                 xt::range(interval_tmp.index + interval.start, interval_tmp.index + interval.end, interval.step));
             }
@@ -128,6 +139,9 @@ namespace samurai
             void resize()
             {
                 this->derived_cast().m_data.resize({this->derived_cast().mesh().nb_cells()});
+#ifdef SAMURAI_CHECK_NAN
+                this->derived_cast().m_data.fill(std::nan(""));
+#endif
             }
         };
 
@@ -187,6 +201,17 @@ namespace samurai
             inline auto operator()(const std::size_t level, const interval_t& interval, const T... index) const
             {
                 auto interval_tmp = this->derived_cast().get_interval("READ", level, interval, index...);
+#ifdef SAMURAI_CHECK_NAN
+                for (decltype(interval_tmp.index) i = interval_tmp.index + interval.start; i < interval_tmp.index + interval.end;
+                     i += interval.step)
+                {
+                    if (std::isnan(this->derived_cast().m_data[static_cast<std::size_t>(i)]))
+                    {
+                        std::cout << "READ NaN at level " << level << ", " << interval << std::endl;
+                        break;
+                    }
+                }
+#endif
                 return xt::view(this->derived_cast().m_data,
                                 xt::range(interval_tmp.index + interval.start, interval_tmp.index + interval.end, interval.step));
             }
@@ -659,11 +684,17 @@ namespace samurai
     inline void Field<mesh_t, value_t, size_, SOA>::to_stream(std::ostream& os) const
     {
         os << "Field " << m_name << "\n";
+
+#ifdef SAMURAI_CHECK_NAN
+        using mesh_id_t = typename Field::mesh_t::mesh_id_t;
+        for_each_cell(this->mesh()[mesh_id_t::reference],
+#else
         for_each_cell(this->mesh(),
+#endif
                       [&](auto& cell)
                       {
-                          os << "\tlevel: " << cell.level << " coords: " << cell.center() << ", index: " << cell.index
-                             << " value: " << this->operator[](cell) << "\n";
+                          os << "\tlevel: " << cell.level << " coords: " << cell.center() << " index: " << cell.index
+                             << ", value: " << this->operator[](cell) << "\n";
                       });
     }
 
@@ -768,7 +799,11 @@ namespace samurai
     auto make_field(std::string name, mesh_t& mesh)
     {
         using field_t = Field<mesh_t, value_t, size, SOA>;
-        return field_t(name, mesh);
+        field_t f(name, mesh);
+#ifdef SAMURAI_CHECK_NAN
+        f.fill(static_cast<value_t>(std::nan("")));
+#endif
+        return f;
     }
 
     template <class value_t, std::size_t size, bool SOA = false, class mesh_t>
@@ -804,7 +839,11 @@ namespace samurai
     auto make_field(std::string name, mesh_t& mesh, Func&& f, const GaussLegendre<polynomial_degree>& gl)
     {
         auto field = make_field<value_t, size, SOA, mesh_t>(name, mesh);
+#ifdef SAMURAI_CHECK_NAN
+        f.fill(std::nan(""));
+#else
         field.fill(0);
+#endif
 
         for_each_cell(mesh,
                       [&](const auto& cell)
@@ -836,7 +875,11 @@ namespace samurai
     auto make_field(std::string name, mesh_t& mesh, Func&& f)
     {
         auto field = make_field<value_t, size, SOA, mesh_t>(name, mesh);
+#ifdef SAMURAI_CHECK_NAN
+        f.fill(std::nan(""));
+#else
         field.fill(0);
+#endif
 
         for_each_cell(mesh,
                       [&](const auto& cell)

--- a/include/samurai/schemes/fv/flux_based/explicit_flux_based_scheme.hpp
+++ b/include/samurai/schemes/fv/flux_based/explicit_flux_based_scheme.hpp
@@ -60,8 +60,9 @@ namespace samurai
 #ifdef SAMURAI_CHECK_NAN
                                 if (std::isnan(field_value(input_field, comput_cells[c], field_j)))
                                 {
-                                    std::cout << "NaN detected when computing the flux on the interior interfaces: " << comput_cells[c]
+                                    std::cerr << "NaN detected when computing the flux on the interior interfaces: " << comput_cells[c]
                                               << std::endl;
+                                    assert(false);
                                 }
 #endif
                                 double left_cell_coeff  = this->scheme().cell_coeff(left_cell_coeffs, c, field_i, field_j);
@@ -89,8 +90,9 @@ namespace samurai
 #ifdef SAMURAI_CHECK_NAN
                                 if (std::isnan(field_value(input_field, comput_cells[c], field_j)))
                                 {
-                                    std::cout << "NaN detected when computing the flux on the boundary interfaces: " << comput_cells[c]
+                                    std::cerr << "NaN detected when computing the flux on the boundary interfaces: " << comput_cells[c]
                                               << std::endl;
+                                    assert(false);
                                 }
 #endif
                                 double coeff = this->scheme().cell_coeff(coeffs, c, field_i, field_j);

--- a/include/samurai/schemes/fv/flux_based/explicit_flux_based_scheme.hpp
+++ b/include/samurai/schemes/fv/flux_based/explicit_flux_based_scheme.hpp
@@ -57,6 +57,13 @@ namespace samurai
                         {
                             for (std::size_t c = 0; c < stencil_size; ++c)
                             {
+#ifdef SAMURAI_CHECK_NAN
+                                if (std::isnan(field_value(input_field, comput_cells[c], field_j)))
+                                {
+                                    std::cout << "NaN detected when computing the flux on the interior interfaces: " << comput_cells[c]
+                                              << std::endl;
+                                }
+#endif
                                 double left_cell_coeff  = this->scheme().cell_coeff(left_cell_coeffs, c, field_i, field_j);
                                 double right_cell_coeff = this->scheme().cell_coeff(right_cell_coeffs, c, field_i, field_j);
                                 field_value(output_field, interface_cells[0], field_i) += left_cell_coeff
@@ -79,6 +86,13 @@ namespace samurai
                         {
                             for (std::size_t c = 0; c < stencil_size; ++c)
                             {
+#ifdef SAMURAI_CHECK_NAN
+                                if (std::isnan(field_value(input_field, comput_cells[c], field_j)))
+                                {
+                                    std::cout << "NaN detected when computing the flux on the boundary interfaces: " << comput_cells[c]
+                                              << std::endl;
+                                }
+#endif
                                 double coeff = this->scheme().cell_coeff(coeffs, c, field_i, field_j);
                                 field_value(output_field, cell, field_i) += coeff * field_value(input_field, comput_cells[c], field_j);
                             }


### PR DESCRIPTION
## Description
Add the compilation variable SAMURAI_CHECK_NAN to initialize fields with NaN and print when a NaN is encountered in the computations.

## Related issue

## How has this been tested?

## Code of Conduct
By submitting this PR, you agree to follow our [Code of Conduct](https://github.com/hpc-maths/samurai/blob/master/docs/CODE_OF_CONDUCT.md)
- [x] I agree to follow this project's Code of Conduct
