### PR TITLE
feat: Add precision (float-->double) in XDMF files

### DIFF
--- a/include/samurai/hdf5.hpp
+++ b/include/samurai/hdf5.hpp
@@ -751,6 +751,7 @@ namespace samurai
                 auto dataitem                           = attribute.append_child("DataItem");
                 dataitem.append_attribute("Dimensions") = field_cumsum.back();
                 dataitem.append_attribute("Format")     = "HDF";
+                dataitem.append_attribute("Precision")  = "8";
                 dataitem.text()                         = fmt::format("{}.h5:{}", m_filename, path).data();
             }
             else


### PR DESCRIPTION
 <!-- Thank you for your contribution to samurai! -->

<!-- Please check the following before submitting your PR -->
- [ x] I have installed [pre-commit](https://pre-commit.com/) locally and use it to validate my commits.
- [ x] The PR title follows the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) convention.
      Available tags: 'build', 'chore', 'ci', 'docs', 'feat', 'fix', 'perf', 'refactor', 'revert', 'style', 'test'
- [x ] This new PR is documented.
- [x ] This new PR is tested.

## Description
Add precision (float-->double) in XDMF files (see  PR #119  erased by PR #28)

## Related issue
XDMF files read HDF5 files only with single precision while double precision is used for storage.

## How has this been tested?
<!-- Give the list of files used to test this new implementation. -->

## Code of Conduct
By submitting this PR, you agree to follow our [Code of Conduct](https://github.com/hpc-maths/samurai/blob/master/docs/CODE_OF_CONDUCT.md)
- [x ] I agree to follow this project's Code of Conduct
