### PR TITLE
feat: OpenMP on fluxes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,6 +44,7 @@ option(IWYU "Activate include-what-you-use" OFF)
 option(SANITIZERS "Activate sanitizers" OFF)
 option(ENABLE_COVERAGE "Activate coverage" OFF)
 option(WITH_MPI "Enable MPI" OFF)
+option(WITH_OPENMP "Enable OpenMP" OFF)
 
 project(samurai VERSION ${SAMURAI_VERSION} LANGUAGES CXX C)
 
@@ -114,6 +115,16 @@ target_link_system_libraries(
   pugixml::pugixml
   fmt::fmt
 )
+
+if(${WITH_OPENMP})
+  find_package(OpenMP)
+  if(OpenMP_CXX_FOUND)
+      target_link_libraries(samurai INTERFACE OpenMP::OpenMP_CXX)
+      target_compile_definitions(samurai INTERFACE SAMURAI_WITH_OPENMP)
+  else()
+      message(FATAL_ERROR "OpenMP not found")
+  endif()
+endif()
 
 if(${WITH_MPI})
   find_package(Boost REQUIRED COMPONENTS serialization mpi)

--- a/include/samurai/schemes/fv/flux_based/explicit_flux_based_scheme.hpp
+++ b/include/samurai/schemes/fv/flux_based/explicit_flux_based_scheme.hpp
@@ -129,8 +129,10 @@ namespace samurai
 
         void apply(output_field_t& output_field, input_field_t& input_field) const override
         {
+            static constexpr bool parallel = true;
+
             // Interior interfaces
-            scheme().for_each_interior_interface(
+            scheme().template for_each_interior_interface<parallel>( // We need the 'template' keyword...
                 input_field,
                 [&](const auto& interface_cells, auto& left_cell_contrib, auto& right_cell_contrib)
                 {
@@ -144,7 +146,7 @@ namespace samurai
                 });
 
             // Boundary interfaces
-            scheme().for_each_boundary_interface(
+            scheme().template for_each_boundary_interface<parallel>( // We need the 'template' keyword...
                 input_field,
                 [&](const auto& cell, auto& contrib)
                 {


### PR DESCRIPTION
## Description
OpenMP is used on flux-based schemes. This change is transparent for the user, who must compile samurai with the cmake option WITH_OPENMP=ON.

## Related issue

## How has this been tested?
Any demo with an explicit flux-based scheme.

## Code of Conduct
By submitting this PR, you agree to follow our [Code of Conduct](https://github.com/hpc-maths/samurai/blob/master/docs/CODE_OF_CONDUCT.md)
- [x] I agree to follow this project's Code of Conduct
