### PR TITLE
feat: the direction provided in the boundary conditions

### DIFF
--- a/demos/FiniteVolume/advection_2d_user_bc.cpp
+++ b/demos/FiniteVolume/advection_2d_user_bc.cpp
@@ -34,7 +34,7 @@ struct Mybc : public samurai::Bc<Field>
         // clang-format on
     }
 
-    apply_function_t get_apply_function(constant_stencil_size_t) const override
+    apply_function_t get_apply_function(constant_stencil_size_t, const direction_t&) const override
     {
         return [](Field& f, const stencil_cells_t& cells, const value_t& value)
         {

--- a/docs/source/reference/bc.rst
+++ b/docs/source/reference/bc.rst
@@ -107,7 +107,7 @@ Let's take the example of a Dirichlet condition to better understand how it work
             return line_stencil<dim, 0>(0, 1);
         }
 
-        apply_function_t get_apply_function(constant_stencil_size_t) const override
+        apply_function_t get_apply_function(constant_stencil_size_t, const direction_t&) const override
         {
             return [](Field& f, const stencil_cells_t& cells, const value_t& value)
             {


### PR DESCRIPTION
## Description
A direction argument is added to the function `get_apply_bc`.

## How has this been tested?
WIth Dirichlet BC.

## Code of Conduct
By submitting this PR, you agree to follow our [Code of Conduct](https://github.com/hpc-maths/samurai/blob/master/docs/CODE_OF_CONDUCT.md)
- [x] I agree to follow this project's Code of Conduct
