### PR TITLE
perf: dynamic regions in extrapolation

### DIFF
--- a/include/samurai/bc.hpp
+++ b/include/samurai/bc.hpp
@@ -1269,7 +1269,6 @@ namespace samurai
                             // Otherwise, we populate the Cartesian directions as well, by polynomial extrapolation.
                             bool only_fill_corners = ghost_layer <= real_max_stencil_size / 2;
                             apply_extrapolation_bc_impl<Field, i>(bc, level, field, only_fill_corners);
-                            // apply_extrapolation_bc_impl__OLD<Field, i>(bc, level, field, only_fill_corners);
                         }
                     }
                 });


### PR DESCRIPTION
## Description
The regions are computed dynamically instead of stored.

## Code of Conduct
By submitting this PR, you agree to follow our [Code of Conduct](https://github.com/hpc-maths/samurai/blob/master/docs/CODE_OF_CONDUCT.md)
- [x] I agree to follow this project's Code of Conduct
