### PR TITLE
fix: periodic

### DIFF
--- a/include/samurai/algorithm/update.hpp
+++ b/include/samurai/algorithm/update.hpp
@@ -505,8 +505,8 @@ namespace samurai
                 stencil.fill(0);
                 stencil[d] = (max_indices[d] - min_indices[d]) >> delta_l;
 
-                min_corner[d] = (min_indices[d] >> delta_l);
-                max_corner[d] = (min_indices[d] >> delta_l) + config::ghost_width;
+                min_corner[d] = (min_indices[d] >> delta_l) - config::ghost_width;
+                max_corner[d] = (min_indices[d] >> delta_l);
                 for (std::size_t dd = 0; dd < dim; ++dd)
                 {
                     if (dd != d)
@@ -525,11 +525,11 @@ namespace samurai
                 set1(
                     [&](const auto& i, const auto& index)
                     {
-                        field(level, i + stencil[0], index + xt::view(stencil, xt::range(1, _))) = field(level, i, index);
+                        field(level, i, index) = field(level, i + stencil[0], index + xt::view(stencil, xt::range(1, _)));
                     });
 
-                min_corner[d] = (max_indices[d] >> delta_l) - config::ghost_width;
-                max_corner[d] = (max_indices[d] >> delta_l);
+                min_corner[d] = (max_indices[d] >> delta_l);
+                max_corner[d] = (max_indices[d] >> delta_l) + config::ghost_width;
                 lca_type lca2{
                     level,
                     Box<interval_value_t, dim>{min_corner, max_corner}
@@ -540,7 +540,7 @@ namespace samurai
                 set2(
                     [&](const auto& i, const auto& index)
                     {
-                        field(level, i - stencil[0], index - xt::view(stencil, xt::range(1, _))) = field(level, i, index);
+                        field(level, i, index) = field(level, i - stencil[0], index - xt::view(stencil, xt::range(1, _)));
                     });
             }
         }
@@ -601,8 +601,8 @@ namespace samurai
                 stencil.fill(0);
                 stencil[d] = (max_indices[d] - min_indices[d]) >> delta_l;
 
-                min_corner[d] = (min_indices[d] >> delta_l);
-                max_corner[d] = (min_indices[d] >> delta_l) + config::ghost_width;
+                min_corner[d] = (min_indices[d] >> delta_l) - config::ghost_width;
+                max_corner[d] = (min_indices[d] >> delta_l);
                 for (std::size_t dd = 0; dd < dim; ++dd)
                 {
                     if (dd != d)
@@ -625,8 +625,8 @@ namespace samurai
                         tag(level, i + stencil[0], index + xt::view(stencil, xt::range(1, _))) |= tag(level, i, index);
                     });
 
-                min_corner[d] = (max_indices[d] >> delta_l) - config::ghost_width;
-                max_corner[d] = (max_indices[d] >> delta_l);
+                min_corner[d] = (max_indices[d] >> delta_l);
+                max_corner[d] = (max_indices[d] >> delta_l) + config::ghost_width;
                 lca_type lca2{
                     level,
                     Box<interval_value_t, dim>{min_corner, max_corner}


### PR DESCRIPTION
## Description
The update ghost for the periodic case is broken. We update the ghosts by looking for the cell strip on the other side. Unfortunately, there may be cases where there are no corresponding ghosts. So it's best to take the ghost strip you're interested in and search for it inside the domain on the other side. This PR fixes this issue by changing the search.

## Related issue
The case `linear_convection.cpp` in `demos/FiniteVolume`was broken.

## How has this been tested?
`linear_convection.cpp` tests the validity of this PR.

## Code of Conduct
By submitting this PR, you agree to follow our [Code of Conduct](https://github.com/hpc-maths/samurai/blob/master/docs/CODE_OF_CONDUCT.md)
- [x] I agree to follow this project's Code of Conduct
