### PR TITLE
fix: detail operator with samurai_check_nan compilation option

### DIFF
--- a/include/samurai/mr/operators.hpp
+++ b/include/samurai/mr/operators.hpp
@@ -194,7 +194,7 @@ namespace samurai
             auto qs_ij = Qs_ij<order>(field, level, i, j);
 
 #ifdef SAMURAI_CHECK_NAN
-            if constexpr (T::size == 1)
+            if constexpr (T1::size == 1)
             {
                 for (std::size_t ii = 0; ii < i.size(); ++ii)
                 {


### PR DESCRIPTION
 <!-- Thank you for your contribution to samurai! -->

<!-- Please check the following before submitting your PR -->
- [x ] I have installed [pre-commit](https://pre-commit.com/) locally and use it to validate my commits.
- [x ] The PR title follows the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) convention.
      Available tags: 'build', 'chore', 'ci', 'docs', 'feat', 'fix', 'perf', 'refactor', 'revert', 'style', 'test'
- [ ] This new PR is documented.
- [ ] This new PR is tested.

## Description
<!-- A clear and concise description of what you have done in this PR. -->

## Related issue
Compilation issue with samurai_check_nan option activated

## How has this been tested?
<!-- Give the list of files used to test this new implementation. -->

## Code of Conduct
By submitting this PR, you agree to follow our [Code of Conduct](https://github.com/hpc-maths/samurai/blob/master/docs/CODE_OF_CONDUCT.md)
- [x ] I agree to follow this project's Code of Conduct
