### PR TITLE
fix: data structure xtensor by default if existing CMakeCache

### DIFF
--- a/include/samurai/schemes/fv/utils.hpp
+++ b/include/samurai/schemes/fv/utils.hpp
@@ -17,10 +17,10 @@ namespace samurai
     namespace data_structure
     {
         template <class value_type, std::size_t size>
-#ifdef FLUX_CONTAINER_xtensor
-        using Array = xt::xtensor_fixed<value_type, xt::xshape<size>>;
-#else
+#ifdef FLUX_CONTAINER_array
         using Array = AlgebraicArray<value_type, size>;
+#else
+        using Array = xt::xtensor_fixed<value_type, xt::xshape<size>>;
 #endif
 
         template <class value_type, std::size_t rows, std::size_t cols>


### PR DESCRIPTION
## Description
When no preprocessing variable FLUX_CONTAINER_xxx, use xtensor.

## Related issue
When the CMakeCache is not removed, the new structure was used instead of xtensor, which is supposed to be default value.


## Code of Conduct
By submitting this PR, you agree to follow our [Code of Conduct](https://github.com/hpc-maths/samurai/blob/master/docs/CODE_OF_CONDUCT.md)
- [x] I agree to follow this project's Code of Conduct
