### PR TITLE
fix: Fix compilation issue on non-linear cell-based scheme

### DIFF
--- a/include/samurai/schemes/fv/cell_based/cell_based_scheme_definition.hpp
+++ b/include/samurai/schemes/fv/cell_based/cell_based_scheme_definition.hpp
@@ -85,7 +85,7 @@ namespace samurai
         using cell_t                            = typename field_t::cell_t;
         static constexpr std::size_t field_size = field_t::size;
 
-        using stencil_cells_t = CollapsArray<cell_t, cfg::scheme_stencil_size>;
+        using stencil_cells_t = CollapsStdArray<cell_t, cfg::scheme_stencil_size>;
 
         using scheme_value_t = CollapsArray<field_value_type, cfg::output_field_size>;
         using scheme_func    = std::function<scheme_value_t(stencil_cells_t&, const field_t&)>;

--- a/include/samurai/schemes/fv/utils.hpp
+++ b/include/samurai/schemes/fv/utils.hpp
@@ -58,6 +58,21 @@ namespace samurai
         {
             using Type = value_type;
         };
+
+        template <class value_type, std::size_t size>
+        struct FixedCollapsableStdArray
+        {
+            using Type = std::array<value_type, size>;
+        };
+
+        /**
+         * Template specialization: if size=1, then just a scalar coefficient
+         */
+        template <class value_type>
+        struct FixedCollapsableStdArray<value_type, 1>
+        {
+            using Type = value_type;
+        };
     }
 
     template <class value_type, std::size_t size>
@@ -71,12 +86,17 @@ namespace samurai
      */
     template <class value_type, std::size_t rows, std::size_t cols>
     using CollapsMatrix = typename detail::FixedCollapsableMatrix<value_type, rows, cols>::Type;
-
     /**
      * Collapsable, fixed size array: reduces to a scalar if size = 1.
      */
     template <class value_type, std::size_t size>
     using CollapsArray = typename detail::FixedCollapsableArray<value_type, size>::Type;
+
+    /**
+     * Collapsable, fixed size array: reduces to a scalar if size = 1.
+     */
+    template <class value_type, std::size_t size>
+    using CollapsStdArray = typename detail::FixedCollapsableStdArray<value_type, size>::Type;
 
     template <class matrix_type>
     matrix_type eye()


### PR DESCRIPTION
## Description
Reintruduce the collapsable std::array that was removed.

## Related issue
Non-linear cell-based schemes didn't compile

## Code of Conduct
By submitting this PR, you agree to follow our [Code of Conduct](https://github.com/hpc-maths/samurai/blob/master/docs/CODE_OF_CONDUCT.md)
- [x] I agree to follow this project's Code of Conduct
