### PR TITLE
build: proper link to PETSc library with absolute path

### DIFF
--- a/demos/FiniteVolume/CMakeLists.txt
+++ b/demos/FiniteVolume/CMakeLists.txt
@@ -5,25 +5,25 @@ if(PETSC_FOUND)
     find_package(MPI)
 
     add_executable(finite-volume-heat heat.cpp)
-    target_link_libraries(finite-volume-heat samurai CLI11::CLI11 ${PETSC_LIBRARIES} ${MPI_LIBRARIES})
+    target_link_libraries(finite-volume-heat samurai CLI11::CLI11 ${PETSC_LINK_LIBRARIES} ${MPI_LIBRARIES})
 
     add_executable(finite-volume-heat-heterogeneous heat_heterogeneous.cpp)
-    target_link_libraries(finite-volume-heat-heterogeneous samurai CLI11::CLI11 ${PETSC_LIBRARIES} ${MPI_LIBRARIES})
+    target_link_libraries(finite-volume-heat-heterogeneous samurai CLI11::CLI11 ${PETSC_LINK_LIBRARIES} ${MPI_LIBRARIES})
 
     add_executable(finite-volume-linear-convection linear_convection.cpp)
-    target_link_libraries(finite-volume-linear-convection samurai CLI11::CLI11 ${PETSC_LIBRARIES} ${MPI_LIBRARIES})
+    target_link_libraries(finite-volume-linear-convection samurai CLI11::CLI11 ${PETSC_LINK_LIBRARIES} ${MPI_LIBRARIES})
 
     add_executable(finite-volume-stokes-2d stokes_2d.cpp)
-    target_link_libraries(finite-volume-stokes-2d samurai CLI11::CLI11 ${PETSC_LIBRARIES} ${MPI_LIBRARIES})
+    target_link_libraries(finite-volume-stokes-2d samurai CLI11::CLI11 ${PETSC_LINK_LIBRARIES} ${MPI_LIBRARIES})
 
     add_executable(finite-volume-lid-driven-cavity lid_driven_cavity.cpp)
-    target_link_libraries(finite-volume-lid-driven-cavity samurai CLI11::CLI11 ${PETSC_LIBRARIES} ${MPI_LIBRARIES})
+    target_link_libraries(finite-volume-lid-driven-cavity samurai CLI11::CLI11 ${PETSC_LINK_LIBRARIES} ${MPI_LIBRARIES})
 
     add_executable(finite-volume-nagumo nagumo.cpp)
-    target_link_libraries(finite-volume-nagumo samurai CLI11::CLI11 ${PETSC_LIBRARIES} ${MPI_LIBRARIES})
+    target_link_libraries(finite-volume-nagumo samurai CLI11::CLI11 ${PETSC_LINK_LIBRARIES} ${MPI_LIBRARIES})
 
     add_executable(manual_block_matrix_assembly manual_block_matrix_assembly.cpp)
-    target_link_libraries(manual_block_matrix_assembly samurai CLI11::CLI11 ${PETSC_LIBRARIES} ${MPI_LIBRARIES})
+    target_link_libraries(manual_block_matrix_assembly samurai CLI11::CLI11 ${PETSC_LINK_LIBRARIES} ${MPI_LIBRARIES})
 endif()
 
 add_executable(finite-volume-amr-burgers-hat AMR_Burgers_Hat.cpp)

--- a/demos/highorder/CMakeLists.txt
+++ b/demos/highorder/CMakeLists.txt
@@ -5,5 +5,5 @@ if (PETSC_FOUND)
 
     add_executable(highorder main.cpp)
 
-    target_link_libraries(highorder samurai ${PETSC_LIBRARIES} ${MPI_LIBRARIES})
+    target_link_libraries(highorder samurai ${PETSC_LINK_LIBRARIES} ${MPI_LIBRARIES})
 endif()

--- a/demos/multigrid/CMakeLists.txt
+++ b/demos/multigrid/CMakeLists.txt
@@ -5,5 +5,5 @@ if (PETSC_FOUND)
 
     add_executable(multigrid main.cpp)
 
-    target_link_libraries(multigrid samurai ${PETSC_LIBRARIES} ${MPI_LIBRARIES})
+    target_link_libraries(multigrid samurai ${PETSC_LINK_LIBRARIES} ${MPI_LIBRARIES})
 endif()


### PR DESCRIPTION
- [x] I have installed [pre-commit](https://pre-commit.com/) locally and use it to validate my commits.
- [x] The PR title follows the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) convention.
      Available tags: 'build', 'chore', 'ci', 'docs', 'feat', 'fix', 'perf', 'refactor', 'revert', 'style', 'test'
- [x] This new PR is documented.
- [x] This new PR is tested.

## Description
When using `pkg_search_module` to find PETSc, it populates (at least) two variables: `PETSC_LIBRARIES` that contains only the name of the library (ie `petsc`) and `PETSC_LINK_LIBRARIES` that contains the absolute path to the library.

Until this fix, only `PETSC_LIBRARIES` was used that leads to linkage error for some configurations, eg when PETSc is not installed system-wide but only through a package manager like in a conda environment.

Using `PETSC_LINK_LIBRARIES` instead fix this issue.

## How has this been tested?
Compiling and launching affected targets. 

## Code of Conduct
By submitting this PR, you agree to follow our [Code of Conduct](https://github.com/hpc-maths/samurai/blob/master/docs/CODE_OF_CONDUCT.md)
- [x] I agree to follow this project's Code of Conduct
