### PR TITLE
refactor: New for_each_interface functions and function renaming

### DIFF
--- a/include/samurai/interface.hpp
+++ b/include/samurai/interface.hpp
@@ -465,7 +465,7 @@ namespace samurai
      *       'cell'         is the inner cell at the boundary.
      *       'comput cells' is the array containing the inner cell and the outside ghost.
      */
-    template <Run run_type = Run::Sequential, Get get_type = Get::Cells, class Mesh, std::size_t comput_stencil_size, class Func>
+    template <Run run_type = Run::Sequential, Get get_type = Get::Cells, class Mesh, class Func>
     void for_each_boundary_interface__both_directions(const Mesh& mesh, const DirectionVector<Mesh::dim>& direction, Func&& f)
     {
         static constexpr std::size_t dim = Mesh::dim;
@@ -483,7 +483,7 @@ namespace samurai
      *       'cell'         is the inner cell at the boundary.
      *       'comput cells' is the array containing the inner cell and the outside ghost.
      */
-    template <Run run_type = Run::Sequential, Get get_type = Get::Cells, class Mesh, std::size_t comput_stencil_size, class Func>
+    template <Run run_type = Run::Sequential, Get get_type = Get::Cells, class Mesh, class Func>
     void for_each_boundary_interface(const Mesh& mesh, Func&& f)
     {
         static constexpr std::size_t dim = Mesh::dim;

--- a/include/samurai/petsc/fv/flux_based_scheme_assembly.hpp
+++ b/include/samurai/petsc/fv/flux_based_scheme_assembly.hpp
@@ -99,7 +99,7 @@ namespace samurai
                             }
                         });
 
-                    for_each_boundary_interface(
+                    for_each_boundary_interface__both_directions(
                         mesh(),
                         flux_def[d].direction,
                         flux_def[d].stencil,

--- a/include/samurai/schemes/fv/flux_based/flux_based_scheme__lin_het.hpp
+++ b/include/samurai/schemes/fv/flux_based/flux_based_scheme__lin_het.hpp
@@ -89,7 +89,7 @@ namespace samurai
                 {
                     auto h = cell_length(level);
 
-                    for_each_interior_interface___same_level(
+                    for_each_interior_interface__same_level(
                         mesh,
                         level,
                         flux_def.direction,
@@ -114,7 +114,7 @@ namespace samurai
                     //    --------->
                     //    direction
                     {
-                        for_each_interior_interface___level_jump_direction(
+                        for_each_interior_interface__level_jump_direction(
                             mesh,
                             level,
                             flux_def.direction,
@@ -133,7 +133,7 @@ namespace samurai
                     //    --------->
                     //    direction
                     {
-                        for_each_interior_interface___level_jump_opposite_direction(
+                        for_each_interior_interface__level_jump_opposite_direction(
                             mesh,
                             level,
                             flux_def.direction,
@@ -167,19 +167,19 @@ namespace samurai
                                    auto h = cell_length(level);
 
                                    // Boundary in direction
-                                   for_each_boundary_interface___direction(mesh,
-                                                                           level,
-                                                                           flux_def.direction,
-                                                                           flux_def.stencil,
-                                                                           [&](auto& cell, auto& comput_cells)
-                                                                           {
-                                                                               auto flux_coeffs = flux_def.cons_flux_function(comput_cells);
-                                                                               auto cell_contrib = contribution(flux_coeffs, h, h);
-                                                                               apply_coeffs(cell, comput_cells, cell_contrib);
-                                                                           });
+                                   for_each_boundary_interface__direction(mesh,
+                                                                          level,
+                                                                          flux_def.direction,
+                                                                          flux_def.stencil,
+                                                                          [&](auto& cell, auto& comput_cells)
+                                                                          {
+                                                                              auto flux_coeffs  = flux_def.cons_flux_function(comput_cells);
+                                                                              auto cell_contrib = contribution(flux_coeffs, h, h);
+                                                                              apply_coeffs(cell, comput_cells, cell_contrib);
+                                                                          });
 
                                    // Boundary in opposite direction
-                                   for_each_boundary_interface___opposite_direction(
+                                   for_each_boundary_interface__opposite_direction(
                                        mesh,
                                        level,
                                        flux_def.direction,

--- a/include/samurai/schemes/fv/flux_based/flux_based_scheme__lin_hom.hpp
+++ b/include/samurai/schemes/fv/flux_based/flux_based_scheme__lin_hom.hpp
@@ -93,7 +93,7 @@ namespace samurai
                     auto left_cell_coeffs                        = contribution(flux_coeffs, h, h);
                     decltype(left_cell_coeffs) right_cell_coeffs = -left_cell_coeffs;
 
-                    for_each_interior_interface___same_level<run_type, get_type>(
+                    for_each_interior_interface__same_level<run_type, get_type>(
                         mesh,
                         level,
                         flux_def.direction,
@@ -120,7 +120,7 @@ namespace samurai
                         auto left_cell_coeffs  = contribution(flux_coeffs, h_lp1, h_l);
                         auto right_cell_coeffs = contribution(minus_flux_coeffs, h_lp1, h_lp1);
 
-                        for_each_interior_interface___level_jump_direction<run_type, get_type>(
+                        for_each_interior_interface__level_jump_direction<run_type, get_type>(
                             mesh,
                             level,
                             flux_def.direction,
@@ -138,7 +138,7 @@ namespace samurai
                         auto left_cell_coeffs  = contribution(flux_coeffs, h_lp1, h_lp1);
                         auto right_cell_coeffs = contribution(minus_flux_coeffs, h_lp1, h_l);
 
-                        for_each_interior_interface___level_jump_opposite_direction<run_type, get_type>(
+                        for_each_interior_interface__level_jump_opposite_direction<run_type, get_type>(
                             mesh,
                             level,
                             flux_def.direction,
@@ -162,37 +162,36 @@ namespace samurai
             {
                 auto& flux_def = flux_definition()[d];
 
-                for_each_level(mesh,
-                               [&](auto level)
-                               {
-                                   auto h = cell_length(level);
+                for_each_level(
+                    mesh,
+                    [&](auto level)
+                    {
+                        auto h = cell_length(level);
 
-                                   // Boundary in direction
-                                   auto flux_coeffs = flux_def.cons_flux_function(h);
-                                   auto cell_coeffs = contribution(flux_coeffs, h, h);
-                                   for_each_boundary_interface___direction<run_type, get_type>(
-                                       mesh,
-                                       level,
-                                       flux_def.direction,
-                                       flux_def.stencil,
-                                       [&](auto& cell, auto& comput_cells)
-                                       {
-                                           apply_coeffs(cell, comput_cells, cell_coeffs);
-                                       });
+                        // Boundary in direction
+                        auto flux_coeffs = flux_def.cons_flux_function(h);
+                        auto cell_coeffs = contribution(flux_coeffs, h, h);
+                        for_each_boundary_interface__direction<run_type, get_type>(mesh,
+                                                                                   level,
+                                                                                   flux_def.direction,
+                                                                                   flux_def.stencil,
+                                                                                   [&](auto& cell, auto& comput_cells)
+                                                                                   {
+                                                                                       apply_coeffs(cell, comput_cells, cell_coeffs);
+                                                                                   });
 
-                                   // Boundary in opposite direction
-                                   decltype(flux_coeffs) minus_flux_coeffs = -flux_coeffs;
-                                   cell_coeffs                             = contribution(minus_flux_coeffs, h, h);
-                                   for_each_boundary_interface___opposite_direction<run_type, get_type>(
-                                       mesh,
-                                       level,
-                                       flux_def.direction,
-                                       flux_def.stencil,
-                                       [&](auto& cell, auto& comput_cells)
-                                       {
-                                           apply_coeffs(cell, comput_cells, cell_coeffs);
-                                       });
-                               });
+                        // Boundary in opposite direction
+                        decltype(flux_coeffs) minus_flux_coeffs = -flux_coeffs;
+                        cell_coeffs                             = contribution(minus_flux_coeffs, h, h);
+                        for_each_boundary_interface__opposite_direction<run_type, get_type>(mesh,
+                                                                                            level,
+                                                                                            flux_def.direction,
+                                                                                            flux_def.stencil,
+                                                                                            [&](auto& cell, auto& comput_cells)
+                                                                                            {
+                                                                                                apply_coeffs(cell, comput_cells, cell_coeffs);
+                                                                                            });
+                    });
             }
         }
     };

--- a/include/samurai/schemes/fv/flux_based/flux_based_scheme__nonlin.hpp
+++ b/include/samurai/schemes/fv/flux_based/flux_based_scheme__nonlin.hpp
@@ -93,7 +93,7 @@ namespace samurai
                 {
                     auto h = cell_length(level);
 
-                    for_each_interior_interface___same_level<run_type>(
+                    for_each_interior_interface__same_level<run_type>(
                         mesh,
                         level,
                         flux_def.direction,
@@ -118,7 +118,7 @@ namespace samurai
                     //    --------->
                     //    direction
                     {
-                        for_each_interior_interface___level_jump_direction<run_type>(
+                        for_each_interior_interface__level_jump_direction<run_type>(
                             mesh,
                             level,
                             flux_def.direction,
@@ -136,7 +136,7 @@ namespace samurai
                     //    --------->
                     //    direction
                     {
-                        for_each_interior_interface___level_jump_opposite_direction<run_type>(
+                        for_each_interior_interface__level_jump_opposite_direction<run_type>(
                             mesh,
                             level,
                             flux_def.direction,
@@ -173,28 +173,28 @@ namespace samurai
                         auto h = cell_length(level);
 
                         // Boundary in direction
-                        for_each_boundary_interface___direction<run_type>(mesh,
-                                                                          level,
-                                                                          flux_def.direction,
-                                                                          flux_def.stencil,
-                                                                          [&](auto& cell, auto& comput_cells)
-                                                                          {
-                                                                              auto flux_values  = flux_function(comput_cells, field);
-                                                                              auto cell_contrib = contribution(flux_values[0], h, h);
-                                                                              apply_contrib(cell, cell_contrib);
-                                                                          });
+                        for_each_boundary_interface__direction<run_type>(mesh,
+                                                                         level,
+                                                                         flux_def.direction,
+                                                                         flux_def.stencil,
+                                                                         [&](auto& cell, auto& comput_cells)
+                                                                         {
+                                                                             auto flux_values  = flux_function(comput_cells, field);
+                                                                             auto cell_contrib = contribution(flux_values[0], h, h);
+                                                                             apply_contrib(cell, cell_contrib);
+                                                                         });
 
                         // Boundary in opposite direction
-                        for_each_boundary_interface___opposite_direction<run_type>(mesh,
-                                                                                   level,
-                                                                                   flux_def.direction,
-                                                                                   flux_def.stencil,
-                                                                                   [&](auto& cell, auto& comput_cells)
-                                                                                   {
-                                                                                       auto flux_values = flux_function(comput_cells, field);
-                                                                                       auto cell_contrib = contribution(flux_values[1], h, h);
-                                                                                       apply_contrib(cell, cell_contrib);
-                                                                                   });
+                        for_each_boundary_interface__opposite_direction<run_type>(mesh,
+                                                                                  level,
+                                                                                  flux_def.direction,
+                                                                                  flux_def.stencil,
+                                                                                  [&](auto& cell, auto& comput_cells)
+                                                                                  {
+                                                                                      auto flux_values = flux_function(comput_cells, field);
+                                                                                      auto cell_contrib = contribution(flux_values[1], h, h);
+                                                                                      apply_contrib(cell, cell_contrib);
+                                                                                  });
                     });
             }
         }


### PR DESCRIPTION
## Description
Additional `for_each_interface` functions and function renaming.
Breaking change: some `for_each_boundary_interface` functions are renamed into `for_each_boundary_interface__both_directions`. The function with `___` (3 underscores) are renamed with `__` (2 underscores).

## Code of Conduct
By submitting this PR, you agree to follow our [Code of Conduct](https://github.com/hpc-maths/samurai/blob/master/docs/CODE_OF_CONDUCT.md)
- [x] I agree to follow this project's Code of Conduct
