### PR TITLE
feat: OpenMP for independent Newton solvers

### DIFF
--- a/demos/FiniteVolume/nagumo.cpp
+++ b/demos/FiniteVolume/nagumo.cpp
@@ -35,8 +35,8 @@ int main(int argc, char* argv[])
 {
     samurai::initialize(argc, argv);
 
-    static constexpr std::size_t dim        = 2; // back to 1 before pushing
-    static constexpr std::size_t field_size = 2; // back to 1 before pushing
+    static constexpr std::size_t dim        = 1;
+    static constexpr std::size_t field_size = 1;
     using Config                            = samurai::MRConfig<dim>;
     using Box                               = samurai::Box<double, dim>;
     using point_t                           = typename Box::point_t;

--- a/include/samurai/algorithm.hpp
+++ b/include/samurai/algorithm.hpp
@@ -12,7 +12,7 @@
 #include "mesh_holder.hpp"
 #include "mesh_interval.hpp"
 
-#include "schemes/fv/Timer.hpp"
+// #include "schemes/fv/Timer.hpp"
 
 namespace samurai
 {
@@ -227,16 +227,16 @@ namespace samurai
         using cell_t        = Cell<dim, TInterval>;
         using index_value_t = typename cell_t::value_t;
 
-        Timer timer;
-        timer.Start();
+        // Timer timer;
+        // timer.Start();
 
 #pragma omp parallel
 #pragma omp single nowait
         {
             for (auto it = lca.cbegin(); it != lca.cend(); ++it)
             {
-                // #pragma omp parallel for // private(index)
-#pragma omp task // private(index)
+                // #pragma omp parallel for
+#pragma omp task
                 for (index_value_t i = it->start; i < it->end; ++i)
                 {
                     typename cell_t::indices_t index;
@@ -254,8 +254,8 @@ namespace samurai
             }
         }
         // #pragma omp taskwait
-        timer.Stop();
-        std::cout << "     time: " << timer.Elapsed(); // << std::endl;
+        // timer.Stop();
+        // std::cout << "     time: " << timer.Elapsed();
     }
 
     template <std::size_t dim, class TInterval, class Func, class F, class... CT>
@@ -280,43 +280,42 @@ namespace samurai
             });
     }
 
-    template <std::size_t dim, class TInterval, std::size_t max_size, class Func>
+    template <Run run_type, std::size_t dim, class TInterval, std::size_t max_size, class Func>
     inline void for_each_cell(const CellArray<dim, TInterval, max_size>& ca, Func&& f)
     {
         for (std::size_t level = ca.min_level(); level <= ca.max_level(); ++level)
         {
             if (!ca[level].empty())
             {
-                for_each_cell(ca[level], std::forward<Func>(f));
+                if constexpr (run_type == Run::Parallel)
+                {
+                    parallel_for_each_cell(ca[level], std::forward<Func>(f));
+                }
+                else
+                {
+                    for_each_cell(ca[level], std::forward<Func>(f));
+                }
             }
         }
     }
 
     template <std::size_t dim, class TInterval, std::size_t max_size, class Func>
-    inline void parallel_for_each_cell(const CellArray<dim, TInterval, max_size>& ca, Func&& f)
+    inline void for_each_cell(const CellArray<dim, TInterval, max_size>& ca, Func&& f)
     {
-        for (std::size_t level = ca.min_level(); level <= ca.max_level(); ++level)
-        {
-            if (!ca[level].empty())
-            {
-                // std::cout << "-------------------- level " << level << std::endl;
-                parallel_for_each_cell(ca[level], std::forward<Func>(f));
-            }
-        }
+        for_each_cell<Run::Sequential>(ca, std::forward<Func>(f));
+    }
+
+    template <Run run_type, class Mesh, class Func>
+    inline void for_each_cell(const Mesh& mesh, Func&& f)
+    {
+        using mesh_id_t = typename Mesh::mesh_id_t;
+        for_each_cell<run_type>(mesh[mesh_id_t::cells], std::forward<Func>(f));
     }
 
     template <class Mesh, class Func>
     inline void for_each_cell(const Mesh& mesh, Func&& f)
     {
-        using mesh_id_t = typename Mesh::mesh_id_t;
-        for_each_cell(mesh[mesh_id_t::cells], std::forward<Func>(f));
-    }
-
-    template <class Mesh, class Func>
-    inline void parallel_for_each_cell(const Mesh& mesh, Func&& f)
-    {
-        using mesh_id_t = typename Mesh::mesh_id_t;
-        parallel_for_each_cell(mesh[mesh_id_t::cells], std::forward<Func>(f));
+        for_each_cell<Run::Sequential>(mesh, std::forward<Func>(f));
     }
 
     template <class Mesh, class Func>

--- a/include/samurai/algorithm.hpp
+++ b/include/samurai/algorithm.hpp
@@ -12,8 +12,6 @@
 #include "mesh_holder.hpp"
 #include "mesh_interval.hpp"
 
-// #include "schemes/fv/Timer.hpp"
-
 namespace samurai
 {
     template <std::size_t dim_, class TInterval, std::size_t max_size_>
@@ -227,15 +225,11 @@ namespace samurai
         using cell_t        = Cell<dim, TInterval>;
         using index_value_t = typename cell_t::value_t;
 
-        // Timer timer;
-        // timer.Start();
-
 #pragma omp parallel
 #pragma omp single nowait
         {
             for (auto it = lca.cbegin(); it != lca.cend(); ++it)
             {
-                // #pragma omp parallel for
 #pragma omp task
                 for (index_value_t i = it->start; i < it->end; ++i)
                 {
@@ -245,17 +239,11 @@ namespace samurai
                         index[d + 1] = it.index()[d];
                     }
                     index[0] = i;
-                    // #pragma omp task private(index)
-                    {
-                        cell_t cell{lca.level(), index, it->index + i};
-                        f(cell);
-                    }
+                    cell_t cell{lca.level(), index, it->index + i};
+                    f(cell);
                 }
             }
         }
-        // #pragma omp taskwait
-        // timer.Stop();
-        // std::cout << "     time: " << timer.Elapsed();
     }
 
     template <Run run_type, std::size_t dim, class TInterval, class Func>

--- a/include/samurai/algorithm.hpp
+++ b/include/samurai/algorithm.hpp
@@ -12,7 +12,7 @@
 #include "mesh_holder.hpp"
 #include "mesh_interval.hpp"
 
-// #include "schemes/fv/Timer.hpp"
+#include "schemes/fv/Timer.hpp"
 
 namespace samurai
 {
@@ -227,8 +227,8 @@ namespace samurai
         using cell_t        = Cell<dim, TInterval>;
         using index_value_t = typename cell_t::value_t;
 
-        // Timer timer;
-        // timer.Start();
+        Timer timer;
+        timer.Start();
 
 #pragma omp parallel
 #pragma omp single nowait
@@ -254,8 +254,8 @@ namespace samurai
             }
         }
         // #pragma omp taskwait
-        // timer.Stop();
-        // std::cout << "     time: " << timer.Elapsed(); // << std::endl;
+        timer.Stop();
+        std::cout << "     time: " << timer.Elapsed(); // << std::endl;
     }
 
     template <std::size_t dim, class TInterval, class Func, class F, class... CT>

--- a/include/samurai/algorithm.hpp
+++ b/include/samurai/algorithm.hpp
@@ -258,6 +258,19 @@ namespace samurai
         // std::cout << "     time: " << timer.Elapsed();
     }
 
+    template <Run run_type, std::size_t dim, class TInterval, class Func>
+    inline void for_each_cell(const LevelCellArray<dim, TInterval>& lca, Func&& f)
+    {
+        if constexpr (run_type == Run::Parallel)
+        {
+            parallel_for_each_cell(lca, std::forward<Func>(f));
+        }
+        else
+        {
+            for_each_cell(lca, std::forward<Func>(f));
+        }
+    }
+
     template <std::size_t dim, class TInterval, class Func, class F, class... CT>
     inline void for_each_cell(const LevelCellArray<dim, TInterval>& lca, subset_operator<F, CT...> set, Func&& f)
     {
@@ -287,14 +300,7 @@ namespace samurai
         {
             if (!ca[level].empty())
             {
-                if constexpr (run_type == Run::Parallel)
-                {
-                    parallel_for_each_cell(ca[level], std::forward<Func>(f));
-                }
-                else
-                {
-                    for_each_cell(ca[level], std::forward<Func>(f));
-                }
+                for_each_cell<run_type>(ca[level], std::forward<Func>(f));
             }
         }
     }

--- a/include/samurai/petsc/nonlinear_local_solvers.hpp
+++ b/include/samurai/petsc/nonlinear_local_solvers.hpp
@@ -143,8 +143,11 @@ namespace samurai
                 for_each_cell<run_type>(unknown().mesh(),
                                         [&](auto& cell)
                                         {
+#ifdef ENABLE_PARALLEL_NONLINEAR_SOLVES
                                             std::size_t thread_num = static_cast<std::size_t>(omp_get_thread_num());
-
+#else
+                                            std::size_t thread_num = 0;
+#endif
                                             SNES& snes = snes_list[thread_num];
                                             Mat& J     = J_list[thread_num];
                                             Vec& r     = r_list[thread_num];

--- a/include/samurai/petsc/nonlinear_local_solvers.hpp
+++ b/include/samurai/petsc/nonlinear_local_solvers.hpp
@@ -133,6 +133,7 @@ namespace samurai
                 std::vector<Mat> J_list(n_threads);
                 std::vector<Vec> r_list(n_threads);
 
+#pragma omp parallel for
                 for (std::size_t thread_num = 0; thread_num < n_threads; ++thread_num)
                 {
                     SNESCreate(PETSC_COMM_SELF, &snes_list[thread_num]);
@@ -184,6 +185,7 @@ namespace samurai
                                             VecDestroy(&b);
                                         });
 
+#pragma omp parallel for
                 for (std::size_t thread_num = 0; thread_num < n_threads; ++thread_num)
                 {
                     MatDestroy(&J_list[thread_num]);

--- a/include/samurai/petsc/nonlinear_local_solvers.hpp
+++ b/include/samurai/petsc/nonlinear_local_solvers.hpp
@@ -198,15 +198,14 @@ namespace samurai
 
             static PetscErrorCode PETSC_nonlinear_function(SNES, Vec x, Vec f, void* ctx)
             {
-                CellContextForPETSc* petsc_ctx = reinterpret_cast<CellContextForPETSc*>(ctx);
-                auto& scheme                   = *petsc_ctx->scheme;
-                auto& cell                     = *petsc_ctx->cell;
+                auto petsc_ctx = reinterpret_cast<CellContextForPETSc*>(ctx);
+                auto& scheme   = *petsc_ctx->scheme;
+                auto& cell     = *petsc_ctx->cell;
 
                 // Wrap a LocalField structure around the data of the Petsc vector x
                 const PetscScalar* x_data;
                 VecGetArrayRead(x, &x_data);
                 LocalField<field_t> x_field(cell, x_data);
-                VecRestoreArrayRead(x, &x_data);
 
                 // PetscScalar* f_data;
                 // VecGetArray(f, &f_data);
@@ -217,7 +216,7 @@ namespace samurai
 
                 copy(f_field, f);
 
-                // VecRestoreArrayRead(x, &x_data);
+                VecRestoreArrayRead(x, &x_data);
                 //  VecRestoreArray(f, &f_data);
                 return 0; // PETSC_SUCCESS
             }

--- a/include/samurai/petsc/nonlinear_local_solvers.hpp
+++ b/include/samurai/petsc/nonlinear_local_solvers.hpp
@@ -217,7 +217,7 @@ namespace samurai
                 copy(f_field, f);
 
                 VecRestoreArrayRead(x, &x_data);
-                //  VecRestoreArray(f, &f_data);
+                // VecRestoreArray(f, &f_data);
                 return 0; // PETSC_SUCCESS
             }
 

--- a/include/samurai/petsc/nonlinear_solver.hpp
+++ b/include/samurai/petsc/nonlinear_solver.hpp
@@ -113,7 +113,6 @@ namespace samurai
             {
                 SNESCreate(PETSC_COMM_SELF, &m_snes);
                 SNESSetType(m_snes, SNESNEWTONLS);
-                SNESSetFromOptions(m_snes);
             }
 
           protected:
@@ -147,6 +146,8 @@ namespace samurai
                 assembly().create_matrix(m_J);
                 // assembly().assemble_matrix(m_J);
                 SNESSetJacobian(m_snes, m_J, m_J, PETSC_jacobian_function, this);
+
+                SNESSetFromOptions(m_snes);
 
                 m_is_set_up = true;
             }

--- a/include/samurai/petsc/utils.hpp
+++ b/include/samurai/petsc/utils.hpp
@@ -158,6 +158,18 @@ namespace samurai
         }
 
         template <class Field>
+        Vec create_petsc_vector_from(Field& f, const typename Field::cell_t& cell)
+        {
+            static_assert(Field::size == 1 || !Field::is_soa);
+
+            Vec v;
+            auto vec_size        = static_cast<PetscInt>(Field::size);
+            auto cell_data_index = Field::size * static_cast<std::size_t>(cell.index);
+            VecCreateSeqWithArray(MPI_COMM_SELF, 1, vec_size, &f.array().data()[cell_data_index], &v);
+            return v;
+        }
+
+        template <class Field>
         void copy(Vec& v, Field& f, const typename Field::cell_t& cell)
         {
             PetscInt n_vec;


### PR DESCRIPTION
## Description
OpenMP can be used to parallelize independent, local Newton solvers.
Requires PETSc >= `3.20.6` configured with the option `--with-threadsafety` (which may require `--with-openmp`). Note that the `petsc` conda package is NOT configured with this option.
Samurai must be compiled with the flag `WITH_OPENMP`.

## How has this been tested?
Nagumo demo in 2D with `field_size = 2` and the arguments `--explicit-diffusion --min-level 1 --max-level 4 -omp_num_threads 8`.
On this problem, the achieved speedup is >= 5.

## Code of Conduct
By submitting this PR, you agree to follow our [Code of Conduct](https://github.com/hpc-maths/samurai/blob/master/docs/CODE_OF_CONDUCT.md)
- [x] I agree to follow this project's Code of Conduct
