### PR TITLE
fix: add fmt:: prefix to function `format_to`

### DIFF
--- a/include/samurai/interval.hpp
+++ b/include/samurai/interval.hpp
@@ -384,6 +384,6 @@ struct fmt::formatter<samurai::Interval<TValue, TIndex>>
     template <typename FormatContext>
     auto format(const samurai::Interval<TValue, TIndex>& interval, FormatContext& ctx)
     {
-        return format_to(ctx.out(), "[{}, {}[@{}:{}", interval.start, interval.end, interval.index, interval.step);
+        return fmt::format_to(ctx.out(), "[{}, {}[@{}:{}", interval.start, interval.end, interval.index, interval.step);
     }
 };


### PR DESCRIPTION
## Description
Need to add `fmt::` prefix to function `format_to` for compatibility with C++ 20, since the same function has been added to the stl.

## Related issue
Compilation error in C++ 20.

## Code of Conduct
By submitting this PR, you agree to follow our [Code of Conduct](https://github.com/hpc-maths/samurai/blob/master/docs/CODE_OF_CONDUCT.md)
- [x] I agree to follow this project's Code of Conduct
