### PR TITLE
fix: fix row_shift and col_shift for monolithic assembly of an operator sum

### DIFF
--- a/include/samurai/petsc/block_assembly.hpp
+++ b/include/samurai/petsc/block_assembly.hpp
@@ -483,8 +483,8 @@ namespace samurai
                 for_each_assembly_op(
                     [&](auto& op, auto, auto col)
                     {
-                        op.row_shift(row_shift);
-                        op.col_shift(col_shift);
+                        op.set_row_shift(row_shift);
+                        op.set_col_shift(col_shift);
                         col_shift += op.matrix_cols();
                         if (col == cols - 1)
                         {

--- a/include/samurai/petsc/fv/operator_sum_assembly.hpp
+++ b/include/samurai/petsc/fv/operator_sum_assembly.hpp
@@ -62,6 +62,28 @@ namespace samurai
                 return *m_sum_scheme;
             }
 
+            void set_row_shift(PetscInt shift) override
+            {
+                MatrixAssembly::set_row_shift(shift);
+
+                for_each(m_assembly_ops,
+                         [&](auto& op)
+                         {
+                             op.set_row_shift(shift);
+                         });
+            }
+
+            void set_col_shift(PetscInt shift) override
+            {
+                MatrixAssembly::set_col_shift(shift);
+
+                for_each(m_assembly_ops,
+                         [&](auto& op)
+                         {
+                             op.set_col_shift(shift);
+                         });
+            }
+
             void set_current_insert_mode(InsertMode insert_mode) override
             {
                 MatrixAssembly::set_current_insert_mode(insert_mode);

--- a/include/samurai/petsc/matrix_assembly.hpp
+++ b/include/samurai/petsc/matrix_assembly.hpp
@@ -89,16 +89,14 @@ namespace samurai
                 return m_fit_block_dimensions;
             }
 
-            template <class int_type>
-            void row_shift(int_type shift)
+            virtual void set_row_shift(PetscInt shift)
             {
-                m_row_shift = static_cast<PetscInt>(shift);
+                m_row_shift = shift;
             }
 
-            template <class int_type>
-            void col_shift(int_type shift)
+            virtual void set_col_shift(PetscInt shift)
             {
-                m_col_shift = static_cast<PetscInt>(shift);
+                m_col_shift = shift;
             }
 
             PetscInt row_shift() const


### PR DESCRIPTION
## Description
`row_shift` and `col_shift` are transferred to all operators in an `OperatorSum`.

## Related issue
The monolithic assembly of a block operator whose one block is a sum of operators was wrong.

## How has this been tested?
Stokes equation, using `id + diff` in the (1, 1) block.

## Code of Conduct
By submitting this PR, you agree to follow our [Code of Conduct](https://github.com/hpc-maths/samurai/blob/master/docs/CODE_OF_CONDUCT.md)
- [x] I agree to follow this project's Code of Conduct
