### PR TITLE
fix: Fix flux-based schemes for MPI

### DIFF
--- a/include/samurai/boundary.hpp
+++ b/include/samurai/boundary.hpp
@@ -9,7 +9,7 @@ namespace samurai
         using mesh_id_t = typename Mesh::mesh_id_t;
 
         auto& cells  = mesh[mesh_id_t::cells][level];
-        auto& domain = mesh.domain();
+        auto& domain = mesh.subdomain();
 
         auto max_level    = domain.level(); // domain.level();//mesh[mesh_id_t::cells].max_level();
         auto one_interval = 1 << (max_level - level);


### PR DESCRIPTION
## Description
Use `mesh.subdomain()` instead of `mesh.domain()`.

## Related issue
The frontier between subdomains wasn't managed.

## How has this been tested?
Linear convection demo

## Code of Conduct
By submitting this PR, you agree to follow our [Code of Conduct](https://github.com/hpc-maths/samurai/blob/master/docs/CODE_OF_CONDUCT.md)
- [x] I agree to follow this project's Code of Conduct
