### PR TITLE
fix: keep_only_one_coarse_tag function

### DIFF
--- a/include/samurai/algorithm/update.hpp
+++ b/include/samurai/algorithm/update.hpp
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include <algorithm>
+
 #include <xtensor/xfixed.hpp>
 
 #include "../bc.hpp"
@@ -412,7 +414,9 @@ namespace samurai
         {
             if (world.rank() > neighbour.rank)
             {
-                for (std::size_t level = mesh[mesh_id_t::reference].min_level(); level <= max_level; ++level)
+                auto min_level = std::max<std::size_t>(1, mesh[mesh_id_t::reference].min_level());
+
+                for (std::size_t level = min_level; level <= max_level; ++level)
                 {
                     auto out_interface = intersection(mesh[mesh_id_t::cells][level], neighbour.mesh.subdomain()).on(level - 1);
                     out_interface(


### PR DESCRIPTION
## Description
<!-- A clear and concise description of what you have done in this PR. -->
When `min_level`is equal to 0, we try to make the intersection with the `level - 1`which is not possible. This PR fixes this issue.

## Code of Conduct
By submitting this PR, you agree to follow our [Code of Conduct](https://github.com/hpc-maths/samurai/blob/master/docs/CODE_OF_CONDUCT.md)
- [ x] I agree to follow this project's Code of Conduct
