### PR TITLE
fix: issue with `get_cell` function in LevelCellArray when `dim > 2`.

### DIFF
--- a/include/samurai/level_cell_array.hpp
+++ b/include/samurai/level_cell_array.hpp
@@ -531,7 +531,7 @@ namespace samurai
     template <typename... T, typename D>
     inline auto LevelCellArray<Dim, TInterval>::get_cell(value_t i, T... index) const -> cell_t
     {
-        return {m_level, i, index..., get_index(i, index...)};
+        return {m_level, i, xt::xtensor_fixed<value_t, xt::xshape<dim - 1>>{index...}, get_index(i, index...)};
     }
 
     template <std::size_t Dim, class TInterval>


### PR DESCRIPTION
## Description
<!-- A clear and concise description of what you have done in this PR. -->
When a cell is created from a variadic index in `LevelCellArray`, the type needed by the `Cell`class was not the good one: an `xtensor_fixed` is needed. 

## Related issue
<!-- List the issues solved by this PR, if any. -->
The 3D case of `get_cell` has an issue.

## Code of Conduct
By submitting this PR, you agree to follow our [Code of Conduct](https://github.com/hpc-maths/samurai/blob/master/docs/CODE_OF_CONDUCT.md)
- [x] I agree to follow this project's Code of Conduct
