### PR TITLE
fix: create missing prediction cells outside the subdomain

### DIFF
--- a/include/samurai/mr/mesh.hpp
+++ b/include/samurai/mr/mesh.hpp
@@ -209,6 +209,19 @@ namespace samurai
                         {
                             lcl_type& lcl = cell_list[level];
                             lcl[index_yz].add_interval(interval);
+
+                            if (level > neighbour.mesh[mesh_id_t::reference].min_level())
+                            {
+                                lcl_type& lclm1 = cell_list[level - 1];
+
+                                static_nested_loop<dim - 1, -config::prediction_order, config::prediction_order + 1>(
+                                    [&](auto stencil)
+                                    {
+                                        auto new_interval = interval >> 1;
+                                        lclm1[(index_yz >> 1) + stencil].add_interval(
+                                            {new_interval.start - config::prediction_order, new_interval.end + config::prediction_order});
+                                    });
+                            }
                         });
                 }
             }


### PR DESCRIPTION
## Description
<!-- A clear and concise description of what you have done in this PR. -->
It may happen that the neighboring sub-domain adds cells that need to be predicted in the current sub-domain. It turns out that the cells needed for prediction were not created.
This PR corrects this by adding the right cells at the boundaries.

## Code of Conduct
By submitting this PR, you agree to follow our [Code of Conduct](https://github.com/hpc-maths/samurai/blob/master/docs/CODE_OF_CONDUCT.md)
- [x] I agree to follow this project's Code of Conduct
