### PR TITLE
feat: some new capabilities in matrix assembly

### DIFF
--- a/demos/FiniteVolume/manual_block_matrix_assembly.cpp
+++ b/demos/FiniteVolume/manual_block_matrix_assembly.cpp
@@ -279,6 +279,15 @@ int main(int argc, char* argv[])
     // Insert the coefficients into the matrix
     assembly.assemble_matrix(J);
 
+    std::cout << "Useless ghost rows: ";
+    // assembly.get<0, 0>().for_each_useless_ghost_row(
+    assembly.for_each_useless_ghost_row(
+        [](auto row)
+        {
+            std::cout << row << " ";
+        });
+    std::cout << std::endl;
+
     Vec v = assembly.create_vector(u_e, aux_Ce, u_s);
     VecView(v, PETSC_VIEWER_STDOUT_(PETSC_COMM_SELF));
     std::cout << std::endl;

--- a/demos/FiniteVolume/manual_block_matrix_assembly.cpp
+++ b/demos/FiniteVolume/manual_block_matrix_assembly.cpp
@@ -266,6 +266,7 @@ int main(int argc, char* argv[])
     assembly.get<0, 0>().include_bc(false);
     assembly.get<2, 2>().include_bc(false);
     assembly.get<0, 0>().include_boundary_fluxes(false);
+    assembly.set_diag_value_for_useless_ghosts(9);
 
     // Set the unknowns of the system (even if you don't want the solve it).
     // They are used to determine the size of each block, and to perform some compatibility checks.

--- a/demos/FiniteVolume/manual_block_matrix_assembly.cpp
+++ b/demos/FiniteVolume/manual_block_matrix_assembly.cpp
@@ -197,8 +197,8 @@ int main(int argc, char* argv[])
 
     PetscInitialize(&argc, &argv, 0, nullptr);
 
-    std::size_t min_level = 2;
-    std::size_t max_level = 2;
+    std::size_t min_level = 3;
+    std::size_t max_level = 3;
 
     Box box({0, 0}, {1, 1});
     samurai::MRMesh<Config> mesh_e{box, min_level, max_level};
@@ -239,6 +239,7 @@ int main(int argc, char* argv[])
     auto diff_e = samurai::make_diffusion_order2<decltype(u_e)>(D_e);
     double D_s  = 2;
     auto diff_s = samurai::make_diffusion_order2<decltype(u_s)>(D_s);
+    auto id     = samurai::make_identity<decltype(u_e)>();
 
     // Definition of the matrix blocks for the couplings to the auxiliary values
     Coupling_auxCe_e auxCe_e(mesh_e);
@@ -250,9 +251,9 @@ int main(int argc, char* argv[])
     // Define the block operator
 
     // clang-format off
-    auto block_op = samurai::make_block_operator<3, 3>(diff_e,  auxCe_e,        0,     // simply put 0 for zero-blocks
-                                                       e_auxCe, auxCe_auxCe, s_auxCe,
-                                                          0,    auxCe_s,     diff_s);
+    auto block_op = samurai::make_block_operator<3, 3>(id + diff_e,  auxCe_e,        0,     // simply put 0 for zero-blocks
+                                                           e_auxCe, auxCe_auxCe, s_auxCe,
+                                                               0,    auxCe_s,     diff_s);
     // clang-format on
 
     //-----------------//
@@ -264,6 +265,7 @@ int main(int argc, char* argv[])
     // Disable the assembly of the BC for the diffusion operators
     assembly.get<0, 0>().include_bc(false);
     assembly.get<2, 2>().include_bc(false);
+    assembly.get<0, 0>().include_boundary_fluxes(false);
 
     // Set the unknowns of the system (even if you don't want the solve it).
     // They are used to determine the size of each block, and to perform some compatibility checks.

--- a/include/samurai/petsc/block_assembly.hpp
+++ b/include/samurai/petsc/block_assembly.hpp
@@ -36,7 +36,7 @@ namespace samurai
                     [&](auto& op, auto row, auto col)
                     {
                         bool diagonal_block = (row == col);
-                        op.must_set_1_on_diag_for_useless_ghosts(diagonal_block);
+                        op.must_insert_value_on_diag_for_useless_ghosts(diagonal_block);
                         op.include_bc(diagonal_block);
                         op.assemble_proj_pred(diagonal_block);
                     });
@@ -298,12 +298,24 @@ namespace samurai
                     });
             }
 
+            void set_diag_value_for_useless_ghosts(PetscScalar value)
+            {
+                for_each_assembly_op(
+                    [&](auto& op, auto row, auto col)
+                    {
+                        if (row == col)
+                        {
+                            op.set_diag_value_for_useless_ghosts(value);
+                        }
+                    });
+            }
+
             void set_0_for_useless_ghosts(Vec& b) const
             {
                 for_each_assembly_op(
                     [&](auto& op, auto row, auto)
                     {
-                        if (op.must_set_1_on_diag_for_useless_ghosts())
+                        if (op.must_insert_value_on_diag_for_useless_ghosts())
                         {
                             Vec b_block;
                             VecNestGetSubVec(b, static_cast<PetscInt>(row), &b_block);
@@ -574,7 +586,7 @@ namespace samurai
                 for_each_assembly_op(
                     [&](auto& op, auto, auto)
                     {
-                        if (op.must_set_1_on_diag_for_useless_ghosts())
+                        if (op.must_insert_value_on_diag_for_useless_ghosts())
                         {
                             op.sparsity_pattern_useless_ghosts(nnz);
                         }
@@ -633,14 +645,26 @@ namespace samurai
                     });
             }
 
-            void set_1_on_diag_for_useless_ghosts(Mat& A) override
+            void set_diag_value_for_useless_ghosts(PetscScalar value) override
+            {
+                for_each_assembly_op(
+                    [&](auto& op, auto row, auto col)
+                    {
+                        if (row == col)
+                        {
+                            op.set_diag_value_for_useless_ghosts(value);
+                        }
+                    });
+            }
+
+            void insert_value_on_diag_for_useless_ghosts(Mat& A) override
             {
                 for_each_assembly_op(
                     [&](auto& op, auto, auto)
                     {
-                        if (op.must_set_1_on_diag_for_useless_ghosts())
+                        if (op.must_insert_value_on_diag_for_useless_ghosts())
                         {
-                            op.set_1_on_diag_for_useless_ghosts(A);
+                            op.insert_value_on_diag_for_useless_ghosts(A);
                         }
                     });
             }
@@ -734,7 +758,7 @@ namespace samurai
                 for_each_assembly_op(
                     [&](auto& op, auto, auto)
                     {
-                        if (op.must_set_1_on_diag_for_useless_ghosts())
+                        if (op.must_insert_value_on_diag_for_useless_ghosts())
                         {
                             op.set_0_for_useless_ghosts(b);
                         }

--- a/include/samurai/petsc/block_assembly.hpp
+++ b/include/samurai/petsc/block_assembly.hpp
@@ -669,6 +669,19 @@ namespace samurai
                     });
             }
 
+            template <class Func>
+            void for_each_useless_ghost_row(Func&& f) const
+            {
+                for_each_assembly_op(
+                    [&](auto& op, auto row, auto col)
+                    {
+                        if (row == col)
+                        {
+                            op.for_each_useless_ghost_row(std::forward<Func>(f));
+                        }
+                    });
+            }
+
             template <class... Fields>
             Vec create_rhs_vector(const std::tuple<Fields&...>& sources) const
             {

--- a/include/samurai/petsc/fv/FV_scheme_assembly.hpp
+++ b/include/samurai/petsc/fv/FV_scheme_assembly.hpp
@@ -590,6 +590,18 @@ namespace samurai
             //                      Useless ghosts                         //
             //-------------------------------------------------------------//
 
+            template <class Func>
+            void for_each_useless_ghost_row(Func&& f) const
+            {
+                for (std::size_t i = 0; i < m_is_row_empty.size(); i++)
+                {
+                    if (m_is_row_empty[i])
+                    {
+                        f(m_row_shift + static_cast<PetscInt>(i));
+                    }
+                }
+            }
+
             void insert_value_on_diag_for_useless_ghosts(Mat& A) override
             {
                 if (current_insert_mode() == ADD_VALUES)

--- a/include/samurai/petsc/fv/FV_scheme_assembly.hpp
+++ b/include/samurai/petsc/fv/FV_scheme_assembly.hpp
@@ -590,7 +590,7 @@ namespace samurai
             //                      Useless ghosts                         //
             //-------------------------------------------------------------//
 
-            void set_1_on_diag_for_useless_ghosts(Mat& A) override
+            void insert_value_on_diag_for_useless_ghosts(Mat& A) override
             {
                 if (current_insert_mode() == ADD_VALUES)
                 {
@@ -599,7 +599,7 @@ namespace samurai
                     MatAssemblyEnd(A, MAT_FLUSH_ASSEMBLY);
                     set_current_insert_mode(INSERT_VALUES);
                 }
-                // std::cout << "set_1_on_diag_for_useless_ghosts of " << this->name() << std::endl;
+                // std::cout << "insert_value_on_diag_for_useless_ghosts of " << this->name() << std::endl;
                 for (std::size_t i = 0; i < m_is_row_empty.size(); i++)
                 {
                     if (m_is_row_empty[i])
@@ -607,7 +607,7 @@ namespace samurai
                         auto error = MatSetValue(A,
                                                  m_row_shift + static_cast<PetscInt>(i),
                                                  m_col_shift + static_cast<PetscInt>(i),
-                                                 1,
+                                                 this->diag_value_for_useless_ghosts(),
                                                  INSERT_VALUES);
                         if (error)
                         {

--- a/include/samurai/petsc/fv/operator_sum_assembly.hpp
+++ b/include/samurai/petsc/fv/operator_sum_assembly.hpp
@@ -226,6 +226,12 @@ namespace samurai
                 std::get<0>(m_assembly_ops).insert_value_on_diag_for_useless_ghosts(A);
             }
 
+            template <class Func>
+            void for_each_useless_ghost_row(Func&& f) const
+            {
+                std::get<0>(m_assembly_ops).for_each_useless_ghost_row(std::forward<Func>(f));
+            }
+
             void set_0_for_all_ghosts(Vec& b) const
             {
                 std::get<0>(m_assembly_ops).set_0_for_all_ghosts(b);

--- a/include/samurai/petsc/fv/operator_sum_assembly.hpp
+++ b/include/samurai/petsc/fv/operator_sum_assembly.hpp
@@ -227,7 +227,7 @@ namespace samurai
             }
 
             template <class Func>
-            void for_each_useless_ghost_row(Func&& f) const
+            void for_each_useless_ghost_row(Func&& f) const // cppcheck-suppress duplInheritedMember
             {
                 std::get<0>(m_assembly_ops).for_each_useless_ghost_row(std::forward<Func>(f));
             }

--- a/include/samurai/petsc/fv/operator_sum_assembly.hpp
+++ b/include/samurai/petsc/fv/operator_sum_assembly.hpp
@@ -215,9 +215,15 @@ namespace samurai
                          });
             }
 
-            void set_1_on_diag_for_useless_ghosts(Mat& A) override
+            void set_diag_value_for_useless_ghosts(PetscScalar value) override
             {
-                std::get<0>(m_assembly_ops).set_1_on_diag_for_useless_ghosts(A);
+                MatrixAssembly::set_diag_value_for_useless_ghosts(value);
+                std::get<0>(m_assembly_ops).set_diag_value_for_useless_ghosts(value);
+            }
+
+            void insert_value_on_diag_for_useless_ghosts(Mat& A) override
+            {
+                std::get<0>(m_assembly_ops).insert_value_on_diag_for_useless_ghosts(A);
             }
 
             void set_0_for_all_ghosts(Vec& b) const

--- a/include/samurai/petsc/fv/operator_sum_assembly.hpp
+++ b/include/samurai/petsc/fv/operator_sum_assembly.hpp
@@ -201,6 +201,20 @@ namespace samurai
                 std::get<0>(m_assembly_ops).assemble_prediction(A);
             }
 
+            void include_boundary_fluxes(bool include)
+            {
+                for_each(m_assembly_ops,
+                         [&](auto& op)
+                         {
+                             using op_scheme_t = typename std::decay_t<decltype(op)>::scheme_t;
+
+                             if constexpr (is_FluxBasedScheme_v<op_scheme_t>)
+                             {
+                                 op.include_boundary_fluxes(include);
+                             }
+                         });
+            }
+
             void set_1_on_diag_for_useless_ghosts(Mat& A) override
             {
                 std::get<0>(m_assembly_ops).set_1_on_diag_for_useless_ghosts(A);

--- a/include/samurai/petsc/manual_assembly.hpp
+++ b/include/samurai/petsc/manual_assembly.hpp
@@ -54,7 +54,7 @@ namespace samurai
             {
             }
 
-            void set_1_on_diag_for_useless_ghosts(Mat&) override
+            void insert_value_on_diag_for_useless_ghosts(Mat&) override
             {
             }
         };

--- a/include/samurai/petsc/manual_assembly.hpp
+++ b/include/samurai/petsc/manual_assembly.hpp
@@ -57,6 +57,11 @@ namespace samurai
             void insert_value_on_diag_for_useless_ghosts(Mat&) override
             {
             }
+
+            template <class Func>
+            void for_each_useless_ghost_row(Func&&) const
+            {
+            }
         };
 
     } // end namespace petsc

--- a/include/samurai/petsc/matrix_assembly.hpp
+++ b/include/samurai/petsc/matrix_assembly.hpp
@@ -12,9 +12,10 @@ namespace samurai
             bool m_is_deleted  = false;
             std::string m_name = "(unnamed)";
 
-            bool m_include_bc                       = true;
-            bool m_assemble_proj_pred               = true;
-            bool m_set_1_on_diag_for_useless_ghosts = true;
+            bool m_include_bc                              = true;
+            bool m_assemble_proj_pred                      = true;
+            bool m_insert_value_on_diag_for_useless_ghosts = true;
+            PetscScalar m_diag_value_for_useless_ghosts    = 1;
 
             InsertMode m_current_insert_mode = INSERT_VALUES;
 
@@ -59,14 +60,24 @@ namespace samurai
                 m_assemble_proj_pred = assemble;
             }
 
-            bool must_set_1_on_diag_for_useless_ghosts() const
+            bool must_insert_value_on_diag_for_useless_ghosts() const
             {
-                return m_set_1_on_diag_for_useless_ghosts;
+                return m_insert_value_on_diag_for_useless_ghosts;
             }
 
-            void must_set_1_on_diag_for_useless_ghosts(bool value)
+            void must_insert_value_on_diag_for_useless_ghosts(bool value)
             {
-                m_set_1_on_diag_for_useless_ghosts = value;
+                m_insert_value_on_diag_for_useless_ghosts = value;
+            }
+
+            virtual void set_diag_value_for_useless_ghosts(PetscScalar value)
+            {
+                m_diag_value_for_useless_ghosts = value;
+            }
+
+            auto diag_value_for_useless_ghosts() const
+            {
+                return m_diag_value_for_useless_ghosts;
             }
 
             virtual void is_block(bool is_block)
@@ -173,7 +184,7 @@ namespace samurai
                     sparsity_pattern_projection(nnz);
                     sparsity_pattern_prediction(nnz);
                 }
-                if (m_set_1_on_diag_for_useless_ghosts)
+                if (m_insert_value_on_diag_for_useless_ghosts)
                 {
                     sparsity_pattern_useless_ghosts(nnz);
                 }
@@ -205,9 +216,9 @@ namespace samurai
                     assemble_projection(A);
                     assemble_prediction(A);
                 }
-                if (m_set_1_on_diag_for_useless_ghosts)
+                if (m_insert_value_on_diag_for_useless_ghosts)
                 {
-                    set_1_on_diag_for_useless_ghosts(A);
+                    insert_value_on_diag_for_useless_ghosts(A);
                 }
 
                 if (!m_is_block)
@@ -277,7 +288,7 @@ namespace samurai
              */
             virtual void assemble_prediction(Mat& A) = 0;
 
-            virtual void set_1_on_diag_for_useless_ghosts(Mat& A) = 0;
+            virtual void insert_value_on_diag_for_useless_ghosts(Mat& A) = 0;
 
             virtual void sparsity_pattern_useless_ghosts(std::vector<PetscInt>& nnz)
             {

--- a/include/samurai/petsc/zero_block_assembly.hpp
+++ b/include/samurai/petsc/zero_block_assembly.hpp
@@ -56,7 +56,7 @@ namespace samurai
             {
             }
 
-            void set_1_on_diag_for_useless_ghosts(Mat&) override
+            void insert_value_on_diag_for_useless_ghosts(Mat&) override
             {
             }
         };

--- a/include/samurai/petsc/zero_block_assembly.hpp
+++ b/include/samurai/petsc/zero_block_assembly.hpp
@@ -59,6 +59,11 @@ namespace samurai
             void insert_value_on_diag_for_useless_ghosts(Mat&) override
             {
             }
+
+            template <class Func>
+            void for_each_useless_ghost_row(Func&&) const
+            {
+            }
         };
 
     } // end namespace petsc


### PR DESCRIPTION
## Description
Given an `assembly` object,

- Disable the assembly of the boundary fluxes by:
```cpp
assembly.include_boundary_fluxes(false);
```
or
```cpp
assembly.get<0, 0>().include_boundary_fluxes(false);
```
for the (0, 0)-block of a block matrix.

- Set the value that is inserted on the diagonal of useless ghost rows:
```cpp
assembly.set_diag_value_for_useless_ghosts(2);
```

- Iterate on the useless ghost rows:
```cpp
assembly.for_each_useless_ghost_row(
        [](auto row)
        {
            ...
        });
```


## Related issue
Need to manually compute the boundary fluxes and to access the list of useless ghosts to process other related objects.

## How has this been tested?
`manual_block_matrix_assembly` demo.

## Code of Conduct
By submitting this PR, you agree to follow our [Code of Conduct](https://github.com/hpc-maths/samurai/blob/master/docs/CODE_OF_CONDUCT.md)
- [X] I agree to follow this project's Code of Conduct
