### PR TITLE
fix: Fix some minor issues in the flux-based schemes

### DIFF
--- a/conda/mpi-environment.yml
+++ b/conda/mpi-environment.yml
@@ -13,4 +13,6 @@ dependencies:
   - pytest
   - h5py
   - libboost-mpi
+  - libboost-devel
+  - libboost-headers
   - hdf5=*=mpi*

--- a/demos/FiniteVolume/manual_block_matrix_assembly.cpp
+++ b/demos/FiniteVolume/manual_block_matrix_assembly.cpp
@@ -237,6 +237,7 @@ int main(int argc, char* argv[])
     // Diffusion operators for the electrolyte and the solid
     double D_e  = 1; // diffusion coefficient
     auto diff_e = samurai::make_diffusion_order2<decltype(u_e)>(D_e);
+    diff_e.include_boundary_fluxes(false);
     double D_s  = 2;
     auto diff_s = samurai::make_diffusion_order2<decltype(u_s)>(D_s);
     auto id     = samurai::make_identity<decltype(u_e)>();
@@ -265,7 +266,6 @@ int main(int argc, char* argv[])
     // Disable the assembly of the BC for the diffusion operators
     assembly.get<0, 0>().include_bc(false);
     assembly.get<2, 2>().include_bc(false);
-    assembly.get<0, 0>().include_boundary_fluxes(false);
     assembly.set_diag_value_for_useless_ghosts(9);
 
     // Set the unknowns of the system (even if you don't want the solve it).

--- a/include/samurai/interface.hpp
+++ b/include/samurai/interface.hpp
@@ -502,7 +502,7 @@ namespace samurai
             DirectionVector<Mesh::dim> direction;
             direction.fill(0);
             direction[d] = 1;
-            for_each_boundary_interface<run_type, get_type>(mesh, direction, std::forward<Func>(f));
+            for_each_boundary_interface__both_directions<run_type, get_type>(mesh, direction, std::forward<Func>(f));
         }
     }
 

--- a/include/samurai/petsc/block_assembly.hpp
+++ b/include/samurai/petsc/block_assembly.hpp
@@ -19,13 +19,13 @@ namespace samurai
 
           private:
 
-            const block_operator_t* m_block_operator;
+            block_operator_t m_block_operator;
             std::tuple<Assembly<Operators>...> m_assembly_ops;
 
           public:
 
             explicit BlockAssembly(const block_operator_t& block_op)
-                : m_block_operator(&block_op)
+                : m_block_operator(block_op)
                 , m_assembly_ops(transform(block_op.operators(),
                                            [](const auto& op)
                                            {
@@ -50,12 +50,12 @@ namespace samurai
 
             auto& block_operator()
             {
-                return *m_block_operator;
+                return m_block_operator;
             }
 
             auto& block_operator() const
             {
-                return *m_block_operator;
+                return m_block_operator;
             }
 
             template <class Func>

--- a/include/samurai/petsc/fv/flux_based_scheme_assembly.hpp
+++ b/include/samurai/petsc/fv/flux_based_scheme_assembly.hpp
@@ -47,6 +47,7 @@ namespace samurai
                 : base_class(s)
             {
                 set_current_insert_mode(ADD_VALUES);
+                m_include_boundary_fluxes = s.include_boundary_fluxes();
             }
 
             void include_boundary_fluxes(bool include)

--- a/include/samurai/petsc/zero_block_assembly.hpp
+++ b/include/samurai/petsc/zero_block_assembly.hpp
@@ -22,6 +22,7 @@ namespace samurai
                     exit(EXIT_FAILURE);
                 }
                 this->fit_block_dimensions(true);
+                this->set_name("0");
             }
 
             void sparsity_pattern_scheme(std::vector<PetscInt>&) const override

--- a/include/samurai/schemes/block_operator.hpp
+++ b/include/samurai/schemes/block_operator.hpp
@@ -29,6 +29,12 @@ namespace samurai
             return m_operators;
         }
 
+        template <std::size_t row, std::size_t col>
+        auto& get()
+        {
+            return std::get<row * cols + col>(m_operators);
+        }
+
         template <class Func>
         void for_each_operator(Func&& f)
         {

--- a/include/samurai/schemes/fv/flux_based/explicit_flux_based_scheme__lin_het.hpp
+++ b/include/samurai/schemes/fv/flux_based/explicit_flux_based_scheme__lin_het.hpp
@@ -74,30 +74,33 @@ namespace samurai
                 });
 
             // Boundary interfaces
-            scheme().for_each_boundary_interface_and_coeffs(
-                input_field,
-                [&](const auto& cell, const auto& comput_cells, auto& coeffs)
-                {
-                    for (std::size_t field_i = 0; field_i < output_field_size; ++field_i)
+            if (scheme.include_boundary_fluxes())
+            {
+                scheme().for_each_boundary_interface_and_coeffs(
+                    input_field,
+                    [&](const auto& cell, const auto& comput_cells, auto& coeffs)
                     {
-                        for (std::size_t field_j = 0; field_j < field_size; ++field_j)
+                        for (std::size_t field_i = 0; field_i < output_field_size; ++field_i)
                         {
-                            for (std::size_t c = 0; c < stencil_size; ++c)
+                            for (std::size_t field_j = 0; field_j < field_size; ++field_j)
                             {
-#ifdef SAMURAI_CHECK_NAN
-                                if (std::isnan(field_value(input_field, comput_cells[c], field_j)))
+                                for (std::size_t c = 0; c < stencil_size; ++c)
                                 {
-                                    std::cerr << "NaN detected when computing the flux on the boundary interfaces: " << comput_cells[c]
-                                              << std::endl;
-                                    assert(false);
-                                }
+#ifdef SAMURAI_CHECK_NAN
+                                    if (std::isnan(field_value(input_field, comput_cells[c], field_j)))
+                                    {
+                                        std::cerr << "NaN detected when computing the flux on the boundary interfaces: " << comput_cells[c]
+                                                  << std::endl;
+                                        assert(false);
+                                    }
 #endif
-                                double coeff = this->scheme().cell_coeff(coeffs, c, field_i, field_j);
-                                field_value(output_field, cell, field_i) += coeff * field_value(input_field, comput_cells[c], field_j);
+                                    double coeff = this->scheme().cell_coeff(coeffs, c, field_i, field_j);
+                                    field_value(output_field, cell, field_i) += coeff * field_value(input_field, comput_cells[c], field_j);
+                                }
                             }
                         }
-                    }
-                });
+                    });
+            }
         }
     };
 

--- a/include/samurai/schemes/fv/flux_based/explicit_flux_based_scheme__lin_het.hpp
+++ b/include/samurai/schemes/fv/flux_based/explicit_flux_based_scheme__lin_het.hpp
@@ -74,7 +74,7 @@ namespace samurai
                 });
 
             // Boundary interfaces
-            if (scheme.include_boundary_fluxes())
+            if (scheme().include_boundary_fluxes())
             {
                 scheme().for_each_boundary_interface_and_coeffs(
                     input_field,

--- a/include/samurai/schemes/fv/flux_based/explicit_flux_based_scheme__lin_hom.hpp
+++ b/include/samurai/schemes/fv/flux_based/explicit_flux_based_scheme__lin_hom.hpp
@@ -265,7 +265,7 @@ namespace samurai
                 });
 
             // Boundary interfaces
-            if (scheme.include_boundary_fluxes())
+            if (scheme().include_boundary_fluxes())
             {
                 scheme().template for_each_boundary_interface_and_coeffs<Run::Parallel, Get::Intervals>(
                     input_field,

--- a/include/samurai/schemes/fv/flux_based/explicit_flux_based_scheme__nonlin.hpp
+++ b/include/samurai/schemes/fv/flux_based/explicit_flux_based_scheme__nonlin.hpp
@@ -47,7 +47,7 @@ namespace samurai
                 });
 
             // Boundary interfaces
-            if (scheme.include_boundary_fluxes())
+            if (scheme().include_boundary_fluxes())
             {
                 scheme().template for_each_boundary_interface<Run::Parallel>( // We need the 'template' keyword...
                     input_field,

--- a/include/samurai/schemes/fv/flux_based/explicit_flux_based_scheme__nonlin.hpp
+++ b/include/samurai/schemes/fv/flux_based/explicit_flux_based_scheme__nonlin.hpp
@@ -47,15 +47,18 @@ namespace samurai
                 });
 
             // Boundary interfaces
-            scheme().template for_each_boundary_interface<Run::Parallel>( // We need the 'template' keyword...
-                input_field,
-                [&](const auto& cell, auto& contrib)
-                {
-                    for (std::size_t field_i = 0; field_i < output_field_size; ++field_i)
+            if (scheme.include_boundary_fluxes())
+            {
+                scheme().template for_each_boundary_interface<Run::Parallel>( // We need the 'template' keyword...
+                    input_field,
+                    [&](const auto& cell, auto& contrib)
                     {
-                        field_value(output_field, cell, field_i) += this->scheme().flux_value_cmpnent(contrib, field_i);
-                    }
-                });
+                        for (std::size_t field_i = 0; field_i < output_field_size; ++field_i)
+                        {
+                            field_value(output_field, cell, field_i) += this->scheme().flux_value_cmpnent(contrib, field_i);
+                        }
+                    });
+            }
         }
     };
 } // end namespace samurai

--- a/include/samurai/schemes/fv/flux_based/flux_based_scheme__lin_het.hpp
+++ b/include/samurai/schemes/fv/flux_based/flux_based_scheme__lin_het.hpp
@@ -28,6 +28,7 @@ namespace samurai
       private:
 
         FluxDefinition<cfg> m_flux_definition;
+        bool m_include_boundary_fluxes = true;
 
       public:
 
@@ -44,6 +45,16 @@ namespace samurai
         auto& flux_definition()
         {
             return m_flux_definition;
+        }
+
+        void include_boundary_fluxes(bool include)
+        {
+            m_include_boundary_fluxes = include;
+        }
+
+        bool include_boundary_fluxes() const
+        {
+            return m_include_boundary_fluxes;
         }
 
         FluxStencilCoeffs<cfg> contribution(const FluxStencilCoeffs<cfg>& flux_coeffs, double h_face, double h_cell) const

--- a/include/samurai/schemes/fv/flux_based/flux_based_scheme__lin_hom.hpp
+++ b/include/samurai/schemes/fv/flux_based/flux_based_scheme__lin_hom.hpp
@@ -28,6 +28,7 @@ namespace samurai
       private:
 
         FluxDefinition<cfg> m_flux_definition;
+        bool m_include_boundary_fluxes = true;
 
       public:
 
@@ -44,6 +45,16 @@ namespace samurai
         auto& flux_definition()
         {
             return m_flux_definition;
+        }
+
+        void include_boundary_fluxes(bool include)
+        {
+            m_include_boundary_fluxes = include;
+        }
+
+        bool include_boundary_fluxes() const
+        {
+            return m_include_boundary_fluxes;
         }
 
         FluxStencilCoeffs<cfg> contribution(const FluxStencilCoeffs<cfg>& flux_coeffs, double h_face, double h_cell) const

--- a/include/samurai/schemes/fv/flux_based/flux_based_scheme__nonlin.hpp
+++ b/include/samurai/schemes/fv/flux_based/flux_based_scheme__nonlin.hpp
@@ -30,6 +30,7 @@ namespace samurai
       private:
 
         FluxDefinition<cfg> m_flux_definition;
+        bool m_include_boundary_fluxes = true;
 
       public:
 
@@ -46,6 +47,16 @@ namespace samurai
         auto& flux_definition()
         {
             return m_flux_definition;
+        }
+
+        void include_boundary_fluxes(bool include)
+        {
+            m_include_boundary_fluxes = include;
+        }
+
+        bool include_boundary_fluxes() const
+        {
+            return m_include_boundary_fluxes;
         }
 
         template <class T> // FluxValue<cfg> or StencilJacobian<cfg>


### PR DESCRIPTION
## Description

- Fix the `for_each_boundary_interface()` function with minimal parameters (it wasn't compiling).
- Fix the PETSc insert mode of the projection/prediction coefficients (implicit context).
- The scheme is now copied into the `Assembly` object (instead of storing a reference).
- Possibility to disable the computation of boundary fluxes.

## How has this been tested?
Very quickly.

## Code of Conduct
By submitting this PR, you agree to follow our [Code of Conduct](https://github.com/hpc-maths/samurai/blob/master/docs/CODE_OF_CONDUCT.md)
- [x] I agree to follow this project's Code of Conduct
