### PR TITLE
feat: Flux operators applicable by direction

### DIFF
--- a/include/samurai/petsc/block_assembly.hpp
+++ b/include/samurai/petsc/block_assembly.hpp
@@ -350,7 +350,7 @@ namespace samurai
                 for_each(fields,
                          [&](auto& f)
                          {
-                             for_each_assembly_op(
+                             this->for_each_assembly_op(
                                  [&](auto&, auto row, auto col)
                                  {
                                      if (row == 0 && col == i)

--- a/include/samurai/schemes/fv/FV_scheme.hpp
+++ b/include/samurai/schemes/fv/FV_scheme.hpp
@@ -81,7 +81,7 @@ namespace samurai
 
     /**
      * Finite Volume scheme.
-     * This is the base class of CellBasedScheme and FluxBasedSchemeAssembly.
+     * This is the base class of CellBasedScheme and FluxBasedScheme.
      * It contains the management of
      *     - the boundary conditions
      *     - the projection/prediction ghosts
@@ -176,6 +176,18 @@ namespace samurai
         {
             auto explicit_scheme = make_explicit(derived_cast());
             explicit_scheme.apply(output_field, input_field);
+        }
+
+        auto operator()(std::size_t d, input_field_t& input_field) const
+        {
+            auto explicit_scheme = make_explicit(derived_cast());
+            return explicit_scheme.apply_to(d, input_field);
+        }
+
+        void apply(std::size_t d, output_field_t& output_field, input_field_t& input_field) const
+        {
+            auto explicit_scheme = make_explicit(derived_cast());
+            explicit_scheme.apply(d, output_field, input_field);
         }
 
         /**

--- a/include/samurai/schemes/fv/cell_based/explicit_cell_based_scheme.hpp
+++ b/include/samurai/schemes/fv/cell_based/explicit_cell_based_scheme.hpp
@@ -27,6 +27,8 @@ namespace samurai
 
       public:
 
+        using base_class::apply;
+
         explicit Explicit(const scheme_t& s)
             : base_class(s)
         {
@@ -72,6 +74,8 @@ namespace samurai
         static constexpr std::size_t output_field_size = cfg::output_field_size;
 
       public:
+
+        using base_class::apply;
 
         explicit Explicit(const scheme_t& s)
             : base_class(s)

--- a/include/samurai/schemes/fv/explicit_FV_scheme.hpp
+++ b/include/samurai/schemes/fv/explicit_FV_scheme.hpp
@@ -53,7 +53,7 @@ namespace samurai
         {
             output_field_t output_field = create_output_field(input_field);
 
-            update_bc(input_field); // To remove
+            // update_bc(input_field);
             apply(output_field, input_field);
 
             return output_field;
@@ -63,7 +63,7 @@ namespace samurai
         {
             output_field_t output_field = create_output_field(input_field);
 
-            update_bc(input_field); // To remove
+            // update_bc(input_field);
             apply(d, output_field, input_field);
 
             return output_field;

--- a/include/samurai/schemes/fv/explicit_FV_scheme.hpp
+++ b/include/samurai/schemes/fv/explicit_FV_scheme.hpp
@@ -16,6 +16,8 @@ namespace samurai
         using input_field_t  = typename scheme_t::input_field_t;
         using output_field_t = typename scheme_t::output_field_t;
 
+        static constexpr std::size_t dim = input_field_t::mesh_t::dim;
+
       private:
 
         const scheme_t* m_scheme = nullptr;
@@ -36,17 +38,50 @@ namespace samurai
             return *m_scheme;
         }
 
-        auto apply_to(input_field_t& input_field) const
+      protected:
+
+        output_field_t create_output_field(input_field_t& input_field) const
         {
             output_field_t output_field(scheme().name() + "(" + input_field.name() + ")", input_field.mesh());
             output_field.fill(0);
+            return output_field;
+        }
 
-            update_bc(input_field);
+      public:
+
+        auto apply_to(input_field_t& input_field) const
+        {
+            output_field_t output_field = create_output_field(input_field);
+
+            update_bc(input_field); // To remove
             apply(output_field, input_field);
 
             return output_field;
         }
 
-        virtual void apply(output_field_t& output_field, input_field_t& input_field) const = 0;
+        auto apply_to(std::size_t d, input_field_t& input_field) const
+        {
+            output_field_t output_field = create_output_field(input_field);
+
+            update_bc(input_field); // To remove
+            apply(d, output_field, input_field);
+
+            return output_field;
+        }
+
+        virtual void apply(output_field_t& output_field, input_field_t& input_field) const
+        {
+            for (std::size_t d = 0; d < dim; ++d)
+            {
+                apply(d, output_field, input_field);
+            }
+        }
+
+        virtual void apply(std::size_t /* d */, output_field_t& /* output_field */, input_field_t& /* input_field */) const
+        {
+            std::cerr << "The scheme '" << scheme().name() << "' cannot be applied by direction." << std::endl;
+            assert(false);
+            exit(EXIT_FAILURE);
+        }
     };
 }

--- a/include/samurai/schemes/fv/explicit_operator_sum.hpp
+++ b/include/samurai/schemes/fv/explicit_operator_sum.hpp
@@ -29,6 +29,15 @@ namespace samurai
                          op.apply(output_field, input_field);
                      });
         }
+
+        void apply(std::size_t d, output_field_t& output_field, input_field_t& input_field) const override
+        {
+            for_each(scheme().operators(),
+                     [&](const auto& op)
+                     {
+                         op.apply(d, output_field, input_field);
+                     });
+        }
     };
 
 } // end namespace samurai

--- a/include/samurai/schemes/fv/flux_based/explicit_flux_based_scheme__lin_het.hpp
+++ b/include/samurai/schemes/fv/flux_based/explicit_flux_based_scheme__lin_het.hpp
@@ -25,12 +25,14 @@ namespace samurai
 
       public:
 
+        using base_class::apply;
+
         explicit Explicit(const scheme_t& s)
             : base_class(s)
         {
         }
 
-        void apply(output_field_t& output_field, input_field_t& input_field) const override
+        void apply(std::size_t d, output_field_t& output_field, input_field_t& input_field) const override
         {
             /**
              * Implementation by matrix-vector multiplication
@@ -45,6 +47,7 @@ namespace samurai
 
             // Interior interfaces
             scheme().for_each_interior_interface_and_coeffs(
+                d,
                 input_field,
                 [&](const auto& interface_cells, const auto& comput_cells, auto& left_cell_coeffs, auto& right_cell_coeffs)
                 {
@@ -77,6 +80,7 @@ namespace samurai
             if (scheme().include_boundary_fluxes())
             {
                 scheme().for_each_boundary_interface_and_coeffs(
+                    d,
                     input_field,
                     [&](const auto& cell, const auto& comput_cells, auto& coeffs)
                     {

--- a/include/samurai/schemes/fv/flux_based/explicit_flux_based_scheme__lin_hom.hpp
+++ b/include/samurai/schemes/fv/flux_based/explicit_flux_based_scheme__lin_hom.hpp
@@ -26,6 +26,8 @@ namespace samurai
 
       public:
 
+        using base_class::apply;
+
         explicit Explicit(const scheme_t& s)
             : base_class(s)
         {
@@ -227,7 +229,7 @@ namespace samurai
 
       public:
 
-        void apply(output_field_t& output_field, input_field_t& input_field) const override
+        void apply(std::size_t d, output_field_t& output_field, input_field_t& input_field) const override
         {
             /**
              * Implementation by matrix-vector multiplication
@@ -242,6 +244,7 @@ namespace samurai
 
             // Interior interfaces
             scheme().template for_each_interior_interface_and_coeffs<Run::Parallel, Get::Intervals>(
+                d,
                 input_field,
                 [&](auto& interface, auto& stencil, auto& left_cell_coeffs, auto& right_cell_coeffs)
                 {
@@ -268,6 +271,7 @@ namespace samurai
             if (scheme().include_boundary_fluxes())
             {
                 scheme().template for_each_boundary_interface_and_coeffs<Run::Parallel, Get::Intervals>(
+                    d,
                     input_field,
                     [&](auto& cell, auto& stencil, auto& coeffs)
                     {

--- a/include/samurai/schemes/fv/flux_based/explicit_flux_based_scheme__nonlin.hpp
+++ b/include/samurai/schemes/fv/flux_based/explicit_flux_based_scheme__nonlin.hpp
@@ -22,15 +22,18 @@ namespace samurai
 
       public:
 
+        using base_class::apply;
+
         explicit Explicit(const scheme_t& s)
             : base_class(s)
         {
         }
 
-        void apply(output_field_t& output_field, input_field_t& input_field) const override
+        void apply(std::size_t d, output_field_t& output_field, input_field_t& input_field) const override
         {
             // Interior interfaces
             scheme().template for_each_interior_interface<Run::Parallel>( // We need the 'template' keyword...
+                d,
                 input_field,
                 [&](const auto& interface_cells, auto& left_cell_contrib, auto& right_cell_contrib)
                 {
@@ -50,6 +53,7 @@ namespace samurai
             if (scheme().include_boundary_fluxes())
             {
                 scheme().template for_each_boundary_interface<Run::Parallel>( // We need the 'template' keyword...
+                    d,
                     input_field,
                     [&](const auto& cell, auto& contrib)
                     {

--- a/include/samurai/schemes/fv/scheme_operators.hpp
+++ b/include/samurai/schemes/fv/scheme_operators.hpp
@@ -109,10 +109,16 @@ namespace samurai
             return explicit_scheme.apply_to(input_field);
         }
 
+        auto operator()(std::size_t d, input_field_t& input_field) const
+        {
+            auto explicit_scheme = make_explicit(*this);
+            return explicit_scheme.apply_to(d, input_field);
+        }
+
         void apply(output_field_t& output_field, input_field_t& input_field) const
         {
             auto explicit_scheme = make_explicit(*this);
-            return explicit_scheme.apply(output_field, input_field);
+            explicit_scheme.apply(output_field, input_field);
         }
     };
 


### PR DESCRIPTION
## Description
Flux operators are now applicable by direction.

```cpp
auto conv = samurai::make_convection_weno5<...>();

static constexpr std::size_t x = 0;
static constexpr std::size_t y = 1;

unp1 = u - dt*conv(x, u); // applies the scheme in the x-direction only
unp1 = u - dt*conv(y, u); // applies the scheme in the y-direction only
```

## Code of Conduct
By submitting this PR, you agree to follow our [Code of Conduct](https://github.com/hpc-maths/samurai/blob/master/docs/CODE_OF_CONDUCT.md)
- [x] I agree to follow this project's Code of Conduct
