### PR TITLE
fix: fmt usage with version 11

### DIFF
--- a/conda/environment.yml
+++ b/conda/environment.yml
@@ -6,7 +6,7 @@ dependencies:
   - ninja
   - xtensor
   - highfive
-  - fmt<11
+  - fmt
   - pugixml
   - cxxopts
   - cli11

--- a/conda/mpi-environment.yml
+++ b/conda/mpi-environment.yml
@@ -6,7 +6,7 @@ dependencies:
   - ninja
   - xtensor
   - highfive
-  - fmt<11
+  - fmt
   - pugixml
   - cxxopts
   - cli11

--- a/demos/FiniteVolume/level_set_from_scratch.cpp
+++ b/demos/FiniteVolume/level_set_from_scratch.cpp
@@ -32,7 +32,7 @@ struct fmt::formatter<SimpleID> : formatter<string_view>
 {
     // parse is inherited from formatter<string_view>.
     template <typename FormatContext>
-    auto format(SimpleID c, FormatContext& ctx)
+    auto format(SimpleID c, FormatContext& ctx) const
     {
         string_view name = "unknown";
         switch (c)

--- a/demos/tutorial/AMR_1D_Burgers/step_3/mesh.hpp
+++ b/demos/tutorial/AMR_1D_Burgers/step_3/mesh.hpp
@@ -94,7 +94,7 @@ template <>
 struct fmt::formatter<MeshID> : formatter<string_view>
 {
     template <typename FormatContext>
-    auto format(MeshID c, FormatContext& ctx)
+    auto format(MeshID c, FormatContext& ctx) const
     {
         string_view name = "unknown";
         switch (c)

--- a/include/samurai/amr/mesh.hpp
+++ b/include/samurai/amr/mesh.hpp
@@ -192,7 +192,7 @@ template <>
 struct fmt::formatter<samurai::amr::AMR_Id> : formatter<string_view>
 {
     template <typename FormatContext>
-    auto format(samurai::amr::AMR_Id c, FormatContext& ctx)
+    auto format(samurai::amr::AMR_Id c, FormatContext& ctx) const
     {
         string_view name = "unknown";
         switch (c)

--- a/include/samurai/interval.hpp
+++ b/include/samurai/interval.hpp
@@ -382,7 +382,7 @@ struct fmt::formatter<samurai::Interval<TValue, TIndex>>
     }
 
     template <typename FormatContext>
-    auto format(const samurai::Interval<TValue, TIndex>& interval, FormatContext& ctx)
+    auto format(const samurai::Interval<TValue, TIndex>& interval, FormatContext& ctx) const
     {
         return fmt::format_to(ctx.out(), "[{}, {}[@{}:{}", interval.start, interval.end, interval.index, interval.step);
     }

--- a/include/samurai/mr/mesh.hpp
+++ b/include/samurai/mr/mesh.hpp
@@ -350,7 +350,7 @@ struct fmt::formatter<samurai::MRMeshId> : formatter<string_view>
 {
     // parse is inherited from formatter<string_view>.
     template <typename FormatContext>
-    auto format(samurai::MRMeshId c, FormatContext& ctx)
+    auto format(samurai::MRMeshId c, FormatContext& ctx) const
     {
         string_view name = "unknown";
         switch (c)

--- a/include/samurai/mr/mesh_with_overleaves.hpp
+++ b/include/samurai/mr/mesh_with_overleaves.hpp
@@ -276,7 +276,7 @@ struct fmt::formatter<samurai::MROMeshId> : formatter<string_view>
 {
     // parse is inherited from formatter<string_view>.
     template <typename FormatContext>
-    auto format(samurai::MROMeshId c, FormatContext& ctx)
+    auto format(samurai::MROMeshId c, FormatContext& ctx) const
     {
         string_view name = "unknown";
         switch (c)

--- a/include/samurai/uniform_mesh.hpp
+++ b/include/samurai/uniform_mesh.hpp
@@ -203,7 +203,7 @@ struct fmt::formatter<samurai::UniformMeshId> : formatter<string_view>
 {
     // parse is inherited from formatter<string_view>.
     template <typename FormatContext>
-    auto format(samurai::UniformMeshId c, FormatContext& ctx)
+    auto format(samurai::UniformMeshId c, FormatContext& ctx) const
     {
         string_view name = "unknown";
         switch (c)


### PR DESCRIPTION
 <!-- Thank you for your contribution to samurai! -->

<!-- Please check the following before submitting your PR -->
- [x] I have installed [pre-commit](https://pre-commit.com/) locally and use it to validate my commits.
- [x] The PR title follows the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) convention.
      Available tags: 'build', 'chore', 'ci', 'docs', 'feat', 'fix', 'perf', 'refactor', 'revert', 'style', 'test'
- [x] This new PR is documented.
- [x] This new PR is tested.

## Description
<!-- A clear and concise description of what you have done in this PR. -->
fmt changed the format method to const in the formatter class. This PR fixes this change in samurai.

## Related issue
<!-- List the issues solved by this PR, if any. -->
samurai didn't compile with fmt > 10.

## Code of Conduct
By submitting this PR, you agree to follow our [Code of Conduct](https://github.com/hpc-maths/samurai/blob/master/docs/CODE_OF_CONDUCT.md)
- [x] I agree to follow this project's Code of Conduct
