### PR TITLE
fix: The matrix size is set upon calling `assembly.set_unknowns(...)`.

### DIFF
--- a/include/samurai/petsc/fv/FV_scheme_assembly.hpp
+++ b/include/samurai/petsc/fv/FV_scheme_assembly.hpp
@@ -162,6 +162,7 @@ namespace samurai
             void set_unknown(field_t& unknown)
             {
                 m_unknown = &unknown;
+                m_n_cells = unknown.mesh().nb_cells();
             }
 
             auto& unknown() const


### PR DESCRIPTION
## Description
The matrix size is set upon calling `assembly.set_unknowns(...)`.

## Related issue
The matrix size was set when the assembly starts. Now it's done sooner.


## Code of Conduct
By submitting this PR, you agree to follow our [Code of Conduct](https://github.com/hpc-maths/samurai/blob/master/docs/CODE_OF_CONDUCT.md)
- [x] I agree to follow this project's Code of Conduct
