### PR TITLE
docs: fix some typos in docs

### DIFF
--- a/docs/CODE_OF_CONDUCT.md
+++ b/docs/CODE_OF_CONDUCT.md
@@ -2,7 +2,7 @@
 
 ## Our Pledge
 
-In the interest of fostering an open and welcoming environment, we as contributors and maintainers pledge to make participation in our project and our community a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, religion, or sexual identity and orientation.
+In the interest of fostering an open and welcoming environment, we as contributors and maintainers pledge to make participation in our project and our community a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socioeconomic status, nationality, personal appearance, race, religion, or sexual identity and orientation.
 
 ## Our Standards
 

--- a/docs/source/reference/bc.rst
+++ b/docs/source/reference/bc.rst
@@ -123,7 +123,7 @@ Let's take the example of a Dirichlet condition to better understand how it work
 
 The :code:`get_stencil` method must return the stencil that allows to manage the boundary condition in the x-direction, i.e. for the boundary on the right.
 The stencil employed for the other directions will be deduced from this one by rotating it.
-The instuction :code:`line_stencil<dim, 0>(0, 1)` builds a stencil of two cells in the x-direction.
+The instruction :code:`line_stencil<dim, 0>(0, 1)` builds a stencil of two cells in the x-direction.
 In 2D, it yields :code:`{{0,0}, {1,0}}`.
 The origin cell in the stencil (coordinates :code:`{0,0}`) always captures the inner cell that touches the boundary.
 Here, we capture the origin cell and its right neighbour, which is the ghost cell we want to populate.

--- a/docs/source/reference/finite_volume_schemes.rst
+++ b/docs/source/reference/finite_volume_schemes.rst
@@ -312,16 +312,16 @@ Each :code:`c[i]` is a matrix of size :code:`output_field_size x input_field_siz
 where :code:`output_field_size` is set in :code:`cfg`,
 and :code:`input_field_size` corresponds to the size of the field type set in :code:`cfg` as :code:`input_field_type`.
 The matrix type is in fact an :code:`xtensor` object.
-You can then, amongs other things, access the :math:`k`-th row of :code:`c[0]` via :code:`xt::row(c[0], k)`,
+You can then, among other things, access the :math:`k`-th row of :code:`c[0]` via :code:`xt::row(c[0], k)`,
 its :math:`l`-th column via :code:`xt::col(c[0], l)`, or its coefficient at indices :math:`(k, l)` via :code:`c[0](k, l)`.
 
 .. note::
     When both :code:`output_field_size` and :code:`input_field_size` equal 1,
-    the matrix type employed to store the coefficents reduces to a scalar type (typically :code:`double`).
+    the matrix type employed to store the coefficients reduces to a scalar type (typically :code:`double`).
     In particular, no accessor or :code:`xtensor` function is available.
     To write an :math:`n`-dimensional program, a separate code for the special case where the matrix reduces to a scalar is usually necessary.
 
-As the operator is declared homogenous over the mesh, the coefficients do not depend on specific cell values.
+As the operator is declared homogeneous over the mesh, the coefficients do not depend on specific cell values.
 They can, however, depend on the mesh size :math:`h`, making :math:`h` the only parameter of the flux function.
 The coefficients can then be computed only once per mesh level, and re-used for all interfaces.
 If other (constant!) parameters are needed, they can be captured by the lambda function.
@@ -457,7 +457,7 @@ The implementation of the vector laplacian operator then writes
 Compared to the scalar laplacian code:
 
 - in the configuration, the :code:`output_field_size` now equals the :code:`field_size`,
-- in the flux fonction, the coefficients for each cell of the stencil are now matrices.
+- in the flux function, the coefficients for each cell of the stencil are now matrices.
   Specifically, they are diagonal matrices with the same coefficients as in the scalar laplacian.
 
 When :code:`field_size = 1`, the matrix type actually reduces to a scalar type, thus forbidding instructions such as :code:`c[L](i, i)`.
@@ -959,7 +959,7 @@ We have
 .. math::
     \int_V \nabla \cdot \mathbf{u}\otimes\mathbf{u} = \int_{\partial V} (\mathbf{u}\otimes\mathbf{u})\mathbf{n}.
 
-Developped in 2D, where :math:`\mathbf{u} := [u\;v]`, it reads
+Developed in 2D, where :math:`\mathbf{u} := [u\;v]`, it reads
 
 .. math::
     (\mathbf{u}\otimes\mathbf{u})\mathbf{n} =
@@ -1055,7 +1055,7 @@ Implementing a non-conservative scheme
 --------------------------------------
 
 Flux-based, non-conservative schemes also exist.
-Exemples can be found in two-phase flow simulation: while the scheme remains conservative within each phase, non-conservative fluxes can be computed at the interface between phases.
+Examples can be found in two-phase flow simulation: while the scheme remains conservative within each phase, non-conservative fluxes can be computed at the interface between phases.
 
 We recall :math:`V_L` and :math:`V_R`, the two cells sharing the face :math:`F`, and ordered in the direction of the corresponding Cartesian vector
 (i.e., in the x-direction, :math:`V_L` and :math:`V_R` are the left and right cells, respectively).

--- a/docs/source/reference/local_schemes.rst
+++ b/docs/source/reference/local_schemes.rst
@@ -7,7 +7,7 @@ The local schemes are part of the Finite Volume module, enabled by
 .. code-block:: c++
 
     #include <samurai/schemes/fv.hpp>
-    #include <samurai/petsc.hpp> // optional, necessary for implicit shemes
+    #include <samurai/petsc.hpp> // optional, necessary for implicit schemes
 
 They are characterized by a function that applies to a field, whose computation only involves information located in the current mesh cell.
 The C++ interface is built similarly to the :doc:`flux-based Finite Volume schemes <finite_volume_schemes>`.

--- a/docs/source/tutorial/graduation_case_1.rst
+++ b/docs/source/tutorial/graduation_case_1.rst
@@ -196,7 +196,7 @@ We can now apply this kernel for different stencils and different levels of the 
         }
     }
 
-At the end of thess operations, we know which cell must be refined and which cell must be kept.
+At the end of these operations, we know which cell must be refined and which cell must be kept.
 We can construct the new mesh using `tag` field and :cpp:class:`samurai::CellList`.
 
 .. code-block:: c++

--- a/docs/source/tutorial/graduation_case_3.rst
+++ b/docs/source/tutorial/graduation_case_3.rst
@@ -37,7 +37,7 @@ We shall apply the `for_each_cell` function to this end.
 
 We create a field named `tag` attached to the mesh.
 Again, this field is an array of booleans.
-If the value is set to true, the correspoding cell must be refined, otherwise, it must be kept .
+If the value is set to true, the corresponding cell must be refined, otherwise, it must be kept .
 
 .. code-block:: c++
 
@@ -78,7 +78,7 @@ The :cpp:func:`samurai::for_each_cell` function takes two parameters: the first 
 This `cell` parameter is of type :cpp:class:`samurai::Cell`.
 We use the method :cpp:func:`corner` to recover the bottom left point of each cell.
 
-We have tagged the cells and we can now re-create a new mesh from the `tag` field by creating four new cells if the correspoding value is `true`.
+We have tagged the cells and we can now re-create a new mesh from the `tag` field by creating four new cells if the corresponding value is `true`.
 We use :cpp:class:`samurai::CellList` to add new intervals efficiently.
 
 .. code-block: c++

--- a/docs/source/tutorial/interval.rst
+++ b/docs/source/tutorial/interval.rst
@@ -101,7 +101,7 @@ We have two cells :math:`0` and :math:`1` on the level :math:`l`. Therefore, we 
 Cell properties
 ---------------
 
-As hinted so far, given an interval and a level, we can reconstruct the correspoding cells.
+As hinted so far, given an interval and a level, we can reconstruct the corresponding cells.
 Indeed:
 
 - The number of cells contained in an interval is equal to the size of the interval.

--- a/docs/source/tutorial/level_set.rst
+++ b/docs/source/tutorial/level_set.rst
@@ -481,7 +481,7 @@ Just to show how to initialize the velocity field, we consider the following C++
 the same is done for the level set, which is a scalar field.
 
 
-The time-step is chosen as :math:`\Delta t = 5\Delta x/8` and :math:`\Delta \tau = \Delta t/100` doing just two iterations with the fictitious time at each time step, which are perfomed only on the cells at the finest level (close to the interface).
+The time-step is chosen as :math:`\Delta t = 5\Delta x/8` and :math:`\Delta \tau = \Delta t/100` doing just two iterations with the fictitious time at each time step, which are performed only on the cells at the finest level (close to the interface).
 
 .. image:: ./figures/level_set.png
     :width: 100%

--- a/docs/source/tutorial/operator_on_subset.rst
+++ b/docs/source/tutorial/operator_on_subset.rst
@@ -180,7 +180,7 @@ Then, we apply a projection operator on cells at level `0` which are completely 
 
 where this property holds for the cells  `1`, `2` and `6` beneath the red arrows.
 
-This projection operator is just the average of valus on the two fine cells. Thus, the result is set in the coarse cell.
+This projection operator is just the average of values on the two fine cells. Thus, the result is set in the coarse cell.
 
 .. code-block:: c++
 


### PR DESCRIPTION
 <!-- Thank you for your contribution to samurai! -->

<!-- Please check the following before submitting your PR -->
- [ ] I have installed [pre-commit](https://pre-commit.com/) locally and use it to validate my commits.
- [x] The PR title follows the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) convention.
      Available tags: 'build', 'chore', 'ci', 'docs', 'feat', 'fix', 'perf', 'refactor', 'revert', 'style', 'test'
- [ ] This new PR is documented.
- [ ] This new PR is tested.

## Description

I have used codespell to find typos and fixed them by hand.

## Related issue
<!-- List the issues solved by this PR, if any. -->

## How has this been tested?
<!-- Give the list of files used to test this new implementation. -->

## Code of Conduct
By submitting this PR, you agree to follow our [Code of Conduct](https://github.com/hpc-maths/samurai/blob/master/docs/CODE_OF_CONDUCT.md)
- [x] I agree to follow this project's Code of Conduct
