### PR TITLE
fix: BC no longer required to assemble the matrix of a local scheme

### DIFF
--- a/include/samurai/petsc/fv/FV_scheme_assembly.hpp
+++ b/include/samurai/petsc/fv/FV_scheme_assembly.hpp
@@ -267,7 +267,7 @@ namespace samurai
 
             void sparsity_pattern_boundary(std::vector<PetscInt>& nnz) const override
             {
-                if (unknown().get_bc().empty())
+                if (cfg_t::stencil_size > 1 && unknown().get_bc().empty())
                 {
                     std::cerr << "Failure to assemble to boundary conditions in the operator '" << this->name()
                               << "': no boundary condition attached to the field '" << unknown().name() << "'." << std::endl;
@@ -371,7 +371,7 @@ namespace samurai
 
             void assemble_boundary_conditions(Mat& A) override
             {
-                if (unknown().get_bc().empty())
+                if (cfg_t::stencil_size > 1 && unknown().get_bc().empty())
                 {
                     std::cerr << "Failure to assemble to boundary conditions in the operator '" << this->name()
                               << "': no boundary condition attached to the field '" << unknown().name() << "'." << std::endl;

--- a/include/samurai/schemes/fv/scheme_operators.hpp
+++ b/include/samurai/schemes/fv/scheme_operators.hpp
@@ -79,7 +79,8 @@ namespace samurai
 
         using cfg_t = Config<scheme_type_of_sum<Operators...>(), stencil_size_of_sum<Operators...>(), output_field_size>;
 
-        static constexpr std::size_t largest_stencil_index = get_largest_stencil_index<Operators...>(); // cppcheck-suppress unreadVariable
+        // cppcheck-suppress unusedStructMember
+        static constexpr std::size_t largest_stencil_index = get_largest_stencil_index<Operators...>();
 
       private:
 

--- a/include/samurai/schemes/fv/scheme_operators.hpp
+++ b/include/samurai/schemes/fv/scheme_operators.hpp
@@ -79,7 +79,7 @@ namespace samurai
 
         using cfg_t = Config<scheme_type_of_sum<Operators...>(), stencil_size_of_sum<Operators...>(), output_field_size>;
 
-        static constexpr std::size_t largest_stencil_index = get_largest_stencil_index<Operators...>();
+        static constexpr std::size_t largest_stencil_index = get_largest_stencil_index<Operators...>(); // cppcheck-suppress unreadVariable
 
       private:
 

--- a/include/samurai/schemes/fv/scheme_operators.hpp
+++ b/include/samurai/schemes/fv/scheme_operators.hpp
@@ -26,6 +26,28 @@ namespace samurai
         }
     }
 
+    template <class... Operators>
+    constexpr std::size_t stencil_size_of_sum()
+    {
+        return std::max({Operators::cfg_t::stencil_size...});
+    }
+
+    template <class... Operators>
+    constexpr std::size_t get_largest_stencil_index()
+    {
+        std::size_t max = std::max({Operators::cfg_t::stencil_size...});
+        std::size_t i   = 0;
+        for (const auto& size : {Operators::cfg_t::stencil_size...})
+        {
+            if (size == max)
+            {
+                break;
+            }
+            i++;
+        }
+        return i;
+    }
+
     /**
      * @class OperatorSum:
      * Stores a list of operators that cannot be combined.
@@ -38,10 +60,11 @@ namespace samurai
     {
       private:
 
-        template <SchemeType scheme_type_, std::size_t output_field_size_>
+        template <SchemeType scheme_type_, std::size_t stencil_size_, std::size_t output_field_size_>
         struct Config
         {
             static constexpr SchemeType scheme_type        = scheme_type_;
+            static constexpr std::size_t stencil_size      = stencil_size_;
             static constexpr std::size_t output_field_size = output_field_size_;
         };
 
@@ -54,7 +77,9 @@ namespace samurai
         using output_field_t                           = typename FirstOperatorType::output_field_t;
         using field_t                                  = input_field_t;
 
-        using cfg_t = Config<scheme_type_of_sum<Operators...>(), output_field_size>;
+        using cfg_t = Config<scheme_type_of_sum<Operators...>(), stencil_size_of_sum<Operators...>(), output_field_size>;
+
+        static constexpr std::size_t largest_stencil_index = get_largest_stencil_index<Operators...>();
 
       private:
 

--- a/include/samurai/schemes/fv/scheme_operators.hpp
+++ b/include/samurai/schemes/fv/scheme_operators.hpp
@@ -79,6 +79,7 @@ namespace samurai
 
         using cfg_t = Config<scheme_type_of_sum<Operators...>(), stencil_size_of_sum<Operators...>(), output_field_size>;
 
+        //
         // cppcheck-suppress unusedStructMember
         static constexpr std::size_t largest_stencil_index = get_largest_stencil_index<Operators...>();
 

--- a/include/samurai/schemes/fv/scheme_operators.hpp
+++ b/include/samurai/schemes/fv/scheme_operators.hpp
@@ -79,7 +79,6 @@ namespace samurai
 
         using cfg_t = Config<scheme_type_of_sum<Operators...>(), stencil_size_of_sum<Operators...>(), output_field_size>;
 
-        //
         // cppcheck-suppress unusedStructMember
         static constexpr std::size_t largest_stencil_index = get_largest_stencil_index<Operators...>();
 


### PR DESCRIPTION
## Description
For a sum of scheme, the one with largest stencil now assembles the BC into the matrix. If all schemes in the sum are local, no BC is required anymore.

## Related issue
Upon assembling the matrix of a local scheme (1-cell stencil), an error was raised saying that the field had no BC.

## Code of Conduct
By submitting this PR, you agree to follow our [Code of Conduct](https://github.com/hpc-maths/samurai/blob/master/docs/CODE_OF_CONDUCT.md)
- [x] I agree to follow this project's Code of Conduct
