### PR TITLE
fix: fill corners on uniform meshes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
       - name: cppcheck installation
         shell: bash -el {0}
         run: |
-          conda install -y cppcheck=2.12 cxx-compiler
+          conda install -y cppcheck=2.13 cxx-compiler
 
       - name: Configure
         shell: bash -el {0}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
       - name: cppcheck installation
         shell: bash -el {0}
         run: |
-          conda install -y cppcheck cxx-compiler
+          conda install -y cppcheck=2.12 cxx-compiler
 
       - name: Configure
         shell: bash -el {0}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
       - name: cppcheck installation
         shell: bash -el {0}
         run: |
-          conda install -y cppcheck=2.13 python=3.12 cxx-compiler
+          conda install -y cppcheck=2.12 python=3.12 cxx-compiler
 
       - name: Configure
         shell: bash -el {0}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
       - name: cppcheck installation
         shell: bash -el {0}
         run: |
-          conda install -y cppcheck=2.12.1 cxx-compiler
+          conda install -y cppcheck cxx-compiler
 
       - name: Configure
         shell: bash -el {0}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
       - name: cppcheck installation
         shell: bash -el {0}
         run: |
-          conda install -y cppcheck=2.13 cxx-compiler
+          conda install -y cppcheck=2.13 python=3.12 cxx-compiler
 
       - name: Configure
         shell: bash -el {0}

--- a/include/samurai/bc.hpp
+++ b/include/samurai/bc.hpp
@@ -1270,7 +1270,7 @@ namespace samurai
                                     PolynomialExtrapolation<Field, i> bc(domain, ConstantBc<Field>(), true);
 
                                     bool only_fill_corners          = false;
-                                    bool only_fill_ghost_neighbours = true;
+                                    bool only_fill_ghost_neighbours = true; // because cell neighbours will be filled by the B.C.
                                     apply_extrapolation_bc_impl<Field, i>(bc, level, field, only_fill_corners, only_fill_ghost_neighbours);
                                 }
                             }
@@ -1300,9 +1300,14 @@ namespace samurai
         }
 
         // Step 2:
-        // Polynomial extrapolation to populate corners and ghosts layers that are not filled by the B.C.
+        // Polynomial extrapolation to populate corners and ghosts layers that are not filled by the B.C. (i.e. outside of the B.C.'s
+        // stencil)
 
-        if (mesh.min_level() != mesh.max_level())
+        // if (mesh.min_level() != mesh.max_level()) // We comment this test because some schemes have a box stencil and need values in
+        //                                              external corners. However, the associated B.C. doesn't fill them, so we do it.
+        //                                              Since on a uniform mesh, the MR process doesn't need corners, it would be better
+        //                                              that the corners be filled by the user as part of the BCs.
+        //                                              But so far the users don't have an easy way to do that...
         {
             // We populate the ghosts sequentially from the closest to the farthest.
             for (std::size_t ghost_layer = 1; ghost_layer <= ghost_width; ++ghost_layer)


### PR DESCRIPTION
## Description
Fill external corners by polynomial extrapolation even on uniform meshes. 
This fixes a regression introduced in #230.

## Related issue
Some schemes have box stencils along with boundary conditions that only fill ghosts in Cartesian direction. Therefore, the corner ghosts are used by the scheme without being filled by the user code.

## Code of Conduct
By submitting this PR, you agree to follow our [Code of Conduct](https://github.com/hpc-maths/samurai/blob/master/docs/CODE_OF_CONDUCT.md)
- [x] I agree to follow this project's Code of Conduct
