### PR TITLE
feat: Timers

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ The [tutorial](./demos/tutorial/) directory is a good first step followed by the
 - [ ] AMR patch-based and block-based methods
 - [x] MRA cell-based methods
 - [ ] MRA point-based methods
-- [x] HDF5 ouput format support
+- [x] HDF5 output format support
 - [ ] MPI implementation
 
 ## Installation

--- a/demos/FiniteVolume/AMR_Burgers_Hat.cpp
+++ b/demos/FiniteVolume/AMR_Burgers_Hat.cpp
@@ -173,7 +173,8 @@ void flux_correction(Field& phi_np1, const Field& phi_n, double dt)
 
 int main(int argc, char* argv[])
 {
-    samurai::initialize(argc, argv);
+    CLI::App app{"Finite volume example for the Burgers equation in 2d using AMR"};
+    samurai::initialize(app, argc, argv);
 
     constexpr std::size_t dim = 1; // cppcheck-suppress unreadVariable
     using Config              = samurai::amr::Config<dim>;
@@ -195,7 +196,6 @@ int main(int argc, char* argv[])
     std::string filename = "FV_AMR_Burgers_Hat_1d";
     std::size_t nfiles   = 1;
 
-    CLI::App app{"Finite volume example for the Burgers equation in 2d using AMR"};
     app.add_option("--left", left_box, "The left border of the box")->capture_default_str()->group("Simulation parameters");
     app.add_option("--right", right_box, "The right border of the box")->capture_default_str()->group("Simulation parameters");
     app.add_option("--cfl", cfl, "The CFL")->capture_default_str()->group("Simulation parameters");
@@ -206,9 +206,9 @@ int main(int argc, char* argv[])
     app.add_option("--with-correction", correction, "Apply flux correction at the interface of two refinement levels")
         ->capture_default_str()
         ->group("AMR parameters");
-    app.add_option("--path", path, "Output path")->capture_default_str()->group("Ouput");
-    app.add_option("--filename", filename, "File name prefix")->capture_default_str()->group("Ouput");
-    app.add_option("--nfiles", nfiles, "Number of output files")->capture_default_str()->group("Ouput");
+    app.add_option("--path", path, "Output path")->capture_default_str()->group("Output");
+    app.add_option("--filename", filename, "File name prefix")->capture_default_str()->group("Output");
+    app.add_option("--nfiles", nfiles, "Number of output files")->capture_default_str()->group("Output");
     CLI11_PARSE(app, argc, argv);
 
     const samurai::Box<double, dim> box({left_box}, {right_box});

--- a/demos/FiniteVolume/AMR_Burgers_Hat.cpp
+++ b/demos/FiniteVolume/AMR_Burgers_Hat.cpp
@@ -172,8 +172,7 @@ void flux_correction(Field& phi_np1, const Field& phi_n, double dt)
 
 int main(int argc, char* argv[])
 {
-    CLI::App app{"Finite volume example for the Burgers equation in 2d using AMR"};
-    samurai::initialize(app, argc, argv);
+    auto& app = samurai::initialize("Finite volume example for the Burgers equation in 2d using AMR", argc, argv);
 
     constexpr std::size_t dim = 1; // cppcheck-suppress unreadVariable
     using Config              = samurai::amr::Config<dim>;
@@ -208,7 +207,7 @@ int main(int argc, char* argv[])
     app.add_option("--path", path, "Output path")->capture_default_str()->group("Output");
     app.add_option("--filename", filename, "File name prefix")->capture_default_str()->group("Output");
     app.add_option("--nfiles", nfiles, "Number of output files")->capture_default_str()->group("Output");
-    CLI11_PARSE(app, argc, argv);
+    SAMURAI_PARSE(argc, argv);
 
     const samurai::Box<double, dim> box({left_box}, {right_box});
     samurai::amr::Mesh<Config> mesh(box, start_level, min_level, max_level);

--- a/demos/FiniteVolume/AMR_Burgers_Hat.cpp
+++ b/demos/FiniteVolume/AMR_Burgers_Hat.cpp
@@ -1,6 +1,5 @@
 // Copyright 2018-2024 the samurai's authors
 // SPDX-License-Identifier:  BSD-3-Clause
-#include <CLI/CLI.hpp>
 
 #include <fmt/format.h>
 #include <iostream>

--- a/demos/FiniteVolume/CMakeLists.txt
+++ b/demos/FiniteVolume/CMakeLists.txt
@@ -13,9 +13,6 @@ if(PETSC_FOUND)
     add_executable(finite-volume-heat-nonlinear heat_nonlinear.cpp)
     target_link_libraries(finite-volume-heat-nonlinear samurai CLI11::CLI11 ${PETSC_LIBRARIES} ${MPI_LIBRARIES})
 
-    add_executable(finite-volume-linear-convection linear_convection.cpp)
-    target_link_libraries(finite-volume-linear-convection samurai CLI11::CLI11 ${PETSC_LINK_LIBRARIES} ${MPI_LIBRARIES})
-
     add_executable(finite-volume-stokes-2d stokes_2d.cpp)
     target_link_libraries(finite-volume-stokes-2d samurai CLI11::CLI11 ${PETSC_LINK_LIBRARIES} ${MPI_LIBRARIES})
 
@@ -54,6 +51,9 @@ target_link_libraries(finite-volume-advection-2d-user-bc samurai CLI11::CLI11)
 
 add_executable(finite-volume-scalar-burgers-2d scalar_burgers_2d.cpp)
 target_link_libraries(finite-volume-scalar-burgers-2d samurai CLI11::CLI11)
+
+add_executable(finite-volume-linear-convection linear_convection.cpp)
+target_link_libraries(finite-volume-linear-convection samurai CLI11::CLI11)
 
 add_executable(finite-volume-burgers burgers.cpp)
 target_link_libraries(finite-volume-burgers samurai CLI11::CLI11)

--- a/demos/FiniteVolume/advection_1d.cpp
+++ b/demos/FiniteVolume/advection_1d.cpp
@@ -111,7 +111,9 @@ void save(const fs::path& path, const std::string& filename, const Field& u, con
 
 int main(int argc, char* argv[])
 {
-    samurai::initialize(argc, argv);
+    CLI::App app{"Finite volume example for the advection equation in 1d "
+                 "using multiresolution"};
+    samurai::initialize(app, argc, argv);
 
     constexpr std::size_t dim = 1; // cppcheck-suppress unreadVariable
     using Config              = samurai::MRConfig<dim>;
@@ -136,8 +138,6 @@ int main(int argc, char* argv[])
     std::string filename = "FV_advection_1d";
     std::size_t nfiles   = 1;
 
-    CLI::App app{"Finite volume example for the advection equation in 1d "
-                 "using multiresolution"};
     app.add_option("--left", left_box, "The left border of the box")->capture_default_str()->group("Simulation parameters");
     app.add_option("--right", right_box, "The right border of the box")->capture_default_str()->group("Simulation parameters");
     app.add_flag("--periodic", is_periodic, "Set the domain periodic")->capture_default_str()->group("Simulation parameters");
@@ -158,9 +158,9 @@ int main(int argc, char* argv[])
     app.add_option("--with-correction", correction, "Apply flux correction at the interface of two refinement levels")
         ->capture_default_str()
         ->group("Multiresolution");
-    app.add_option("--path", path, "Output path")->capture_default_str()->group("Ouput");
-    app.add_option("--filename", filename, "File name prefix")->capture_default_str()->group("Ouput");
-    app.add_option("--nfiles", nfiles, "Number of output files")->capture_default_str()->group("Ouput");
+    app.add_option("--path", path, "Output path")->capture_default_str()->group("Output");
+    app.add_option("--filename", filename, "File name prefix")->capture_default_str()->group("Output");
+    app.add_option("--nfiles", nfiles, "Number of output files")->capture_default_str()->group("Output");
     CLI11_PARSE(app, argc, argv);
 
     const samurai::Box<double, dim> box({left_box}, {right_box});

--- a/demos/FiniteVolume/advection_1d.cpp
+++ b/demos/FiniteVolume/advection_1d.cpp
@@ -1,7 +1,5 @@
 // Copyright 2018-2024 the samurai's authors
 // SPDX-License-Identifier:  BSD-3-Clause
-#include <CLI/CLI.hpp>
-
 #include <xtensor/xfixed.hpp>
 
 #include <samurai/algorithm.hpp>

--- a/demos/FiniteVolume/advection_1d.cpp
+++ b/demos/FiniteVolume/advection_1d.cpp
@@ -109,9 +109,7 @@ void save(const fs::path& path, const std::string& filename, const Field& u, con
 
 int main(int argc, char* argv[])
 {
-    CLI::App app{"Finite volume example for the advection equation in 1d "
-                 "using multiresolution"};
-    samurai::initialize(app, argc, argv);
+    auto& app = samurai::initialize("Finite volume example for the advection equation in 1d using multiresolution", argc, argv);
 
     constexpr std::size_t dim = 1; // cppcheck-suppress unreadVariable
     using Config              = samurai::MRConfig<dim>;
@@ -159,7 +157,7 @@ int main(int argc, char* argv[])
     app.add_option("--path", path, "Output path")->capture_default_str()->group("Output");
     app.add_option("--filename", filename, "File name prefix")->capture_default_str()->group("Output");
     app.add_option("--nfiles", nfiles, "Number of output files")->capture_default_str()->group("Output");
-    CLI11_PARSE(app, argc, argv);
+    SAMURAI_PARSE(argc, argv);
 
     const samurai::Box<double, dim> box({left_box}, {right_box});
     samurai::MRMesh<Config> mesh(box, min_level, max_level, std::array<bool, dim>{is_periodic});

--- a/demos/FiniteVolume/advection_2d.cpp
+++ b/demos/FiniteVolume/advection_2d.cpp
@@ -169,9 +169,7 @@ void save(const fs::path& path, const std::string& filename, const Field& u, con
 
 int main(int argc, char* argv[])
 {
-    CLI::App app{"Finite volume example for the advection equation in 2d "
-                 "using multiresolution"};
-    samurai::initialize(app, argc, argv);
+    auto& app = samurai::initialize("Finite volume example for the advection equation in 2d using multiresolution", argc, argv);
 
     constexpr std::size_t dim = 2;
     using Config              = samurai::MRConfig<dim>;
@@ -219,7 +217,7 @@ int main(int argc, char* argv[])
     app.add_option("--path", path, "Output path")->capture_default_str()->group("Output");
     app.add_option("--filename", filename, "File name prefix")->capture_default_str()->group("Output");
     app.add_option("--nfiles", nfiles, "Number of output files")->capture_default_str()->group("Output");
-    CLI11_PARSE(app, argc, argv);
+    SAMURAI_PARSE(argc, argv);
 
     const samurai::Box<double, dim> box(min_corner, max_corner);
     samurai::MRMesh<Config> mesh{box, min_level, max_level};

--- a/demos/FiniteVolume/advection_2d.cpp
+++ b/demos/FiniteVolume/advection_2d.cpp
@@ -170,7 +170,9 @@ void save(const fs::path& path, const std::string& filename, const Field& u, con
 
 int main(int argc, char* argv[])
 {
-    samurai::initialize(argc, argv);
+    CLI::App app{"Finite volume example for the advection equation in 2d "
+                 "using multiresolution"};
+    samurai::initialize(app, argc, argv);
 
     constexpr std::size_t dim = 2;
     using Config              = samurai::MRConfig<dim>;
@@ -196,8 +198,6 @@ int main(int argc, char* argv[])
     std::string filename = "FV_advection_2d";
     std::size_t nfiles   = 1;
 
-    CLI::App app{"Finite volume example for the advection equation in 2d "
-                 "using multiresolution"};
     app.add_option("--min-corner", min_corner, "The min corner of the box")->capture_default_str()->group("Simulation parameters");
     app.add_option("--max-corner", max_corner, "The max corner of the box")->capture_default_str()->group("Simulation parameters");
     app.add_option("--velocity", a, "The velocity of the advection equation")->capture_default_str()->group("Simulation parameters");
@@ -217,9 +217,9 @@ int main(int argc, char* argv[])
     app.add_option("--with-correction", correction, "Apply flux correction at the interface of two refinement levels")
         ->capture_default_str()
         ->group("Multiresolution");
-    app.add_option("--path", path, "Output path")->capture_default_str()->group("Ouput");
-    app.add_option("--filename", filename, "File name prefix")->capture_default_str()->group("Ouput");
-    app.add_option("--nfiles", nfiles, "Number of output files")->capture_default_str()->group("Ouput");
+    app.add_option("--path", path, "Output path")->capture_default_str()->group("Output");
+    app.add_option("--filename", filename, "File name prefix")->capture_default_str()->group("Output");
+    app.add_option("--nfiles", nfiles, "Number of output files")->capture_default_str()->group("Output");
     CLI11_PARSE(app, argc, argv);
 
     const samurai::Box<double, dim> box(min_corner, max_corner);

--- a/demos/FiniteVolume/advection_2d.cpp
+++ b/demos/FiniteVolume/advection_2d.cpp
@@ -1,6 +1,5 @@
 // Copyright 2018-2024 the samurai's authors
 // SPDX-License-Identifier:  BSD-3-Clause
-#include <CLI/CLI.hpp>
 
 #include <array>
 

--- a/demos/FiniteVolume/advection_2d_user_bc.cpp
+++ b/demos/FiniteVolume/advection_2d_user_bc.cpp
@@ -190,9 +190,7 @@ void save(const fs::path& path, const std::string& filename, const Field& u, con
 
 int main(int argc, char* argv[])
 {
-    CLI::App app{"Finite volume example for the advection equation in 2d "
-                 "using multiresolution"};
-    samurai::initialize(app, argc, argv);
+    auto& app = samurai::initialize("Finite volume example for the advection equation in 2d using multiresolution", argc, argv);
 
     constexpr std::size_t dim = 2;
     using Config              = samurai::MRConfig<dim>;
@@ -240,7 +238,7 @@ int main(int argc, char* argv[])
     app.add_option("--path", path, "Output path")->capture_default_str()->group("Output");
     app.add_option("--filename", filename, "File name prefix")->capture_default_str()->group("Output");
     app.add_option("--nfiles", nfiles, "Number of output files")->capture_default_str()->group("Output");
-    CLI11_PARSE(app, argc, argv);
+    SAMURAI_PARSE(argc, argv);
 
     const samurai::Box<double, dim> box(min_corner, max_corner);
     samurai::MRMesh<Config> mesh{box, min_level, max_level};

--- a/demos/FiniteVolume/advection_2d_user_bc.cpp
+++ b/demos/FiniteVolume/advection_2d_user_bc.cpp
@@ -1,7 +1,5 @@
 // Copyright 2018-2024 the samurai's authors
 // SPDX-License-Identifier:  BSD-3-Clause
-#include <CLI/CLI.hpp>
-
 #include <array>
 
 #include <xtensor/xfixed.hpp>

--- a/demos/FiniteVolume/advection_2d_user_bc.cpp
+++ b/demos/FiniteVolume/advection_2d_user_bc.cpp
@@ -192,7 +192,9 @@ void save(const fs::path& path, const std::string& filename, const Field& u, con
 
 int main(int argc, char* argv[])
 {
-    samurai::initialize(argc, argv);
+    CLI::App app{"Finite volume example for the advection equation in 2d "
+                 "using multiresolution"};
+    samurai::initialize(app, argc, argv);
 
     constexpr std::size_t dim = 2;
     using Config              = samurai::MRConfig<dim>;
@@ -218,8 +220,6 @@ int main(int argc, char* argv[])
     std::string filename = "FV_advection_2d";
     std::size_t nfiles   = 1;
 
-    CLI::App app{"Finite volume example for the advection equation in 2d "
-                 "using multiresolution"};
     app.add_option("--min-corner", min_corner, "The min corner of the box")->capture_default_str()->group("Simulation parameters");
     app.add_option("--max-corner", max_corner, "The max corner of the box")->capture_default_str()->group("Simulation parameters");
     app.add_option("--velocity", a, "The velocity of the advection equation")->capture_default_str()->group("Simulation parameters");
@@ -239,9 +239,9 @@ int main(int argc, char* argv[])
     app.add_option("--with-correction", correction, "Apply flux correction at the interface of two refinement levels")
         ->capture_default_str()
         ->group("Multiresolution");
-    app.add_option("--path", path, "Output path")->capture_default_str()->group("Ouput");
-    app.add_option("--filename", filename, "File name prefix")->capture_default_str()->group("Ouput");
-    app.add_option("--nfiles", nfiles, "Number of output files")->capture_default_str()->group("Ouput");
+    app.add_option("--path", path, "Output path")->capture_default_str()->group("Output");
+    app.add_option("--filename", filename, "File name prefix")->capture_default_str()->group("Output");
+    app.add_option("--nfiles", nfiles, "Number of output files")->capture_default_str()->group("Output");
     CLI11_PARSE(app, argc, argv);
 
     const samurai::Box<double, dim> box(min_corner, max_corner);

--- a/demos/FiniteVolume/burgers.cpp
+++ b/demos/FiniteVolume/burgers.cpp
@@ -43,8 +43,7 @@ void save(const fs::path& path, const std::string& filename, const Field& u, con
 template <std::size_t dim, std::size_t field_size>
 int main_dim(int argc, char* argv[])
 {
-    CLI::App app{"Finite volume example for the heat equation in 1d"};
-    samurai::initialize(app, argc, argv);
+    auto& app = samurai::initialize("Finite volume example for the heat equation in 1d", argc, argv);
 
     using Config  = samurai::MRConfig<dim, 3>;
     using Box     = samurai::Box<double, dim>;
@@ -98,7 +97,7 @@ int main_dim(int argc, char* argv[])
     app.add_option("--filename", filename, "File name prefix")->capture_default_str()->group("Output");
     app.add_option("--nfiles", nfiles, "Number of output files")->capture_default_str()->group("Output");
     app.allow_extras();
-    CLI11_PARSE(app, argc, argv);
+    SAMURAI_PARSE(argc, argv);
 
     //--------------------//
     // Problem definition //

--- a/demos/FiniteVolume/burgers.cpp
+++ b/demos/FiniteVolume/burgers.cpp
@@ -1,6 +1,5 @@
 // Copyright 2018-2024 the samurai's authors
 // SPDX-License-Identifier:  BSD-3-Clause
-#include <CLI/CLI.hpp>
 
 #include <samurai/hdf5.hpp>
 #include <samurai/mr/adapt.hpp>

--- a/demos/FiniteVolume/burgers.cpp
+++ b/demos/FiniteVolume/burgers.cpp
@@ -44,7 +44,8 @@ void save(const fs::path& path, const std::string& filename, const Field& u, con
 template <std::size_t dim, std::size_t field_size>
 int main_dim(int argc, char* argv[])
 {
-    samurai::initialize(argc, argv);
+    CLI::App app{"Finite volume example for the heat equation in 1d"};
+    samurai::initialize(app, argc, argv);
 
     using Config  = samurai::MRConfig<dim, 3>;
     using Box     = samurai::Box<double, dim>;
@@ -77,7 +78,6 @@ int main_dim(int argc, char* argv[])
     std::string filename = "burgers_" + std::to_string(dim) + "D";
     std::size_t nfiles   = 50;
 
-    CLI::App app{"Finite volume example for the heat equation in 1d"};
     app.add_option("--left", left_box, "The left border of the box")->capture_default_str()->group("Simulation parameters");
     app.add_option("--right", right_box, "The right border of the box")->capture_default_str()->group("Simulation parameters");
     app.add_option("--init-sol", init_sol, "Initial solution: hat/linear/bands")->capture_default_str()->group("Simulation parameters");
@@ -95,9 +95,9 @@ int main_dim(int argc, char* argv[])
                    "adapt the mesh")
         ->capture_default_str()
         ->group("Multiresolution");
-    app.add_option("--path", path, "Output path")->capture_default_str()->group("Ouput");
-    app.add_option("--filename", filename, "File name prefix")->capture_default_str()->group("Ouput");
-    app.add_option("--nfiles", nfiles, "Number of output files")->capture_default_str()->group("Ouput");
+    app.add_option("--path", path, "Output path")->capture_default_str()->group("Output");
+    app.add_option("--filename", filename, "File name prefix")->capture_default_str()->group("Output");
+    app.add_option("--nfiles", nfiles, "Number of output files")->capture_default_str()->group("Output");
     app.allow_extras();
     CLI11_PARSE(app, argc, argv);
 

--- a/demos/FiniteVolume/heat.cpp
+++ b/demos/FiniteVolume/heat.cpp
@@ -44,8 +44,7 @@ void save(const fs::path& path, const std::string& filename, const Field& u, con
 
 int main(int argc, char* argv[])
 {
-    CLI::App app{"Finite volume example for the heat equation"};
-    samurai::initialize(app, argc, argv);
+    auto& app = samurai::initialize("Finite volume example for the heat equation", argc, argv);
 
     static constexpr std::size_t dim = 2;
     using Config                     = samurai::MRConfig<dim>;
@@ -114,7 +113,7 @@ int main(int argc, char* argv[])
     app.add_option("--filename", filename, "File name prefix")->capture_default_str()->group("Output");
     app.add_flag("--save-final-state-only", save_final_state_only, "Save final state only")->group("Output");
     app.allow_extras();
-    CLI11_PARSE(app, argc, argv);
+    SAMURAI_PARSE(argc, argv);
 
     //------------------//
     // Petsc initialize //

--- a/demos/FiniteVolume/heat.cpp
+++ b/demos/FiniteVolume/heat.cpp
@@ -45,7 +45,8 @@ void save(const fs::path& path, const std::string& filename, const Field& u, con
 
 int main(int argc, char* argv[])
 {
-    samurai::initialize(argc, argv);
+    CLI::App app{"Finite volume example for the heat equation"};
+    samurai::initialize(app, argc, argv);
 
     static constexpr std::size_t dim = 2;
     using Config                     = samurai::MRConfig<dim>;
@@ -91,7 +92,6 @@ int main(int argc, char* argv[])
     std::string filename       = "heat_" + std::to_string(dim) + "D";
     bool save_final_state_only = false;
 
-    CLI::App app{"Finite volume example for the heat equation"};
     app.add_option("--left", left_box, "The left border of the box")->capture_default_str()->group("Simulation parameters");
     app.add_option("--right", right_box, "The right border of the box")->capture_default_str()->group("Simulation parameters");
     app.add_option("--init-sol", init_sol, "Initial solution: dirac/crenel")->capture_default_str()->group("Simulation parameters");
@@ -111,8 +111,8 @@ int main(int argc, char* argv[])
                    "adapt the mesh")
         ->capture_default_str()
         ->group("Multiresolution");
-    app.add_option("--path", path, "Output path")->capture_default_str()->group("Ouput");
-    app.add_option("--filename", filename, "File name prefix")->capture_default_str()->group("Ouput");
+    app.add_option("--path", path, "Output path")->capture_default_str()->group("Output");
+    app.add_option("--filename", filename, "File name prefix")->capture_default_str()->group("Output");
     app.add_flag("--save-final-state-only", save_final_state_only, "Save final state only")->group("Output");
     app.allow_extras();
     CLI11_PARSE(app, argc, argv);
@@ -121,6 +121,7 @@ int main(int argc, char* argv[])
     // Petsc initialize //
     //------------------//
 
+    samurai::times::timers.start("petsc init");
     PetscInitialize(&argc, &argv, 0, nullptr);
 
     PetscMPIInt size;
@@ -128,6 +129,7 @@ int main(int argc, char* argv[])
     PetscCheck(size == 1, PETSC_COMM_WORLD, PETSC_ERR_WRONG_MPI_SIZE, "This is a uniprocessor example only!");
     PetscOptionsSetValue(NULL, "-options_left", "off"); // If on, Petsc will issue warnings saying that
                                                         // the options managed by CLI are unused
+    samurai::times::timers.stop("petsc init");
 
     //--------------------//
     // Problem definition //
@@ -259,7 +261,9 @@ int main(int argc, char* argv[])
         save(path, filename, u);
     }
 
+    samurai::times::timers.start("petsc finalize");
     PetscFinalize();
+    samurai::times::timers.stop("petsc finalize");
 
     samurai::finalize();
     return 0;

--- a/demos/FiniteVolume/heat.cpp
+++ b/demos/FiniteVolume/heat.cpp
@@ -1,6 +1,5 @@
 // Copyright 2018-2024 the samurai's authors
 // SPDX-License-Identifier:  BSD-3-Clause
-#include <CLI/CLI.hpp>
 
 #include <samurai/hdf5.hpp>
 #include <samurai/mr/adapt.hpp>

--- a/demos/FiniteVolume/heat_heterogeneous.cpp
+++ b/demos/FiniteVolume/heat_heterogeneous.cpp
@@ -33,7 +33,8 @@ void save(const fs::path& path, const std::string& filename, const Field& u, con
 
 int main(int argc, char* argv[])
 {
-    samurai::initialize(argc, argv);
+    CLI::App app{"Finite volume example for the heat equation in 2D"};
+    samurai::initialize(app, argc, argv);
 
     static constexpr std::size_t dim = 2;
     using Config                     = samurai::MRConfig<dim>;
@@ -67,7 +68,6 @@ int main(int argc, char* argv[])
     std::string filename       = "heat_heterog_" + std::to_string(dim) + "D";
     bool save_final_state_only = false;
 
-    CLI::App app{"Finite volume example for the heat equation in 2D"};
     app.add_flag("--explicit", explicit_scheme, "Explicit scheme instead of implicit")->group("Simulation parameters");
     app.add_option("--Tf", Tf, "Final time")->capture_default_str()->group("Simulation parameters");
     app.add_option("--dt", dt, "Time step")->capture_default_str()->group("Simulation parameters");
@@ -83,8 +83,8 @@ int main(int argc, char* argv[])
                    "adapt the mesh")
         ->capture_default_str()
         ->group("Multiresolution");
-    app.add_option("--path", path, "Output path")->capture_default_str()->group("Ouput");
-    app.add_option("--filename", filename, "File name prefix")->capture_default_str()->group("Ouput");
+    app.add_option("--path", path, "Output path")->capture_default_str()->group("Output");
+    app.add_option("--filename", filename, "File name prefix")->capture_default_str()->group("Output");
     app.add_flag("--save-final-state-only", save_final_state_only, "Save final state only")->group("Output");
     app.allow_extras();
     CLI11_PARSE(app, argc, argv);

--- a/demos/FiniteVolume/heat_heterogeneous.cpp
+++ b/demos/FiniteVolume/heat_heterogeneous.cpp
@@ -32,8 +32,7 @@ void save(const fs::path& path, const std::string& filename, const Field& u, con
 
 int main(int argc, char* argv[])
 {
-    CLI::App app{"Finite volume example for the heat equation in 2D"};
-    samurai::initialize(app, argc, argv);
+    auto& app = samurai::initialize("Finite volume example for the heat equation", argc, argv);
 
     static constexpr std::size_t dim = 2;
     using Config                     = samurai::MRConfig<dim>;
@@ -86,7 +85,7 @@ int main(int argc, char* argv[])
     app.add_option("--filename", filename, "File name prefix")->capture_default_str()->group("Output");
     app.add_flag("--save-final-state-only", save_final_state_only, "Save final state only")->group("Output");
     app.allow_extras();
-    CLI11_PARSE(app, argc, argv);
+    SAMURAI_PARSE(argc, argv);
 
     //------------------//
     // Petsc initialize //

--- a/demos/FiniteVolume/heat_heterogeneous.cpp
+++ b/demos/FiniteVolume/heat_heterogeneous.cpp
@@ -1,6 +1,5 @@
 // Copyright 2018-2024 the samurai's authors
 // SPDX-License-Identifier:  BSD-3-Clause
-#include <CLI/CLI.hpp>
 
 #include <samurai/hdf5.hpp>
 #include <samurai/mr/adapt.hpp>

--- a/demos/FiniteVolume/heat_nonlinear.cpp
+++ b/demos/FiniteVolume/heat_nonlinear.cpp
@@ -97,8 +97,7 @@ auto make_nonlinear_diffusion()
 
 int main(int argc, char* argv[])
 {
-    CLI::App app{"Finite volume example for the heat equation"};
-    samurai::initialize(app, argc, argv);
+    auto& app = samurai::initialize("Finite volume example for the heat equation", argc, argv);
 
     static constexpr std::size_t dim = 2;
     using Config                     = samurai::MRConfig<dim>;
@@ -158,7 +157,7 @@ int main(int argc, char* argv[])
     app.add_option("--filename", filename, "File name prefix")->capture_default_str()->group("Output");
     app.add_flag("--save-final-state-only", save_final_state_only, "Save final state only")->group("Output");
     app.allow_extras();
-    CLI11_PARSE(app, argc, argv);
+    SAMURAI_PARSE(argc, argv);
 
     //------------------//
     // Petsc initialize //

--- a/demos/FiniteVolume/heat_nonlinear.cpp
+++ b/demos/FiniteVolume/heat_nonlinear.cpp
@@ -98,7 +98,8 @@ auto make_nonlinear_diffusion()
 
 int main(int argc, char* argv[])
 {
-    samurai::initialize(argc, argv);
+    CLI::App app{"Finite volume example for the heat equation"};
+    samurai::initialize(app, argc, argv);
 
     static constexpr std::size_t dim = 2;
     using Config                     = samurai::MRConfig<dim>;
@@ -142,7 +143,6 @@ int main(int argc, char* argv[])
     std::string filename       = "heat_nonlinear_" + std::to_string(dim) + "D";
     bool save_final_state_only = false;
 
-    CLI::App app{"Finite volume example for the heat equation in 2D"};
     app.add_flag("--explicit", explicit_scheme, "Explicit scheme instead of implicit")->group("Simulation parameters");
     app.add_option("--Tf", Tf, "Final time")->capture_default_str()->group("Simulation parameters");
     app.add_option("--dt", dt, "Time step")->capture_default_str()->group("Simulation parameters");
@@ -155,8 +155,8 @@ int main(int argc, char* argv[])
     app.add_option("--mr-reg", mr_regularity, "The regularity criteria used by the multiresolution to adapt the mesh")
         ->capture_default_str()
         ->group("Multiresolution");
-    app.add_option("--path", path, "Output path")->capture_default_str()->group("Ouput");
-    app.add_option("--filename", filename, "File name prefix")->capture_default_str()->group("Ouput");
+    app.add_option("--path", path, "Output path")->capture_default_str()->group("Output");
+    app.add_option("--filename", filename, "File name prefix")->capture_default_str()->group("Output");
     app.add_flag("--save-final-state-only", save_final_state_only, "Save final state only")->group("Output");
     app.allow_extras();
     CLI11_PARSE(app, argc, argv);

--- a/demos/FiniteVolume/heat_nonlinear.cpp
+++ b/demos/FiniteVolume/heat_nonlinear.cpp
@@ -1,6 +1,5 @@
 // Copyright 2018-2024 the samurai's authors
 // SPDX-License-Identifier:  BSD-3-Clause
-#include <CLI/CLI.hpp>
 
 #include <samurai/hdf5.hpp>
 #include <samurai/mr/adapt.hpp>

--- a/demos/FiniteVolume/level_set.cpp
+++ b/demos/FiniteVolume/level_set.cpp
@@ -248,8 +248,7 @@ void save(const fs::path& path, const std::string& filename, const Field& u, con
 
 int main(int argc, char* argv[])
 {
-    CLI::App app{"Finite volume example with a level set in 2d using AMR"};
-    samurai::initialize(app, argc, argv);
+    auto& app = samurai::initialize("Finite volume example with a level set in 2d using AMR", argc, argv);
 
     constexpr std::size_t dim = 2;
     using Config              = samurai::amr::Config<dim, 2>;
@@ -284,7 +283,7 @@ int main(int argc, char* argv[])
     app.add_option("--path", path, "Output path")->capture_default_str()->group("Output");
     app.add_option("--filename", filename, "File name prefix")->capture_default_str()->group("Output");
     app.add_option("--nfiles", nfiles, "Number of output files")->capture_default_str()->group("Output");
-    CLI11_PARSE(app, argc, argv);
+    SAMURAI_PARSE(argc, argv);
 
     const samurai::Box<double, dim> box(min_corner, max_corner);
     samurai::amr::Mesh<Config> mesh(box, start_level, min_level, max_level);

--- a/demos/FiniteVolume/level_set.cpp
+++ b/demos/FiniteVolume/level_set.cpp
@@ -249,7 +249,8 @@ void save(const fs::path& path, const std::string& filename, const Field& u, con
 
 int main(int argc, char* argv[])
 {
-    samurai::initialize(argc, argv);
+    CLI::App app{"Finite volume example with a level set in 2d using AMR"};
+    samurai::initialize(app, argc, argv);
 
     constexpr std::size_t dim = 2;
     using Config              = samurai::amr::Config<dim, 2>;
@@ -271,7 +272,6 @@ int main(int argc, char* argv[])
     std::string filename = "FV_level_set_2d";
     std::size_t nfiles   = 1;
 
-    CLI::App app{"Finite volume example with a level set in 2d using AMR"};
     app.add_option("--min-corner", min_corner, "The min corner of the box")->capture_default_str()->group("Simulation parameters");
     app.add_option("--max-corner", max_corner, "The max corner of the box")->capture_default_str()->group("Simulation parameters");
     app.add_option("--cfl", cfl, "The CFL")->capture_default_str()->group("Simulation parameters");
@@ -282,9 +282,9 @@ int main(int argc, char* argv[])
     app.add_option("--with-correction", correction, "Apply flux correction at the interface of two refinement levels")
         ->capture_default_str()
         ->group("AMR parameters");
-    app.add_option("--path", path, "Output path")->capture_default_str()->group("Ouput");
-    app.add_option("--filename", filename, "File name prefix")->capture_default_str()->group("Ouput");
-    app.add_option("--nfiles", nfiles, "Number of output files")->capture_default_str()->group("Ouput");
+    app.add_option("--path", path, "Output path")->capture_default_str()->group("Output");
+    app.add_option("--filename", filename, "File name prefix")->capture_default_str()->group("Output");
+    app.add_option("--nfiles", nfiles, "Number of output files")->capture_default_str()->group("Output");
     CLI11_PARSE(app, argc, argv);
 
     const samurai::Box<double, dim> box(min_corner, max_corner);

--- a/demos/FiniteVolume/level_set.cpp
+++ b/demos/FiniteVolume/level_set.cpp
@@ -1,6 +1,5 @@
 // Copyright 2018-2024 the samurai's authors
 // SPDX-License-Identifier:  BSD-3-Clause
-#include <CLI/CLI.hpp>
 
 #include <samurai/algorithm/graduation.hpp>
 #include <samurai/algorithm/update.hpp>

--- a/demos/FiniteVolume/level_set_from_scratch.cpp
+++ b/demos/FiniteVolume/level_set_from_scratch.cpp
@@ -1,6 +1,5 @@
 // Copyright 2018-2024 the samurai's authors
 // SPDX-License-Identifier:  BSD-3-Clause
-#include <CLI/CLI.hpp>
 
 #include <samurai/algorithm/update.hpp>
 #include <samurai/algorithm/utils.hpp>

--- a/demos/FiniteVolume/level_set_from_scratch.cpp
+++ b/demos/FiniteVolume/level_set_from_scratch.cpp
@@ -557,8 +557,7 @@ void save(const fs::path& path, const std::string& filename, const Field& u, con
 
 int main(int argc, char* argv[])
 {
-    CLI::App app{"Finite volume example with a level set in 2d using AMR"};
-    samurai::initialize(app, argc, argv);
+    auto& app = samurai::initialize("Finite volume example with a level set in 2d using AMR", argc, argv);
 
     constexpr size_t dim = 2;
     using Config         = AMRConfig<dim>;
@@ -593,7 +592,7 @@ int main(int argc, char* argv[])
     app.add_option("--path", path, "Output path")->capture_default_str()->group("Output");
     app.add_option("--filename", filename, "File name prefix")->capture_default_str()->group("Output");
     app.add_option("--nfiles", nfiles, "Number of output files")->capture_default_str()->group("Output");
-    CLI11_PARSE(app, argc, argv);
+    SAMURAI_PARSE(argc, argv);
 
     const samurai::Box<double, dim> box(min_corner, max_corner);
     AMRMesh<Config> mesh{box, max_level, min_level, max_level};

--- a/demos/FiniteVolume/level_set_from_scratch.cpp
+++ b/demos/FiniteVolume/level_set_from_scratch.cpp
@@ -558,7 +558,8 @@ void save(const fs::path& path, const std::string& filename, const Field& u, con
 
 int main(int argc, char* argv[])
 {
-    samurai::initialize(argc, argv);
+    CLI::App app{"Finite volume example with a level set in 2d using AMR"};
+    samurai::initialize(app, argc, argv);
 
     constexpr size_t dim = 2;
     using Config         = AMRConfig<dim>;
@@ -580,7 +581,6 @@ int main(int argc, char* argv[])
     std::string filename = "FV_level_set_2d";
     std::size_t nfiles   = 1;
 
-    CLI::App app{"Finite volume example with a level set in 2d using AMR"};
     app.add_option("--min-corner", min_corner, "The min corner of the box")->capture_default_str()->group("Simulation parameters");
     app.add_option("--max-corner", max_corner, "The max corner of the box")->capture_default_str()->group("Simulation parameters");
     app.add_option("--cfl", cfl, "The CFL")->capture_default_str()->group("Simulation parameters");
@@ -591,9 +591,9 @@ int main(int argc, char* argv[])
     app.add_flag("--with-correction", correction, "Apply flux correction at the interface of two refinement levels")
         ->capture_default_str()
         ->group("AMR parameters");
-    app.add_option("--path", path, "Output path")->capture_default_str()->group("Ouput");
-    app.add_option("--filename", filename, "File name prefix")->capture_default_str()->group("Ouput");
-    app.add_option("--nfiles", nfiles, "Number of output files")->capture_default_str()->group("Ouput");
+    app.add_option("--path", path, "Output path")->capture_default_str()->group("Output");
+    app.add_option("--filename", filename, "File name prefix")->capture_default_str()->group("Output");
+    app.add_option("--nfiles", nfiles, "Number of output files")->capture_default_str()->group("Output");
     CLI11_PARSE(app, argc, argv);
 
     const samurai::Box<double, dim> box(min_corner, max_corner);

--- a/demos/FiniteVolume/lid_driven_cavity.cpp
+++ b/demos/FiniteVolume/lid_driven_cavity.cpp
@@ -1,8 +1,6 @@
 // Copyright 2018-2024 the samurai's authors
 // SPDX-License-Identifier:  BSD-3-Clause
 
-#include <CLI/CLI.hpp>
-
 #include <iostream>
 #include <samurai/hdf5.hpp>
 #include <samurai/mr/adapt.hpp>

--- a/demos/FiniteVolume/lid_driven_cavity.cpp
+++ b/demos/FiniteVolume/lid_driven_cavity.cpp
@@ -94,8 +94,7 @@ void configure_solver(Solver& solver)
 
 int main(int argc, char* argv[])
 {
-    CLI::App app{"Lid-driven cavity"};
-    samurai::initialize(app, argc, argv);
+    auto& app = samurai::initialize("Lid-driven cavity", argc, argv);
 
     constexpr std::size_t dim = 2;
     using Config              = samurai::MRConfig<dim, 2>;
@@ -147,7 +146,7 @@ int main(int argc, char* argv[])
     app.add_flag("--export-velocity", export_velocity, "Export velocity field")->capture_default_str()->group("Output");
     app.add_flag("--export-reconstruct", export_reconstruct, "Export reconstructed fields")->capture_default_str()->group("Output");
     app.allow_extras();
-    CLI11_PARSE(app, argc, argv);
+    SAMURAI_PARSE(argc, argv);
 
     if (!fs::exists(path))
     {

--- a/demos/FiniteVolume/linear_convection.cpp
+++ b/demos/FiniteVolume/linear_convection.cpp
@@ -82,9 +82,9 @@ int main(int argc, char* argv[])
                    "adapt the mesh")
         ->capture_default_str()
         ->group("Multiresolution");
-    app.add_option("--path", path, "Output path")->capture_default_str()->group("Ouput");
-    app.add_option("--filename", filename, "File name prefix")->capture_default_str()->group("Ouput");
-    app.add_option("--nfiles", nfiles, "Number of output files")->capture_default_str()->group("Ouput");
+    app.add_option("--path", path, "Output path")->capture_default_str()->group("Output");
+    app.add_option("--filename", filename, "File name prefix")->capture_default_str()->group("Output");
+    app.add_option("--nfiles", nfiles, "Number of output files")->capture_default_str()->group("Output");
     app.allow_extras();
     CLI11_PARSE(app, argc, argv);
 

--- a/demos/FiniteVolume/linear_convection.cpp
+++ b/demos/FiniteVolume/linear_convection.cpp
@@ -1,6 +1,5 @@
 // Copyright 2018-2024 the samurai's authors
 // SPDX-License-Identifier:  BSD-3-Clause
-#include <CLI/CLI.hpp>
 
 #include <samurai/hdf5.hpp>
 #include <samurai/mr/adapt.hpp>
@@ -33,7 +32,8 @@ void save(const fs::path& path, const std::string& filename, const Field& u, con
 
 int main(int argc, char* argv[])
 {
-    samurai::initialize(argc, argv);
+    CLI::App app{"Finite volume example for the linear convection equation"};
+    samurai::initialize(app, argc, argv);
 
     static constexpr std::size_t dim = 2;
     using Config                     = samurai::MRConfig<dim, 3>;
@@ -66,7 +66,6 @@ int main(int argc, char* argv[])
     std::string filename = "linear_convection_" + std::to_string(dim) + "D";
     std::size_t nfiles   = 0;
 
-    CLI::App app{"Finite volume example for the linear convection equation"};
     app.add_option("--left", left_box, "The left border of the box")->capture_default_str()->group("Simulation parameters");
     app.add_option("--right", right_box, "The right border of the box")->capture_default_str()->group("Simulation parameters");
     app.add_option("--Tf", Tf, "Final time")->capture_default_str()->group("Simulation parameters");

--- a/demos/FiniteVolume/linear_convection.cpp
+++ b/demos/FiniteVolume/linear_convection.cpp
@@ -4,8 +4,8 @@
 #include <samurai/hdf5.hpp>
 #include <samurai/mr/adapt.hpp>
 #include <samurai/mr/mesh.hpp>
-#include <samurai/petsc.hpp>
 #include <samurai/samurai.hpp>
+#include <samurai/schemes/fv.hpp>
 
 #include <filesystem>
 namespace fs = std::filesystem;
@@ -32,8 +32,7 @@ void save(const fs::path& path, const std::string& filename, const Field& u, con
 
 int main(int argc, char* argv[])
 {
-    CLI::App app{"Finite volume example for the linear convection equation"};
-    samurai::initialize(app, argc, argv);
+    auto& app = samurai::initialize("Finite volume example for the linear convection equation", argc, argv);
 
     static constexpr std::size_t dim = 2;
     using Config                     = samurai::MRConfig<dim, 3>;
@@ -86,7 +85,7 @@ int main(int argc, char* argv[])
     app.add_option("--filename", filename, "File name prefix")->capture_default_str()->group("Output");
     app.add_option("--nfiles", nfiles, "Number of output files")->capture_default_str()->group("Output");
     app.allow_extras();
-    CLI11_PARSE(app, argc, argv);
+    SAMURAI_PARSE(argc, argv);
 
     //--------------------//
     // Problem definition //

--- a/demos/FiniteVolume/linear_convection.cpp
+++ b/demos/FiniteVolume/linear_convection.cpp
@@ -106,13 +106,13 @@ int main(int argc, char* argv[])
                                     {
                                         if constexpr (dim == 1)
                                         {
-                                            auto& x = coords(0);
+                                            const auto& x = coords(0);
                                             return (x >= -0.8 && x <= -0.3) ? 1. : 0.;
                                         }
                                         else
                                         {
-                                            auto& x = coords(0);
-                                            auto& y = coords(1);
+                                            const auto& x = coords(0);
+                                            const auto& y = coords(1);
                                             return (x >= -0.8 && x <= -0.3 && y >= 0.3 && y <= 0.8) ? 1. : 0.;
                                         }
                                     });

--- a/demos/FiniteVolume/manual_block_matrix_assembly.cpp
+++ b/demos/FiniteVolume/manual_block_matrix_assembly.cpp
@@ -185,7 +185,6 @@ struct Coupling_auxCe_s : public samurai::petsc::ManualAssembly<aux_t>
 };
 
 int main(int argc, char* argv[])
-
 {
     samurai::initialize(argc, argv);
 

--- a/demos/FiniteVolume/manual_block_matrix_assembly.cpp
+++ b/demos/FiniteVolume/manual_block_matrix_assembly.cpp
@@ -1,6 +1,5 @@
 // Copyright 2018-2024 the samurai's authors
 // SPDX-License-Identifier:  BSD-3-Clause
-#include <CLI/CLI.hpp>
 
 #include <samurai/hdf5.hpp>
 #include <samurai/mr/adapt.hpp>

--- a/demos/FiniteVolume/nagumo.cpp
+++ b/demos/FiniteVolume/nagumo.cpp
@@ -1,7 +1,5 @@
 // Copyright 2018-2024 the samurai's authors
 // SPDX-License-Identifier:  BSD-3-Clause
-#include "CLI/CLI.hpp"
-
 #include <samurai/hdf5.hpp>
 #include <samurai/mr/adapt.hpp>
 #include <samurai/mr/mesh.hpp>

--- a/demos/FiniteVolume/nagumo.cpp
+++ b/demos/FiniteVolume/nagumo.cpp
@@ -31,8 +31,7 @@ void save(const fs::path& path, const std::string& filename, const Field& u, con
 
 int main(int argc, char* argv[])
 {
-    CLI::App app{"Finite volume example for the Nagumo equation"};
-    samurai::initialize(app, argc, argv);
+    auto& app = samurai::initialize("Finite volume example for the Nagumo equation", argc, argv);
 
     static constexpr std::size_t dim        = 1;
     static constexpr std::size_t field_size = 1;
@@ -102,7 +101,7 @@ int main(int argc, char* argv[])
     app.add_option("--filename", filename, "File name prefix")->capture_default_str()->group("Output");
     app.add_flag("--save-final-state-only", save_final_state_only, "Save final state only")->group("Output");
     app.allow_extras();
-    CLI11_PARSE(app, argc, argv);
+    SAMURAI_PARSE(argc, argv);
 
     //------------------//
     // Petsc initialize //

--- a/demos/FiniteVolume/scalar_burgers_2d.cpp
+++ b/demos/FiniteVolume/scalar_burgers_2d.cpp
@@ -1,6 +1,5 @@
 // Copyright 2018-2024 the samurai's authors
 // SPDX-License-Identifier:  BSD-3-Clause
-#include <CLI/CLI.hpp>
 
 #include <xtensor/xfixed.hpp>
 

--- a/demos/FiniteVolume/scalar_burgers_2d.cpp
+++ b/demos/FiniteVolume/scalar_burgers_2d.cpp
@@ -182,7 +182,9 @@ void save(const fs::path& path, const std::string& filename, const Field& u, con
 
 int main(int argc, char* argv[])
 {
-    samurai::initialize(argc, argv);
+    CLI::App app{"Finite volume example for the scalar Burgers equation in 2d "
+                 "using multiresolution"};
+    samurai::initialize(app, argc, argv);
 
     constexpr size_t dim = 2;
     using Config         = samurai::MRConfig<dim>;
@@ -208,8 +210,6 @@ int main(int argc, char* argv[])
     std::string filename = "FV_scalar_burgers_2d";
     std::size_t nfiles   = 1;
 
-    CLI::App app{"Finite volume example for the scalar Burgers equation in 2d "
-                 "using multiresolution"};
     app.add_option("--min-corner", min_corner, "The min corner of the box")->capture_default_str()->group("Simulation parameters");
     app.add_option("--max-corner", max_corner, "The max corner of the box")->capture_default_str()->group("Simulation parameters");
     app.add_option("--velocity", k, "The velocity of the Burgers equation")->capture_default_str()->group("Simulation parameters");
@@ -229,9 +229,9 @@ int main(int argc, char* argv[])
     app.add_option("--with-correction", correction, "Apply flux correction at the interface of two refinement levels")
         ->capture_default_str()
         ->group("Multiresolution");
-    app.add_option("--path", path, "Output path")->capture_default_str()->group("Ouput");
-    app.add_option("--filename", filename, "File name prefix")->capture_default_str()->group("Ouput");
-    app.add_option("--nfiles", nfiles, "Number of output files")->capture_default_str()->group("Ouput");
+    app.add_option("--path", path, "Output path")->capture_default_str()->group("Output");
+    app.add_option("--filename", filename, "File name prefix")->capture_default_str()->group("Output");
+    app.add_option("--nfiles", nfiles, "Number of output files")->capture_default_str()->group("Output");
     CLI11_PARSE(app, argc, argv);
 
     const samurai::Box<double, dim> box(min_corner, max_corner);

--- a/demos/FiniteVolume/scalar_burgers_2d.cpp
+++ b/demos/FiniteVolume/scalar_burgers_2d.cpp
@@ -181,9 +181,7 @@ void save(const fs::path& path, const std::string& filename, const Field& u, con
 
 int main(int argc, char* argv[])
 {
-    CLI::App app{"Finite volume example for the scalar Burgers equation in 2d "
-                 "using multiresolution"};
-    samurai::initialize(app, argc, argv);
+    auto& app = samurai::initialize("Finite volume example for the scalar Burgers equation in 2d using multiresolution", argc, argv);
 
     constexpr size_t dim = 2;
     using Config         = samurai::MRConfig<dim>;
@@ -231,7 +229,7 @@ int main(int argc, char* argv[])
     app.add_option("--path", path, "Output path")->capture_default_str()->group("Output");
     app.add_option("--filename", filename, "File name prefix")->capture_default_str()->group("Output");
     app.add_option("--nfiles", nfiles, "Number of output files")->capture_default_str()->group("Output");
-    CLI11_PARSE(app, argc, argv);
+    SAMURAI_PARSE(argc, argv);
 
     const samurai::Box<double, dim> box(min_corner, max_corner);
     samurai::MRMesh<Config> mesh{box, min_level, max_level};

--- a/demos/FiniteVolume/stokes_2d.cpp
+++ b/demos/FiniteVolume/stokes_2d.cpp
@@ -1,6 +1,5 @@
 // Copyright 2018-2024 the samurai's authors
 // SPDX-License-Identifier:  BSD-3-Clause
-#include <CLI/CLI.hpp>
 
 #include <iostream>
 #include <samurai/hdf5.hpp>

--- a/demos/FiniteVolume/stokes_2d.cpp
+++ b/demos/FiniteVolume/stokes_2d.cpp
@@ -152,7 +152,8 @@ void configure_solver(Solver& solver)
 
 int main(int argc, char* argv[])
 {
-    samurai::initialize(argc, argv);
+    CLI::App app{"Stokes problem"};
+    samurai::initialize(app, argc, argv);
 
     constexpr std::size_t dim        = 2;
     using Config                     = samurai::MRConfig<dim, 2>;
@@ -179,7 +180,6 @@ int main(int argc, char* argv[])
     fs::path path        = fs::current_path();
     std::string filename = "";
 
-    CLI::App app{"Stokes problem"};
     app.add_option("--test-case", test_case, "Test case (s = stationary, ns = non-stationary)")
         ->capture_default_str()
         ->group("Simulation parameters");
@@ -193,9 +193,9 @@ int main(int argc, char* argv[])
     app.add_option("--mr-reg", mr_regularity, "The regularity criteria used by the multiresolution to adapt the mesh")
         ->capture_default_str()
         ->group("Multiresolution");
-    app.add_option("--path", path, "Output path")->capture_default_str()->group("Ouput");
-    app.add_option("--filename", filename, "File name prefix")->capture_default_str()->group("Ouput");
-    app.add_option("--nfiles", nfiles, "Number of output files")->capture_default_str()->group("Ouput");
+    app.add_option("--path", path, "Output path")->capture_default_str()->group("Output");
+    app.add_option("--filename", filename, "File name prefix")->capture_default_str()->group("Output");
+    app.add_option("--nfiles", nfiles, "Number of output files")->capture_default_str()->group("Output");
     app.allow_extras();
     CLI11_PARSE(app, argc, argv);
 

--- a/demos/FiniteVolume/stokes_2d.cpp
+++ b/demos/FiniteVolume/stokes_2d.cpp
@@ -151,8 +151,7 @@ void configure_solver(Solver& solver)
 
 int main(int argc, char* argv[])
 {
-    CLI::App app{"Stokes problem"};
-    samurai::initialize(app, argc, argv);
+    auto& app = samurai::initialize("Stokes problem", argc, argv);
 
     constexpr std::size_t dim        = 2;
     using Config                     = samurai::MRConfig<dim, 2>;
@@ -196,7 +195,7 @@ int main(int argc, char* argv[])
     app.add_option("--filename", filename, "File name prefix")->capture_default_str()->group("Output");
     app.add_option("--nfiles", nfiles, "Number of output files")->capture_default_str()->group("Output");
     app.allow_extras();
-    CLI11_PARSE(app, argc, argv);
+    SAMURAI_PARSE(argc, argv);
 
     if (!fs::exists(path))
     {

--- a/demos/highorder/main.cpp
+++ b/demos/highorder/main.cpp
@@ -1,6 +1,5 @@
 // Copyright 2018-2024 the samurai's authors
 // SPDX-License-Identifier:  BSD-3-Clause
-#include <CLI/CLI.hpp>
 
 #include <samurai/hdf5.hpp>
 #include <samurai/mr/adapt.hpp>
@@ -113,9 +112,7 @@ class HighOrderDiffusion : public samurai::CellBasedScheme<cfg, bdry_cfg>
 
 int main(int argc, char* argv[])
 {
-    CLI::App app{"Finite volume example for the advection equation in 2d "
-                 "using multiresolution"};
-    samurai::initialize(app, argc, argv);
+    auto& app = samurai::initialize("Finite volume example for the advection equation in 2d using multiresolution", argc, argv);
 
     constexpr std::size_t dim              = 2;
     constexpr std::size_t stencil_width    = 2;
@@ -161,7 +158,7 @@ int main(int argc, char* argv[])
     app.add_option("--filename", filename, "File name prefix")->capture_default_str()->group("Output");
     app.add_option("--nfiles", nfiles, "Number of output files")->capture_default_str()->group("Output");
     app.allow_extras();
-    CLI11_PARSE(app, argc, argv);
+    SAMURAI_PARSE(argc, argv);
 
     samurai::Box<double, dim> box(min_corner, max_corner);
     using mesh_t    = samurai::MRMesh<Config>;

--- a/demos/highorder/main.cpp
+++ b/demos/highorder/main.cpp
@@ -113,7 +113,9 @@ class HighOrderDiffusion : public samurai::CellBasedScheme<cfg, bdry_cfg>
 
 int main(int argc, char* argv[])
 {
-    samurai::initialize(argc, argv);
+    CLI::App app{"Finite volume example for the advection equation in 2d "
+                 "using multiresolution"};
+    samurai::initialize(app, argc, argv);
 
     constexpr std::size_t dim              = 2;
     constexpr std::size_t stencil_width    = 2;
@@ -138,8 +140,6 @@ int main(int argc, char* argv[])
     std::string filename = "poisson_highorder_2d";
     std::size_t nfiles   = 1;
 
-    CLI::App app{"Finite volume example for the advection equation in 2d "
-                 "using multiresolution"};
     app.add_option("--min-corner", min_corner, "The min corner of the box")->capture_default_str()->group("Simulation parameters");
     app.add_option("--max-corner", min_corner, "The max corner of the box")->capture_default_str()->group("Simulation parameters");
     app.add_option("--min-level", min_level, "Minimum level of the multiresolution")->capture_default_str()->group("Multiresolution");
@@ -157,9 +157,9 @@ int main(int argc, char* argv[])
     app.add_option("--with-correction", correction, "Apply flux correction at the interface of two refinement levels")
         ->capture_default_str()
         ->group("Multiresolution");
-    app.add_option("--path", path, "Output path")->capture_default_str()->group("Ouput");
-    app.add_option("--filename", filename, "File name prefix")->capture_default_str()->group("Ouput");
-    app.add_option("--nfiles", nfiles, "Number of output files")->capture_default_str()->group("Ouput");
+    app.add_option("--path", path, "Output path")->capture_default_str()->group("Output");
+    app.add_option("--filename", filename, "File name prefix")->capture_default_str()->group("Output");
+    app.add_option("--nfiles", nfiles, "Number of output files")->capture_default_str()->group("Output");
     app.allow_extras();
     CLI11_PARSE(app, argc, argv);
 

--- a/demos/p4est/simple_2d.cpp
+++ b/demos/p4est/simple_2d.cpp
@@ -192,7 +192,10 @@ void refine_2(mesh_t& mesh, std::size_t max_level)
 
 int main(int argc, char* argv[])
 {
-    samurai::initialize(argc, argv);
+    CLI::App app{"simple 2d p4est example (see "
+                 "https://github.com/cburstedde/p4est/blob/master/example/"
+                 "simple/simple2.c)"};
+    samurai::initialize(app, argc, argv);
 
     constexpr size_t dim = 2;
 
@@ -203,12 +206,9 @@ int main(int argc, char* argv[])
     fs::path path        = fs::current_path();
     std::string filename = "simple_2d";
 
-    CLI::App app{"simple 2d p4est example (see "
-                 "https://github.com/cburstedde/p4est/blob/master/example/"
-                 "simple/simple2.c)"};
     app.add_option("--max-level", max_level, "Maximum level of the adaptation")->capture_default_str()->group("Adaptation parameters");
-    app.add_option("--path", path, "Output path")->capture_default_str()->group("Ouput");
-    app.add_option("--filename", filename, "File name prefix")->capture_default_str()->group("Ouput");
+    app.add_option("--path", path, "Output path")->capture_default_str()->group("Output");
+    app.add_option("--filename", filename, "File name prefix")->capture_default_str()->group("Output");
     CLI11_PARSE(app, argc, argv);
 
     if (!fs::exists(path))

--- a/demos/p4est/simple_2d.cpp
+++ b/demos/p4est/simple_2d.cpp
@@ -1,6 +1,5 @@
 // Copyright 2018-2024 the samurai's authors
 // SPDX-License-Identifier:  BSD-3-Clause
-#include <CLI/CLI.hpp>
 
 #include <iostream>
 
@@ -192,10 +191,11 @@ void refine_2(mesh_t& mesh, std::size_t max_level)
 
 int main(int argc, char* argv[])
 {
-    CLI::App app{"simple 2d p4est example (see "
-                 "https://github.com/cburstedde/p4est/blob/master/example/"
-                 "simple/simple2.c)"};
-    samurai::initialize(app, argc, argv);
+    auto& app = samurai::initialize("simple 2d p4est example (see "
+                                    "https://github.com/cburstedde/p4est/blob/master/example/"
+                                    "simple/simple2.c)",
+                                    argc,
+                                    argv);
 
     constexpr size_t dim = 2;
 
@@ -209,7 +209,7 @@ int main(int argc, char* argv[])
     app.add_option("--max-level", max_level, "Maximum level of the adaptation")->capture_default_str()->group("Adaptation parameters");
     app.add_option("--path", path, "Output path")->capture_default_str()->group("Output");
     app.add_option("--filename", filename, "File name prefix")->capture_default_str()->group("Output");
-    CLI11_PARSE(app, argc, argv);
+    SAMURAI_PARSE(argc, argv);
 
     if (!fs::exists(path))
     {

--- a/demos/pablo/bubble_2d.cpp
+++ b/demos/pablo/bubble_2d.cpp
@@ -228,7 +228,10 @@ void make_graduation(samurai::CellArray<dim>& ca)
 
 int main(int argc, char* argv[])
 {
-    samurai::initialize(argc, argv);
+    CLI::App app{"2d bubble example from pablo (see "
+                 "https://github.com/optimad/bitpit/blob/master/examples/"
+                 "PABLO_bubbles_2D.cpp)"};
+    samurai::initialize(app, argc, argv);
 
     constexpr std::size_t dim = 2; // cppcheck-suppress unreadVariable
 
@@ -249,9 +252,6 @@ int main(int argc, char* argv[])
     std::string filename = "bubble_2d";
     std::size_t nfiles   = 1;
 
-    CLI::App app{"2d bubble example from pablo (see "
-                 "https://github.com/optimad/bitpit/blob/master/examples/"
-                 "PABLO_bubbles_2D.cpp)"};
     app.add_option("--min-corner", min_corner_v, "The min corner of the box")->capture_default_str()->group("Simulation parameters");
     app.add_option("--max-corner", max_corner_v, "The max corner of the box")->capture_default_str()->group("Simulation parameters");
     app.add_option("--nb-bubbles", nb_bubbles, "Number of bubbles")->capture_default_str()->group("Simulation parameters");
@@ -260,9 +260,9 @@ int main(int argc, char* argv[])
     app.add_option("--start-level", start_level, "Start level of AMR")->capture_default_str()->group("Adaptation parameters");
     app.add_option("--min-level", min_level, "Minimum level of AMR")->capture_default_str()->group("Adaptation parameters");
     app.add_option("--max-level", max_level, "Maximum level of AMR")->capture_default_str()->group("Adaptation parameters");
-    app.add_option("--path", path, "Output path")->capture_default_str()->group("Ouput");
-    app.add_option("--filename", filename, "File name prefix")->capture_default_str()->group("Ouput");
-    app.add_option("--nfiles", nfiles, "Number of output files")->capture_default_str()->group("Ouput");
+    app.add_option("--path", path, "Output path")->capture_default_str()->group("Output");
+    app.add_option("--filename", filename, "File name prefix")->capture_default_str()->group("Output");
+    app.add_option("--nfiles", nfiles, "Number of output files")->capture_default_str()->group("Output");
     CLI11_PARSE(app, argc, argv);
 
     if (!fs::exists(path))

--- a/demos/pablo/bubble_2d.cpp
+++ b/demos/pablo/bubble_2d.cpp
@@ -1,6 +1,5 @@
 // Copyright 2018-2024 the samurai's authors
 // SPDX-License-Identifier:  BSD-3-Clause
-#include <CLI/CLI.hpp>
 
 #include <iostream>
 
@@ -228,10 +227,11 @@ void make_graduation(samurai::CellArray<dim>& ca)
 
 int main(int argc, char* argv[])
 {
-    CLI::App app{"2d bubble example from pablo (see "
-                 "https://github.com/optimad/bitpit/blob/master/examples/"
-                 "PABLO_bubbles_2D.cpp)"};
-    samurai::initialize(app, argc, argv);
+    auto& app = samurai::initialize("2d bubble example from pablo (see "
+                                    "https://github.com/optimad/bitpit/blob/master/examples/"
+                                    "PABLO_bubbles_2D.cpp)",
+                                    argc,
+                                    argv);
 
     constexpr std::size_t dim = 2; // cppcheck-suppress unreadVariable
 
@@ -263,7 +263,7 @@ int main(int argc, char* argv[])
     app.add_option("--path", path, "Output path")->capture_default_str()->group("Output");
     app.add_option("--filename", filename, "File name prefix")->capture_default_str()->group("Output");
     app.add_option("--nfiles", nfiles, "Number of output files")->capture_default_str()->group("Output");
-    CLI11_PARSE(app, argc, argv);
+    SAMURAI_PARSE(argc, argv);
 
     if (!fs::exists(path))
     {

--- a/demos/tutorial/2D_mesh.cpp
+++ b/demos/tutorial/2D_mesh.cpp
@@ -1,6 +1,5 @@
 // Copyright 2018-2024 the samurai's authors
 // SPDX-License-Identifier:  BSD-3-Clause
-#include <CLI/CLI.hpp>
 
 #include <iostream>
 
@@ -15,8 +14,7 @@ namespace fs = std::filesystem;
 
 int main(int argc, char* argv[])
 {
-    CLI::App app{"Create mesh from CellList and save it"};
-    samurai::initialize(app, argc, argv);
+    auto& app = samurai::initialize("Create mesh from CellList and save it", argc, argv);
 
     constexpr std::size_t dim = 2; // cppcheck-suppress unreadVariable
     samurai::CellList<dim> cl;
@@ -27,7 +25,7 @@ int main(int argc, char* argv[])
 
     app.add_option("--path", path, "Output path")->capture_default_str()->group("Output");
     app.add_option("--filename", filename, "File name prefix")->capture_default_str()->group("Output");
-    CLI11_PARSE(app, argc, argv);
+    SAMURAI_PARSE(argc, argv);
 
     if (!fs::exists(path))
     {

--- a/demos/tutorial/2D_mesh.cpp
+++ b/demos/tutorial/2D_mesh.cpp
@@ -15,7 +15,8 @@ namespace fs = std::filesystem;
 
 int main(int argc, char* argv[])
 {
-    samurai::initialize(argc, argv);
+    CLI::App app{"Create mesh from CellList and save it"};
+    samurai::initialize(app, argc, argv);
 
     constexpr std::size_t dim = 2; // cppcheck-suppress unreadVariable
     samurai::CellList<dim> cl;
@@ -24,9 +25,8 @@ int main(int argc, char* argv[])
     fs::path path        = fs::current_path();
     std::string filename = "2d_mesh_construction";
 
-    CLI::App app{"Create mesh from CellList and save it"};
-    app.add_option("--path", path, "Output path")->capture_default_str()->group("Ouput");
-    app.add_option("--filename", filename, "File name prefix")->capture_default_str()->group("Ouput");
+    app.add_option("--path", path, "Output path")->capture_default_str()->group("Output");
+    app.add_option("--filename", filename, "File name prefix")->capture_default_str()->group("Output");
     CLI11_PARSE(app, argc, argv);
 
     if (!fs::exists(path))

--- a/demos/tutorial/AMR_1D_Burgers/step_0/main.cpp
+++ b/demos/tutorial/AMR_1D_Burgers/step_0/main.cpp
@@ -23,15 +23,15 @@ namespace fs = std::filesystem;
 
 int main(int argc, char* argv[])
 {
-    samurai::initialize(argc, argv);
+    CLI::App app{"Tutorial AMR Burgers 1D step 0"};
+    samurai::initialize(app, argc, argv);
 
     // Output parameters
     fs::path path        = fs::current_path();
     std::string filename = "amr_1d_burgers_step_0";
 
-    CLI::App app{"Tutorial AMR Burgers 1D step 0"};
-    app.add_option("--path", path, "Output path")->capture_default_str()->group("Ouput");
-    app.add_option("--filename", filename, "File name prefix")->capture_default_str()->group("Ouput");
+    app.add_option("--path", path, "Output path")->capture_default_str()->group("Output");
+    app.add_option("--filename", filename, "File name prefix")->capture_default_str()->group("Output");
     CLI11_PARSE(app, argc, argv);
 
     if (!fs::exists(path))

--- a/demos/tutorial/AMR_1D_Burgers/step_0/main.cpp
+++ b/demos/tutorial/AMR_1D_Burgers/step_0/main.cpp
@@ -1,6 +1,5 @@
 // Copyright 2018-2024 the samurai's authors
 // SPDX-License-Identifier:  BSD-3-Clause
-#include <CLI/CLI.hpp>
 
 #include <filesystem>
 
@@ -23,8 +22,7 @@ namespace fs = std::filesystem;
 
 int main(int argc, char* argv[])
 {
-    CLI::App app{"Tutorial AMR Burgers 1D step 0"};
-    samurai::initialize(app, argc, argv);
+    auto& app = samurai::initialize("Tutorial AMR Burgers 1D step 0", argc, argv);
 
     // Output parameters
     fs::path path        = fs::current_path();
@@ -32,7 +30,7 @@ int main(int argc, char* argv[])
 
     app.add_option("--path", path, "Output path")->capture_default_str()->group("Output");
     app.add_option("--filename", filename, "File name prefix")->capture_default_str()->group("Output");
-    CLI11_PARSE(app, argc, argv);
+    SAMURAI_PARSE(argc, argv);
 
     if (!fs::exists(path))
     {

--- a/demos/tutorial/AMR_1D_Burgers/step_1/main.cpp
+++ b/demos/tutorial/AMR_1D_Burgers/step_1/main.cpp
@@ -1,6 +1,5 @@
 // Copyright 2018-2024 the samurai's authors
 // SPDX-License-Identifier:  BSD-3-Clause
-#include <CLI/CLI.hpp>
 
 #include <filesystem>
 
@@ -26,8 +25,7 @@ namespace fs = std::filesystem;
 
 int main(int argc, char* argv[])
 {
-    CLI::App app{"Tutorial AMR Burgers 1D step 1"};
-    samurai::initialize(app, argc, argv);
+    auto& app = samurai::initialize("Tutorial AMR Burgers 1D step 1", argc, argv);
 
     // Output parameters
     fs::path path        = fs::current_path();
@@ -35,7 +33,7 @@ int main(int argc, char* argv[])
 
     app.add_option("--path", path, "Output path")->capture_default_str()->group("Output");
     app.add_option("--filename", filename, "File name prefix")->capture_default_str()->group("Output");
-    CLI11_PARSE(app, argc, argv);
+    SAMURAI_PARSE(argc, argv);
 
     if (!fs::exists(path))
     {

--- a/demos/tutorial/AMR_1D_Burgers/step_1/main.cpp
+++ b/demos/tutorial/AMR_1D_Burgers/step_1/main.cpp
@@ -26,15 +26,15 @@ namespace fs = std::filesystem;
 
 int main(int argc, char* argv[])
 {
-    samurai::initialize(argc, argv);
+    CLI::App app{"Tutorial AMR Burgers 1D step 1"};
+    samurai::initialize(app, argc, argv);
 
     // Output parameters
     fs::path path        = fs::current_path();
     std::string filename = "amr_1d_burgers_step_1";
 
-    CLI::App app{"Tutorial AMR Burgers 1D step 1"};
-    app.add_option("--path", path, "Output path")->capture_default_str()->group("Ouput");
-    app.add_option("--filename", filename, "File name prefix")->capture_default_str()->group("Ouput");
+    app.add_option("--path", path, "Output path")->capture_default_str()->group("Output");
+    app.add_option("--filename", filename, "File name prefix")->capture_default_str()->group("Output");
     CLI11_PARSE(app, argc, argv);
 
     if (!fs::exists(path))

--- a/demos/tutorial/AMR_1D_Burgers/step_2/main.cpp
+++ b/demos/tutorial/AMR_1D_Burgers/step_2/main.cpp
@@ -1,6 +1,5 @@
 // Copyright 2018-2024 the samurai's authors
 // SPDX-License-Identifier:  BSD-3-Clause
-#include <CLI/CLI.hpp>
 
 #include <filesystem>
 
@@ -26,8 +25,7 @@ namespace fs = std::filesystem;
 
 int main(int argc, char* argv[])
 {
-    CLI::App app{"Tutorial AMR Burgers 1D step 2"};
-    samurai::initialize(app, argc, argv);
+    auto& app = samurai::initialize("Tutorial AMR Burgers 1D step 2", argc, argv);
 
     // Simulation parameters
     double cfl = 0.99;
@@ -43,7 +41,7 @@ int main(int argc, char* argv[])
     app.add_option("--path", path, "Output path")->capture_default_str()->group("Output");
     app.add_option("--filename", filename, "File name prefix")->capture_default_str()->group("Output");
     app.add_option("--nfiles", nfiles, "Number of output files")->capture_default_str()->group("Output");
-    CLI11_PARSE(app, argc, argv);
+    SAMURAI_PARSE(argc, argv);
 
     if (!fs::exists(path))
     {

--- a/demos/tutorial/AMR_1D_Burgers/step_2/main.cpp
+++ b/demos/tutorial/AMR_1D_Burgers/step_2/main.cpp
@@ -26,7 +26,8 @@ namespace fs = std::filesystem;
 
 int main(int argc, char* argv[])
 {
-    samurai::initialize(argc, argv);
+    CLI::App app{"Tutorial AMR Burgers 1D step 2"};
+    samurai::initialize(app, argc, argv);
 
     // Simulation parameters
     double cfl = 0.99;
@@ -37,12 +38,11 @@ int main(int argc, char* argv[])
     std::string filename = "amr_1d_burgers_step_2";
     std::size_t nfiles   = 1;
 
-    CLI::App app{"Tutorial AMR Burgers 1D step 2"};
     app.add_option("--cfl", cfl, "The CFL")->capture_default_str()->group("Simulation parameters");
     app.add_option("--Tf", Tf, "Final time")->capture_default_str()->group("Simulation parameters");
-    app.add_option("--path", path, "Output path")->capture_default_str()->group("Ouput");
-    app.add_option("--filename", filename, "File name prefix")->capture_default_str()->group("Ouput");
-    app.add_option("--nfiles", nfiles, "Number of output files")->capture_default_str()->group("Ouput");
+    app.add_option("--path", path, "Output path")->capture_default_str()->group("Output");
+    app.add_option("--filename", filename, "File name prefix")->capture_default_str()->group("Output");
+    app.add_option("--nfiles", nfiles, "Number of output files")->capture_default_str()->group("Output");
     CLI11_PARSE(app, argc, argv);
 
     if (!fs::exists(path))

--- a/demos/tutorial/AMR_1D_Burgers/step_3/main.cpp
+++ b/demos/tutorial/AMR_1D_Burgers/step_3/main.cpp
@@ -1,6 +1,5 @@
 // Copyright 2018-2024 the samurai's authors
 // SPDX-License-Identifier:  BSD-3-Clause
-#include <CLI/CLI.hpp>
 
 #include <filesystem>
 
@@ -28,8 +27,7 @@ namespace fs = std::filesystem;
 
 int main(int argc, char* argv[])
 {
-    CLI::App app{"Tutorial AMR Burgers 1D step 3"};
-    samurai::initialize(app, argc, argv);
+    auto& app = samurai::initialize("Tutorial AMR Burgers 1D step 3", argc, argv);
 
     // Simulation parameters
     double cfl = 0.99;
@@ -45,7 +43,7 @@ int main(int argc, char* argv[])
     app.add_option("--path", path, "Output path")->capture_default_str()->group("Output");
     app.add_option("--filename", filename, "File name prefix")->capture_default_str()->group("Output");
     app.add_option("--nfiles", nfiles, "Number of output files")->capture_default_str()->group("Output");
-    CLI11_PARSE(app, argc, argv);
+    SAMURAI_PARSE(argc, argv);
 
     if (!fs::exists(path))
     {

--- a/demos/tutorial/AMR_1D_Burgers/step_3/main.cpp
+++ b/demos/tutorial/AMR_1D_Burgers/step_3/main.cpp
@@ -28,7 +28,8 @@ namespace fs = std::filesystem;
 
 int main(int argc, char* argv[])
 {
-    samurai::initialize(argc, argv);
+    CLI::App app{"Tutorial AMR Burgers 1D step 3"};
+    samurai::initialize(app, argc, argv);
 
     // Simulation parameters
     double cfl = 0.99;
@@ -39,12 +40,11 @@ int main(int argc, char* argv[])
     std::string filename = "amr_1d_burgers_step_3";
     std::size_t nfiles   = 1;
 
-    CLI::App app{"Tutorial AMR Burgers 1D step 3"};
     app.add_option("--cfl", cfl, "The CFL")->capture_default_str()->group("Simulation parameters");
     app.add_option("--Tf", Tf, "Final time")->capture_default_str()->group("Simulation parameters");
-    app.add_option("--path", path, "Output path")->capture_default_str()->group("Ouput");
-    app.add_option("--filename", filename, "File name prefix")->capture_default_str()->group("Ouput");
-    app.add_option("--nfiles", nfiles, "Number of output files")->capture_default_str()->group("Ouput");
+    app.add_option("--path", path, "Output path")->capture_default_str()->group("Output");
+    app.add_option("--filename", filename, "File name prefix")->capture_default_str()->group("Output");
+    app.add_option("--nfiles", nfiles, "Number of output files")->capture_default_str()->group("Output");
     CLI11_PARSE(app, argc, argv);
 
     if (!fs::exists(path))

--- a/demos/tutorial/AMR_1D_Burgers/step_4/main.cpp
+++ b/demos/tutorial/AMR_1D_Burgers/step_4/main.cpp
@@ -1,6 +1,5 @@
 // Copyright 2018-2024 the samurai's authors
 // SPDX-License-Identifier:  BSD-3-Clause
-#include <CLI/CLI.hpp>
 
 #include <filesystem>
 
@@ -30,8 +29,7 @@ namespace fs = std::filesystem;
 
 int main(int argc, char* argv[])
 {
-    CLI::App app{"Tutorial AMR Burgers 1D step 4"};
-    samurai::initialize(app, argc, argv);
+    auto& app = samurai::initialize("Tutorial AMR Burgers 1D step 4", argc, argv);
 
     // AMR parameters
     std::size_t start_level = 8;
@@ -47,7 +45,7 @@ int main(int argc, char* argv[])
     app.add_option("--max-level", max_level, "Maximum level of the AMR")->capture_default_str()->group("AMR parameter");
     app.add_option("--path", path, "Output path")->capture_default_str()->group("Output");
     app.add_option("--filename", filename, "File name prefix")->capture_default_str()->group("Output");
-    CLI11_PARSE(app, argc, argv);
+    SAMURAI_PARSE(argc, argv);
 
     if (!fs::exists(path))
     {

--- a/demos/tutorial/AMR_1D_Burgers/step_4/main.cpp
+++ b/demos/tutorial/AMR_1D_Burgers/step_4/main.cpp
@@ -30,7 +30,8 @@ namespace fs = std::filesystem;
 
 int main(int argc, char* argv[])
 {
-    samurai::initialize(argc, argv);
+    CLI::App app{"Tutorial AMR Burgers 1D step 4"};
+    samurai::initialize(app, argc, argv);
 
     // AMR parameters
     std::size_t start_level = 8;
@@ -41,12 +42,11 @@ int main(int argc, char* argv[])
     fs::path path        = fs::current_path();
     std::string filename = "amr_1d_burgers_step_4";
 
-    CLI::App app{"Tutorial AMR Burgers 1D step 4"};
     app.add_option("--start-level", start_level, "Start level of the AMR")->capture_default_str()->group("AMR parameter");
     app.add_option("--min-level", min_level, "Minimum level of the AMR")->capture_default_str()->group("AMR parameter");
     app.add_option("--max-level", max_level, "Maximum level of the AMR")->capture_default_str()->group("AMR parameter");
-    app.add_option("--path", path, "Output path")->capture_default_str()->group("Ouput");
-    app.add_option("--filename", filename, "File name prefix")->capture_default_str()->group("Ouput");
+    app.add_option("--path", path, "Output path")->capture_default_str()->group("Output");
+    app.add_option("--filename", filename, "File name prefix")->capture_default_str()->group("Output");
     CLI11_PARSE(app, argc, argv);
 
     if (!fs::exists(path))

--- a/demos/tutorial/AMR_1D_Burgers/step_5/main.cpp
+++ b/demos/tutorial/AMR_1D_Burgers/step_5/main.cpp
@@ -1,6 +1,5 @@
 // Copyright 2018-2024 the samurai's authors
 // SPDX-License-Identifier:  BSD-3-Clause
-#include <CLI/CLI.hpp>
 
 #include <filesystem>
 
@@ -32,8 +31,7 @@ namespace fs = std::filesystem;
 
 int main(int argc, char* argv[])
 {
-    CLI::App app{"Tutorial AMR Burgers 1D step 5"};
-    samurai::initialize(app, argc, argv);
+    auto& app = samurai::initialize("Tutorial AMR Burgers 1D step 5", argc, argv);
 
     // AMR parameters
     std::size_t start_level = 8;
@@ -49,7 +47,7 @@ int main(int argc, char* argv[])
     app.add_option("--max-level", max_level, "Maximum level of the AMR")->capture_default_str()->group("AMR parameter");
     app.add_option("--path", path, "Output path")->capture_default_str()->group("Output");
     app.add_option("--filename", filename, "File name prefix")->capture_default_str()->group("Output");
-    CLI11_PARSE(app, argc, argv);
+    SAMURAI_PARSE(argc, argv);
 
     if (!fs::exists(path))
     {

--- a/demos/tutorial/AMR_1D_Burgers/step_5/main.cpp
+++ b/demos/tutorial/AMR_1D_Burgers/step_5/main.cpp
@@ -32,7 +32,8 @@ namespace fs = std::filesystem;
 
 int main(int argc, char* argv[])
 {
-    samurai::initialize(argc, argv);
+    CLI::App app{"Tutorial AMR Burgers 1D step 5"};
+    samurai::initialize(app, argc, argv);
 
     // AMR parameters
     std::size_t start_level = 8;
@@ -43,12 +44,11 @@ int main(int argc, char* argv[])
     fs::path path        = fs::current_path();
     std::string filename = "amr_1d_burgers_step_5";
 
-    CLI::App app{"Tutorial AMR Burgers 1D step 5"};
     app.add_option("--start-level", start_level, "Start level of the AMR")->capture_default_str()->group("AMR parameter");
     app.add_option("--min-level", min_level, "Minimum level of the AMR")->capture_default_str()->group("AMR parameter");
     app.add_option("--max-level", max_level, "Maximum level of the AMR")->capture_default_str()->group("AMR parameter");
-    app.add_option("--path", path, "Output path")->capture_default_str()->group("Ouput");
-    app.add_option("--filename", filename, "File name prefix")->capture_default_str()->group("Ouput");
+    app.add_option("--path", path, "Output path")->capture_default_str()->group("Output");
+    app.add_option("--filename", filename, "File name prefix")->capture_default_str()->group("Output");
     CLI11_PARSE(app, argc, argv);
 
     if (!fs::exists(path))

--- a/demos/tutorial/AMR_1D_Burgers/step_6/main.cpp
+++ b/demos/tutorial/AMR_1D_Burgers/step_6/main.cpp
@@ -1,6 +1,5 @@
 // Copyright 2018-2024 the samurai's authors
 // SPDX-License-Identifier:  BSD-3-Clause
-#include <CLI/CLI.hpp>
 
 #include <filesystem>
 
@@ -36,8 +35,7 @@ namespace fs = std::filesystem;
 
 int main(int argc, char* argv[])
 {
-    CLI::App app{"Tutorial AMR Burgers 1D step 6"};
-    samurai::initialize(app, argc, argv);
+    auto& app = samurai::initialize("Tutorial AMR Burgers 1D step 6", argc, argv);
 
     // Simulation parameters
     double cfl         = 0.99;
@@ -61,7 +59,7 @@ int main(int argc, char* argv[])
     app.add_option("--path", path, "Output path")->capture_default_str()->group("Output");
     app.add_option("--filename", filename, "File name prefix")->capture_default_str()->group("Output");
     app.add_option("--nfiles", nfiles, "Number of output files")->capture_default_str()->group("Output");
-    CLI11_PARSE(app, argc, argv);
+    SAMURAI_PARSE(argc, argv);
 
     if (!fs::exists(path))
     {

--- a/demos/tutorial/AMR_1D_Burgers/step_6/main.cpp
+++ b/demos/tutorial/AMR_1D_Burgers/step_6/main.cpp
@@ -36,7 +36,8 @@ namespace fs = std::filesystem;
 
 int main(int argc, char* argv[])
 {
-    samurai::initialize(argc, argv);
+    CLI::App app{"Tutorial AMR Burgers 1D step 6"};
+    samurai::initialize(app, argc, argv);
 
     // Simulation parameters
     double cfl         = 0.99;
@@ -52,15 +53,14 @@ int main(int argc, char* argv[])
     fs::path path        = fs::current_path();
     std::string filename = "amr_1d_burgers_step_6";
 
-    CLI::App app{"Tutorial AMR Burgers 1D step 6"};
     app.add_option("--cfl", cfl, "The CFL")->capture_default_str()->group("Simulation parameters");
     app.add_option("--Tf", Tf, "Final time")->capture_default_str()->group("Simulation parameters");
     app.add_option("--start-level", start_level, "Start level of the AMR")->capture_default_str()->group("AMR parameter");
     app.add_option("--min-level", min_level, "Minimum level of the AMR")->capture_default_str()->group("AMR parameter");
     app.add_option("--max-level", max_level, "Maximum level of the AMR")->capture_default_str()->group("AMR parameter");
-    app.add_option("--path", path, "Output path")->capture_default_str()->group("Ouput");
-    app.add_option("--filename", filename, "File name prefix")->capture_default_str()->group("Ouput");
-    app.add_option("--nfiles", nfiles, "Number of output files")->capture_default_str()->group("Ouput");
+    app.add_option("--path", path, "Output path")->capture_default_str()->group("Output");
+    app.add_option("--filename", filename, "File name prefix")->capture_default_str()->group("Output");
+    app.add_option("--nfiles", nfiles, "Number of output files")->capture_default_str()->group("Output");
     CLI11_PARSE(app, argc, argv);
 
     if (!fs::exists(path))

--- a/demos/tutorial/graduation_case_1.cpp
+++ b/demos/tutorial/graduation_case_1.cpp
@@ -60,7 +60,8 @@ auto generate_mesh(std::size_t start_level, std::size_t max_level)
 
 int main(int argc, char* argv[])
 {
-    samurai::initialize(argc, argv);
+    CLI::App app{"Graduation example: test case 1"};
+    samurai::initialize(app, argc, argv);
 
     constexpr std::size_t dim        = 2;
     std::size_t start_level          = 1;
@@ -71,12 +72,11 @@ int main(int argc, char* argv[])
     fs::path path        = fs::current_path();
     std::string filename = "graduation_case_1";
 
-    CLI::App app{"Graduation example: test case 1"};
     app.add_option("--start-level", start_level, "where to start the mesh generator")->capture_default_str();
     app.add_option("--max-refinement-level", max_refinement_level, "Maximum level of the mesh generator")->capture_default_str();
     app.add_flag("--with-corner", with_corner, "Make the graduation including the diagonal")->capture_default_str();
-    app.add_option("--path", path, "Output path")->capture_default_str()->group("Ouput");
-    app.add_option("--filename", filename, "File name prefix")->capture_default_str()->group("Ouput");
+    app.add_option("--path", path, "Output path")->capture_default_str()->group("Output");
+    app.add_option("--filename", filename, "File name prefix")->capture_default_str()->group("Output");
     CLI11_PARSE(app, argc, argv);
 
     if (!fs::exists(path))

--- a/demos/tutorial/graduation_case_1.cpp
+++ b/demos/tutorial/graduation_case_1.cpp
@@ -1,6 +1,5 @@
 // Copyright 2018-2024 the samurai's authors
 // SPDX-License-Identifier:  BSD-3-Clause
-#include <CLI/CLI.hpp>
 
 #include <filesystem>
 
@@ -60,8 +59,7 @@ auto generate_mesh(std::size_t start_level, std::size_t max_level)
 
 int main(int argc, char* argv[])
 {
-    CLI::App app{"Graduation example: test case 1"};
-    samurai::initialize(app, argc, argv);
+    auto& app = samurai::initialize("Graduation example: test case 1", argc, argv);
 
     constexpr std::size_t dim        = 2;
     std::size_t start_level          = 1;
@@ -77,7 +75,7 @@ int main(int argc, char* argv[])
     app.add_flag("--with-corner", with_corner, "Make the graduation including the diagonal")->capture_default_str();
     app.add_option("--path", path, "Output path")->capture_default_str()->group("Output");
     app.add_option("--filename", filename, "File name prefix")->capture_default_str()->group("Output");
-    CLI11_PARSE(app, argc, argv);
+    SAMURAI_PARSE(argc, argv);
 
     if (!fs::exists(path))
     {

--- a/demos/tutorial/graduation_case_2.cpp
+++ b/demos/tutorial/graduation_case_2.cpp
@@ -40,7 +40,8 @@ auto generate_mesh(std::size_t min_level, std::size_t max_level, std::size_t nsa
 
 int main(int argc, char* argv[])
 {
-    samurai::initialize(argc, argv);
+    CLI::App app{"Graduation example: test case 2"};
+    samurai::initialize(app, argc, argv);
 
     constexpr std::size_t dim = 2;
     std::size_t min_level     = 1;
@@ -51,12 +52,11 @@ int main(int argc, char* argv[])
     fs::path path        = fs::current_path();
     std::string filename = "graduation_case_2";
 
-    CLI::App app{"Graduation example: test case 2"};
     app.add_option("--min-level", min_level, "Minimum level of the mesh generator")->capture_default_str();
     app.add_option("--max-level", max_level, "Maximum level of the mesh generator")->capture_default_str();
     app.add_flag("--with-corner", with_corner, "Make the graduation including the diagonal")->capture_default_str();
-    app.add_option("--path", path, "Output path")->capture_default_str()->group("Ouput");
-    app.add_option("--filename", filename, "File name prefix")->capture_default_str()->group("Ouput");
+    app.add_option("--path", path, "Output path")->capture_default_str()->group("Output");
+    app.add_option("--filename", filename, "File name prefix")->capture_default_str()->group("Output");
     CLI11_PARSE(app, argc, argv);
 
     if (!fs::exists(path))

--- a/demos/tutorial/graduation_case_2.cpp
+++ b/demos/tutorial/graduation_case_2.cpp
@@ -1,6 +1,5 @@
 // Copyright 2018-2024 the samurai's authors
 // SPDX-License-Identifier:  BSD-3-Clause
-#include <CLI/CLI.hpp>
 
 #include <filesystem>
 
@@ -40,8 +39,7 @@ auto generate_mesh(std::size_t min_level, std::size_t max_level, std::size_t nsa
 
 int main(int argc, char* argv[])
 {
-    CLI::App app{"Graduation example: test case 2"};
-    samurai::initialize(app, argc, argv);
+    auto& app = samurai::initialize("Graduation example: test case 2", argc, argv);
 
     constexpr std::size_t dim = 2;
     std::size_t min_level     = 1;
@@ -57,7 +55,7 @@ int main(int argc, char* argv[])
     app.add_flag("--with-corner", with_corner, "Make the graduation including the diagonal")->capture_default_str();
     app.add_option("--path", path, "Output path")->capture_default_str()->group("Output");
     app.add_option("--filename", filename, "File name prefix")->capture_default_str()->group("Output");
-    CLI11_PARSE(app, argc, argv);
+    SAMURAI_PARSE(argc, argv);
 
     if (!fs::exists(path))
     {

--- a/demos/tutorial/graduation_case_3.cpp
+++ b/demos/tutorial/graduation_case_3.cpp
@@ -1,6 +1,5 @@
 // Copyright 2018-2024 the samurai's authors
 // SPDX-License-Identifier:  BSD-3-Clause
-#include <CLI/CLI.hpp>
 
 #include <cmath>
 
@@ -30,8 +29,7 @@ auto generate_mesh(std::size_t start_level)
 
 int main(int argc, char* argv[])
 {
-    CLI::App app{"Graduation example: test case 3"};
-    samurai::initialize(app, argc, argv);
+    auto& app = samurai::initialize("Graduation example: test case 3", argc, argv);
 
     constexpr std::size_t dim = 2; // cppcheck-suppress unreadVariable
     std::size_t start_level   = 1;
@@ -49,7 +47,7 @@ int main(int argc, char* argv[])
     app.add_flag("--with-graduation", with_graduation, "Make the mesh graduated")->capture_default_str();
     app.add_option("--path", path, "Output path")->capture_default_str()->group("Output");
     app.add_option("--filename", filename, "File name prefix")->capture_default_str()->group("Output");
-    CLI11_PARSE(app, argc, argv);
+    SAMURAI_PARSE(argc, argv);
 
     if (!fs::exists(path))
     {

--- a/demos/tutorial/graduation_case_3.cpp
+++ b/demos/tutorial/graduation_case_3.cpp
@@ -30,7 +30,8 @@ auto generate_mesh(std::size_t start_level)
 
 int main(int argc, char* argv[])
 {
-    samurai::initialize(argc, argv);
+    CLI::App app{"Graduation example: test case 3"};
+    samurai::initialize(app, argc, argv);
 
     constexpr std::size_t dim = 2; // cppcheck-suppress unreadVariable
     std::size_t start_level   = 1;
@@ -43,12 +44,11 @@ int main(int argc, char* argv[])
     fs::path path        = fs::current_path();
     std::string filename = "graduation_case_3";
 
-    CLI::App app{"Graduation example: test case 3"};
     app.add_option("--start-level", start_level, "where to start the mesh generator")->capture_default_str();
     app.add_option("--max-level", max_level, "Maximum level of the mesh generator")->capture_default_str();
     app.add_flag("--with-graduation", with_graduation, "Make the mesh graduated")->capture_default_str();
-    app.add_option("--path", path, "Output path")->capture_default_str()->group("Ouput");
-    app.add_option("--filename", filename, "File name prefix")->capture_default_str()->group("Ouput");
+    app.add_option("--path", path, "Output path")->capture_default_str()->group("Output");
+    app.add_option("--filename", filename, "File name prefix")->capture_default_str()->group("Output");
     CLI11_PARSE(app, argc, argv);
 
     if (!fs::exists(path))

--- a/demos/tutorial/reconstruction_1d.cpp
+++ b/demos/tutorial/reconstruction_1d.cpp
@@ -1,6 +1,5 @@
 // Copyright 2018-2024 the samurai's authors
 // SPDX-License-Identifier:  BSD-3-Clause
-#include <CLI/CLI.hpp>
 
 #include <chrono>
 #include <filesystem>
@@ -54,8 +53,7 @@ auto init(Mesh& mesh, Case& c)
 
 int main(int argc, char* argv[])
 {
-    CLI::App app{"1d reconstruction of an adapted solution using multiresolution"};
-    samurai::initialize(app, argc, argv);
+    auto& app = samurai::initialize("1d reconstruction of an adapted solution using multiresolution", argc, argv);
 
     constexpr size_t dim                        = 1;
     constexpr std::size_t max_stencil_width_    = 2;
@@ -95,7 +93,7 @@ int main(int argc, char* argv[])
         ->group("Multiresolution");
     app.add_option("--path", path, "Output path")->capture_default_str()->group("Output");
     app.add_option("--filename", filename, "File name prefix")->capture_default_str()->group("Output");
-    CLI11_PARSE(app, argc, argv);
+    SAMURAI_PARSE(argc, argv);
 
     if (!fs::exists(path))
     {

--- a/demos/tutorial/reconstruction_1d.cpp
+++ b/demos/tutorial/reconstruction_1d.cpp
@@ -54,7 +54,8 @@ auto init(Mesh& mesh, Case& c)
 
 int main(int argc, char* argv[])
 {
-    samurai::initialize(argc, argv);
+    CLI::App app{"1d reconstruction of an adapted solution using multiresolution"};
+    samurai::initialize(app, argc, argv);
 
     constexpr size_t dim                        = 1;
     constexpr std::size_t max_stencil_width_    = 2;
@@ -80,7 +81,6 @@ int main(int argc, char* argv[])
     fs::path path        = fs::current_path();
     std::string filename = "reconstruction_1d";
 
-    CLI::App app{"1d reconstruction of an adapted solution using multiresolution"};
     app.add_option("--case", test_case, "Test case")->capture_default_str()->transform(CLI::CheckedTransformer(map, CLI::ignore_case));
     app.add_option("--min-level", min_level, "Minimum level of the multiresolution")->capture_default_str()->group("Multiresolution");
     app.add_option("--max-level", max_level, "Maximum level of the multiresolution")->capture_default_str()->group("Multiresolution");
@@ -93,8 +93,8 @@ int main(int argc, char* argv[])
                    "adapt the mesh")
         ->capture_default_str()
         ->group("Multiresolution");
-    app.add_option("--path", path, "Output path")->capture_default_str()->group("Ouput");
-    app.add_option("--filename", filename, "File name prefix")->capture_default_str()->group("Ouput");
+    app.add_option("--path", path, "Output path")->capture_default_str()->group("Output");
+    app.add_option("--filename", filename, "File name prefix")->capture_default_str()->group("Output");
     CLI11_PARSE(app, argc, argv);
 
     if (!fs::exists(path))

--- a/demos/tutorial/reconstruction_2d.cpp
+++ b/demos/tutorial/reconstruction_2d.cpp
@@ -1,6 +1,5 @@
 // Copyright 2018-2024 the samurai's authors
 // SPDX-License-Identifier:  BSD-3-Clause
-#include <CLI/CLI.hpp>
 
 #include <chrono>
 #include <filesystem>
@@ -83,8 +82,7 @@ auto init(Mesh& mesh, Case& c)
 
 int main(int argc, char* argv[])
 {
-    CLI::App app{"2d reconstruction of an adapted solution using multiresolution"};
-    samurai::initialize(app, argc, argv);
+    auto& app = samurai::initialize("2d reconstruction of an adapted solution using multiresolution", argc, argv);
 
     constexpr size_t dim                        = 2;
     constexpr std::size_t max_stencil_width_    = 2;
@@ -124,7 +122,7 @@ int main(int argc, char* argv[])
         ->group("Multiresolution");
     app.add_option("--path", path, "Output path")->capture_default_str()->group("Output");
     app.add_option("--filename", filename, "File name prefix")->capture_default_str()->group("Output");
-    CLI11_PARSE(app, argc, argv);
+    SAMURAI_PARSE(argc, argv);
 
     if (!fs::exists(path))
     {

--- a/demos/tutorial/reconstruction_2d.cpp
+++ b/demos/tutorial/reconstruction_2d.cpp
@@ -83,7 +83,8 @@ auto init(Mesh& mesh, Case& c)
 
 int main(int argc, char* argv[])
 {
-    samurai::initialize(argc, argv);
+    CLI::App app{"2d reconstruction of an adapted solution using multiresolution"};
+    samurai::initialize(app, argc, argv);
 
     constexpr size_t dim                        = 2;
     constexpr std::size_t max_stencil_width_    = 2;
@@ -109,7 +110,6 @@ int main(int argc, char* argv[])
     fs::path path        = fs::current_path();
     std::string filename = "reconstruction_2d";
 
-    CLI::App app{"2d reconstruction of an adapted solution using multiresolution"};
     app.add_option("--case", test_case, "Test case")->capture_default_str()->transform(CLI::CheckedTransformer(map, CLI::ignore_case));
     app.add_option("--min-level", min_level, "Minimum level of the multiresolution")->capture_default_str()->group("Multiresolution");
     app.add_option("--max-level", max_level, "Maximum level of the multiresolution")->capture_default_str()->group("Multiresolution");
@@ -122,8 +122,8 @@ int main(int argc, char* argv[])
                    "adapt the mesh")
         ->capture_default_str()
         ->group("Multiresolution");
-    app.add_option("--path", path, "Output path")->capture_default_str()->group("Ouput");
-    app.add_option("--filename", filename, "File name prefix")->capture_default_str()->group("Ouput");
+    app.add_option("--path", path, "Output path")->capture_default_str()->group("Output");
+    app.add_option("--filename", filename, "File name prefix")->capture_default_str()->group("Output");
     CLI11_PARSE(app, argc, argv);
 
     if (!fs::exists(path))

--- a/demos/tutorial/reconstruction_3d.cpp
+++ b/demos/tutorial/reconstruction_3d.cpp
@@ -1,6 +1,5 @@
 // Copyright 2018-2024 the samurai's authors
 // SPDX-License-Identifier:  BSD-3-Clause
-#include <CLI/CLI.hpp>
 
 #include <chrono>
 #include <filesystem>
@@ -86,8 +85,7 @@ auto init(Mesh& mesh, Case& c)
 
 int main(int argc, char* argv[])
 {
-    CLI::App app{"3d reconstruction of an adapted solution using multiresolution"};
-    samurai::initialize(app, argc, argv);
+    auto& app = samurai::initialize("3d reconstruction of an adapted solution using multiresolution", argc, argv);
 
     constexpr size_t dim                     = 3;
     constexpr std::size_t max_stencil_width_ = 2;
@@ -129,7 +127,7 @@ int main(int argc, char* argv[])
         ->group("Multiresolution");
     app.add_option("--path", path, "Output path")->capture_default_str()->group("Output");
     app.add_option("--filename", filename, "File name prefix")->capture_default_str()->group("Output");
-    CLI11_PARSE(app, argc, argv);
+    SAMURAI_PARSE(argc, argv);
 
     if (!fs::exists(path))
     {

--- a/demos/tutorial/reconstruction_3d.cpp
+++ b/demos/tutorial/reconstruction_3d.cpp
@@ -86,7 +86,8 @@ auto init(Mesh& mesh, Case& c)
 
 int main(int argc, char* argv[])
 {
-    samurai::initialize(argc, argv);
+    CLI::App app{"3d reconstruction of an adapted solution using multiresolution"};
+    samurai::initialize(app, argc, argv);
 
     constexpr size_t dim                     = 3;
     constexpr std::size_t max_stencil_width_ = 2;
@@ -114,7 +115,6 @@ int main(int argc, char* argv[])
     fs::path path        = fs::current_path();
     std::string filename = "reconstruction_3d";
 
-    CLI::App app{"3d reconstruction of an adapted solution using multiresolution"};
     app.add_option("--case", test_case, "Test case")->capture_default_str()->transform(CLI::CheckedTransformer(map, CLI::ignore_case));
     app.add_option("--min-level", min_level, "Minimum level of the multiresolution")->capture_default_str()->group("Multiresolution");
     app.add_option("--max-level", max_level, "Maximum level of the multiresolution")->capture_default_str()->group("Multiresolution");
@@ -127,8 +127,8 @@ int main(int argc, char* argv[])
                    "adapt the mesh")
         ->capture_default_str()
         ->group("Multiresolution");
-    app.add_option("--path", path, "Output path")->capture_default_str()->group("Ouput");
-    app.add_option("--filename", filename, "File name prefix")->capture_default_str()->group("Ouput");
+    app.add_option("--path", path, "Output path")->capture_default_str()->group("Output");
+    app.add_option("--filename", filename, "File name prefix")->capture_default_str()->group("Output");
     CLI11_PARSE(app, argc, argv);
 
     if (!fs::exists(path))

--- a/include/samurai/algorithm/update.hpp
+++ b/include/samurai/algorithm/update.hpp
@@ -12,6 +12,7 @@
 #include "../numeric/prediction.hpp"
 #include "../numeric/projection.hpp"
 #include "../subset/subset_op.hpp"
+#include "../timers.hpp"
 #include "utils.hpp"
 
 using namespace xt::placeholders;
@@ -92,6 +93,8 @@ namespace samurai
         using mesh_id_t                  = typename Field::mesh_t::mesh_id_t;
         constexpr std::size_t pred_order = Field::mesh_t::config::prediction_order;
 
+        times::timers.start("ghost update");
+
         auto& mesh = field.mesh();
 
 #ifdef SAMURAI_WITH_MPI
@@ -135,6 +138,8 @@ namespace samurai
             update_ghost_subdomains(level, field, other_fields...);
             update_bc(level, field, other_fields...);
         }
+
+        times::timers.stop("ghost update");
     }
 
     inline void update_ghost_mr()

--- a/include/samurai/arguments.hpp
+++ b/include/samurai/arguments.hpp
@@ -11,11 +11,11 @@ namespace samurai
         static bool timers = false;
     }
 
-    auto read_samurai_arguments(CLI::App& app, int& argc, char**& argv)
+    inline void read_samurai_arguments(CLI::App& app, int& argc, char**& argv)
     {
-        app.add_flag("--timers", args::timers, "Print timers at the end of the program")->capture_default_str()->group("SAMURAI tools");
+        app.add_flag("--timers", args::timers, "Print timers at the end of the program")->capture_default_str()->group("Tools");
         app.allow_extras();
-        app.set_help_flag("", "");
+        app.set_help_flag("", ""); // deactivate --help option
         try
         {
             app.parse(argc, argv);
@@ -24,6 +24,6 @@ namespace samurai
         {
             app.exit(e);
         }
-        app.set_help_flag("-h,--help", "Print this help message and exit");
+        app.set_help_flag("-h,--help", "Print this help message and exit"); // re-activate --help option
     }
 }

--- a/include/samurai/arguments.hpp
+++ b/include/samurai/arguments.hpp
@@ -1,0 +1,29 @@
+// Copyright 2018-2024 the samurai's authors
+// SPDX-License-Identifier:  BSD-3-Clause
+#pragma once
+
+#include <CLI/CLI.hpp>
+
+namespace samurai
+{
+    namespace args
+    {
+        static bool timers = false;
+    }
+
+    auto read_samurai_arguments(CLI::App& app, int& argc, char**& argv)
+    {
+        app.add_flag("--timers", args::timers, "Print timers at the end of the program")->capture_default_str()->group("SAMURAI tools");
+        app.allow_extras();
+        app.set_help_flag("", "");
+        try
+        {
+            app.parse(argc, argv);
+        }
+        catch (const CLI::ParseError& e)
+        {
+            app.exit(e);
+        }
+        app.set_help_flag("-h,--help", "Print this help message and exit");
+    }
+}

--- a/include/samurai/assert_log_trace.hpp
+++ b/include/samurai/assert_log_trace.hpp
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <iostream>
+
+#define SAMURAI_ASSERT(condition, msg)                                                                                \
+    do                                                                                                                \
+    {                                                                                                                 \
+        if (!(condition))                                                                                             \
+        {                                                                                                             \
+            std::cerr << "Assertion failed \nin " << __FILE__ << "\n @line " << __LINE__ << ": " << msg << std::endl; \
+            std::terminate();                                                                                         \
+        }                                                                                                             \
+    } while (false)
+
+// #ifdef NDEBUG
+#define SAMURAI_LOG(msg)                                \
+    do                                                  \
+    {                                                   \
+        std::cerr << "SMR::Log:: " << msg << std::endl; \
+    } while (0)
+
+#define SAMURAI_TRACE(msg)                                                        \
+    do                                                                            \
+    {                                                                             \
+        std::cerr << "SMR::Trace[line " << __LINE__ << "] :" << msg << std::endl; \
+    } while (0)
+// #else
+// #define MGS_LOG( msg )
+// #endif

--- a/include/samurai/field.hpp
+++ b/include/samurai/field.hpp
@@ -22,6 +22,7 @@ namespace fs = std::filesystem;
 #include "cell.hpp"
 #include "cell_array.hpp"
 #include "field_expression.hpp"
+#include "timers.hpp"
 // #include "hdf5.hpp"
 #include "mesh_holder.hpp"
 #include "numeric/gauss_legendre.hpp"
@@ -648,6 +649,7 @@ namespace samurai
     template <class mesh_t, class value_t, std::size_t size_, bool SOA>
     inline auto Field<mesh_t, value_t, size_, SOA>::operator=(const Field& field) -> Field&
     {
+        times::timers.start("field expressions");
         inner_mesh_t::operator=(field.mesh());
         m_name = field.m_name;
         m_data = field.m_data;
@@ -661,6 +663,7 @@ namespace samurai
                            return v->clone();
                        });
         std::swap(p_bc, tmp);
+        times::timers.stop("field expressions");
         return *this;
     }
 
@@ -668,11 +671,13 @@ namespace samurai
     template <class E>
     inline auto Field<mesh_t, value_t, size_, SOA>::operator=(const field_expression<E>& e) -> Field&
     {
+        times::timers.start("field expressions");
         for_each_interval(this->mesh(),
                           [&](std::size_t level, const auto& i, const auto& index)
                           {
                               (*this)(level, i, index) = e.derived_cast()(level, i, index);
                           });
+        times::timers.stop("field expressions");
         return *this;
     }
 

--- a/include/samurai/hdf5.hpp
+++ b/include/samurai/hdf5.hpp
@@ -37,6 +37,7 @@ namespace mpi = boost::mpi;
 
 #include "algorithm.hpp"
 #include "cell.hpp"
+#include "timers.hpp"
 #include "utils.hpp"
 
 namespace samurai
@@ -969,17 +970,21 @@ namespace samurai
     template <std::size_t dim, class TInterval, class... T>
     void save(const fs::path& path, const std::string& filename, const LevelCellArray<dim, TInterval>& mesh, const T&... fields)
     {
+        times::timers.start("data saving");
         using hdf5_t = Hdf5_LevelCellArray<LevelCellArray<dim, TInterval>, T...>;
         auto h5      = hdf5_t(path, filename, {}, mesh, fields...);
         h5.save();
+        times::timers.stop("data saving");
     }
 
     template <std::size_t dim, class TInterval, class... T>
     void save(const std::string& filename, const LevelCellArray<dim, TInterval>& mesh, const T&... fields)
     {
+        times::timers.start("data saving");
         using hdf5_t = Hdf5_LevelCellArray<LevelCellArray<dim, TInterval>, T...>;
         auto h5      = hdf5_t(fs::current_path(), filename, {}, mesh, fields...);
         h5.save();
+        times::timers.stop("data saving");
     }
 
     template <std::size_t dim, class TInterval, class... T>
@@ -989,9 +994,11 @@ namespace samurai
               const LevelCellArray<dim, TInterval>& mesh,
               const T&... fields)
     {
+        times::timers.start("data saving");
         using hdf5_t = Hdf5_LevelCellArray<LevelCellArray<dim, TInterval>, T...>;
         auto h5      = hdf5_t(path, filename, options, mesh, fields...);
         h5.save();
+        times::timers.stop("data saving");
     }
 
     template <std::size_t dim, class TInterval, class... T>
@@ -1000,25 +1007,31 @@ namespace samurai
               const LevelCellArray<dim, TInterval>& mesh,
               const T&... fields)
     {
+        times::timers.start("data saving");
         using hdf5_t = Hdf5_LevelCellArray<LevelCellArray<dim, TInterval>, T...>;
         auto h5      = hdf5_t(fs::current_path(), filename, options, mesh, fields...);
         h5.save();
+        times::timers.stop("data saving");
     }
 
     template <std::size_t dim, class TInterval, std::size_t max_size, class... T>
     void save(const fs::path& path, const std::string& filename, const CellArray<dim, TInterval, max_size>& mesh, const T&... fields)
     {
+        times::timers.start("data saving");
         using hdf5_t = Hdf5_CellArray<CellArray<dim, TInterval, max_size>, T...>;
         auto h5      = hdf5_t(path, filename, {}, mesh, fields...);
         h5.save();
+        times::timers.stop("data saving");
     }
 
     template <std::size_t dim, class TInterval, std::size_t max_size, class... T>
     void save(const std::string& filename, const CellArray<dim, TInterval, max_size>& mesh, const T&... fields)
     {
+        times::timers.start("data saving");
         using hdf5_t = Hdf5_CellArray<CellArray<dim, TInterval, max_size>, T...>;
         auto h5      = hdf5_t(fs::current_path(), filename, {}, mesh, fields...);
         h5.save();
+        times::timers.stop("data saving");
     }
 
     template <std::size_t dim, class TInterval, std::size_t max_size, class... T>
@@ -1028,9 +1041,11 @@ namespace samurai
               const CellArray<dim, TInterval, max_size>& mesh,
               const T&... fields)
     {
+        times::timers.start("data saving");
         using hdf5_t = Hdf5_CellArray<CellArray<dim, TInterval, max_size>, T...>;
         auto h5      = hdf5_t(path, filename, options, mesh, fields...);
         h5.save();
+        times::timers.stop("data saving");
     }
 
     template <std::size_t dim, class TInterval, std::size_t max_size, class... T>
@@ -1039,25 +1054,31 @@ namespace samurai
               const CellArray<dim, TInterval, max_size>& mesh,
               const T&... fields)
     {
+        times::timers.start("data saving");
         using hdf5_t = Hdf5_CellArray<CellArray<dim, TInterval, max_size>, T...>;
         auto h5      = hdf5_t(fs::current_path(), filename, options, mesh, fields...);
         h5.save();
+        times::timers.stop("data saving");
     }
 
     template <class D, class Config, class... T>
     void save(const fs::path& path, const std::string& filename, const Mesh_base<D, Config>& mesh, const T&... fields)
     {
+        times::timers.start("data saving");
         using hdf5_t = Hdf5_mesh_base<Mesh_base<D, Config>, T...>;
         auto h5      = hdf5_t(path, filename, {}, mesh, fields...);
         h5.save();
+        times::timers.stop("data saving");
     }
 
     template <class D, class Config, class... T>
     void save(const std::string& filename, const Mesh_base<D, Config>& mesh, const T&... fields)
     {
+        times::timers.start("data saving");
         using hdf5_t = Hdf5_mesh_base<Mesh_base<D, Config>, T...>;
         auto h5      = hdf5_t(fs::current_path(), filename, {}, mesh, fields...);
         h5.save();
+        times::timers.stop("data saving");
     }
 
     template <class D, class Config, class... T>
@@ -1067,34 +1088,42 @@ namespace samurai
               const Mesh_base<D, Config>& mesh,
               const T&... fields)
     {
+        times::timers.start("data saving");
         using hdf5_t = Hdf5_mesh_base<Mesh_base<D, Config>, T...>;
         auto h5      = hdf5_t(path, filename, options, mesh, fields...);
         h5.save();
+        times::timers.stop("data saving");
     }
 
     template <class D, class Config, class... T>
     void
     save(const std::string& filename, const Hdf5Options<Mesh_base<D, Config>>& options, const Mesh_base<D, Config>& mesh, const T&... fields)
     {
+        times::timers.start("data saving");
         using hdf5_t = Hdf5_mesh_base<Mesh_base<D, Config>, T...>;
         auto h5      = hdf5_t(fs::current_path(), filename, options, mesh, fields...);
         h5.save();
+        times::timers.stop("data saving");
     }
 
     template <class Config, class... T>
     void save(const fs::path& path, const std::string& filename, const UniformMesh<Config>& mesh, const T&... fields)
     {
+        times::timers.start("data saving");
         using hdf5_t = Hdf5_mesh_base_level<UniformMesh<Config>, T...>;
         auto h5      = hdf5_t(path, filename, {}, mesh, fields...);
         h5.save();
+        times::timers.stop("data saving");
     }
 
     template <class Config, class... T>
     void save(const std::string& filename, const UniformMesh<Config>& mesh, const T&... fields)
     {
+        times::timers.start("data saving");
         using hdf5_t = Hdf5_mesh_base_level<UniformMesh<Config>, T...>;
         auto h5      = hdf5_t(fs::current_path(), filename, {}, mesh, fields...);
         h5.save();
+        times::timers.stop("data saving");
     }
 
     template <class Config, class... T>
@@ -1104,17 +1133,21 @@ namespace samurai
               const UniformMesh<Config>& mesh,
               const T&... fields)
     {
+        times::timers.start("data saving");
         using hdf5_t = Hdf5_mesh_base_level<UniformMesh<Config>, T...>;
         auto h5      = hdf5_t(path, filename, options, mesh, fields...);
         h5.save();
+        times::timers.stop("data saving");
     }
 
     template <class Config, class... T>
     void
     save(const std::string& filename, const Hdf5Options<UniformMesh<Config>>& options, const UniformMesh<Config>& mesh, const T&... fields)
     {
+        times::timers.start("data saving");
         using hdf5_t = Hdf5_mesh_base_level<UniformMesh<Config>, T...>;
         auto h5      = hdf5_t(fs::current_path(), filename, options, mesh, fields...);
         h5.save();
+        times::timers.stop("data saving");
     }
 } // namespace samurai

--- a/include/samurai/mr/adapt.hpp
+++ b/include/samurai/mr/adapt.hpp
@@ -8,6 +8,7 @@
 #include "../field.hpp"
 #include "../hdf5.hpp"
 #include "../static_algorithm.hpp"
+#include "../timers.hpp"
 #include "criteria.hpp"
 #include <type_traits>
 
@@ -137,6 +138,7 @@ namespace samurai
         }
         update_ghost_mr(m_fields);
 
+        times::timers.start("mesh adaptation");
         for (std::size_t i = 0; i < max_level - min_level; ++i)
         {
             // std::cout << "MR mesh adaptation " << i << std::endl;
@@ -149,6 +151,7 @@ namespace samurai
                 break;
             }
         }
+        times::timers.stop("mesh adaptation");
     }
 
     // TODO: to remove since it is used at several place
@@ -210,7 +213,10 @@ namespace samurai
         {
             update_tag_subdomains(level, m_tag, true);
         }
+
+        times::timers.stop("mesh adaptation");
         update_ghost_mr(m_fields);
+        times::timers.start("mesh adaptation");
 
         for (std::size_t level = ((min_level > 0) ? min_level - 1 : 0); level < max_level - ite; ++level)
         {
@@ -335,8 +341,10 @@ namespace samurai
             // update_tag_subdomains(level, m_tag);
             update_tag_subdomains<false>(level, m_tag);
         }
-
+        times::timers.stop("mesh adaptation");
         update_ghost_mr(other_fields...);
+        times::timers.start("mesh adaptation");
+
         keep_only_one_coarse_tag(m_tag);
 
         return update_field_mr(m_tag, m_fields, other_fields...);

--- a/include/samurai/numeric/error.hpp
+++ b/include/samurai/numeric/error.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include "../timers.hpp"
 #include "gauss_legendre.hpp"
 
 namespace samurai
@@ -10,6 +11,8 @@ namespace samurai
     template <bool relative_error, class Field, class Func>
     double L2_error(Field& approximate, Func&& exact)
     {
+        times::timers.start("error computation");
+
         // In FV, we want only 1 quadrature point.
         // This is equivalent to
         //       error += pow(exact(cell.center()) - approximate(cell.index), 2) * cell.length^dim;
@@ -57,6 +60,9 @@ namespace samurai
 
         error_norm    = sqrt(error_norm);
         solution_norm = sqrt(solution_norm);
+
+        times::timers.stop("error computation");
+
         if constexpr (relative_error)
         {
             return error_norm / solution_norm;

--- a/include/samurai/petsc/linear_block_solver.hpp
+++ b/include/samurai/petsc/linear_block_solver.hpp
@@ -122,8 +122,10 @@ namespace samurai
                 KSPGetPC(m_ksp, &pc);
 
                 KSPSetFromOptions(m_ksp);
+                times::timers.start("solver setup");
                 PCSetUp(pc);
                 // KSPSetUp(m_ksp); // PETSc fails at KSPSolve() for some reason.
+                times::timers.stop("solver setup");
 
                 m_is_set_up = true;
             }

--- a/include/samurai/petsc/matrix_assembly.hpp
+++ b/include/samurai/petsc/matrix_assembly.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include "../timers.hpp"
 #include <petsc.h>
 
 namespace samurai
@@ -162,6 +163,8 @@ namespace samurai
              */
             virtual void create_matrix(Mat& A)
             {
+                times::timers.start("matrix assembly");
+
                 reset();
                 auto m = matrix_rows();
                 auto n = matrix_cols();
@@ -198,6 +201,7 @@ namespace samurai
                     MatSeqAIJSetPreallocation(A, PETSC_DEFAULT, nnz.data());
                 }
                 // MatSetOption(A, MAT_NEW_NONZERO_ALLOCATION_ERR, PETSC_FALSE);
+                times::timers.stop("matrix assembly");
             }
 
             /**
@@ -206,6 +210,8 @@ namespace samurai
              */
             virtual void assemble_matrix(Mat& A, bool final_assembly = true)
             {
+                times::timers.start("matrix assembly");
+
                 assemble_scheme(A);
                 if (m_include_bc)
                 {
@@ -235,6 +241,7 @@ namespace samurai
                         MatAssemblyEnd(A, MAT_FINAL_ASSEMBLY);
                     }
                 }
+                times::timers.stop("matrix assembly");
             }
 
             virtual ~MatrixAssembly()

--- a/include/samurai/samurai.hpp
+++ b/include/samurai/samurai.hpp
@@ -37,9 +37,9 @@ namespace samurai
 
     inline void finalize()
     {
-        times::timers.stop("total runtime");
         if (args::timers) // cppcheck-suppress knownConditionTrueFalse
         {
+            times::timers.stop("total runtime");
             std::cout << std::endl;
             times::timers.print();
         }

--- a/include/samurai/samurai.hpp
+++ b/include/samurai/samurai.hpp
@@ -32,6 +32,7 @@ namespace samurai
     {
         times::timers.stop("total runtime");
 
+        std::cout << std::endl;
         times::timers.print();
 #ifdef SAMURAI_WITH_MPI
         MPI_Finalize();

--- a/include/samurai/samurai.hpp
+++ b/include/samurai/samurai.hpp
@@ -7,6 +7,8 @@
 namespace mpi = boost::mpi;
 #endif
 
+#include "timers.hpp"
+
 namespace samurai
 {
 
@@ -15,6 +17,7 @@ namespace samurai
 #ifdef SAMURAI_WITH_MPI
         MPI_Init(&argc, &argv);
 #endif
+        times::timers.start("total runtime");
     }
 
     inline void initialize()
@@ -22,10 +25,14 @@ namespace samurai
 #ifdef SAMURAI_WITH_MPI
         MPI_Init(nullptr, nullptr);
 #endif
+        times::timers.start("total runtime");
     }
 
     inline void finalize()
     {
+        times::timers.stop("total runtime");
+
+        times::timers.print();
 #ifdef SAMURAI_WITH_MPI
         MPI_Finalize();
 #endif

--- a/include/samurai/samurai.hpp
+++ b/include/samurai/samurai.hpp
@@ -7,17 +7,28 @@
 namespace mpi = boost::mpi;
 #endif
 
+#include "arguments.hpp"
 #include "timers.hpp"
 
 namespace samurai
 {
-
-    inline void initialize([[maybe_unused]] int& argc, [[maybe_unused]] char**& argv)
+    inline void initialize(CLI::App& app, int& argc, char**& argv)
     {
+        read_samurai_arguments(app, argc, argv);
+
 #ifdef SAMURAI_WITH_MPI
         MPI_Init(&argc, &argv);
 #endif
-        times::timers.start("total runtime");
+        if (args::timers)
+        {
+            times::timers.start("total runtime");
+        }
+    }
+
+    inline void initialize(int& argc, char**& argv)
+    {
+        CLI::App app{"SAMURAI"};
+        initialize(app, argc, argv);
     }
 
     inline void initialize()
@@ -25,15 +36,17 @@ namespace samurai
 #ifdef SAMURAI_WITH_MPI
         MPI_Init(nullptr, nullptr);
 #endif
-        times::timers.start("total runtime");
     }
 
     inline void finalize()
     {
-        times::timers.stop("total runtime");
+        if (args::timers)
+        {
+            times::timers.stop("total runtime");
 
-        std::cout << std::endl;
-        times::timers.print();
+            std::cout << std::endl;
+            times::timers.print();
+        }
 #ifdef SAMURAI_WITH_MPI
         MPI_Finalize();
 #endif

--- a/include/samurai/samurai.hpp
+++ b/include/samurai/samurai.hpp
@@ -19,10 +19,7 @@ namespace samurai
 #ifdef SAMURAI_WITH_MPI
         MPI_Init(&argc, &argv);
 #endif
-        if (args::timers)
-        {
-            times::timers.start("total runtime");
-        }
+        times::timers.start("total runtime");
     }
 
     inline void initialize(int& argc, char**& argv)

--- a/include/samurai/samurai.hpp
+++ b/include/samurai/samurai.hpp
@@ -12,20 +12,33 @@ namespace mpi = boost::mpi;
 
 namespace samurai
 {
-    inline void initialize(CLI::App& app, int& argc, char**& argv)
+    static CLI::App app;
+
+#define SAMURAI_PARSE(argc, argv)       \
+    try                                 \
+    {                                   \
+        samurai::app.parse(argc, argv); \
+    }                                   \
+    catch (const CLI::ParseError& e)    \
+    {                                   \
+        return samurai::app.exit(e);    \
+    }
+
+    inline auto& initialize(const std::string& description, int& argc, char**& argv)
     {
+        app.description(description);
         read_samurai_arguments(app, argc, argv);
 
 #ifdef SAMURAI_WITH_MPI
         MPI_Init(&argc, &argv);
 #endif
         times::timers.start("total runtime");
+        return app;
     }
 
-    inline void initialize(int& argc, char**& argv)
+    inline auto& initialize(int& argc, char**& argv)
     {
-        CLI::App app{"SAMURAI"};
-        initialize(app, argc, argv);
+        return initialize("SAMURAI", argc, argv);
     }
 
     inline void initialize()

--- a/include/samurai/samurai.hpp
+++ b/include/samurai/samurai.hpp
@@ -37,10 +37,9 @@ namespace samurai
 
     inline void finalize()
     {
-        if (args::timers)
+        times::timers.stop("total runtime");
+        if (args::timers) // cppcheck-suppress knownConditionTrueFalse
         {
-            times::timers.stop("total runtime");
-
             std::cout << std::endl;
             times::timers.print();
         }

--- a/include/samurai/schemes/fv/FV_scheme.hpp
+++ b/include/samurai/schemes/fv/FV_scheme.hpp
@@ -188,8 +188,9 @@ namespace samurai
         {
             times::timers.start(name() + " operator");
             auto explicit_scheme = make_explicit(derived_cast());
-            return explicit_scheme.apply_to(d, input_field);
+            auto output_field    = explicit_scheme.apply_to(d, input_field);
             times::timers.stop(name() + " operator");
+            return output_field;
         }
 
         void apply(std::size_t d, output_field_t& output_field, input_field_t& input_field) const

--- a/include/samurai/schemes/fv/FV_scheme.hpp
+++ b/include/samurai/schemes/fv/FV_scheme.hpp
@@ -169,35 +169,35 @@ namespace samurai
          */
         auto operator()(input_field_t& input_field) const
         {
-            times::timers.start("operator " + name());
+            times::timers.start(name() + " operator");
             auto explicit_scheme = make_explicit(derived_cast());
             auto output_field    = explicit_scheme.apply_to(input_field);
-            times::timers.stop("operator " + name());
+            times::timers.stop(name() + " operator");
             return output_field;
         }
 
         void apply(output_field_t& output_field, input_field_t& input_field) const
         {
-            times::timers.start("operator " + name());
+            times::timers.start(name() + " operator");
             auto explicit_scheme = make_explicit(derived_cast());
             explicit_scheme.apply(output_field, input_field);
-            times::timers.stop("operator " + name());
+            times::timers.stop(name() + " operator");
         }
 
         auto operator()(std::size_t d, input_field_t& input_field) const
         {
-            times::timers.start("operator " + name());
+            times::timers.start(name() + " operator");
             auto explicit_scheme = make_explicit(derived_cast());
             return explicit_scheme.apply_to(d, input_field);
-            times::timers.stop("operator " + name());
+            times::timers.stop(name() + " operator");
         }
 
         void apply(std::size_t d, output_field_t& output_field, input_field_t& input_field) const
         {
-            times::timers.start("operator " + name());
+            times::timers.start(name() + " operator");
             auto explicit_scheme = make_explicit(derived_cast());
             explicit_scheme.apply(d, output_field, input_field);
-            times::timers.stop("operator " + name());
+            times::timers.stop(name() + " operator");
         }
 
         /**

--- a/include/samurai/schemes/fv/FV_scheme.hpp
+++ b/include/samurai/schemes/fv/FV_scheme.hpp
@@ -3,6 +3,7 @@
 #include "../../boundary.hpp"
 #include "../../field.hpp"
 #include "../../static_algorithm.hpp"
+#include "../../timers.hpp"
 #include "utils.hpp"
 
 namespace samurai
@@ -168,26 +169,35 @@ namespace samurai
          */
         auto operator()(input_field_t& input_field) const
         {
+            times::timers.start("operator " + name());
             auto explicit_scheme = make_explicit(derived_cast());
-            return explicit_scheme.apply_to(input_field);
+            auto output_field    = explicit_scheme.apply_to(input_field);
+            times::timers.stop("operator " + name());
+            return output_field;
         }
 
         void apply(output_field_t& output_field, input_field_t& input_field) const
         {
+            times::timers.start("operator " + name());
             auto explicit_scheme = make_explicit(derived_cast());
             explicit_scheme.apply(output_field, input_field);
+            times::timers.stop("operator " + name());
         }
 
         auto operator()(std::size_t d, input_field_t& input_field) const
         {
+            times::timers.start("operator " + name());
             auto explicit_scheme = make_explicit(derived_cast());
             return explicit_scheme.apply_to(d, input_field);
+            times::timers.stop("operator " + name());
         }
 
         void apply(std::size_t d, output_field_t& output_field, input_field_t& input_field) const
         {
+            times::timers.start("operator " + name());
             auto explicit_scheme = make_explicit(derived_cast());
             explicit_scheme.apply(d, output_field, input_field);
+            times::timers.stop("operator " + name());
         }
 
         /**

--- a/include/samurai/schemes/fv/cell_based/algebraic_operators.hpp
+++ b/include/samurai/schemes/fv/cell_based/algebraic_operators.hpp
@@ -56,6 +56,17 @@ namespace samurai
                 };
             }
         }
+
+        std::ostringstream name;
+        if (scalar == static_cast<int>(scalar))
+        {
+            name << static_cast<int>(scalar) << " * " << scheme.name();
+        }
+        else
+        {
+            name << std::setprecision(1) << std::scientific << scalar << " * " << scheme.name();
+        }
+        multiplied_scheme.set_name(name.str());
         return multiplied_scheme;
     }
 

--- a/include/samurai/schemes/fv/flux_based/algebraic_operators.hpp
+++ b/include/samurai/schemes/fv/flux_based/algebraic_operators.hpp
@@ -68,7 +68,16 @@ namespace samurai
             });
 
         multiplied_scheme.is_spd(scheme.is_spd() && scalar != 0);
-        multiplied_scheme.set_name(std::to_string(scalar) + " * " + scheme.name());
+        std::ostringstream name;
+        if (scalar == static_cast<int>(scalar))
+        {
+            name << static_cast<int>(scalar) << " * " << scheme.name();
+        }
+        else
+        {
+            name << std::setprecision(1) << std::scientific << scalar << " * " << scheme.name();
+        }
+        multiplied_scheme.set_name(name.str());
         return multiplied_scheme;
     }
 

--- a/include/samurai/schemes/fv/operators/convection_lin.hpp
+++ b/include/samurai/schemes/fv/operators/convection_lin.hpp
@@ -76,7 +76,9 @@ namespace samurai
                 }
             });
 
-        return make_flux_based_scheme(upwind);
+        auto scheme = make_flux_based_scheme(upwind);
+        scheme.set_name("convection");
+        return scheme;
     }
 
     /**
@@ -127,7 +129,9 @@ namespace samurai
                 }
             });
 
-        return make_flux_based_scheme(weno5);
+        auto scheme = make_flux_based_scheme(weno5);
+        scheme.set_name("convection");
+        return scheme;
     }
 
     /**
@@ -197,7 +201,9 @@ namespace samurai
                 };
             });
 
-        return make_flux_based_scheme(upwind);
+        auto scheme = make_flux_based_scheme(upwind);
+        scheme.set_name("convection");
+        return scheme;
     }
 
     /**
@@ -249,7 +255,9 @@ namespace samurai
                 };
             });
 
-        return make_flux_based_scheme(weno5);
+        auto scheme = make_flux_based_scheme(weno5);
+        scheme.set_name("convection");
+        return scheme;
     }
 
 } // end namespace samurai

--- a/include/samurai/schemes/fv/operators/convection_nonlin.hpp
+++ b/include/samurai/schemes/fv/operators/convection_nonlin.hpp
@@ -174,7 +174,9 @@ namespace samurai
                 };
             });
 
-        return make_flux_based_scheme(upwind);
+        auto scheme = make_flux_based_scheme(upwind);
+        scheme.set_name("convection");
+        return scheme;
     }
 
     template <class Field>
@@ -242,7 +244,9 @@ namespace samurai
                 };
             });
 
-        return make_flux_based_scheme(weno5);
+        auto scheme = make_flux_based_scheme(weno5);
+        scheme.set_name("convection");
+        return scheme;
     }
 
 } // end namespace samurai

--- a/include/samurai/schemes/fv/operators/diffusion.hpp
+++ b/include/samurai/schemes/fv/operators/diffusion.hpp
@@ -171,7 +171,9 @@ namespace samurai
                     return coeffs;
                 };
             });
-        return make_diffusion__<cfg, dirichlet_enfcmt>(K_grad);
+        auto scheme = make_diffusion__<cfg, dirichlet_enfcmt>(K_grad);
+        scheme.set_name("diffusion");
+        return scheme;
     }
 
     /**
@@ -234,7 +236,9 @@ namespace samurai
                     return coeffs;
                 };
             });
-        return make_diffusion__<cfg, dirichlet_enfcmt>(K_grad);
+        auto scheme = make_diffusion__<cfg, dirichlet_enfcmt>(K_grad);
+        scheme.set_name("diffusion");
+        return scheme;
     }
 
     template <class Field, DirichletEnforcement dirichlet_enfcmt = Equation>
@@ -315,7 +319,9 @@ namespace samurai
                 };
             });
 
-        return make_diffusion__<cfg>(K_grad);
+        auto scheme = make_diffusion__<cfg>(K_grad);
+        scheme.set_name("diffusion");
+        return scheme;
     }
 
 } // end namespace samurai

--- a/include/samurai/timers.hpp
+++ b/include/samurai/timers.hpp
@@ -1,0 +1,291 @@
+#pragma once
+
+#include <cassert>
+#include <iomanip>
+#include <iostream>
+#include <limits>
+#include <map>
+#include <vector>
+
+#include "assert_log_trace.hpp"
+
+#ifdef SAMURAI_WITH_MPI
+#include <boost/mpi.hpp>
+#else
+#include <chrono>
+#include <sys/time.h>
+#include <time.h>
+#endif
+
+namespace samurai
+{
+    struct Timer
+    {
+#ifdef SAMURAI_WITH_MPI
+        double start, elapsed;
+#else
+        std::chrono::time_point<std::chrono::high_resolution_clock> start;
+        std::chrono::microseconds elapsed;
+#endif
+        uint32_t ntimes;
+    };
+
+    class Timers
+    {
+      public:
+
+        Timers()
+        {
+        }
+
+        ~Timers() = default;
+
+        inline auto getElapsedTime(const std::string& tname) const
+        {
+            SAMURAI_ASSERT(_times.find(tname) != _times.end(), "[Timers::getElapsedTime] Requested timer not found '" + tname + "' !");
+
+            if (_times.find(tname) != _times.end())
+            {
+                return _times.at(tname).elapsed;
+            }
+            else
+            {
+#ifdef SAMURAI_WITH_MPI
+                return 0.0;
+#else
+                return std::chrono::microseconds(0);
+#endif
+            }
+        }
+
+        inline void start(const std::string& tname)
+        {
+            if (_times.find(tname) != _times.end())
+            {
+                _times.at(tname).start = _getTime();
+            }
+            else
+            {
+                _times.emplace(std::make_pair(tname, Timer{_getTime(), _zero_duration(), 0}));
+            }
+        }
+
+        inline void stop(const std::string& tname)
+        {
+            SAMURAI_ASSERT(_times.find(tname) != _times.end(), "[Timers::stop] Requested timer not found '" + tname + "' !");
+            // if (_times.find(tname) != _times.end())
+            // {
+#ifdef SAMURAI_WITH_MPI
+            _times.at(tname).elapsed += (_getTime() - _times.at(tname).start);
+#else
+            auto duration = std::chrono::duration_cast<std::chrono::microseconds>(_getTime() - _times.at(tname).start);
+            _times.at(tname).elapsed += duration;
+#endif
+            _times.at(tname).ntimes++;
+            // }
+            // else
+            // {
+            //     _times.emplace(std::make_pair(tname, Timer{0.0, 0.0, 0}));
+            // }
+        }
+
+#ifdef SAMURAI_WITH_MPI
+        void print() const
+        {
+            boost::mpi::communicator world;
+
+            int setwSize = 20;
+
+            if (world.rank() == 0)
+            {
+                std::cout << "\n\t> [Master] Timers " << std::endl;
+                std::cout << "\t" << std::setw(setwSize) << "Name " << std::setw(setwSize) << "Min time (s)" << std::setw(8) << ""
+                          << std::setw(setwSize) << "Max time (s)" << std::setw(8) << "" << std::setw(setwSize) << "Ave time (s)"
+                          << std::setw(setwSize) << "Std dev" << std::setw(setwSize) << "Calls" << std::endl;
+            }
+
+            for (const auto& timer : _times)
+            {
+                int minrank = -1, maxrank = -1;
+                double min = std::numeric_limits<double>::max(), max = std::numeric_limits<double>::min();
+                double ave = 0., std = 0.;
+
+                std::vector<double> all(static_cast<std::size_t>(world.size()), 0.0);
+                boost::mpi::all_gather(world, timer.second.elapsed, all);
+
+                for (size_t iproc = 0; iproc < all.size(); ++iproc)
+                {
+                    if (all[iproc] < min)
+                    {
+                        min     = all[iproc];
+                        minrank = static_cast<int>(iproc);
+                    }
+
+                    if (all[iproc] > max)
+                    {
+                        max     = all[iproc];
+                        maxrank = static_cast<int>(iproc);
+                    }
+
+                    ave += timer.second.elapsed;
+                }
+
+                ave /= static_cast<double>(world.size());
+
+                for (size_t iproc = 0; iproc < all.size(); ++iproc)
+                {
+                    std = (all[iproc] - ave) * (all[iproc] - ave);
+                }
+                std /= static_cast<double>(world.size());
+                std = std::sqrt(std);
+
+                // boost::mpi::reduce( world, timer.second.elapsed, min, boost::mpi::minimum<double>(), root );
+                // boost::mpi::reduce( world, timer.second.elapsed, max, boost::mpi::maximum<double>(), root );
+                // boost::mpi::reduce( world, timer.second.elapsed, ave, std::plus<double>(), root );
+
+                if (world.rank() == 0)
+                {
+                    std::cout << std::fixed << std::setprecision(5) << "\t" << std::setw(setwSize) << timer.first << std::setw(setwSize)
+                              << min << std::setw(2) << "[" << std::setw(4) << minrank << std::setw(2) << "]" << std::setw(setwSize) << max
+                              << std::setw(2) << "[" << std::setw(4) << maxrank << std::setw(2) << "]" << std::setw(setwSize) << ave
+                              << std::setw(setwSize) << std << std::setw(setwSize) << timer.second.ntimes << std::endl;
+                }
+            }
+        }
+
+#else
+        void print() const
+        {
+            std::chrono::microseconds total_runtime(0);
+            std::chrono::microseconds total_measured(0);
+            bool has_total_runtime = false;
+            for (const auto& timer : _times)
+            {
+                if (timer.first == "total runtime")
+                {
+                    has_total_runtime = true;
+                    total_runtime     = timer.second.elapsed;
+                }
+                else
+                {
+                    total_measured += timer.second.elapsed;
+                }
+            }
+            std::chrono::microseconds total = has_total_runtime ? total_runtime : total_measured;
+
+            std::vector<std::pair<std::string, Timer>> sorted_data(_times.begin(), _times.end());
+            std::sort(sorted_data.begin(),
+                      sorted_data.end(),
+                      [](const std::pair<std::string, Timer>& a, const std::pair<std::string, Timer>& b)
+                      {
+                          return a.second.elapsed > b.second.elapsed;
+                      });
+
+            double total_perc = 0.0;
+            std::cout << "\n\t> [Process] Timers " << std::endl;
+            int setwSize = 20;
+
+            std::cout << "\t";
+            std::cout << std::setw(setwSize) << " ";
+            std::cout << std::setw(setwSize) << "Elapsed (s)";
+            std::cout << std::setw(setwSize) << "Fraction (%)";
+            std::cout << std::setw(setwSize) << "Calls";
+            std::cout << std::endl;
+
+            std::cout << std::fixed;
+            for (const auto& timer : sorted_data)
+            {
+                if (timer.first != "total runtime")
+                {
+                    auto elapsedInSeconds = std::chrono::duration_cast<std::chrono::duration<double, std::ratio<1>>>(timer.second.elapsed);
+                    std::cout << "\t";
+                    std::cout << std::setw(setwSize) << timer.first;
+                    std::cout << std::setw(setwSize) << std::setprecision(3) << elapsedInSeconds.count();
+                    std::cout << std::setw(setwSize) << std::setprecision(1) << _percent(timer.second.elapsed, total);
+                    std::cout << std::setw(setwSize) << timer.second.ntimes;
+                    std::cout << std::endl;
+                    total_perc += timer.second.elapsed * 100.0 / total;
+                }
+            }
+
+            for (const auto& timer : _times)
+            {
+                if (timer.first == "total runtime")
+                {
+                    auto untimed          = total_runtime - total_measured;
+                    auto untimedInSeconds = std::chrono::duration_cast<std::chrono::duration<double, std::ratio<1>>>(untimed);
+                    std::cout << "\t";
+                    std::cout << std::setw(setwSize) << "(untimed)";
+                    std::cout << std::setw(setwSize) << std::setprecision(3) << untimedInSeconds.count();
+                    std::cout << std::setw(setwSize) << std::setprecision(1) << _percent(untimed, total);
+                    std::cout << std::endl;
+
+                    std::string msg = "--------------------";
+                    std::cout << "\t" << std::setw(setwSize) << msg << std::setw(setwSize) << msg << std::setw(setwSize) << msg
+                              << std::setw(setwSize) << msg << std::endl;
+
+                    auto totalInSeconds = std::chrono::duration_cast<std::chrono::duration<double, std::ratio<1>>>(timer.second.elapsed);
+                    std::cout << "\t";
+                    std::cout << std::setw(setwSize) << timer.first;
+                    std::cout << std::setw(setwSize) << std::setprecision(3) << totalInSeconds.count();
+                    std::cout << std::setw(setwSize) << std::setprecision(1) << 100.0;
+                    std::cout << std::endl;
+                    total_perc += _percent(timer.second.elapsed, total);
+                }
+            }
+
+            if (!has_total_runtime)
+            {
+                std::cout << "\t";
+                std::cout << std::setw(setwSize) << "Total";
+                std::cout << std::setw(setwSize) << total_measured.count();
+                std::cout << std::setw(setwSize) << total_perc << std::endl;
+            }
+
+            std::flush(std::cout);
+        }
+#endif
+
+      private:
+
+        std::map<std::string, Timer> _times;
+
+#ifdef SAMURAI_WITH_MPI
+        inline double _getTime() const
+        {
+            return MPI_Wtime();
+        }
+
+        inline double _zero_duration() const
+        {
+            return 0.0;
+        }
+#else
+        inline std::chrono::time_point<std::chrono::high_resolution_clock> _getTime() const
+        {
+            // timeval now;
+            // SAMURAI_ASSERT(-1 != gettimeofday(&now, 0), "[Timers::_getTime()] Error getting timeofday !");
+            // return double(now.tv_sec) + (double(now.tv_usec) * 1e-6);
+            // double durationInmicroseconds = chrono::duration_cast<chrono::duration<double, std::milli>>(_elapsed_stop -
+            // _elapsed_start).count();
+            return std::chrono::high_resolution_clock::now();
+        }
+
+        inline std::chrono::microseconds _zero_duration() const
+        {
+            return std::chrono::microseconds(0);
+        }
+#endif
+        inline double _percent(const std::chrono::microseconds& value, const std::chrono::microseconds& total) const
+        {
+            return static_cast<double>(value.count() * 100) / static_cast<double>(total.count());
+        }
+    };
+
+    namespace times
+    {
+
+        static Timers timers;
+
+    }
+}

--- a/include/samurai/timers.hpp
+++ b/include/samurai/timers.hpp
@@ -158,7 +158,8 @@ namespace samurai
         {
             std::chrono::microseconds total_runtime(0);
             std::chrono::microseconds total_measured(0);
-            bool has_total_runtime = false;
+            std::size_t max_name_length = 0;
+            bool has_total_runtime      = false;
             for (const auto& timer : _times)
             {
                 if (timer.first == "total runtime")
@@ -169,6 +170,7 @@ namespace samurai
                 else
                 {
                     total_measured += timer.second.elapsed;
+                    max_name_length = std::max(max_name_length, timer.first.length());
                 }
             }
             std::chrono::microseconds total = has_total_runtime ? total_runtime : total_measured;
@@ -182,14 +184,15 @@ namespace samurai
                       });
 
             double total_perc = 0.0;
-            std::cout << "\n\t> [Process] Timers " << std::endl;
-            int setwSize = 20;
+            // std::cout << "\n\t> [Process] Timers " << std::endl;
+            int setwSizeName = static_cast<int>(max_name_length) + 4;
+            int setwSizeData = 16;
 
-            std::cout << "\t";
-            std::cout << std::setw(setwSize) << " ";
-            std::cout << std::setw(setwSize) << "Elapsed (s)";
-            std::cout << std::setw(setwSize) << "Fraction (%)";
-            std::cout << std::setw(setwSize) << "Calls";
+            // std::cout << "\t";
+            std::cout << std::setw(setwSizeName) << " ";
+            std::cout << std::setw(setwSizeData) << "Elapsed (s)";
+            std::cout << std::setw(setwSizeData) << "Fraction (%)";
+            // std::cout << std::setw(setwSizeData) << "Calls";
             std::cout << std::endl;
 
             std::cout << std::fixed;
@@ -198,11 +201,11 @@ namespace samurai
                 if (timer.first != "total runtime")
                 {
                     auto elapsedInSeconds = std::chrono::duration_cast<std::chrono::duration<double, std::ratio<1>>>(timer.second.elapsed);
-                    std::cout << "\t";
-                    std::cout << std::setw(setwSize) << timer.first;
-                    std::cout << std::setw(setwSize) << std::setprecision(3) << elapsedInSeconds.count();
-                    std::cout << std::setw(setwSize) << std::setprecision(1) << _percent(timer.second.elapsed, total);
-                    std::cout << std::setw(setwSize) << timer.second.ntimes;
+                    // std::cout << "\t";
+                    std::cout << std::setw(setwSizeName) << timer.first;
+                    std::cout << std::setw(setwSizeData) << std::setprecision(3) << elapsedInSeconds.count();
+                    std::cout << std::setw(setwSizeData) << std::setprecision(1) << _percent(timer.second.elapsed, total);
+                    // std::cout << std::setw(setwSizeData) << timer.second.ntimes;
                     std::cout << std::endl;
                     total_perc += timer.second.elapsed * 100.0 / total;
                 }
@@ -212,23 +215,27 @@ namespace samurai
             {
                 if (timer.first == "total runtime")
                 {
+                    std::string msg = "----------------";
+                    std::cout << std::setw(setwSizeName) << msg /*<< std::setw(setwSizeData) << msg << std::setw(setwSizeData) << msg
+                              << std::setw(setwSizeData)*/
+                              << std::endl;
+
                     auto untimed          = total_runtime - total_measured;
                     auto untimedInSeconds = std::chrono::duration_cast<std::chrono::duration<double, std::ratio<1>>>(untimed);
-                    std::cout << "\t";
-                    std::cout << std::setw(setwSize) << "(untimed)";
-                    std::cout << std::setw(setwSize) << std::setprecision(3) << untimedInSeconds.count();
-                    std::cout << std::setw(setwSize) << std::setprecision(1) << _percent(untimed, total);
+                    // std::cout << "\t";
+                    std::cout << std::setw(setwSizeName) << "(untimed)";
+                    std::cout << std::setw(setwSizeData) << std::setprecision(3) << untimedInSeconds.count();
+                    std::cout << std::setw(setwSizeData) << std::setprecision(1) << _percent(untimed, total);
                     std::cout << std::endl;
 
-                    std::string msg = "--------------------";
-                    std::cout << "\t" << std::setw(setwSize) << msg << std::setw(setwSize) << msg << std::setw(setwSize) << msg
-                              << std::setw(setwSize) << msg << std::endl;
+                    std::cout << std::setw(setwSizeName) << msg << std::setw(setwSizeData) << msg << std::setw(setwSizeData) << msg
+                              << std::setw(setwSizeData) << std::endl;
 
                     auto totalInSeconds = std::chrono::duration_cast<std::chrono::duration<double, std::ratio<1>>>(timer.second.elapsed);
-                    std::cout << "\t";
-                    std::cout << std::setw(setwSize) << timer.first;
-                    std::cout << std::setw(setwSize) << std::setprecision(3) << totalInSeconds.count();
-                    std::cout << std::setw(setwSize) << std::setprecision(1) << 100.0;
+                    // std::cout << "\t";
+                    std::cout << std::setw(setwSizeName) << timer.first;
+                    std::cout << std::setw(setwSizeData) << std::setprecision(3) << totalInSeconds.count();
+                    std::cout << std::setw(setwSizeData) << std::setprecision(1) << 100.0;
                     std::cout << std::endl;
                     total_perc += _percent(timer.second.elapsed, total);
                 }
@@ -236,13 +243,14 @@ namespace samurai
 
             if (!has_total_runtime)
             {
-                std::cout << "\t";
-                std::cout << std::setw(setwSize) << "Total";
-                std::cout << std::setw(setwSize) << total_measured.count();
-                std::cout << std::setw(setwSize) << total_perc << std::endl;
+                // std::cout << "\t";
+                std::cout << std::setw(setwSizeName) << "Total";
+                std::cout << std::setw(setwSizeData) << total_measured.count();
+                std::cout << std::setw(setwSizeData) << total_perc;
+                std::cout << std::endl;
             }
 
-            std::flush(std::cout);
+            std::cout << std::endl;
         }
 #endif
 


### PR DESCRIPTION
## Description
Timers can be activated by the `--timers` argument.
Main samurai execution steps are timed, and the results are displayed at the end of the program, within the call to `samurai::finalize()`.
Example: 
````
                            Elapsed (s)    Fraction (%)
           ghost update           2.448            30.8
        mesh adaptation           2.419            30.4
    convection operator           1.956            24.6
            data saving           0.802            10.1
      field expressions           0.261             3.3
       ----------------
              (untimed)           0.061             0.8
       ------------------------------------------------
          total runtime           7.946           100.0
````

## Changes in user code
- samurai now requires cli11.
- Although the new code is retrocompatible, the user codes that already use cli11 should get the `app` object from `samurai::initialize()`:
```cpp
auto& app = samurai::initialize("My app's description", argc, argv);
```
- `CLI11_PARSE(app, argc, argv)` should also be replaced with `SAMURAI_PARSE(argc, argv)`. 

## Code of Conduct
By submitting this PR, you agree to follow our [Code of Conduct](https://github.com/hpc-maths/samurai/blob/master/docs/CODE_OF_CONDUCT.md)
- [x] I agree to follow this project's Code of Conduct
