### PR TITLE
feat: fieldsplit PC for monolithic matrix

### DIFF
--- a/demos/FiniteVolume/lid_driven_cavity.cpp
+++ b/demos/FiniteVolume/lid_driven_cavity.cpp
@@ -42,13 +42,17 @@ void configure_saddle_point_solver(Solver& block_solver)
     KSP ksp = block_solver.Ksp();
     PC pc;
     KSPGetPC(ksp, &pc);
-    PCSetType(pc, PCFIELDSPLIT);                 // (equiv. '-pc_type fieldsplit')
+
+    block_solver.assemble_matrix(); // if nested matrix, must be called before calling set_pc_fieldsplit().
+
+    block_solver.set_pc_fieldsplit(pc);
     PCFieldSplitSetType(pc, PC_COMPOSITE_SCHUR); // Schur complement preconditioner (equiv. '-pc_fieldsplit_type schur')
     PCFieldSplitSetSchurPre(pc, PC_FIELDSPLIT_SCHUR_PRE_SELFP, PETSC_NULLPTR); // (equiv. '-pc_fieldsplit_schur_precondition selfp')
     PCFieldSplitSetSchurFactType(pc, PC_FIELDSPLIT_SCHUR_FACT_FULL);           // (equiv. '-pc_fieldsplit_schur_fact_type full')
 
     // Configure the sub-solvers
-    block_solver.setup(); // must be called before using PCFieldSplitSchurGetSubKSP(), because the matrices are needed.
+    block_solver.setup(); // KSPSetUp() or PCSetUp() must be called before calling PCFieldSplitSchurGetSubKSP(), because the matrices are
+                          // needed.
     KSP* sub_ksp;
     PCFieldSplitSchurGetSubKSP(pc, nullptr, &sub_ksp);
     KSP A_ksp     = sub_ksp[0];
@@ -86,7 +90,7 @@ void configure_solver(Solver& solver)
     }
     else
     {
-        configure_saddle_point_solver(solver);
+        configure_saddle_point_solver(solver); // works also for monolithic
     }
 }
 

--- a/include/samurai/petsc/linear_block_solver.hpp
+++ b/include/samurai/petsc/linear_block_solver.hpp
@@ -11,22 +11,19 @@ namespace samurai
          * Block solver
          */
         template <bool monolithic, std::size_t rows_, std::size_t cols_, class... Operators>
-        class LinearBlockSolver
+        class LinearBlockSolver : public LinearSolverBase<BlockAssembly<monolithic, rows_, cols_, Operators...>>
         {
-        };
-
-        /**
-         * Nested block solver
-         */
-        template <std::size_t rows_, std::size_t cols_, class... Operators>
-        class LinearBlockSolver<false, rows_, cols_, Operators...> : public LinearSolverBase<NestedBlockAssembly<rows_, cols_, Operators...>>
-        {
-            using assembly_t = NestedBlockAssembly<rows_, cols_, Operators...>;
+            using assembly_t = BlockAssembly<monolithic, rows_, cols_, Operators...>;
             using base_class = LinearSolverBase<assembly_t>;
-            using base_class::assembly;
             using base_class::m_A;
             using base_class::m_is_set_up;
             using base_class::m_ksp;
+
+          public:
+
+            using base_class::assembly;
+
+          private:
 
             using block_operator_t            = typename assembly_t::scheme_t;
             static constexpr std::size_t rows = assembly_t::rows;
@@ -34,7 +31,7 @@ namespace samurai
 
           public:
 
-            static constexpr bool is_monolithic = false;
+            static constexpr bool is_monolithic = monolithic;
 
             explicit LinearBlockSolver(const block_operator_t& block_op)
                 : base_class(block_op)
@@ -47,7 +44,7 @@ namespace samurai
             void _configure_solver()
             {
                 KSPCreate(PETSC_COMM_SELF, &m_ksp);
-                // KSPSetFromOptions(m_ksp);
+                KSPSetFromOptions(m_ksp);
             }
 
           public:
@@ -55,6 +52,36 @@ namespace samurai
             void configure_solver() override
             {
                 _configure_solver();
+            }
+
+            void set_pc_fieldsplit(PC& pc)
+            {
+                PCSetType(pc, PCFIELDSPLIT);
+                if constexpr (is_monolithic)
+                {
+                    auto IS_fields   = assembly().create_fields_IS();
+                    auto field_names = assembly().field_names();
+                    for (std::size_t i = 0; i < cols; ++i)
+                    {
+                        PCFieldSplitSetIS(pc, field_names[i].c_str(), IS_fields[i]);
+                        ISDestroy(&IS_fields[i]);
+                    }
+                }
+                else
+                {
+                    if (m_A == nullptr)
+                    {
+                        std::cerr << "The matrix must be assemble before calling set_pc_fieldsplit()." << std::endl;
+                        exit(EXIT_FAILURE);
+                    }
+                    IS IS_fields[cols];
+                    MatNestGetISs(m_A, IS_fields, NULL);
+                    auto field_names = assembly().field_names();
+                    for (std::size_t i = 0; i < cols; ++i)
+                    {
+                        PCFieldSplitSetIS(pc, field_names[i].c_str(), IS_fields[i]);
+                    }
+                }
             }
 
             template <class... Fields>
@@ -76,40 +103,27 @@ namespace samurai
 
             void setup() override
             {
+                if constexpr (is_monolithic)
+                {
+                    base_class::setup();
+                    return;
+                }
+
                 if (m_is_set_up)
                 {
                     return;
                 }
 
-                if (assembly().undefined_unknown())
-                {
-                    std::cerr << "Undefined unknowns for this linear system. Please set the unknowns using the instruction '[solver].set_unknowns(u1, u2...);'."
-                              << std::endl;
-                    assert(false && "Undefined unknowns");
-                    exit(EXIT_FAILURE);
-                }
-
-                // assembly().reset();
-                assembly().create_matrix(m_A);
-                assembly().assemble_matrix(m_A);
-                PetscObjectSetName(reinterpret_cast<PetscObject>(m_A), "A");
+                this->assemble_matrix();
                 // MatView(m_A, PETSC_VIEWER_STDOUT_(PETSC_COMM_SELF)); std::cout << std::endl;
                 KSPSetOperators(m_ksp, m_A, m_A);
 
-                // Set names to the petsc fields
                 PC pc;
                 KSPGetPC(m_ksp, &pc);
-                IS is_fields[cols];
-                MatNestGetISs(m_A, is_fields, NULL);
-                auto field_names = assembly().field_names();
-                for (std::size_t i = 0; i < cols; ++i)
-                {
-                    PCFieldSplitSetIS(pc, field_names[i].c_str(), is_fields[i]);
-                }
 
                 KSPSetFromOptions(m_ksp);
                 PCSetUp(pc);
-                // KSPSetUp(m_ksp); // Here, PETSc fails for some reason.
+                // KSPSetUp(m_ksp); // PETSc fails at KSPSolve() for some reason.
 
                 m_is_set_up = true;
             }
@@ -130,74 +144,10 @@ namespace samurai
                 Vec x = assembly().create_solution_vector();
                 this->prepare_rhs_and_solve(b, x);
 
-                VecDestroy(&b);
-                VecDestroy(&x);
-            }
-        };
-
-        /**
-         * Monolithic block solver
-         */
-        template <std::size_t rows_, std::size_t cols_, class... Operators>
-        class LinearBlockSolver<true, rows_, cols_, Operators...>
-            : public LinearSolverBase<MonolithicBlockAssembly<rows_, cols_, Operators...>>
-        {
-            using assembly_t = MonolithicBlockAssembly<rows_, cols_, Operators...>;
-            using base_class = LinearSolverBase<assembly_t>;
-            using base_class::assembly;
-            using base_class::m_A;
-            using base_class::m_is_set_up;
-            using base_class::m_ksp;
-
-            using block_operator_t = typename assembly_t::scheme_t;
-
-            static constexpr std::size_t rows = assembly_t::rows;
-            static constexpr std::size_t cols = assembly_t::cols;
-
-          public:
-
-            static constexpr bool is_monolithic = true;
-
-            explicit LinearBlockSolver(const block_operator_t& block_op)
-                : base_class(block_op)
-            {
-            }
-
-            template <class... Fields>
-            void set_unknowns(Fields&... unknowns)
-            {
-                auto unknown_tuple = assembly().block_operator().tie_unknowns(unknowns...);
-                set_unknown(unknown_tuple);
-            }
-
-            template <class UnknownTuple>
-            void set_unknown(UnknownTuple& unknown_tuple)
-            {
-                static_assert(std::tuple_size_v<UnknownTuple> == cols,
-                              "The number of unknown fields passed to solve() must equal "
-                              "the number of columns of the block operator.");
-                assembly().set_unknown(unknown_tuple);
-                assembly().reset();
-            }
-
-            template <class... Fields>
-            void solve(Fields&... rhs_fields)
-            {
-                auto rhs_tuple = assembly().block_operator().tie_rhs(rhs_fields...);
-                // static_assert(std::tuple_size_v<RHSTuple> == rows,
-                //                   "The number of source fields passed to solve() must equal "
-                //                   "the number of rows of the block operator.");
-
-                if (!m_is_set_up)
+                if constexpr (is_monolithic)
                 {
-                    this->setup();
+                    assembly().update_unknowns(x);
                 }
-
-                Vec b = assembly().create_rhs_vector(rhs_tuple);
-                Vec x = assembly().create_solution_vector();
-                this->prepare_rhs_and_solve(b, x);
-
-                assembly().update_unknowns(x);
 
                 VecDestroy(&b);
                 VecDestroy(&x);


### PR DESCRIPTION
## Description
The fieldsplit PC can be used with a monolithic matrix.

## How has this been tested?
Stokes demo.

## Code of Conduct
By submitting this PR, you agree to follow our [Code of Conduct](https://github.com/hpc-maths/samurai/blob/master/docs/CODE_OF_CONDUCT.md)
- [x] I agree to follow this project's Code of Conduct
