### PR TITLE
perf: Improve nb cells

### DIFF
--- a/include/samurai/mesh.hpp
+++ b/include/samurai/mesh.hpp
@@ -331,7 +331,7 @@ namespace samurai
     inline std::size_t Mesh_base<D, Config>::max_nb_cells(std::size_t level) const
     {
         auto last_xinterval = m_cells[mesh_id_t::reference][level][0].back();
-        return last_xinterval.start + last_xinterval.index + last_xinterval.size();
+        return static_cast<std::size_t>(last_xinterval.start) + last_xinterval.index + last_xinterval.size();
     }
 
     template <class D, class Config>

--- a/include/samurai/mesh.hpp
+++ b/include/samurai/mesh.hpp
@@ -168,6 +168,7 @@ namespace samurai
         void partition_mesh(std::size_t start_level, const Box<double, dim>& global_box);
         void load_balancing();
         void load_transfer(const std::vector<double>& load_fluxes);
+        std::size_t max_nb_cells(std::size_t level) const;
 
         lca_type m_domain;
         lca_type m_subdomain;
@@ -327,14 +328,29 @@ namespace samurai
     }
 
     template <class D, class Config>
+    inline std::size_t Mesh_base<D, Config>::max_nb_cells(std::size_t level) const
+    {
+        auto last_xinterval = m_cells[mesh_id_t::reference][level][0].back();
+        return last_xinterval.start + last_xinterval.index + last_xinterval.size();
+    }
+
+    template <class D, class Config>
     inline std::size_t Mesh_base<D, Config>::nb_cells(mesh_id_t mesh_id) const
     {
+        if (mesh_id == mesh_id_t::reference)
+        {
+            return max_nb_cells(m_cells[mesh_id].max_level());
+        }
         return m_cells[mesh_id].nb_cells();
     }
 
     template <class D, class Config>
     inline std::size_t Mesh_base<D, Config>::nb_cells(std::size_t level, mesh_id_t mesh_id) const
     {
+        if (mesh_id == mesh_id_t::reference)
+        {
+            return max_nb_cells(level);
+        }
         return m_cells[mesh_id][level].nb_cells();
     }
 


### PR DESCRIPTION
## Description
The number of cells for a given mesh is computed using the sum of the size of each interval in x-direction. However, if we want to compute the maximum number of cells (which is used when we resize a field), we can do this much faster using the last x-interval:

- The start of the interval + the offset gives the memory location of the cell for that start.
- If we add the size of the interval, we get the maximum number of cells.

## Code of Conduct
By submitting this PR, you agree to follow our [Code of Conduct](https://github.com/hpc-maths/samurai/blob/master/docs/CODE_OF_CONDUCT.md)
- [x] I agree to follow this project's Code of Conduct
