### PR TITLE
perf: remove apply interval index

### DIFF
--- a/include/samurai/mesh.hpp
+++ b/include/samurai/mesh.hpp
@@ -550,18 +550,11 @@ namespace samurai
 
             if (mt != mesh_id_t::reference)
             {
-                for (std::size_t level = 0; level <= max_refinement_level; ++level)
-                {
-                    lca_type& lhs       = m_cells[mt][level];
-                    const lca_type& rhs = m_cells[mesh_id_t::reference][level];
-
-                    auto expr = intersection(lhs, rhs);
-                    expr.apply_interval_index(
-                        [&](const auto& interval_index)
-                        {
-                            lhs[0][interval_index[0]].index = rhs[0][interval_index[1]].index;
-                        });
-                }
+                for_each_interval(m_cells[mt],
+                                  [&](std::size_t level, auto& i, auto& index)
+                                  {
+                                      i.index = m_cells[mesh_id_t::reference][level].get_interval(i, index).index;
+                                  });
             }
         }
     }

--- a/include/samurai/mesh.hpp
+++ b/include/samurai/mesh.hpp
@@ -331,27 +331,19 @@ namespace samurai
     inline std::size_t Mesh_base<D, Config>::max_nb_cells(std::size_t level) const
     {
         auto last_xinterval = m_cells[mesh_id_t::reference][level][0].back();
-        return static_cast<std::size_t>(last_xinterval.start) + last_xinterval.index + last_xinterval.size();
+        return static_cast<std::size_t>(static_cast<index_t>(last_xinterval.start) + last_xinterval.index) + last_xinterval.size();
     }
 
     template <class D, class Config>
     inline std::size_t Mesh_base<D, Config>::nb_cells(mesh_id_t mesh_id) const
     {
-        if (mesh_id == mesh_id_t::reference)
-        {
-            return max_nb_cells(m_cells[mesh_id].max_level());
-        }
-        return m_cells[mesh_id].nb_cells();
+        return (mesh_id == mesh_id_t::reference) ? max_nb_cells(m_cells[mesh_id].max_level()) : m_cells[mesh_id].nb_cells();
     }
 
     template <class D, class Config>
     inline std::size_t Mesh_base<D, Config>::nb_cells(std::size_t level, mesh_id_t mesh_id) const
     {
-        if (mesh_id == mesh_id_t::reference)
-        {
-            return max_nb_cells(level);
-        }
-        return m_cells[mesh_id][level].nb_cells();
+        return (mesh_id == mesh_id_t::reference) ? max_nb_cells(level) : m_cells[mesh_id][level].nb_cells();
     }
 
     template <class D, class Config>

--- a/include/samurai/subset/subset_node.hpp
+++ b/include/samurai/subset/subset_node.hpp
@@ -61,7 +61,6 @@ namespace samurai
         void set_shift(std::size_t ref_level, std::size_t common_level);
 
         const node_type& get_node() const;
-        void get_interval_index(std::vector<std::size_t>& index) const;
 
       private:
 
@@ -513,11 +512,5 @@ namespace samurai
     inline auto subset_node<T>::get_node() const -> const node_type&
     {
         return m_node;
-    }
-
-    template <class T>
-    inline void subset_node<T>::get_interval_index(std::vector<std::size_t>& index) const
-    {
-        index.push_back(m_index[m_d] + m_ipos[m_d] - 1);
     }
 } // namespace samurai

--- a/include/samurai/uniform_mesh.hpp
+++ b/include/samurai/uniform_mesh.hpp
@@ -173,15 +173,11 @@ namespace samurai
 
             if (mt != mesh_id_t::reference)
             {
-                ca_type& lhs       = m_cells[mt];
-                const ca_type& rhs = m_cells[mesh_id_t::reference];
-
-                auto expr = intersection(lhs, rhs);
-                expr.apply_interval_index(
-                    [&](const auto& interval_index)
-                    {
-                        lhs[0][interval_index[0]].index = rhs[0][interval_index[1]].index;
-                    });
+                for_each_interval(m_cells[mt],
+                                  [&](std::size_t level, auto& i, auto& index)
+                                  {
+                                      i.index = m_cells[mesh_id_t::reference][level].get_interval(i, index).index;
+                                  });
             }
         }
     }

--- a/include/samurai/uniform_mesh.hpp
+++ b/include/samurai/uniform_mesh.hpp
@@ -174,9 +174,9 @@ namespace samurai
             if (mt != mesh_id_t::reference)
             {
                 for_each_interval(m_cells[mt],
-                                  [&](std::size_t level, auto& i, auto& index)
+                                  [&](std::size_t, auto& i, auto& index)
                                   {
-                                      i.index = m_cells[mesh_id_t::reference][level].get_interval(i, index).index;
+                                      i.index = m_cells[mesh_id_t::reference].get_interval(i, index).index;
                                   });
             }
         }


### PR DESCRIPTION
## Description
This PR removes the computation of the index of each interval found in the algebra of set. This index is only used during the renumbering phase of the sub meshes. We improve the performance of the renumbering by removing the old implementation.

## Code of Conduct
By submitting this PR, you agree to follow our [Code of Conduct](https://github.com/hpc-maths/samurai/blob/master/docs/CODE_OF_CONDUCT.md)
- [x] I agree to follow this project's Code of Conduct
