### PR TITLE
perf: remove hardcoded access modes in get_interval

### DIFF
--- a/include/samurai/field.hpp
+++ b/include/samurai/field.hpp
@@ -681,9 +681,8 @@ namespace samurai
 
     template <class mesh_t, class value_t, std::size_t size_, bool SOA>
     template <class... T>
-    inline auto Field<mesh_t, value_t, size_, SOA>::get_interval(std::size_t level,
-                                                                 const interval_t& interval,
-                                                                 const T... index) const -> const interval_t&
+    inline auto Field<mesh_t, value_t, size_, SOA>::get_interval(std::size_t level, const interval_t& interval, const T... index) const
+        -> const interval_t&
     {
         const interval_t& interval_tmp = this->mesh().get_interval(level, interval, index...);
 
@@ -714,10 +713,10 @@ namespace samurai
     }
 
     template <class mesh_t, class value_t, std::size_t size_, bool SOA>
-    inline auto
-    Field<mesh_t, value_t, size_, SOA>::get_interval(std::size_t level,
-                                                     const interval_t& interval,
-                                                     const xt::xtensor_fixed<value_t, xt::xshape<dim - 1>>& index) const -> const interval_t&
+    inline auto Field<mesh_t, value_t, size_, SOA>::get_interval(std::size_t level,
+                                                                 const interval_t& interval,
+                                                                 const xt::xtensor_fixed<value_t, xt::xshape<dim - 1>>& index) const
+        -> const interval_t&
     {
         const interval_t& interval_tmp = this->mesh().get_interval(level, interval, index);
 

--- a/include/samurai/field.hpp
+++ b/include/samurai/field.hpp
@@ -116,7 +116,7 @@ namespace samurai
             template <class... T>
             inline auto operator()(const std::size_t level, const interval_t& interval, const T... index)
             {
-                auto interval_tmp = this->derived_cast().get_interval("READ OR WRITE", level, interval, index...);
+                auto interval_tmp = this->derived_cast().get_interval(level, interval, index...);
                 return xt::view(this->derived_cast().m_data,
                                 xt::range(interval_tmp.index + interval.start, interval_tmp.index + interval.end, interval.step));
             }
@@ -124,7 +124,7 @@ namespace samurai
             template <class... T>
             inline auto operator()(const std::size_t level, const interval_t& interval, const T... index) const
             {
-                auto interval_tmp = this->derived_cast().get_interval("READ", level, interval, index...);
+                auto interval_tmp = this->derived_cast().get_interval(level, interval, index...);
                 auto data         = xt::view(this->derived_cast().m_data,
                                      xt::range(interval_tmp.index + interval.start, interval_tmp.index + interval.end, interval.step));
 #ifdef SAMURAI_CHECK_NAN
@@ -206,7 +206,7 @@ namespace samurai
             template <class... T>
             inline auto operator()(const std::size_t level, const interval_t& interval, const T... index)
             {
-                auto interval_tmp = this->derived_cast().get_interval("READ OR WRITE", level, interval, index...);
+                auto interval_tmp = this->derived_cast().get_interval(level, interval, index...);
                 return xt::view(this->derived_cast().m_data,
                                 xt::range(interval_tmp.index + interval.start, interval_tmp.index + interval.end, interval.step));
             }
@@ -214,7 +214,7 @@ namespace samurai
             template <class... T>
             inline auto operator()(const std::size_t level, const interval_t& interval, const T... index) const
             {
-                auto interval_tmp = this->derived_cast().get_interval("READ", level, interval, index...);
+                auto interval_tmp = this->derived_cast().get_interval(level, interval, index...);
                 auto data         = xt::view(this->derived_cast().m_data,
                                      xt::range(interval_tmp.index + interval.start, interval_tmp.index + interval.end, interval.step));
 #ifdef SAMURAI_CHECK_NAN
@@ -231,7 +231,7 @@ namespace samurai
             template <class... T>
             inline auto operator()(std::size_t item, std::size_t level, const interval_t& interval, T... index)
             {
-                auto interval_tmp = this->derived_cast().get_interval("WRITE", level, interval, index...);
+                auto interval_tmp = this->derived_cast().get_interval(level, interval, index...);
                 return xt::view(this->derived_cast().m_data,
                                 xt::range(interval_tmp.index + interval.start, interval_tmp.index + interval.end, interval.step),
                                 item);
@@ -240,7 +240,7 @@ namespace samurai
             template <class... T>
             inline auto operator()(std::size_t item, std::size_t level, const interval_t& interval, T... index) const
             {
-                auto interval_tmp = this->derived_cast().get_interval("READ", level, interval, index...);
+                auto interval_tmp = this->derived_cast().get_interval(level, interval, index...);
                 return xt::view(this->derived_cast().m_data,
                                 xt::range(interval_tmp.index + interval.start, interval_tmp.index + interval.end, interval.step),
                                 item);
@@ -249,7 +249,7 @@ namespace samurai
             template <class... T>
             inline auto operator()(std::size_t item_s, std::size_t item_e, std::size_t level, const interval_t& interval, T... index)
             {
-                auto interval_tmp = this->derived_cast().get_interval("WRITE", level, interval, index...);
+                auto interval_tmp = this->derived_cast().get_interval(level, interval, index...);
                 return xt::view(this->derived_cast().m_data,
                                 xt::range(interval_tmp.index + interval.start, interval_tmp.index + interval.end, interval.step),
                                 xt::range(item_s, item_e));
@@ -258,7 +258,7 @@ namespace samurai
             template <class... T>
             inline auto operator()(std::size_t item_s, std::size_t item_e, std::size_t level, const interval_t& interval, T... index) const
             {
-                auto interval_tmp = this->derived_cast().get_interval("READ", level, interval, index...);
+                auto interval_tmp = this->derived_cast().get_interval(level, interval, index...);
                 return xt::view(this->derived_cast().m_data,
                                 xt::range(interval_tmp.index + interval.start, interval_tmp.index + interval.end, interval.step),
                                 xt::range(item_s, item_e));
@@ -268,7 +268,7 @@ namespace samurai
             inline auto
             operator()(std::size_t item_s, std::size_t item_e, std::size_t level, const interval_t& interval, const xt::xexpression<E>& index)
             {
-                auto interval_tmp = this->derived_cast().get_interval("WRITE", level, interval, index);
+                auto interval_tmp = this->derived_cast().get_interval(level, interval, index);
                 return xt::view(this->derived_cast().m_data,
                                 xt::range(interval_tmp.index + interval.start, interval_tmp.index + interval.end, interval.step),
                                 xt::range(item_s, item_e));
@@ -278,7 +278,7 @@ namespace samurai
             inline auto
             operator()(std::size_t item_s, std::size_t item_e, std::size_t level, const interval_t& interval, const xt::xexpression<E>& index) const
             {
-                auto interval_tmp = this->derived_cast().get_interval("READ", level, interval, index);
+                auto interval_tmp = this->derived_cast().get_interval(level, interval, index);
                 return xt::view(this->derived_cast().m_data,
                                 xt::range(interval_tmp.index + interval.start, interval_tmp.index + interval.end, interval.step),
                                 xt::range(item_s, item_e));
@@ -334,7 +334,7 @@ namespace samurai
             template <class... T>
             inline auto operator()(const std::size_t level, const interval_t& interval, const T... index)
             {
-                auto interval_tmp = this->derived_cast().get_interval("READ OR WRITE", level, interval, index...);
+                auto interval_tmp = this->derived_cast().get_interval(level, interval, index...);
                 return xt::view(this->derived_cast().m_data,
                                 xt::all(),
                                 xt::range(interval_tmp.index + interval.start, interval_tmp.index + interval.end, interval.step));
@@ -343,7 +343,7 @@ namespace samurai
             template <class... T>
             inline auto operator()(const std::size_t level, const interval_t& interval, const T... index) const
             {
-                auto interval_tmp = this->derived_cast().get_interval("READ", level, interval, index...);
+                auto interval_tmp = this->derived_cast().get_interval(level, interval, index...);
                 return xt::view(this->derived_cast().m_data,
                                 xt::all(),
                                 xt::range(interval_tmp.index + interval.start, interval_tmp.index + interval.end, interval.step));
@@ -352,7 +352,7 @@ namespace samurai
             template <class... T>
             inline auto operator()(std::size_t item, std::size_t level, const interval_t& interval, T... index)
             {
-                auto interval_tmp = this->derived_cast().get_interval("WRITE", level, interval, index...);
+                auto interval_tmp = this->derived_cast().get_interval(level, interval, index...);
                 return xt::view(this->derived_cast().m_data,
                                 item,
                                 xt::range(interval_tmp.index + interval.start, interval_tmp.index + interval.end, interval.step));
@@ -361,7 +361,7 @@ namespace samurai
             template <class... T>
             inline auto operator()(std::size_t item, std::size_t level, const interval_t& interval, T... index) const
             {
-                auto interval_tmp = this->derived_cast().get_interval("READ", level, interval, index...);
+                auto interval_tmp = this->derived_cast().get_interval(level, interval, index...);
                 return xt::view(this->derived_cast().m_data,
                                 item,
                                 xt::range(interval_tmp.index + interval.start, interval_tmp.index + interval.end, interval.step));
@@ -370,7 +370,7 @@ namespace samurai
             template <class... T>
             inline auto operator()(std::size_t item_s, std::size_t item_e, std::size_t level, const interval_t& interval, T... index)
             {
-                auto interval_tmp = this->derived_cast().get_interval("WRITE", level, interval, index...);
+                auto interval_tmp = this->derived_cast().get_interval(level, interval, index...);
                 return xt::view(this->derived_cast().m_data,
                                 xt::range(item_s, item_e),
                                 xt::range(interval_tmp.index + interval.start, interval_tmp.index + interval.end, interval.step));
@@ -379,7 +379,7 @@ namespace samurai
             template <class... T>
             inline auto operator()(std::size_t item_s, std::size_t item_e, std::size_t level, const interval_t& interval, T... index) const
             {
-                auto interval_tmp = this->derived_cast().get_interval("READ", level, interval, index...);
+                auto interval_tmp = this->derived_cast().get_interval(level, interval, index...);
                 return xt::view(this->derived_cast().m_data,
                                 xt::range(item_s, item_e),
                                 xt::range(interval_tmp.index + interval.start, interval_tmp.index + interval.end, interval.step));
@@ -389,7 +389,7 @@ namespace samurai
             inline auto
             operator()(std::size_t item_s, std::size_t item_e, std::size_t level, const interval_t& interval, const xt::xexpression<E>& index)
             {
-                auto interval_tmp = this->derived_cast().get_interval("READ", level, interval, index);
+                auto interval_tmp = this->derived_cast().get_interval(level, interval, index);
                 return xt::view(this->derived_cast().m_data,
                                 xt::range(item_s, item_e),
                                 xt::range(interval_tmp.index + interval.start, interval_tmp.index + interval.end, interval.step));
@@ -399,7 +399,7 @@ namespace samurai
             inline auto
             operator()(std::size_t item_s, std::size_t item_e, std::size_t level, const interval_t& interval, const xt::xexpression<E>& index) const
             {
-                auto interval_tmp = this->derived_cast().get_interval("READ", level, interval, index);
+                auto interval_tmp = this->derived_cast().get_interval(level, interval, index);
                 return xt::view(this->derived_cast().m_data,
                                 xt::range(item_s, item_e),
                                 xt::range(interval_tmp.index + interval.start, interval_tmp.index + interval.end, interval.step));
@@ -501,12 +501,10 @@ namespace samurai
       private:
 
         template <class... T>
-        const interval_t& get_interval(std::string rw, std::size_t level, const interval_t& interval, const T... index) const;
+        const interval_t& get_interval(std::size_t level, const interval_t& interval, const T... index) const;
 
-        const interval_t& get_interval(std::string rw,
-                                       std::size_t level,
-                                       const interval_t& interval,
-                                       const xt::xtensor_fixed<value_t, xt::xshape<dim - 1>>& index) const;
+        const interval_t&
+        get_interval(std::size_t level, const interval_t& interval, const xt::xtensor_fixed<value_t, xt::xshape<dim - 1>>& index) const;
 
         std::string m_name;
         data_type m_data;
@@ -683,9 +681,9 @@ namespace samurai
 
     template <class mesh_t, class value_t, std::size_t size_, bool SOA>
     template <class... T>
-    inline auto
-    Field<mesh_t, value_t, size_, SOA>::get_interval(std::string rw, std::size_t level, const interval_t& interval, const T... index) const
-        -> const interval_t&
+    inline auto Field<mesh_t, value_t, size_, SOA>::get_interval(std::size_t level,
+                                                                 const interval_t& interval,
+                                                                 const T... index) const -> const interval_t&
     {
         const interval_t& interval_tmp = this->mesh().get_interval(level, interval, index...);
 
@@ -709,24 +707,23 @@ namespace samurai
             //               });
             // save(fs::current_path(), "mesh_throw", {true, true}, this->mesh(), coords, level_field);
             (std::cout << ... << index) << std::endl;
-            throw std::out_of_range(fmt::format("{} FIELD ERROR on level {}: try to find interval {}", rw, level, interval));
+            throw std::out_of_range(fmt::format("FIELD ERROR on level {}: try to find interval {}", level, interval));
         }
 
         return interval_tmp;
     }
 
     template <class mesh_t, class value_t, std::size_t size_, bool SOA>
-    inline auto Field<mesh_t, value_t, size_, SOA>::get_interval(std::string rw,
-                                                                 std::size_t level,
-                                                                 const interval_t& interval,
-                                                                 const xt::xtensor_fixed<value_t, xt::xshape<dim - 1>>& index) const
-        -> const interval_t&
+    inline auto
+    Field<mesh_t, value_t, size_, SOA>::get_interval(std::size_t level,
+                                                     const interval_t& interval,
+                                                     const xt::xtensor_fixed<value_t, xt::xshape<dim - 1>>& index) const -> const interval_t&
     {
         const interval_t& interval_tmp = this->mesh().get_interval(level, interval, index);
 
         if ((interval_tmp.end - interval_tmp.step < interval.end - interval.step) || (interval_tmp.start > interval.start))
         {
-            throw std::out_of_range(fmt::format("{} FIELD ERROR on level {}: try to find interval {}", rw, level, interval));
+            throw std::out_of_range(fmt::format("FIELD ERROR on level {}: try to find interval {}", level, interval));
         }
 
         return interval_tmp;


### PR DESCRIPTION
## Description
Update calls to `get_interval` by removing hardcoded "READ" and  "WRITE" strings.

## Code of Conduct
By submitting this PR, you agree to follow our [Code of Conduct](https://github.com/hpc-maths/samurai/blob/master/docs/CODE_OF_CONDUCT.md)
- [x] I agree to follow this project's Code of Conduct
