### PR TITLE
perf: replace views/ranges with loops

### DIFF
--- a/include/samurai/level_cell_array.hpp
+++ b/include/samurai/level_cell_array.hpp
@@ -80,6 +80,7 @@ namespace samurai
         using const_iterator         = LevelCellArray_iterator<const LevelCellArray<Dim, TInterval>, true>;
         using const_reverse_iterator = LevelCellArray_reverse_iterator<const_iterator>;
 
+        using coord_type = typename iterator::coord_type;
         using index_type = std::array<value_t, dim>;
 
         static constexpr double default_approx_box_tol = 0.05;
@@ -120,18 +121,21 @@ namespace samurai
         // get_interval
         template <typename... T, typename = std::enable_if_t<std::conjunction_v<std::is_convertible<T, value_t>...>, void>>
         const interval_t& get_interval(const interval_t& interval, T... index) const;
-        template <class E>
-        const interval_t& get_interval(const interval_t& interval, const xt::xexpression<E>& index) const;
-        template <class E>
-        const interval_t& get_interval(const xt::xexpression<E>& coord) const;
+        const interval_t& get_interval(const interval_t& interval, const coord_type& index) const;
+        // template <class E>
+        // const interval_t& get_interval(const interval_t& interval, const xt::xexpression<E>& index) const;
+        // template <class E>
+        // const interval_t& get_interval(const xt::xexpression<E>& coord) const;
+        const interval_t& get_interval(const xt::xtensor_fixed<value_t, xt::xshape<dim>>& coord) const;
 
         // get_index
         template <typename... T, typename = std::enable_if_t<std::conjunction_v<std::is_convertible<T, value_t>...>, void>>
         index_t get_index(value_t i, T... index) const;
         template <class E>
         index_t get_index(value_t i, const xt::xexpression<E>& others) const;
-        template <class E>
-        index_t get_index(const xt::xexpression<E>& coord) const;
+        // template <class E>
+        // index_t get_index(const xt::xexpression<E>& coord) const;
+        index_t get_index(const xt::xtensor_fixed<value_t, xt::xshape<dim>>& coord) const;
 
         // get_cell
         template <typename... T, typename = std::enable_if_t<std::conjunction_v<std::is_convertible<T, value_t>...>, void>>
@@ -529,25 +533,35 @@ namespace samurai
     }
 
     template <std::size_t Dim, class TInterval>
-    template <class E>
-    inline auto LevelCellArray<Dim, TInterval>::get_interval(const interval_t& interval, const xt::xexpression<E>& index) const
-        -> const interval_t&
+    inline auto LevelCellArray<Dim, TInterval>::get_interval(const interval_t& interval, const coord_type& index) const -> const interval_t&
     {
         xt::xtensor_fixed<value_t, xt::xshape<dim>> point;
-        point[0]                         = interval.start;
-        xt::view(point, xt::range(1, _)) = index;
-        auto row                         = find(*this, point);
+        point[0] = interval.start;
+        // xt::view(point, xt::range(1, _)) = index;
+        for (std::size_t d = 1; d < dim; ++d)
+        {
+            point[d] = index[d - 1];
+        }
+        auto row = find(*this, point);
         return m_cells[0][static_cast<std::size_t>(row)];
     }
 
     template <std::size_t Dim, class TInterval>
-    template <class E>
-    inline auto LevelCellArray<Dim, TInterval>::get_interval(const xt::xexpression<E>& coord) const -> const interval_t&
+    inline auto LevelCellArray<Dim, TInterval>::get_interval(const xt::xtensor_fixed<value_t, xt::xshape<dim>>& coord) const
+        -> const interval_t&
     {
-        xt::xtensor_fixed<value_t, xt::xshape<dim>> coord_array = coord;
-        auto row                                                = find(*this, coord_array);
+        auto row = find(*this, coord);
         return m_cells[0][static_cast<std::size_t>(row)];
     }
+
+    // template <std::size_t Dim, class TInterval>
+    // template <class E>
+    // inline auto LevelCellArray<Dim, TInterval>::get_interval(const xt::xexpression<E>& coord) const -> const interval_t&
+    // {
+    //     xt::xtensor_fixed<value_t, xt::xshape<dim>> coord_array = coord;
+    //     auto row                                                = find(*this, coord_array);
+    //     return m_cells[0][static_cast<std::size_t>(row)];
+    // }
 
     template <std::size_t Dim, class TInterval>
     template <typename... T, typename D>
@@ -564,13 +578,19 @@ namespace samurai
     }
 
     template <std::size_t Dim, class TInterval>
-    template <class E>
-    inline auto LevelCellArray<Dim, TInterval>::get_index(const xt::xexpression<E>& coord) const -> index_t
+    inline auto LevelCellArray<Dim, TInterval>::get_index(const xt::xtensor_fixed<value_t, xt::xshape<dim>>& coord) const -> index_t
     {
-        using namespace xt::placeholders;
-        xt::xtensor_fixed<value_t, xt::xshape<dim>> coord_array = coord;
-        return get_interval({coord_array(0), coord_array(0) + 1}, xt::view(coord_array, xt::range(1, _))).index + coord_array(0);
+        return get_interval(coord).index + coord(0);
     }
+
+    // template <std::size_t Dim, class TInterval>
+    // template <class E>
+    // inline auto LevelCellArray<Dim, TInterval>::get_index(const xt::xexpression<E>& coord) const -> index_t
+    // {
+    //     using namespace xt::placeholders;
+    //     xt::xtensor_fixed<value_t, xt::xshape<dim>> coord_array = coord;
+    //     return get_interval({coord_array(0), coord_array(0) + 1}, xt::view(coord_array, xt::range(1, _))).index + coord_array(0);
+    // }
 
     template <std::size_t Dim, class TInterval>
     template <typename... T, typename D>


### PR DESCRIPTION
## Description
Some views/ranges are replaced with explicit loops.

## Code of Conduct
By submitting this PR, you agree to follow our [Code of Conduct](https://github.com/hpc-maths/samurai/blob/master/docs/CODE_OF_CONDUCT.md)
- [x] I agree to follow this project's Code of Conduct
