### PR TITLE
fix: Fix prediction order 0

### DIFF
--- a/include/samurai/static_algorithm.hpp
+++ b/include/samurai/static_algorithm.hpp
@@ -173,9 +173,12 @@ namespace samurai
         }
 
         template <typename lambda_t>
-        static inline constexpr void apply(lambda_t&& f)
+        static inline constexpr void apply([[maybe_unused]] lambda_t&& f)
         {
-            apply_impl(std::forward<lambda_t>(f), std::make_integer_sequence<std::size_t, end - begin>());
+            if constexpr (begin <= end)
+            {
+                apply_impl(std::forward<lambda_t>(f), std::make_integer_sequence<std::size_t, end - begin>());
+            }
         }
     };
 } // namespace samurai


### PR DESCRIPTION
## Description
Fix prediction of order 0.

## Related issue
Compilation either raising a recursive error, or taking too much memory before being killed by the OS.

## How has this been tested?
In linear convection demo:
```cpp
samurai::MRConfig<dim, 3, 3, 0>;
```

## Code of Conduct
By submitting this PR, you agree to follow our [Code of Conduct](https://github.com/hpc-maths/samurai/blob/master/docs/CODE_OF_CONDUCT.md)
- [x] I agree to follow this project's Code of Conduct
