### PR TITLE
fix: the tagged cells with the graduation

### DIFF
--- a/include/samurai/mr/adapt.hpp
+++ b/include/samurai/mr/adapt.hpp
@@ -271,13 +271,16 @@ namespace samurai
             keep_subset.apply_op(maximum(m_tag));
 
             int grad_width = static_cast<int>(mesh_t::config::graduation_width);
-            auto stencil   = grad_width * detail::box_dir<dim>();
+            auto stencil   = detail::box_dir<dim>();
 
-            for (std::size_t is = 0; is < stencil.shape(0); ++is)
+            for (int ig = 1; ig <= grad_width; ++ig)
             {
-                auto s = xt::view(stencil, is);
-                auto subset = intersection(mesh[mesh_id_t::cells][level], translate(mesh[mesh_id_t::all_cells][level - 1], s)).on(level - 1);
-                subset.apply_op(balance_2to1(m_tag, s));
+                for (std::size_t is = 0; is < stencil.shape(0); ++is)
+                {
+                    auto s = ig * xt::view(stencil, is);
+                    auto subset = intersection(mesh[mesh_id_t::cells][level], translate(mesh[mesh_id_t::all_cells][level - 1], s)).on(level - 1);
+                    subset.apply_op(balance_2to1(m_tag, s));
+                }
             }
 
             update_tag_periodic(level, m_tag);
@@ -294,15 +297,17 @@ namespace samurai
             update_tag_subdomains<false>(level, m_tag);
 
             int grad_width = static_cast<int>(mesh_t::config::graduation_width);
-            auto stencil   = grad_width * detail::box_dir<dim>();
+            auto stencil   = detail::box_dir<dim>();
 
-            for (std::size_t is = 0; is < stencil.shape(0); ++is)
+            for (int ig = 1; ig <= grad_width; ++ig)
             {
-                auto s = xt::view(stencil, is);
-                auto subset = intersection(translate(mesh[mesh_id_t::cells][level], s), mesh[mesh_id_t::all_cells][level - 1], mesh.domain())
-                                  .on(level);
+                for (std::size_t is = 0; is < stencil.shape(0); ++is)
+                {
+                    auto s = ig * xt::view(stencil, is);
+                    auto subset = intersection(translate(mesh[mesh_id_t::cells][level], s), mesh[mesh_id_t::all_cells][level - 1]).on(level);
 
-                subset.apply_op(make_graduation(m_tag));
+                    subset.apply_op(make_graduation(m_tag));
+                }
             }
 
             update_tag_periodic(level, m_tag);


### PR DESCRIPTION
## Description
If the gradation is greater than one, we need to look at the intersections between two levels by translating one of them by one at each time until to reach the graduation width.
Before this PR, we made the translation of a graduation width which means that we can move too fast.

## Code of Conduct
By submitting this PR, you agree to follow our [Code of Conduct](https://github.com/hpc-maths/samurai/blob/master/docs/CODE_OF_CONDUCT.md)
- [x] I agree to follow this project's Code of Conduct
