### PR TITLE
fix: default value for SOA in Array

### DIFF
--- a/include/samurai/storage/containers_config.hpp
+++ b/include/samurai/storage/containers_config.hpp
@@ -56,14 +56,14 @@ namespace samurai
     // Static array //
     //--------------//
 
-    template <class value_type, std::size_t size, bool SOA>
+    template <class value_type, std::size_t size, bool SOA = false>
 #if defined(SAMURAI_FIELD_CONTAINER_EIGEN3)
     using Array = eigen_static_array<value_type, size, SOA>;
 #else // SAMURAI_FIELD_CONTAINER_XTENSOR
     using Array           = xtensor_static_array<value_type, size>;
 #endif
 
-    template <class value_type, std::size_t size, bool SOA>
+    template <class value_type, std::size_t size, bool SOA = false>
     using CollapsArray = CollapsableArray<Array<value_type, size, SOA>, value_type, size>;
 
     //----------------//


### PR DESCRIPTION
## Description
In structure `Array`, the template parameter `SOA` is defaulted to `false`.

## Related issue
It broke some user codes.

## Code of Conduct
By submitting this PR, you agree to follow our [Code of Conduct](https://github.com/hpc-maths/samurai/blob/master/docs/CODE_OF_CONDUCT.md)
- [x] I agree to follow this project's Code of Conduct
