### PR TITLE
feat: find cell from cartesian coordinates

### DIFF
--- a/include/samurai/algorithm.hpp
+++ b/include/samurai/algorithm.hpp
@@ -485,17 +485,16 @@ namespace samurai
         cell_t cell;
         for (std::size_t level = min_level; level <= max_level; ++level)
         {
-            auto cell_length = mesh.cell_length(level);
-            cell.indices     = xt::floor((cartesian_coords - mesh.origin_point()) / cell_length);
-            auto offset      = find(mesh[mesh_id_t::cells][level], cell.indices);
+            auto length  = mesh.cell_length(level);
+            cell.indices = xt::floor((cartesian_coords - mesh.origin_point()) / length);
+            auto offset  = find(mesh[mesh_id_t::cells][level], cell.indices);
             if (offset >= 0)
             {
                 auto interval     = mesh[mesh_id_t::cells][level][0][static_cast<std::size_t>(offset)];
                 cell.index        = interval.index + cell.indices[0];
                 cell.level        = level;
-                cell.length       = cell_length;
+                cell.length       = length;
                 cell.origin_point = mesh.origin_point();
-                std::cout << cell.corner() << ", " << cell.corner() + cell_length << std::endl;
                 return cell;
             }
         }

--- a/include/samurai/level_cell_array.hpp
+++ b/include/samurai/level_cell_array.hpp
@@ -525,6 +525,7 @@ namespace samurai
     inline auto LevelCellArray<Dim, TInterval>::get_interval(const interval_t& interval, T... index) const -> const interval_t&
     {
         auto offset = find(*this, {interval.start, index...});
+        assert(offset >= 0 && "Interval not found");
         return m_cells[0][static_cast<std::size_t>(offset)];
     }
 
@@ -538,6 +539,7 @@ namespace samurai
             point[d] = index[d - 1];
         }
         auto offset = find(*this, point);
+        assert(offset >= 0 && "Interval not found");
         return m_cells[0][static_cast<std::size_t>(offset)];
     }
 
@@ -545,6 +547,7 @@ namespace samurai
     inline auto LevelCellArray<Dim, TInterval>::get_interval(const all_coord_type& coord) const -> const interval_t&
     {
         auto offset = find(*this, coord);
+        assert(offset >= 0 && "Interval not found");
         return m_cells[0][static_cast<std::size_t>(offset)];
     }
 

--- a/include/samurai/mesh.hpp
+++ b/include/samurai/mesh.hpp
@@ -129,8 +129,6 @@ namespace samurai
         template <class E>
         cell_t get_cell(std::size_t level, const xt::xexpression<E>& coord) const;
 
-        cell_t get_cell(const typename cell_t::coords_t& cartesian_coords) const;
-
         void update_mesh_neighbour();
         void to_stream(std::ostream& os) const;
 
@@ -494,32 +492,6 @@ namespace samurai
     inline auto Mesh_base<D, Config>::get_cell(std::size_t level, const xt::xexpression<E>& coord) const -> cell_t
     {
         return m_cells[mesh_id_t::reference].get_cell(level, coord);
-    }
-
-    template <class D, class Config>
-    inline auto Mesh_base<D, Config>::get_cell(const typename cell_t::coords_t& cartesian_coords) const -> cell_t
-    {
-        std::size_t min_level_ = m_cells[mesh_id_t::cells].min_level();
-        std::size_t max_level_ = m_cells[mesh_id_t::cells].max_level();
-
-        cell_t cell;
-        for (std::size_t level = min_level_; level <= max_level_; ++level)
-        {
-            cell.indices = xt::floor((cartesian_coords - origin_point()) / cell_length(level));
-            auto offset  = find(m_cells[mesh_id_t::cells][level], cell.indices);
-            if (offset >= 0)
-            {
-                auto interval     = m_cells[mesh_id_t::cells][level][0][static_cast<std::size_t>(offset)];
-                cell.index        = interval.index + cell.indices[0];
-                cell.level        = level;
-                cell.length       = cell_length(level);
-                cell.origin_point = origin_point();
-                return cell;
-            }
-        }
-        // cell not found
-        cell.length = 0;
-        return cell;
     }
 
     template <class D, class Config>

--- a/include/samurai/mesh.hpp
+++ b/include/samurai/mesh.hpp
@@ -499,11 +499,11 @@ namespace samurai
     template <class D, class Config>
     inline auto Mesh_base<D, Config>::get_cell(const typename cell_t::coords_t& cartesian_coords) const -> cell_t
     {
-        std::size_t min_level = m_cells[mesh_id_t::cells].min_level();
-        std::size_t max_level = m_cells[mesh_id_t::cells].max_level();
+        std::size_t min_level_ = m_cells[mesh_id_t::cells].min_level();
+        std::size_t max_level_ = m_cells[mesh_id_t::cells].max_level();
 
         cell_t cell;
-        for (std::size_t level = min_level; level <= max_level; ++level)
+        for (std::size_t level = min_level_; level <= max_level_; ++level)
         {
             cell.indices = xt::floor((cartesian_coords - origin_point()) / cell_length(level));
             auto offset  = find(m_cells[mesh_id_t::cells][level], cell.indices);

--- a/include/samurai/mesh.hpp
+++ b/include/samurai/mesh.hpp
@@ -129,6 +129,8 @@ namespace samurai
         template <class E>
         cell_t get_cell(std::size_t level, const xt::xexpression<E>& coord) const;
 
+        cell_t get_cell(const typename cell_t::coords_t& cartesian_coords) const;
+
         void update_mesh_neighbour();
         void to_stream(std::ostream& os) const;
 
@@ -492,6 +494,32 @@ namespace samurai
     inline auto Mesh_base<D, Config>::get_cell(std::size_t level, const xt::xexpression<E>& coord) const -> cell_t
     {
         return m_cells[mesh_id_t::reference].get_cell(level, coord);
+    }
+
+    template <class D, class Config>
+    inline auto Mesh_base<D, Config>::get_cell(const typename cell_t::coords_t& cartesian_coords) const -> cell_t
+    {
+        std::size_t min_level = m_cells[mesh_id_t::cells].min_level();
+        std::size_t max_level = m_cells[mesh_id_t::cells].max_level();
+
+        cell_t cell;
+        for (std::size_t level = min_level; level <= max_level; ++level)
+        {
+            cell.indices = xt::floor((cartesian_coords - origin_point()) / cell_length(level));
+            auto offset  = find(m_cells[mesh_id_t::cells][level], cell.indices);
+            if (offset >= 0)
+            {
+                auto interval     = m_cells[mesh_id_t::cells][level][0][static_cast<std::size_t>(offset)];
+                cell.index        = interval.index + cell.indices[0];
+                cell.level        = level;
+                cell.length       = cell_length(level);
+                cell.origin_point = origin_point();
+                return cell;
+            }
+        }
+        // cell not found
+        cell.length = 0;
+        return cell;
     }
 
     template <class D, class Config>

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -18,6 +18,7 @@ set(SAMURAI_TESTS
     test_cell_array.cpp
     test_cell_list.cpp
     test_field.cpp
+    test_find.cpp
     test_for_each.cpp
     test_graduation.cpp
     test_interval.cpp

--- a/tests/test_find.cpp
+++ b/tests/test_find.cpp
@@ -1,0 +1,44 @@
+#include <gtest/gtest.h>
+
+#include <samurai/box.hpp>
+#include <samurai/field.hpp>
+#include <samurai/mr/adapt.hpp>
+#include <samurai/mr/mesh.hpp>
+
+namespace samurai
+{
+    TEST(find, test)
+    {
+        static constexpr std::size_t dim = 2;
+        using Config                     = samurai::MRConfig<dim>;
+        using Box                        = samurai::Box<double, dim>;
+        using Mesh                       = samurai::MRMesh<Config>;
+        using coords_t                   = typename Mesh::cell_t::coords_t;
+
+        Box box({-1., -1.}, {1., 1.});
+
+        std::size_t min_level = 2;
+        std::size_t max_level = 6;
+
+        Mesh mesh{box, min_level, max_level};
+
+        auto u = samurai::make_field<1>("u",
+                                        mesh,
+                                        [](const auto& coords)
+                                        {
+                                            const auto& x = coords(0);
+                                            const auto& y = coords(1);
+                                            return (x >= -0.8 && x <= -0.3 && y >= 0.3 && y <= 0.8) ? 1. : 0.;
+                                        });
+
+        auto MRadaptation = samurai::make_MRAdapt(u);
+        MRadaptation(1e-3, 1);
+
+        coords_t coords = {0.4, 0.8};
+        auto cell       = samurai::find_cell(mesh, coords);
+
+        EXPECT_TRUE(cell.length > 0);                                                             // cell found
+        EXPECT_TRUE(static_cast<std::size_t>(cell.index) < mesh.nb_cells());                      // cell index makes sense
+        EXPECT_TRUE(xt::all(cell.corner() <= coords && coords <= (cell.corner() + cell.length))); // coords in cell
+    }
+}


### PR DESCRIPTION
## Description
The new function returns the cell that contains the given cartesian coordinates:
```cpp
auto cell = samurai::find_cell(mesh, {0.4, 0.8});
```

## Code of Conduct
By submitting this PR, you agree to follow our [Code of Conduct](https://github.com/hpc-maths/samurai/blob/master/docs/CODE_OF_CONDUCT.md)
- [x] I agree to follow this project's Code of Conduct
