### PR TITLE
fix: Add overload for get_index() and get_interval() with xt::xtensor_fixed<value_t, xt::xshape<dim - 1>> parameter

### DIFF
--- a/include/samurai/cell_array.hpp
+++ b/include/samurai/cell_array.hpp
@@ -96,15 +96,16 @@ namespace samurai
 
         template <typename... T>
         const interval_t& get_interval(std::size_t level, const interval_t& interval, T... index) const;
-
+        const interval_t&
+        get_interval(std::size_t level, const interval_t& interval, const xt::xtensor_fixed<value_t, xt::xshape<dim - 1>>& index) const;
         template <class E>
         const interval_t& get_interval(std::size_t level, const interval_t& interval, const xt::xexpression<E>& index) const;
-
         template <class E>
         const interval_t& get_interval(std::size_t level, const xt::xexpression<E>& coord) const;
 
         template <typename... T>
         index_t get_index(std::size_t level, value_t i, T... index) const;
+        index_t get_index(std::size_t level, value_t i, const xt::xtensor_fixed<value_t, xt::xshape<dim - 1>>& others) const;
         template <class E>
         index_t get_index(std::size_t level, value_t i, const xt::xexpression<E>& others) const;
         template <class E>
@@ -297,6 +298,15 @@ namespace samurai
     }
 
     template <std::size_t dim_, class TInterval, std::size_t max_size_>
+    inline auto CellArray<dim_, TInterval, max_size_>::get_interval(std::size_t level,
+                                                                    const interval_t& interval,
+                                                                    const xt::xtensor_fixed<value_t, xt::xshape<dim - 1>>& index) const
+        -> const interval_t&
+    {
+        return m_cells[level].get_interval(interval, index);
+    }
+
+    template <std::size_t dim_, class TInterval, std::size_t max_size_>
     template <class E>
     inline auto
     CellArray<dim_, TInterval, max_size_>::get_interval(std::size_t level, const interval_t& interval, const xt::xexpression<E>& index) const
@@ -318,6 +328,15 @@ namespace samurai
     inline auto CellArray<dim_, TInterval, max_size_>::get_index(std::size_t level, value_t i, T... index) const -> index_t
     {
         return m_cells[level].get_index(i, index...);
+    }
+
+    template <std::size_t dim_, class TInterval, std::size_t max_size_>
+    inline auto CellArray<dim_, TInterval, max_size_>::get_index(std::size_t level,
+                                                                 value_t i,
+                                                                 const xt::xtensor_fixed<value_t, xt::xshape<dim - 1>>& others) const
+        -> index_t
+    {
+        return m_cells[level].get_index(i, others);
     }
 
     template <std::size_t dim_, class TInterval, std::size_t max_size_>

--- a/include/samurai/field.hpp
+++ b/include/samurai/field.hpp
@@ -349,8 +349,9 @@ namespace samurai
         using bc_container = std::vector<std::unique_ptr<Bc<Field>>>;
 
         using inner_types::dim;
-        using interval_t = typename mesh_t::interval_t;
-        using cell_t     = typename inner_types::cell_t;
+        using interval_t       = typename mesh_t::interval_t;
+        using interval_value_t = typename interval_t::value_t;
+        using cell_t           = typename inner_types::cell_t;
 
         using iterator               = Field_iterator<self_type, false>;
         using const_iterator         = Field_iterator<const self_type, true>;
@@ -416,8 +417,9 @@ namespace samurai
         template <class... T>
         const interval_t& get_interval(std::size_t level, const interval_t& interval, const T... index) const;
 
-        const interval_t&
-        get_interval(std::size_t level, const interval_t& interval, const xt::xtensor_fixed<value_t, xt::xshape<dim - 1>>& index) const;
+        const interval_t& get_interval(std::size_t level,
+                                       const interval_t& interval,
+                                       const xt::xtensor_fixed<interval_value_t, xt::xshape<dim - 1>>& index) const;
 
         std::string m_name;
 
@@ -629,7 +631,7 @@ namespace samurai
     template <class mesh_t, class value_t, std::size_t size_, bool SOA>
     inline auto Field<mesh_t, value_t, size_, SOA>::get_interval(std::size_t level,
                                                                  const interval_t& interval,
-                                                                 const xt::xtensor_fixed<value_t, xt::xshape<dim - 1>>& index) const
+                                                                 const xt::xtensor_fixed<interval_value_t, xt::xshape<dim - 1>>& index) const
         -> const interval_t&
     {
         const interval_t& interval_tmp = this->mesh().get_interval(level, interval, index);

--- a/include/samurai/mesh.hpp
+++ b/include/samurai/mesh.hpp
@@ -110,6 +110,8 @@ namespace samurai
 
         template <typename... T>
         const interval_t& get_interval(std::size_t level, const interval_t& interval, T... index) const;
+        const interval_t&
+        get_interval(std::size_t level, const interval_t& interval, const xt::xtensor_fixed<value_t, xt::xshape<dim - 1>>& index) const;
         template <class E>
         const interval_t& get_interval(std::size_t level, const interval_t& interval, const xt::xexpression<E>& index) const;
         template <class E>
@@ -117,6 +119,7 @@ namespace samurai
 
         template <typename... T>
         index_t get_index(std::size_t level, value_t i, T... index) const;
+        index_t get_index(std::size_t level, value_t i, const xt::xtensor_fixed<value_t, xt::xshape<dim - 1>>& others) const;
         template <class E>
         index_t get_index(std::size_t level, value_t i, const xt::xexpression<E>& others) const;
         template <class E>
@@ -438,6 +441,14 @@ namespace samurai
     }
 
     template <class D, class Config>
+    inline auto Mesh_base<D, Config>::get_interval(std::size_t level,
+                                                   const interval_t& interval,
+                                                   const xt::xtensor_fixed<value_t, xt::xshape<dim - 1>>& index) const -> const interval_t&
+    {
+        return m_cells[mesh_id_t::reference].get_interval(level, interval, index);
+    }
+
+    template <class D, class Config>
     template <class E>
     inline auto Mesh_base<D, Config>::get_interval(std::size_t level, const interval_t& interval, const xt::xexpression<E>& index) const
         -> const interval_t&
@@ -457,6 +468,14 @@ namespace samurai
     inline auto Mesh_base<D, Config>::get_index(std::size_t level, value_t i, T... index) const -> index_t
     {
         return m_cells[mesh_id_t::reference].get_index(level, i, index...);
+    }
+
+    template <class D, class Config>
+    inline auto
+    Mesh_base<D, Config>::get_index(std::size_t level, value_t i, const xt::xtensor_fixed<value_t, xt::xshape<dim - 1>>& others) const
+        -> index_t
+    {
+        return m_cells[mesh_id_t::reference].get_index(level, i, others);
     }
 
     template <class D, class Config>


### PR DESCRIPTION
## Description
Add overload for `get_index()` and `get_interval()` with `xt::xtensor_fixed<value_t, xt::xshape<dim - 1>>` parameter

## Related issue
The functions with variadic parameters were used instead, which may cause performance issues due to the copies. 

## Code of Conduct
By submitting this PR, you agree to follow our [Code of Conduct](https://github.com/hpc-maths/samurai/blob/master/docs/CODE_OF_CONDUCT.md)
- [x] I agree to follow this project's Code of Conduct
