### PR TITLE
refactor: improve `StencilIterator` and the schemes are not `const` anymore

### DIFF
--- a/include/samurai/boundary.hpp
+++ b/include/samurai/boundary.hpp
@@ -20,7 +20,7 @@ namespace samurai
     template <class Mesh, class Subset, std::size_t stencil_size, class GetCoeffsFunc, class Func>
     void for_each_stencil_on_boundary(const Mesh& mesh,
                                       const Subset& boundary_region,
-                                      const Stencil<stencil_size, Mesh::dim>& stencil,
+                                      const StencilAnalyzer<stencil_size, Mesh::dim>& stencil,
                                       GetCoeffsFunc&& get_coefficients,
                                       Func&& func)
     {
@@ -44,7 +44,7 @@ namespace samurai
     template <class Mesh, class Subset, std::size_t stencil_size, class Equation, std::size_t nb_equations, class Func>
     void for_each_stencil_on_boundary(const Mesh& mesh,
                                       const Subset& boundary_region,
-                                      const Stencil<stencil_size, Mesh::dim>& stencil,
+                                      const StencilAnalyzer<stencil_size, Mesh::dim>& stencil,
                                       std::array<Equation, nb_equations> equations,
                                       Func&& func)
     {

--- a/include/samurai/interface.hpp
+++ b/include/samurai/interface.hpp
@@ -4,6 +4,30 @@
 
 namespace samurai
 {
+    template <Get get_type, class interface_iterator_t, class stencil_iterator_t, class Func>
+    inline void apply_on_interval(const typename interface_iterator_t::mesh_interval_t& mesh_interval,
+                                  interface_iterator_t& interface_it,
+                                  stencil_iterator_t& comput_stencil_it,
+                                  Func&& f)
+    {
+        comput_stencil_it.init(mesh_interval);
+        interface_it.init(mesh_interval);
+
+        if constexpr (get_type == Get::Intervals)
+        {
+            f(interface_it, comput_stencil_it);
+        }
+        else if constexpr (get_type == Get::Cells)
+        {
+            for (std::size_t ii = 0; ii < mesh_interval.i.size(); ++ii)
+            {
+                f(interface_it.cells(), comput_stencil_it.cells());
+                interface_it.move_next();
+                comput_stencil_it.move_next();
+            }
+        }
+    }
+
     /**
      * Iterates over the interfaces of same level only (no level jump).
      * Same parameters as the preceding function.
@@ -12,14 +36,15 @@ namespace samurai
     void for_each_interior_interface__same_level(const Mesh& mesh,
                                                  std::size_t level,
                                                  const DirectionVector<Mesh::dim>& direction,
-                                                 const Stencil<comput_stencil_size, Mesh::dim>& comput_stencil,
+                                                 const StencilAnalyzer<comput_stencil_size, Mesh::dim>& comput_stencil,
                                                  Func&& f)
     {
         static constexpr std::size_t dim = Mesh::dim;
         using mesh_id_t                  = typename Mesh::mesh_id_t;
         using mesh_interval_t            = typename Mesh::mesh_interval_t;
 
-        Stencil<2, dim> interface_stencil = in_out_stencil<dim>(direction);
+        Stencil<2, dim> interface_stencil_ = in_out_stencil<dim>(direction);
+        auto interface_stencil             = make_stencil_analyzer(interface_stencil_);
 
         auto& cells        = mesh[mesh_id_t::cells][level];
         auto shifted_cells = translate(cells, -direction);
@@ -39,31 +64,17 @@ namespace samurai
         auto comput_stencil_it       = make_stencil_iterator(mesh, comput_stencil);
 #endif
 
-        for_each_meshinterval<mesh_interval_t, run_type>(intersect,
-                                                         [&](auto mesh_interval)
-                                                         {
+        for_each_meshinterval<mesh_interval_t, run_type>(
+            intersect,
+            [&](auto mesh_interval)
+            {
 #ifdef SAMURAI_WITH_OPENMP
-                                                             std::size_t thread      = static_cast<std::size_t>(omp_get_thread_num());
-                                                             auto& interface_it      = interface_its[thread];
-                                                             auto& comput_stencil_it = comput_stencil_its[thread];
+                std::size_t thread      = static_cast<std::size_t>(omp_get_thread_num());
+                auto& interface_it      = interface_its[thread];
+                auto& comput_stencil_it = comput_stencil_its[thread];
 #endif
-                                                             interface_it.init(mesh_interval);
-                                                             comput_stencil_it.init(mesh_interval);
-
-                                                             if constexpr (get_type == Get::Intervals)
-                                                             {
-                                                                 f(interface_it, comput_stencil_it);
-                                                             }
-                                                             else if constexpr (get_type == Get::Cells)
-                                                             {
-                                                                 for (std::size_t ii = 0; ii < mesh_interval.i.size(); ++ii)
-                                                                 {
-                                                                     f(interface_it.cells(), comput_stencil_it.cells());
-                                                                     interface_it.move_next();
-                                                                     comput_stencil_it.move_next();
-                                                                 }
-                                                             }
-                                                         });
+                apply_on_interval<get_type>(mesh_interval, interface_it, comput_stencil_it, std::forward<Func>(f));
+            });
     }
 
     /**
@@ -83,7 +94,7 @@ namespace samurai
     void for_each_interior_interface__level_jump_direction(const Mesh& mesh,
                                                            std::size_t level,
                                                            const DirectionVector<Mesh::dim>& direction,
-                                                           const Stencil<comput_stencil_size, Mesh::dim>& comput_stencil,
+                                                           const StencilAnalyzer<comput_stencil_size, Mesh::dim>& comput_stencil,
                                                            Func&& f)
     {
         using mesh_id_t       = typename Mesh::mesh_id_t;
@@ -100,7 +111,7 @@ namespace samurai
         auto shifted_fine_cells = translate(fine_cells, -direction);
         auto fine_intersect     = intersection(coarse_cells, shifted_fine_cells).on(level + 1);
 
-        int direction_index_int = find(comput_stencil, direction);
+        int direction_index_int = comput_stencil.find(direction);
         auto direction_index    = static_cast<std::size_t>(direction_index_int);
 #ifdef SAMURAI_WITH_OPENMP
         std::size_t num_threads = static_cast<std::size_t>(omp_get_max_threads());
@@ -118,31 +129,17 @@ namespace samurai
         auto interface_it            = make_leveljump_iterator<0>(comput_stencil_it, direction_index);
 #endif
 
-        for_each_meshinterval<mesh_interval_t, run_type>(fine_intersect,
-                                                         [&](auto fine_mesh_interval)
-                                                         {
+        for_each_meshinterval<mesh_interval_t, run_type>(
+            fine_intersect,
+            [&](auto fine_mesh_interval)
+            {
 #ifdef SAMURAI_WITH_OPENMP
-                                                             std::size_t thread      = static_cast<std::size_t>(omp_get_thread_num());
-                                                             auto& interface_it      = interface_its[thread];
-                                                             auto& comput_stencil_it = comput_stencil_its[thread];
+                std::size_t thread      = static_cast<std::size_t>(omp_get_thread_num());
+                auto& interface_it      = interface_its[thread];
+                auto& comput_stencil_it = comput_stencil_its[thread];
 #endif
-                                                             comput_stencil_it.init(fine_mesh_interval);
-                                                             interface_it.init(fine_mesh_interval);
-
-                                                             if constexpr (get_type == Get::Intervals)
-                                                             {
-                                                                 f(interface_it, comput_stencil_it);
-                                                             }
-                                                             else if constexpr (get_type == Get::Cells)
-                                                             {
-                                                                 for (std::size_t ii = 0; ii < fine_mesh_interval.i.size(); ++ii)
-                                                                 {
-                                                                     f(interface_it.cells(), comput_stencil_it.cells());
-                                                                     interface_it.move_next();
-                                                                     comput_stencil_it.move_next();
-                                                                 }
-                                                             }
-                                                         });
+                apply_on_interval<get_type>(fine_mesh_interval, interface_it, comput_stencil_it, std::forward<Func>(f));
+            });
     }
 
     /**
@@ -162,7 +159,7 @@ namespace samurai
     void for_each_interior_interface__level_jump_opposite_direction(const Mesh& mesh,
                                                                     std::size_t level,
                                                                     const DirectionVector<Mesh::dim>& direction,
-                                                                    const Stencil<comput_stencil_size, Mesh::dim>& comput_stencil,
+                                                                    const StencilAnalyzer<comput_stencil_size, Mesh::dim>& comput_stencil,
                                                                     Func&& f)
     {
         static constexpr std::size_t dim = Mesh::dim;
@@ -180,10 +177,11 @@ namespace samurai
         auto shifted_fine_cells = translate(fine_cells, direction);
         auto fine_intersect     = intersection(coarse_cells, shifted_fine_cells).on(level + 1);
 
-        Stencil<comput_stencil_size, dim> minus_comput_stencil = comput_stencil - direction;
-        DirectionVector<dim> minus_direction                   = -direction;
-        int minus_direction_index_int                          = find(minus_comput_stencil, minus_direction);
-        auto minus_direction_index                             = static_cast<std::size_t>(minus_direction_index_int);
+        Stencil<comput_stencil_size, dim> minus_comput_stencil_ = comput_stencil.stencil - direction;
+        auto minus_comput_stencil                               = make_stencil_analyzer(minus_comput_stencil_);
+        DirectionVector<dim> minus_direction                    = -direction;
+        int minus_direction_index_int                           = minus_comput_stencil.find(minus_direction);
+        auto minus_direction_index                              = static_cast<std::size_t>(minus_direction_index_int);
 
 #ifdef SAMURAI_WITH_OPENMP
         std::size_t num_threads = static_cast<std::size_t>(omp_get_max_threads());
@@ -201,31 +199,24 @@ namespace samurai
         auto interface_it            = make_leveljump_iterator<1>(minus_comput_stencil_it, minus_direction_index);
 #endif
 
-        for_each_meshinterval<mesh_interval_t, run_type>(fine_intersect,
-                                                         [&](auto fine_mesh_interval)
-                                                         {
+        for_each_meshinterval<mesh_interval_t, run_type>(
+            fine_intersect,
+            [&](auto fine_mesh_interval)
+            {
 #ifdef SAMURAI_WITH_OPENMP
-                                                             std::size_t thread            = static_cast<std::size_t>(omp_get_thread_num());
-                                                             auto& interface_it            = interface_its[thread];
-                                                             auto& minus_comput_stencil_it = comput_stencil_its[thread];
+                std::size_t thread            = static_cast<std::size_t>(omp_get_thread_num());
+                auto& interface_it            = interface_its[thread];
+                auto& minus_comput_stencil_it = comput_stencil_its[thread];
 #endif
-                                                             minus_comput_stencil_it.init(fine_mesh_interval);
-                                                             interface_it.init(fine_mesh_interval);
-
-                                                             if constexpr (get_type == Get::Intervals)
-                                                             {
-                                                                 f(interface_it, minus_comput_stencil_it);
-                                                             }
-                                                             else if constexpr (get_type == Get::Cells)
-                                                             {
-                                                                 for (std::size_t ii = 0; ii < fine_mesh_interval.i.size(); ++ii)
-                                                                 {
-                                                                     f(interface_it.cells(), minus_comput_stencil_it.cells());
-                                                                     interface_it.move_next();
-                                                                     minus_comput_stencil_it.move_next();
-                                                                 }
-                                                             }
-                                                         });
+                apply_on_interval<get_type>(fine_mesh_interval, interface_it, minus_comput_stencil_it, std::forward<Func>(f));
+            });
+        // DirectionVector<Mesh::dim> opposite_direction    = -direction;
+        // decltype(comput_stencil) opposite_comput_stencil = comput_stencil - direction;
+        // for_each_interior_interface__level_jump_direction<run_type, get_type>(mesh,
+        //                                                                       level,
+        //                                                                       opposite_direction,
+        //                                                                       opposite_comput_stencil,
+        //                                                                       std::forward<Func>(f));
     }
 
     /**
@@ -245,7 +236,7 @@ namespace samurai
     void for_each_interior_interface(const Mesh& mesh,
                                      std::size_t level,
                                      const DirectionVector<Mesh::dim>& direction,
-                                     const Stencil<comput_stencil_size, Mesh::dim>& comput_stencil,
+                                     const StencilAnalyzer<comput_stencil_size, Mesh::dim>& comput_stencil,
                                      Func&& f)
     {
         for_each_interior_interface__same_level<run_type, get_type>(mesh, level, direction, comput_stencil, std::forward<Func>(f));
@@ -273,7 +264,7 @@ namespace samurai
     template <Run run_type = Run::Sequential, Get get_type = Get::Cells, class Mesh, std::size_t comput_stencil_size, class Func>
     void for_each_interior_interface(const Mesh& mesh,
                                      const DirectionVector<Mesh::dim>& direction,
-                                     const Stencil<comput_stencil_size, Mesh::dim>& comput_stencil,
+                                     const StencilAnalyzer<comput_stencil_size, Mesh::dim>& comput_stencil,
                                      Func&& f)
     {
         for_each_level(mesh,
@@ -303,7 +294,8 @@ namespace samurai
         static constexpr std::size_t dim = Mesh::dim;
 
         Stencil<2, dim> comput_stencil = in_out_stencil<dim>(direction);
-        for_each_interior_interface<run_type, get_type>(mesh, direction, comput_stencil, std::forward<Func>(f));
+        auto stencil_analyzer          = make_stencil_analyzer(comput_stencil);
+        for_each_interior_interface<run_type, get_type>(mesh, direction, stencil_analyzer, std::forward<Func>(f));
     }
 
     /**
@@ -337,13 +329,14 @@ namespace samurai
     void for_each_boundary_interface__direction(const Mesh& mesh,
                                                 std::size_t level,
                                                 const DirectionVector<Mesh::dim>& direction,
-                                                const Stencil<comput_stencil_size, Mesh::dim>& comput_stencil,
+                                                const StencilAnalyzer<comput_stencil_size, Mesh::dim>& comput_stencil,
                                                 Func&& f)
     {
         static constexpr std::size_t dim = Mesh::dim;
         using mesh_interval_t            = typename Mesh::mesh_interval_t;
 
-        Stencil<2, dim> interface_stencil = in_out_stencil<dim>(direction);
+        Stencil<2, dim> interface_stencil_ = in_out_stencil<dim>(direction);
+        auto interface_stencil             = make_stencil_analyzer(interface_stencil_);
 
 #ifdef SAMURAI_WITH_OPENMP
         std::size_t num_threads = static_cast<std::size_t>(omp_get_max_threads());
@@ -372,7 +365,7 @@ namespace samurai
                                                              comput_stencil_it.init(mesh_interval);
                                                              if constexpr (get_type == Get::Intervals)
                                                              {
-                                                                 f(interface_it.cells()[0], comput_stencil_it);
+                                                                 f(interface_it, comput_stencil_it);
                                                              }
                                                              else if constexpr (get_type == Get::Cells)
                                                              {
@@ -390,22 +383,23 @@ namespace samurai
     void for_each_boundary_interface__opposite_direction(const Mesh& mesh,
                                                          std::size_t level,
                                                          const DirectionVector<Mesh::dim>& direction,
-                                                         const Stencil<comput_stencil_size, Mesh::dim>& comput_stencil,
+                                                         const StencilAnalyzer<comput_stencil_size, Mesh::dim>& comput_stencil_analyzer,
                                                          Func&& f)
     {
-        DirectionVector<Mesh::dim> opposite_direction    = -direction;
-        decltype(comput_stencil) opposite_comput_stencil = comput_stencil - direction;
+        DirectionVector<Mesh::dim> opposite_direction                   = -direction;
+        Stencil<comput_stencil_size, Mesh::dim> opposite_comput_stencil = comput_stencil_analyzer.stencil - direction;
+        auto opposite_comput_stencil_analyzer                           = make_stencil_analyzer(opposite_comput_stencil);
         for_each_boundary_interface__direction<run_type, get_type>(mesh,
                                                                    level,
                                                                    opposite_direction,
-                                                                   opposite_comput_stencil,
+                                                                   opposite_comput_stencil_analyzer,
                                                                    std::forward<Func>(f));
     }
 
     template <Run run_type = Run::Sequential, Get get_type = Get::Cells, class Mesh, std::size_t comput_stencil_size, class Func>
     void for_each_boundary_interface__direction(const Mesh& mesh,
                                                 const DirectionVector<Mesh::dim>& direction,
-                                                const Stencil<comput_stencil_size, Mesh::dim>& comput_stencil,
+                                                const StencilAnalyzer<comput_stencil_size, Mesh::dim>& comput_stencil,
                                                 Func&& f)
     {
         for_each_level(
@@ -416,20 +410,31 @@ namespace samurai
             });
     }
 
+    template <Run run_type = Run::Sequential, Get get_type = Get::Cells, class Mesh, std::size_t comput_stencil_size, class Func>
+    void for_each_boundary_interface__direction(const Mesh& mesh,
+                                                const DirectionVector<Mesh::dim>& direction,
+                                                const Stencil<comput_stencil_size, Mesh::dim>& comput_stencil,
+                                                Func&& f)
+    {
+        auto stencil_analyzer = make_stencil_analyzer(comput_stencil);
+        for_each_boundary_interface__direction<run_type, get_type>(mesh, direction, stencil_analyzer, std::forward<Func>(f));
+    }
+
     template <Run run_type = Run::Sequential, Get get_type = Get::Cells, class Mesh, class Func>
     void for_each_boundary_interface__direction(const Mesh& mesh, const DirectionVector<Mesh::dim>& direction, Func&& f)
     {
         static constexpr std::size_t dim = Mesh::dim;
 
         Stencil<2, dim> comput_stencil = in_out_stencil<dim>(direction);
-        for_each_boundary_interface__direction<run_type, get_type>(mesh, direction, comput_stencil, std::forward<Func>(f));
+        auto compute_stencil_analyzer  = make_stencil_analyzer(comput_stencil);
+        for_each_boundary_interface__direction<run_type, get_type>(mesh, direction, compute_stencil_analyzer, std::forward<Func>(f));
     }
 
     template <Run run_type = Run::Sequential, Get get_type = Get::Cells, class Mesh, std::size_t comput_stencil_size, class Func>
     void for_each_boundary_interface__both_directions(const Mesh& mesh,
                                                       std::size_t level,
                                                       const DirectionVector<Mesh::dim>& direction,
-                                                      const Stencil<comput_stencil_size, Mesh::dim>& comput_stencil,
+                                                      const StencilAnalyzer<comput_stencil_size, Mesh::dim>& comput_stencil,
                                                       Func&& f)
     {
         for_each_boundary_interface__direction<run_type, get_type>(mesh, level, direction, comput_stencil, std::forward<Func>(f));
@@ -452,7 +457,7 @@ namespace samurai
     template <Run run_type = Run::Sequential, Get get_type = Get::Cells, class Mesh, std::size_t comput_stencil_size, class Func>
     void for_each_boundary_interface__both_directions(const Mesh& mesh,
                                                       const DirectionVector<Mesh::dim>& direction,
-                                                      const Stencil<comput_stencil_size, Mesh::dim>& comput_stencil,
+                                                      const StencilAnalyzer<comput_stencil_size, Mesh::dim>& comput_stencil,
                                                       Func&& f)
     {
         for_each_level(
@@ -461,6 +466,29 @@ namespace samurai
             {
                 for_each_boundary_interface__both_directions<run_type, get_type>(mesh, level, direction, comput_stencil, std::forward<Func>(f));
             });
+    }
+
+    /**
+     * Iterates over the boundary interfaces in a given direction and its opposite direction.
+     * @param direction: positive Cartesian direction defining, for each cell, which neighbour defines the desired interface.
+     *                   In 2D: {1,0} to browse horizontal interfaces, {0,1} to browse vertical interfaces.
+     * @param comput_stencil: the computational stencil, defining the set of cells (of same level)
+     *                        captured in second argument of the callback function.
+     *
+     * The provided callback @param f has the following signature:
+     *           void f(auto& cell, auto& comput_cells)
+     * where
+     *       'cell'         is the inner cell at the boundary.
+     *       'comput cells' is the set of cells/ghosts defined by @param comput_stencil.
+     */
+    template <Run run_type = Run::Sequential, Get get_type = Get::Cells, class Mesh, std::size_t comput_stencil_size, class Func>
+    void for_each_boundary_interface__both_directions(const Mesh& mesh,
+                                                      const DirectionVector<Mesh::dim>& direction,
+                                                      const Stencil<comput_stencil_size, Mesh::dim>& comput_stencil,
+                                                      Func&& f)
+    {
+        auto compute_stencil_analyzer = make_stencil_analyzer(comput_stencil);
+        for_each_boundary_interface__both_directions<run_type, get_type>(mesh, direction, compute_stencil_analyzer, std::forward<Func>(f));
     }
 
     /**
@@ -480,7 +508,8 @@ namespace samurai
         static constexpr std::size_t dim = Mesh::dim;
 
         Stencil<2, dim> comput_stencil = in_out_stencil<dim>(direction);
-        for_each_boundary_interface__both_directions<run_type, get_type>(mesh, direction, comput_stencil, std::forward<Func>(f));
+        auto compute_stencil_analyzer  = make_stencil_analyzer(comput_stencil);
+        for_each_boundary_interface__both_directions<run_type, get_type>(mesh, direction, compute_stencil_analyzer, std::forward<Func>(f));
     }
 
     /**

--- a/include/samurai/mesh_interval.hpp
+++ b/include/samurai/mesh_interval.hpp
@@ -19,7 +19,10 @@ namespace samurai
         interval_t i;
         coord_type index;
 
-        MeshInterval() = default;
+        MeshInterval()
+            : level(0)
+        {
+        }
 
         MeshInterval(std::size_t _level)
             : level(_level)

--- a/include/samurai/mesh_interval.hpp
+++ b/include/samurai/mesh_interval.hpp
@@ -19,6 +19,8 @@ namespace samurai
         interval_t i;
         coord_type index;
 
+        MeshInterval() = default;
+
         MeshInterval(std::size_t _level)
             : level(_level)
         {

--- a/include/samurai/petsc/block_assembly.hpp
+++ b/include/samurai/petsc/block_assembly.hpp
@@ -26,8 +26,8 @@ namespace samurai
 
             explicit BlockAssemblyBase(const block_operator_t& block_op)
                 : m_block_operator(block_op)
-                , m_assembly_ops(transform(block_op.operators(),
-                                           [](const auto& op)
+                , m_assembly_ops(transform(m_block_operator.operators(),
+                                           [](auto& op)
                                            {
                                                return make_assembly(op);
                                            }))

--- a/include/samurai/petsc/fv/FV_scheme_assembly.hpp
+++ b/include/samurai/petsc/fv/FV_scheme_assembly.hpp
@@ -74,7 +74,12 @@ namespace samurai
                 this->set_name(scheme.name());
             }
 
-            auto& scheme() const
+            auto& scheme()
+            {
+                return m_scheme;
+            }
+
+            const auto& scheme() const
             {
                 return m_scheme;
             }

--- a/include/samurai/petsc/fv/operator_sum_assembly.hpp
+++ b/include/samurai/petsc/fv/operator_sum_assembly.hpp
@@ -67,7 +67,7 @@ namespace samurai
                          });
             }
 
-            auto& scheme()
+            auto& scheme() // cppcheck-suppress functionRedefined
             {
                 return *m_sum_scheme;
             }

--- a/include/samurai/petsc/fv/operator_sum_assembly.hpp
+++ b/include/samurai/petsc/fv/operator_sum_assembly.hpp
@@ -16,16 +16,16 @@ namespace samurai
 
           private:
 
-            const scheme_t* m_sum_scheme;
+            scheme_t* m_sum_scheme;
 
             std::tuple<Assembly<Operators>...> m_assembly_ops;
 
           public:
 
-            explicit Assembly(const scheme_t& sum_scheme)
+            explicit Assembly(scheme_t& sum_scheme)
                 : m_sum_scheme(&sum_scheme)
                 , m_assembly_ops(transform(sum_scheme.operators(),
-                                           [](const auto& op)
+                                           [](auto& op)
                                            {
                                                return make_assembly(op);
                                            }))
@@ -65,6 +65,11 @@ namespace samurai
                          {
                              op.set_unknown(unknown);
                          });
+            }
+
+            auto& scheme()
+            {
+                return *m_sum_scheme;
             }
 
             auto& scheme() const

--- a/include/samurai/petsc/linear_block_solver.hpp
+++ b/include/samurai/petsc/linear_block_solver.hpp
@@ -33,7 +33,7 @@ namespace samurai
 
             static constexpr bool is_monolithic = monolithic;
 
-            explicit LinearBlockSolver(const block_operator_t& block_op)
+            explicit LinearBlockSolver(block_operator_t& block_op)
                 : base_class(block_op)
             {
                 _configure_solver();

--- a/include/samurai/petsc/linear_solver.hpp
+++ b/include/samurai/petsc/linear_solver.hpp
@@ -28,7 +28,7 @@ namespace samurai
 
           public:
 
-            explicit LinearSolverBase(const scheme_t& scheme)
+            explicit LinearSolverBase(scheme_t& scheme)
                 : m_assembly(scheme)
             {
                 _configure_solver();
@@ -252,7 +252,7 @@ namespace samurai
 
           public:
 
-            explicit LinearSolver(const scheme_t& scheme)
+            explicit LinearSolver(scheme_t& scheme)
                 : base_class(scheme)
             {
                 _configure_solver();

--- a/include/samurai/petsc/matrix_assembly.hpp
+++ b/include/samurai/petsc/matrix_assembly.hpp
@@ -352,11 +352,11 @@ namespace samurai
         };
 
         template <class Scheme>
-        auto make_assembly(const Scheme& s)
+        auto make_assembly(Scheme& s)
         {
             if constexpr (std::is_base_of_v<MatrixAssembly, Scheme>)
             {
-                return *reinterpret_cast<const Assembly<Scheme>*>(&s);
+                return *reinterpret_cast<Assembly<Scheme>*>(&s);
             }
             else
             {

--- a/include/samurai/petsc/nonlinear_solver.hpp
+++ b/include/samurai/petsc/nonlinear_solver.hpp
@@ -24,7 +24,7 @@ namespace samurai
 
           public:
 
-            explicit NonLinearSolverBase(const scheme_t& scheme)
+            explicit NonLinearSolverBase(scheme_t& scheme)
                 : m_assembly(scheme)
             {
                 _configure_solver();
@@ -308,7 +308,7 @@ namespace samurai
             using base_class::m_is_set_up;
             using base_class::m_J;
 
-            explicit NonLinearSolver(const scheme_t& scheme)
+            explicit NonLinearSolver(scheme_t& scheme)
                 : base_class(scheme)
             {
             }

--- a/include/samurai/petsc/solver_helpers.hpp
+++ b/include/samurai/petsc/solver_helpers.hpp
@@ -14,21 +14,21 @@ namespace samurai
 
         // Linear solver
         template <class Scheme, std::enable_if_t<Scheme::cfg_t::scheme_type != SchemeType::NonLinear, bool> = true>
-        auto make_solver(const Scheme& scheme)
+        auto make_solver(Scheme& scheme)
         {
             return LinearSolver<Scheme>(scheme);
         }
 
         // Linear block solver (choice monolithic or not)
         template <bool monolithic, std::size_t rows, std::size_t cols, class... Operators>
-        auto make_solver(const BlockOperator<rows, cols, Operators...>& block_operator)
+        auto make_solver(BlockOperator<rows, cols, Operators...>& block_operator)
         {
             return LinearBlockSolver<monolithic, rows, cols, Operators...>(block_operator);
         }
 
         // Linear block solver (monolithic)
         template <std::size_t rows, std::size_t cols, class... Operators>
-        auto make_solver(const BlockOperator<rows, cols, Operators...>& block_operator)
+        auto make_solver(BlockOperator<rows, cols, Operators...>& block_operator)
         {
             static constexpr bool default_monolithic = true;
             return make_solver<default_monolithic, rows, cols, Operators...>(block_operator);
@@ -36,14 +36,14 @@ namespace samurai
 
         // Non-linear solver
         template <class Scheme, std::enable_if_t<Scheme::cfg_t::scheme_type == SchemeType::NonLinear, bool> = true>
-        auto make_solver(const Scheme& scheme)
+        auto make_solver(Scheme& scheme)
         {
             return NonLinearSolver<Scheme>(scheme);
         }
 
         // Non-linear local solvers
         template <class cfg, class bdry_cfg, std::enable_if_t<cfg::scheme_type == SchemeType::NonLinear && cfg::stencil_size == 1, bool> = true>
-        auto make_solver(const CellBasedScheme<cfg, bdry_cfg>& scheme)
+        auto make_solver(CellBasedScheme<cfg, bdry_cfg>& scheme)
         {
             return NonLinearLocalSolvers<CellBasedScheme<cfg, bdry_cfg>>(scheme);
         }
@@ -53,17 +53,25 @@ namespace samurai
          */
 
         template <class Scheme>
-        void solve(const Scheme& scheme, typename Scheme::field_t& unknown, typename Scheme::field_t& rhs)
+        void solve(Scheme& scheme, typename Scheme::field_t& unknown, typename Scheme::field_t& rhs)
         {
             auto solver = make_solver(scheme);
             solver.solve(unknown, rhs);
         }
 
         template <class Scheme, class E>
-        void solve(const Scheme& scheme, typename Scheme::field_t& unknown, const field_expression<E>& rhs_expression)
+        void solve(Scheme& scheme, typename Scheme::field_t& unknown, const field_expression<E>& rhs_expression)
         {
             typename Scheme::field_t rhs = rhs_expression;
             solve(scheme, unknown, rhs);
+        }
+
+        template <class Scheme>
+        void solve(Scheme&& scheme, typename Scheme::field_t& unknown, typename Scheme::field_t& rhs)
+        {
+            Scheme scheme_ = std::move(scheme);
+            auto solver    = make_solver(scheme_);
+            solver.solve(unknown, rhs);
         }
 
     } // end namespace petsc

--- a/include/samurai/schemes/block_operator.hpp
+++ b/include/samurai/schemes/block_operator.hpp
@@ -24,7 +24,12 @@ namespace samurai
             static_assert(n_operators == rows * cols, "The number of operators must correspond to rows*cols.");
         }
 
-        auto& operators() const
+        const auto& operators() const
+        {
+            return m_operators;
+        }
+
+        auto& operators()
         {
             return m_operators;
         }

--- a/include/samurai/schemes/explicit_scheme.hpp
+++ b/include/samurai/schemes/explicit_scheme.hpp
@@ -13,7 +13,7 @@ namespace samurai
     };
 
     template <class Scheme>
-    auto make_explicit(const Scheme& s)
+    auto make_explicit(Scheme& s)
     {
         return Explicit<std::decay_t<Scheme>>(s);
     }

--- a/include/samurai/schemes/fv/FV_scheme.hpp
+++ b/include/samurai/schemes/fv/FV_scheme.hpp
@@ -168,7 +168,7 @@ namespace samurai
         /**
          * Explicit application of the scheme
          */
-        auto operator()(input_field_t& input_field) const
+        auto operator()(input_field_t& input_field)
         {
             times::timers.start(name() + " operator");
             auto explicit_scheme = make_explicit(derived_cast());
@@ -177,7 +177,7 @@ namespace samurai
             return output_field;
         }
 
-        void apply(output_field_t& output_field, input_field_t& input_field) const
+        void apply(output_field_t& output_field, input_field_t& input_field)
         {
             times::timers.start(name() + " operator");
             auto explicit_scheme = make_explicit(derived_cast());
@@ -185,7 +185,7 @@ namespace samurai
             times::timers.stop(name() + " operator");
         }
 
-        auto operator()(std::size_t d, input_field_t& input_field) const
+        auto operator()(std::size_t d, input_field_t& input_field)
         {
             times::timers.start(name() + " operator");
             auto explicit_scheme = make_explicit(derived_cast());
@@ -194,7 +194,7 @@ namespace samurai
             return output_field;
         }
 
-        void apply(std::size_t d, output_field_t& output_field, input_field_t& input_field) const
+        void apply(std::size_t d, output_field_t& output_field, input_field_t& input_field)
         {
             times::timers.start(name() + " operator");
             auto explicit_scheme = make_explicit(derived_cast());

--- a/include/samurai/schemes/fv/cell_based/cell_based_scheme_definition.hpp
+++ b/include/samurai/schemes/fv/cell_based/cell_based_scheme_definition.hpp
@@ -55,7 +55,7 @@ namespace samurai
     struct CellBasedSchemeDefinitionBase
     {
         static constexpr std::size_t dim = cfg::input_field_t::dim;
-        using scheme_stencil_t           = Stencil<cfg::stencil_size, dim>;
+        using scheme_stencil_t           = StencilAnalyzer<cfg::stencil_size, dim>;
         scheme_stencil_t stencil;
 
         CellBasedSchemeDefinitionBase()

--- a/include/samurai/schemes/fv/cell_based/explicit_cell_based_scheme.hpp
+++ b/include/samurai/schemes/fv/cell_based/explicit_cell_based_scheme.hpp
@@ -30,12 +30,12 @@ namespace samurai
 
         using base_class::apply;
 
-        explicit Explicit(const scheme_t& s)
+        explicit Explicit(scheme_t& s)
             : base_class(s)
         {
         }
 
-        void apply(output_field_t& output_field, input_field_t& input_field) const override
+        void apply(output_field_t& output_field, input_field_t& input_field) override
         {
             scheme().for_each_stencil_and_coeffs(
                 input_field,
@@ -79,12 +79,12 @@ namespace samurai
 
         using base_class::apply;
 
-        explicit Explicit(const scheme_t& s)
+        explicit Explicit(scheme_t& s)
             : base_class(s)
         {
         }
 
-        void apply(output_field_t& output_field, input_field_t& input_field) const override
+        void apply(output_field_t& output_field, input_field_t& input_field) override
         {
             scheme().for_each_stencil_center(
                 input_field,

--- a/include/samurai/schemes/fv/explicit_FV_scheme.hpp
+++ b/include/samurai/schemes/fv/explicit_FV_scheme.hpp
@@ -21,11 +21,11 @@ namespace samurai
 
       private:
 
-        const scheme_t* m_scheme = nullptr;
+        scheme_t* m_scheme = nullptr;
 
       public:
 
-        explicit ExplicitFVScheme(const scheme_t& scheme)
+        explicit ExplicitFVScheme(scheme_t& scheme)
             : m_scheme(&scheme)
         {
         }
@@ -34,7 +34,12 @@ namespace samurai
         {
         }
 
-        auto& scheme() const
+        auto& scheme()
+        {
+            return *m_scheme;
+        }
+
+        const auto& scheme() const
         {
             return *m_scheme;
         }
@@ -50,7 +55,7 @@ namespace samurai
 
       public:
 
-        auto apply_to(input_field_t& input_field) const
+        auto apply_to(input_field_t& input_field)
         {
             output_field_t output_field = create_output_field(input_field);
 
@@ -60,7 +65,7 @@ namespace samurai
             return output_field;
         }
 
-        auto apply_to(std::size_t d, input_field_t& input_field) const
+        auto apply_to(std::size_t d, input_field_t& input_field)
         {
             output_field_t output_field = create_output_field(input_field);
 
@@ -70,7 +75,7 @@ namespace samurai
             return output_field;
         }
 
-        virtual void apply(output_field_t& output_field, input_field_t& input_field) const
+        virtual void apply(output_field_t& output_field, input_field_t& input_field)
         {
             for (std::size_t d = 0; d < dim; ++d)
             {
@@ -78,7 +83,7 @@ namespace samurai
             }
         }
 
-        virtual void apply(std::size_t /* d */, output_field_t& /* output_field */, input_field_t& /* input_field */) const
+        virtual void apply(std::size_t /* d */, output_field_t& /* output_field */, input_field_t& /* input_field */)
         {
             std::cerr << "The scheme '" << scheme().name() << "' cannot be applied by direction." << std::endl;
             assert(false);

--- a/include/samurai/schemes/fv/explicit_operator_sum.hpp
+++ b/include/samurai/schemes/fv/explicit_operator_sum.hpp
@@ -17,24 +17,24 @@ namespace samurai
         using size_type      = typename base_class::size_type;
         using base_class::scheme;
 
-        explicit Explicit(const scheme_t& sum_scheme)
+        explicit Explicit(scheme_t& sum_scheme)
             : base_class(sum_scheme)
         {
         }
 
-        void apply(output_field_t& output_field, input_field_t& input_field) const override
+        void apply(output_field_t& output_field, input_field_t& input_field) override
         {
             for_each(scheme().operators(),
-                     [&](const auto& op)
+                     [&](auto& op)
                      {
                          op.apply(output_field, input_field);
                      });
         }
 
-        void apply(std::size_t d, output_field_t& output_field, input_field_t& input_field) const override
+        void apply(std::size_t d, output_field_t& output_field, input_field_t& input_field) override
         {
             for_each(scheme().operators(),
-                     [&](const auto& op)
+                     [&](auto& op)
                      {
                          op.apply(d, output_field, input_field);
                      });

--- a/include/samurai/schemes/fv/flux_based/explicit_flux_based_scheme__lin_het.hpp
+++ b/include/samurai/schemes/fv/flux_based/explicit_flux_based_scheme__lin_het.hpp
@@ -28,12 +28,12 @@ namespace samurai
 
         using base_class::apply;
 
-        explicit Explicit(const scheme_t& s)
+        explicit Explicit(scheme_t& s)
             : base_class(s)
         {
         }
 
-        void apply(std::size_t d, output_field_t& output_field, input_field_t& input_field) const override
+        void apply(std::size_t d, output_field_t& output_field, input_field_t& input_field) override
         {
             /**
              * Implementation by matrix-vector multiplication

--- a/include/samurai/schemes/fv/flux_based/explicit_flux_based_scheme__lin_hom.hpp
+++ b/include/samurai/schemes/fv/flux_based/explicit_flux_based_scheme__lin_hom.hpp
@@ -29,7 +29,7 @@ namespace samurai
 
         using base_class::apply;
 
-        explicit Explicit(const scheme_t& s)
+        explicit Explicit(scheme_t& s)
             : base_class(s)
         {
         }
@@ -230,7 +230,7 @@ namespace samurai
 
       public:
 
-        void apply(std::size_t d, output_field_t& output_field, input_field_t& input_field) const override
+        void apply(std::size_t d, output_field_t& output_field, input_field_t& input_field) override
         {
             /**
              * Implementation by matrix-vector multiplication

--- a/include/samurai/schemes/fv/flux_based/explicit_flux_based_scheme__lin_hom.hpp
+++ b/include/samurai/schemes/fv/flux_based/explicit_flux_based_scheme__lin_hom.hpp
@@ -294,7 +294,7 @@ namespace samurai
                                     auto coeff = this->scheme().cell_coeff(coeffs, c, field_i, field_j);
                                     // field_value(output_field, cell, field_i) += coeff * field_value(input_field, stencil[c], field_j);
 
-                                    auto cell_index_init   = cell.index;
+                                    auto cell_index_init   = cell.cells()[0].index;
                                     auto comput_index_init = stencil.cells()[c].index;
 
                                     using index_t = decltype(cell_index_init);

--- a/include/samurai/schemes/fv/flux_based/explicit_flux_based_scheme__nonlin.hpp
+++ b/include/samurai/schemes/fv/flux_based/explicit_flux_based_scheme__nonlin.hpp
@@ -25,12 +25,12 @@ namespace samurai
 
         using base_class::apply;
 
-        explicit Explicit(const scheme_t& s)
+        explicit Explicit(scheme_t& s)
             : base_class(s)
         {
         }
 
-        void apply(std::size_t d, output_field_t& output_field, input_field_t& input_field) const override
+        void apply(std::size_t d, output_field_t& output_field, input_field_t& input_field) override
         {
             // Interior interfaces
             scheme().template for_each_interior_interface<Run::Parallel>( // We need the 'template' keyword...

--- a/include/samurai/schemes/fv/flux_based/flux_definition.hpp
+++ b/include/samurai/schemes/fv/flux_based/flux_definition.hpp
@@ -44,7 +44,7 @@ namespace samurai
          *                   normal flux
          *
          */
-        Stencil<cfg::stencil_size, cfg::dim> stencil;
+        StencilAnalyzer<cfg::stencil_size, cfg::dim> stencil;
     };
 
     /**

--- a/include/samurai/schemes/fv/scheme_operators.hpp
+++ b/include/samurai/schemes/fv/scheme_operators.hpp
@@ -130,19 +130,19 @@ namespace samurai
             return ss.str();
         }
 
-        auto operator()(input_field_t& input_field) const
+        auto operator()(input_field_t& input_field)
         {
             auto explicit_scheme = make_explicit(*this);
             return explicit_scheme.apply_to(input_field);
         }
 
-        auto operator()(std::size_t d, input_field_t& input_field) const
+        auto operator()(std::size_t d, input_field_t& input_field)
         {
             auto explicit_scheme = make_explicit(*this);
             return explicit_scheme.apply_to(d, input_field);
         }
 
-        void apply(output_field_t& output_field, input_field_t& input_field) const
+        void apply(output_field_t& output_field, input_field_t& input_field)
         {
             auto explicit_scheme = make_explicit(*this);
             explicit_scheme.apply(output_field, input_field);

--- a/include/samurai/static_algorithm.hpp
+++ b/include/samurai/static_algorithm.hpp
@@ -151,11 +151,23 @@ namespace samurai
     template <typename... Ts, typename Func, size_t... Is>
     auto transform_impl(const std::tuple<Ts...>& t, Func&& f, std::index_sequence<Is...>)
     {
-        return std::tuple<std::invoke_result_t<Func, Ts>...>{f(std::get<Is>(t))...};
+        return std::make_tuple(f(std::get<Is>(t))...);
     }
 
     template <typename... Ts, typename Func>
     auto transform(const std::tuple<Ts...>& t, Func&& f)
+    {
+        return transform_impl(t, std::forward<Func>(f), std::make_index_sequence<sizeof...(Ts)>{});
+    }
+
+    template <typename... Ts, typename Func, size_t... Is>
+    auto transform_impl(std::tuple<Ts...>& t, Func&& f, std::index_sequence<Is...>)
+    {
+        return std::make_tuple(f(std::get<Is>(t))...);
+    }
+
+    template <typename... Ts, typename Func>
+    auto transform(std::tuple<Ts...>& t, Func&& f)
     {
         return transform_impl(t, std::forward<Func>(f), std::make_index_sequence<sizeof...(Ts)>{});
     }

--- a/include/samurai/stencil.hpp
+++ b/include/samurai/stencil.hpp
@@ -23,13 +23,13 @@ namespace samurai
             same_row_as_origin.fill(false);
         }
 
-        StencilAnalyzer(const Stencil<stencil_size, dim>& stencil_)
+        explicit StencilAnalyzer(const Stencil<stencil_size, dim>& stencil_)
             : stencil(stencil_)
         {
             init();
         }
 
-        StencilAnalyzer(Stencil<stencil_size, dim>&& stencil_)
+        explicit StencilAnalyzer(Stencil<stencil_size, dim>&& stencil_)
             : stencil(std::move(stencil_))
         {
             init();

--- a/include/samurai/stencil.hpp
+++ b/include/samurai/stencil.hpp
@@ -13,12 +13,15 @@ namespace samurai
     template <std::size_t stencil_size, std::size_t dim>
     struct StencilAnalyzer
     {
-        std::size_t origin_index;
-        bool has_origin = false;
+        std::size_t origin_index = 0;
+        bool has_origin          = false;
         std::array<bool, stencil_size> same_row_as_origin;
         Stencil<stencil_size, dim> stencil;
 
-        StencilAnalyzer() = default;
+        StencilAnalyzer()
+        {
+            same_row_as_origin.fill(false);
+        }
 
         StencilAnalyzer(const Stencil<stencil_size, dim>& stencil_)
             : stencil(stencil_)

--- a/include/samurai/stencil.hpp
+++ b/include/samurai/stencil.hpp
@@ -11,10 +11,97 @@ namespace samurai
     using DirectionVector = xt::xtensor_fixed<int, xt::xshape<dim>>;
 
     template <std::size_t stencil_size, std::size_t dim>
+    struct StencilAnalyzer
+    {
+        std::size_t origin_index;
+        bool has_origin = false;
+        std::array<bool, stencil_size> same_row_as_origin;
+        Stencil<stencil_size, dim> stencil;
+
+        StencilAnalyzer() = default;
+
+        StencilAnalyzer(const Stencil<stencil_size, dim>& stencil_)
+            : stencil(stencil_)
+        {
+            init();
+        }
+
+        StencilAnalyzer(Stencil<stencil_size, dim>&& stencil_)
+            : stencil(std::move(stencil_))
+        {
+            init();
+        }
+
+        void operator=(Stencil<stencil_size, dim>&& stencil_)
+        {
+            stencil = std::move(stencil_);
+            init();
+        }
+
+        void init()
+        {
+            for (std::size_t id = 0; id < stencil_size; ++id)
+            {
+                auto dir = xt::view(stencil, id);
+
+                bool is_zero_vector = true;
+                bool same_row       = true;
+                for (std::size_t i = 0; i < dim; ++i)
+                {
+                    if (dir[i] != 0)
+                    {
+                        is_zero_vector = false;
+                        if (i > 0)
+                        {
+                            // We are on the same row as the stencil origin if dir = {dir[0], 0,..., 0}
+                            same_row = false;
+                            break;
+                        }
+                    }
+                }
+                if (is_zero_vector)
+                {
+                    has_origin   = true;
+                    origin_index = id;
+                }
+                same_row_as_origin[id] = same_row;
+            }
+        }
+
+        int find(const DirectionVector<dim>& vector) const
+        {
+            for (unsigned int id = 0; id < stencil_size; ++id)
+            {
+                auto d     = xt::view(stencil, id);
+                bool found = true;
+                for (unsigned int i = 0; i < dim; ++i)
+                {
+                    if (d[i] != vector[i])
+                    {
+                        found = false;
+                        break;
+                    }
+                }
+                if (found)
+                {
+                    return static_cast<int>(id);
+                }
+            }
+            return -1;
+        }
+    };
+
+    template <std::size_t stencil_size, std::size_t dim>
+    auto make_stencil_analyzer(const Stencil<stencil_size, dim>& stencil)
+    {
+        return StencilAnalyzer<stencil_size, dim>(stencil);
+    }
+
+    template <std::size_t stencil_size, std::size_t dim>
     struct DirectionalStencil
     {
         DirectionVector<dim> direction;
-        Stencil<stencil_size, dim> stencil;
+        StencilAnalyzer<stencil_size, dim> stencil;
     };
 
     //-----------------------//
@@ -25,52 +112,6 @@ namespace samurai
     bool is_cartesian(const T& direction)
     {
         return xt::sum(xt::abs(direction))[0] == 1; // only one non-zero in the vector
-    }
-
-    template <std::size_t stencil_size, std::size_t dim>
-    int find_stencil_origin(const Stencil<stencil_size, dim>& stencil)
-    {
-        for (unsigned int id = 0; id < stencil_size; ++id)
-        {
-            auto d              = xt::view(stencil, id);
-            bool is_zero_vector = true;
-            for (unsigned int i = 0; i < dim; ++i)
-            {
-                if (d[i] != 0)
-                {
-                    is_zero_vector = false;
-                    break;
-                }
-            }
-            if (is_zero_vector)
-            {
-                return static_cast<int>(id);
-            }
-        }
-        return -1;
-    }
-
-    template <std::size_t stencil_size, std::size_t dim>
-    int find(const Stencil<stencil_size, dim>& stencil, const DirectionVector<dim>& vector)
-    {
-        for (unsigned int id = 0; id < stencil_size; ++id)
-        {
-            auto d     = xt::view(stencil, id);
-            bool found = true;
-            for (unsigned int i = 0; i < dim; ++i)
-            {
-                if (d[i] != vector[i])
-                {
-                    found = false;
-                    break;
-                }
-            }
-            if (found)
-            {
-                return static_cast<int>(id);
-            }
-        }
-        return -1;
     }
 
     template <std::size_t dim>
@@ -243,25 +284,13 @@ namespace samurai
     template <std::size_t dim>
     constexpr Stencil<dim, dim> positive_cartesian_directions()
     {
-        static_assert(dim >= 1 && dim <= 3, "positive_cartesian_directions() not implemented for this dimension");
-        // clang-format off
-        if constexpr (dim == 1)
+        Stencil<dim, dim> s;
+        s.fill(0);
+        for (std::size_t i = 0; i < dim; ++i)
         {
-            //     right
-            return {{1}};
+            s(i, i) = 1;
         }
-        else if constexpr (dim == 2)
-        {
-            //      right,   top
-            return {{1, 0}, {0, 1}};
-        }
-        else if constexpr (dim == 3)
-        {
-            //        right,     back,       top
-            return {{1, 0, 0}, {0, 1, 0}, {0, 0, 1}};
-        }
-        // clang-format on
-        return Stencil<dim, dim>();
+        return s;
     }
 
     /**
@@ -394,7 +423,9 @@ namespace samurai
     template <std::size_t dim>
     constexpr Stencil<1, dim> center_only_stencil()
     {
-        return star_stencil<dim, 0>();
+        Stencil<1, dim> s;
+        s.fill(0);
+        return s;
     }
 
     template <std::size_t dim, class Vector>
@@ -405,6 +436,9 @@ namespace samurai
         xt::view(stencil_shape, 1) = towards_out_from_in;
         return stencil_shape;
     }
+
+    template <std::size_t dim>
+    static const StencilAnalyzer<1, dim> center_only_stencil_analyzer = StencilAnalyzer<1, dim>(center_only_stencil<dim>());
 
     template <std::size_t stencil_size, std::size_t dim>
     Stencil<stencil_size, dim> convert_for_direction(const Stencil<stencil_size, dim>& stencil_in_x, const DirectionVector<dim>& direction)
@@ -443,102 +477,106 @@ namespace samurai
         return stencil_in_d;
     }
 
-    template <class Mesh, std::size_t stencil_size>
+    template <class Mesh, std::size_t stencil_size_>
     class IteratorStencil
     {
       public:
 
-        static constexpr std::size_t dim = Mesh::dim;
-        using mesh_interval_t            = typename Mesh::mesh_interval_t;
-        using coord_index_t              = typename Mesh::config::interval_t::coord_index_t;
-        using cell_t                     = Cell<dim, typename Mesh::interval_t>;
+        static constexpr std::size_t dim          = Mesh::dim;
+        static constexpr std::size_t stencil_size = stencil_size_;
+        using mesh_t                              = Mesh;
+        using mesh_interval_t                     = typename Mesh::mesh_interval_t;
+        using coord_index_t                       = typename Mesh::config::interval_t::coord_index_t;
+        using cell_t                              = Cell<dim, typename Mesh::interval_t>;
 
       private:
 
-        const Mesh& m_mesh;                         // NOLINT(cppcoreguidelines-avoid-const-or-ref-data-members)
-        const Stencil<stencil_size, dim> m_stencil; // NOLINT(cppcoreguidelines-avoid-const-or-ref-data-members)
-        std::array<cell_t, stencil_size> m_cells;
-        unsigned int m_origin_cell;
+        const Mesh& m_mesh; // NOLINT(cppcoreguidelines-avoid-const-or-ref-data-members)
         const mesh_interval_t* m_mesh_interval = nullptr;
+        const StencilAnalyzer<stencil_size, dim>& m_stencil_analyzer;
+        std::array<cell_t, stencil_size> m_cells;
 
       public:
 
-        IteratorStencil(const Mesh& mesh, const Stencil<stencil_size, dim>& stencil)
+        IteratorStencil(const Mesh& mesh, const StencilAnalyzer<stencil_size, dim>& stencil_analyzer)
             : m_mesh(mesh)
-            , m_stencil(stencil)
+            , m_stencil_analyzer(stencil_analyzer)
         {
-            int origin_index = find_stencil_origin(stencil);
-            assert(origin_index >= 0 && "the zero vector is required in the stencil definition.");
-            m_origin_cell = static_cast<unsigned int>(origin_index);
+            assert(m_stencil_analyzer.has_origin && "the zero vector is required in the stencil definition.");
+            auto length = mesh.cell_length(mesh.min_level());
             for (cell_t& cell : m_cells)
             {
                 cell.origin_point = mesh.origin_point();
+                cell.level        = mesh.min_level();
+                cell.length       = length;
             }
         }
 
-        void init(const mesh_interval_t& mesh_interval)
+        void init(const mesh_interval_t& origin_mesh_interval)
         {
-            m_mesh_interval = &mesh_interval;
-
-            double length = m_mesh.cell_length(mesh_interval.level);
-            for (cell_t& cell : m_cells)
+            if (origin_mesh_interval.level != m_cells[0].level)
             {
-                cell.level  = mesh_interval.level;
-                cell.length = length;
+                double length = m_mesh.cell_length(origin_mesh_interval.level);
+                for (cell_t& cell : m_cells)
+                {
+                    cell.level  = origin_mesh_interval.level;
+                    cell.length = length;
+                }
             }
+            m_mesh_interval = &origin_mesh_interval;
 
             // origin of the stencil
-            cell_t& origin_cell    = m_cells[m_origin_cell];
-            origin_cell.indices[0] = mesh_interval.i.start;
+            cell_t& origin_cell    = m_cells[m_stencil_analyzer.origin_index];
+            origin_cell.indices[0] = origin_mesh_interval.i.start;
             for (unsigned int d = 0; d < dim - 1; ++d)
             {
-                origin_cell.indices[d + 1] = mesh_interval.index[d];
+                origin_cell.indices[d + 1] = origin_mesh_interval.index[d];
             }
-            origin_cell.index = get_index_start(m_mesh, mesh_interval);
-            if (origin_cell.index > 0 && static_cast<std::size_t>(origin_cell.index) > m_mesh.nb_cells())
+            origin_cell.index = get_index_start(m_mesh, origin_mesh_interval);
+#ifndef NDEBUG
+            if (origin_cell.index > 0 && static_cast<std::size_t>(origin_cell.index) > m_mesh.nb_cells()) // nb_cells() is very costly
             {
                 std::cout << "Cell not found in the mesh: " << origin_cell << std::endl;
                 assert(false);
             }
-
-            for (unsigned int id = 0; id < stencil_size; ++id)
+#endif
+            if constexpr (stencil_size > 1)
             {
-                if (id == m_origin_cell)
+                for (unsigned int i = 0; i < stencil_size; ++i)
                 {
-                    continue;
-                }
-
-                auto d = xt::view(m_stencil, id);
-
-                // Translate the coordinates according the direction d
-                cell_t& cell = m_cells[id];
-                for (unsigned int k = 0; k < dim; ++k)
-                {
-                    cell.indices[k] = origin_cell.indices[k] + d[k];
-                }
-
-                // We are on the same row as the stencil origin if d = {d[0], 0,..., 0}
-                bool same_row = true;
-                for (std::size_t k = 1; k < dim; ++k)
-                {
-                    if (d[k] != 0)
+                    if (i == m_stencil_analyzer.origin_index)
                     {
-                        same_row = false;
-                        break;
+                        continue;
                     }
-                }
-                if (same_row) // same row as the stencil origin
-                {
-                    // translation on the row
-                    cell.index = origin_cell.index + d[0];
-                }
-                else
-                {
-                    cell.index = get_index_start_translated(m_mesh, mesh_interval, d);
-                    if (cell.index > 0 && static_cast<std::size_t>(cell.index) > m_mesh.nb_cells())
+
+                    // Translate the coordinates according the direction d
+                    cell_t& cell = m_cells[i];
+                    for (unsigned int k = 0; k < dim; ++k)
                     {
-                        std::cout << "Non-existing neighbour for " << origin_cell << " in the direction " << d << std::endl;
-                        assert(false);
+                        cell.indices[k] = origin_cell.indices[k] + m_stencil_analyzer.stencil(i, k);
+                    }
+
+                    // Find cell index
+                    if (m_stencil_analyzer.same_row_as_origin[i])
+                    {
+                        // translation on the row
+                        cell.index = origin_cell.index + m_stencil_analyzer.stencil(i, 0);
+                    }
+                    else
+                    {
+                        DirectionVector<dim> dir;
+                        for (std::size_t k = 0; k < dim; ++k)
+                        {
+                            dir(k) = m_stencil_analyzer.stencil(i, k);
+                        }
+                        cell.index = get_index_start_translated(m_mesh, origin_mesh_interval, dir);
+#ifndef NDEBUG
+                        if (cell.index > 0 && static_cast<std::size_t>(cell.index) > m_mesh.nb_cells()) // nb_cells() is very costly
+                        {
+                            std::cout << "Non-existing neighbour for " << origin_cell << " in the direction " << dir << std::endl;
+                            assert(false);
+                        }
+#endif
                     }
                 }
             }
@@ -549,23 +587,24 @@ namespace samurai
             return m_mesh;
         }
 
+        inline auto& mesh_interval() const
+        {
+            return *m_mesh_interval;
+        }
+
         inline auto& interval() const
         {
             return m_mesh_interval->i;
         }
 
-        inline const auto& stencil() const
+        inline auto& level() const
         {
-            return m_stencil;
+            return m_mesh_interval->level;
         }
 
-        inline void move_next()
+        inline const auto& stencil() const
         {
-            for (cell_t& cell : m_cells)
-            {
-                cell.index++;      // increment cell index
-                cell.indices[0]++; // increment x-coordinate
-            }
+            return m_stencil_analyzer.stencil;
         }
 
         inline const auto& cells() const
@@ -577,11 +616,22 @@ namespace samurai
         {
             return m_cells;
         }
+
+        inline void move_next()
+        {
+            for (cell_t& cell : m_cells)
+            {
+                ++cell.index;      // increment cell index
+                ++cell.indices[0]; // increment x-coordinate
+            }
+        }
     };
 
     template <std::size_t index_coarse_cell, class Mesh, std::size_t stencil_size>
     class LevelJumpIterator
     {
+      public:
+
         static constexpr std::size_t dim = Mesh::dim;
         using cell_t                     = Cell<dim, typename Mesh::interval_t>;
         using mesh_interval_t            = typename Mesh::mesh_interval_t;
@@ -589,17 +639,20 @@ namespace samurai
         static constexpr std::size_t coarse = index_coarse_cell;
         static constexpr std::size_t fine   = (index_coarse_cell + 1) % 2;
 
+      private:
+
         std::size_t m_direction_index;
+
         IteratorStencil<Mesh, 1> m_coarse_it;
         const IteratorStencil<Mesh, stencil_size>* m_fine_it = nullptr;
         std::array<cell_t, 2> m_cells;
-        std::size_t m_ii = 0;
+        bool m_move_coarse_cell = false;
 
       public:
 
         LevelJumpIterator(const IteratorStencil<Mesh, stencil_size>& fine_it, std::size_t direction_index)
             : m_direction_index(direction_index)
-            , m_coarse_it(fine_it.mesh(), center_only_stencil<dim>())
+            , m_coarse_it(fine_it.mesh(), center_only_stencil_analyzer<dim>)
             , m_fine_it(&fine_it)
         {
         }
@@ -613,7 +666,7 @@ namespace samurai
             m_cells[coarse] = m_coarse_it.cells()[0];
             m_cells[fine]   = m_fine_it->cells()[m_direction_index];
 
-            m_ii = 0;
+            m_move_coarse_cell = false;
         }
 
         inline auto& interval() const
@@ -621,26 +674,26 @@ namespace samurai
             return m_fine_it->interval();
         }
 
-        inline void move_next()
-        {
-            // Move fine cell
-            m_cells[fine].index++;      // increment cell index
-            m_cells[fine].indices[0]++; // increment x-coordinate
-
-            // Move coarse cell only once every two iterations
-            m_cells[coarse].index += (m_ii % 2 == 1) ? 1 : 0;
-            m_cells[coarse].indices[0] += (m_ii % 2 == 1) ? 1 : 0;
-            m_ii++;
-        }
-
         inline const auto& cells() const
         {
             return m_cells;
         }
+
+        inline void move_next()
+        {
+            // Move fine cell
+            ++m_cells[fine].index;      // increment cell index
+            ++m_cells[fine].indices[0]; // increment x-coordinate
+
+            // Move coarse cell only once every two iterations
+            m_cells[coarse].index += static_cast<std::size_t>(m_move_coarse_cell);
+            m_cells[coarse].indices[0] += static_cast<std::size_t>(m_move_coarse_cell);
+            m_move_coarse_cell = !m_move_coarse_cell;
+        }
     };
 
     template <class Mesh, std::size_t stencil_size>
-    auto make_stencil_iterator(const Mesh& mesh, const Stencil<stencil_size, Mesh::dim>& stencil)
+    auto make_stencil_iterator(const Mesh& mesh, const StencilAnalyzer<stencil_size, Mesh::dim>& stencil)
     {
         return IteratorStencil<Mesh, stencil_size>(mesh, stencil);
     }
@@ -661,7 +714,7 @@ namespace samurai
     template <class Mesh, std::size_t stencil_size, class Func>
     inline void for_each_stencil_sliding_in_interval(const Mesh& mesh,
                                                      const typename Mesh::mesh_interval_t& mesh_interval,
-                                                     const Stencil<stencil_size, Mesh::dim>& stencil,
+                                                     const StencilAnalyzer<stencil_size, Mesh::dim>& stencil,
                                                      Func&& f)
     {
         auto stencil_it = make_stencil_iterator(mesh, stencil);
@@ -680,7 +733,7 @@ namespace samurai
     }
 
     template <class Mesh, std::size_t stencil_size, class Func>
-    inline void for_each_stencil(const Mesh& mesh, const Stencil<stencil_size, Mesh::dim>& stencil, Func&& f)
+    inline void for_each_stencil(const Mesh& mesh, const StencilAnalyzer<stencil_size, Mesh::dim>& stencil, Func&& f)
     {
         auto stencil_it = make_stencil_iterator(mesh, stencil);
         for_each_level(mesh,
@@ -702,7 +755,7 @@ namespace samurai
     }
 
     template <class Mesh, class Set, std::size_t stencil_size, class Func>
-    inline void for_each_stencil(const Mesh& mesh, Set& set, const Stencil<stencil_size, Mesh::dim>& stencil, Func&& f)
+    inline void for_each_stencil(const Mesh& mesh, Set& set, const StencilAnalyzer<stencil_size, Mesh::dim>& stencil, Func&& f)
     {
         auto stencil_it = make_stencil_iterator(mesh, stencil);
         for_each_stencil(set, stencil_it, std::forward<Func>(f));
@@ -713,5 +766,4 @@ namespace samurai
     {
         return LevelJumpIterator<index_coarse_cell, Mesh, stencil_size>(fine_iterator, direction_index);
     }
-
 }

--- a/include/samurai/storage/containers_config.hpp
+++ b/include/samurai/storage/containers_config.hpp
@@ -35,7 +35,7 @@ namespace samurai
     template <class value_type, std::size_t size = 1, bool SOA = false>
     using field_data_storage_t = eigen_container<value_type, size, SOA>;
 
-    template <class value_type, std::size_t size, bool SOA>
+    template <class value_type, std::size_t size, bool SOA = false>
     using local_field_data_t = eigen_collapsable_static_array<value_type, size, SOA>;
 
     template <class T>
@@ -45,7 +45,7 @@ namespace samurai
     template <class value_type, std::size_t size = 1, bool SOA = false>
     using field_data_storage_t = xtensor_container<value_type, size, SOA>;
 
-    template <class value_type, std::size_t size, bool>
+    template <class value_type, std::size_t size, bool SOA = false>
     using local_field_data_t = xtensor_collapsable_static_array<value_type, size>;
 
     template <class T>

--- a/include/samurai/timers.hpp
+++ b/include/samurai/timers.hpp
@@ -243,10 +243,10 @@ namespace samurai
 
             if (!has_total_runtime)
             {
-                // std::cout << "\t";
+                auto totalInSeconds = std::chrono::duration_cast<std::chrono::duration<double, std::ratio<1>>>(total_measured);
                 std::cout << std::setw(setwSizeName) << "Total";
-                std::cout << std::setw(setwSizeData) << total_measured.count();
-                std::cout << std::setw(setwSizeData) << total_perc;
+                std::cout << std::setw(setwSizeData) << std::setprecision(3) << totalInSeconds.count();
+                std::cout << std::setw(setwSizeData) << std::setprecision(1) << total_perc;
                 std::cout << std::endl;
             }
 


### PR DESCRIPTION
## Description
- A `StencilAnalyzer` class has been added to gather information about the stencil. This way, the analysis of the stencil is done only once instead of at every interval, thus improving the performance of the `StencilIterator`.
- The scheme object is no longer `const`, so that temporary variables can be stored in the class and reused upon application of the scheme. This change prepares the possibility of applying a scheme by batches.

## Code of Conduct
By submitting this PR, you agree to follow our [Code of Conduct](https://github.com/hpc-maths/samurai/blob/master/docs/CODE_OF_CONDUCT.md)
- [x] I agree to follow this project's Code of Conduct
