### PR TITLE
fix: add make_field_function

### DIFF
--- a/include/samurai/field_expression.hpp
+++ b/include/samurai/field_expression.hpp
@@ -122,6 +122,13 @@ namespace samurai
         , m_f(std::forward<Func>(f))
     {
     }
+
+    template <class F, class... E>
+    inline auto make_field_function(E&&... e) noexcept
+    {
+        using type = field_function<F, E...>;
+        return type(F(), std::forward<E>(e)...);
+    }
 } // namespace samurai
 
 namespace xt::detail


### PR DESCRIPTION
 ## Description
The `make_field_function` was removed in a previous version, but it is used in external projects. This PR simply adds it back.

## Code of Conduct
By submitting this PR, you agree to follow our [Code of Conduct](https://github.com/hpc-maths/samurai/blob/master/docs/CODE_OF_CONDUCT.md)
- [x] I agree to follow this project's Code of Conduct
