### PR TITLE
feat: Refine boundary

### DIFF
--- a/include/samurai/arguments.hpp
+++ b/include/samurai/arguments.hpp
@@ -10,6 +10,7 @@ namespace samurai
     {
         static bool timers                = false;
         static bool enable_max_level_flux = false;
+        static bool refine_boundary       = false;
     }
 
     inline void read_samurai_arguments(CLI::App& app, int& argc, char**& argv)
@@ -18,6 +19,7 @@ namespace samurai
         app.add_flag("--enable-max-level-flux", args::enable_max_level_flux, "Enable the computation of fluxes at the finest level")
             ->capture_default_str()
             ->group("SAMURAI");
+        app.add_flag("--refine-boundary", args::refine_boundary, "Keep the boundary refined at max_level")->capture_default_str()->group("SAMURAI");
         app.allow_extras();
         app.set_help_flag("", ""); // deactivate --help option
         try

--- a/include/samurai/boundary.hpp
+++ b/include/samurai/boundary.hpp
@@ -4,7 +4,7 @@
 namespace samurai
 {
     template <class Mesh, class Vector>
-    auto boundary(const Mesh& mesh, std::size_t level, const Vector& direction)
+    auto boundary_layer(const Mesh& mesh, std::size_t level, const Vector& direction, std::size_t layer_width)
     {
         using mesh_id_t = typename Mesh::mesh_id_t;
 
@@ -12,9 +12,24 @@ namespace samurai
         auto& domain = mesh.subdomain();
 
         auto max_level    = domain.level(); // domain.level();//mesh[mesh_id_t::cells].max_level();
-        auto one_interval = 1 << (max_level - level);
+        auto one_interval = layer_width << (max_level - level);
 
         return difference(cells, translate(domain, -one_interval * direction)).on(level);
+    }
+
+    template <class Mesh, class Vector>
+    auto boundary(const Mesh& mesh, std::size_t level, const Vector& direction)
+    {
+        // using mesh_id_t = typename Mesh::mesh_id_t;
+
+        // auto& cells  = mesh[mesh_id_t::cells][level];
+        // auto& domain = mesh.subdomain();
+
+        // auto max_level    = domain.level(); // domain.level();//mesh[mesh_id_t::cells].max_level();
+        // auto one_interval = 1 << (max_level - level);
+
+        // return difference(cells, translate(domain, -one_interval * direction)).on(level);
+        return boundary_layer(mesh, level, direction, 1);
     }
 
     template <class Mesh, class Subset, std::size_t stencil_size, class GetCoeffsFunc, class Func>

--- a/include/samurai/boundary.hpp
+++ b/include/samurai/boundary.hpp
@@ -20,15 +20,6 @@ namespace samurai
     template <class Mesh, class Vector>
     auto boundary(const Mesh& mesh, std::size_t level, const Vector& direction)
     {
-        // using mesh_id_t = typename Mesh::mesh_id_t;
-
-        // auto& cells  = mesh[mesh_id_t::cells][level];
-        // auto& domain = mesh.subdomain();
-
-        // auto max_level    = domain.level(); // domain.level();//mesh[mesh_id_t::cells].max_level();
-        // auto one_interval = 1 << (max_level - level);
-
-        // return difference(cells, translate(domain, -one_interval * direction)).on(level);
         return boundary_layer(mesh, level, direction, 1);
     }
 

--- a/include/samurai/mr/adapt.hpp
+++ b/include/samurai/mr/adapt.hpp
@@ -5,6 +5,7 @@
 
 #include "../algorithm/graduation.hpp"
 #include "../algorithm/update.hpp"
+#include "../arguments.hpp"
 #include "../boundary.hpp"
 #include "../field.hpp"
 #include "../hdf5.hpp"

--- a/include/samurai/mr/adapt.hpp
+++ b/include/samurai/mr/adapt.hpp
@@ -275,7 +275,7 @@ namespace samurai
             update_tag_subdomains(level, m_tag, true);
         }
 
-        if (args::refine_boundary)
+        if (args::refine_boundary) // cppcheck-suppress knownConditionTrueFalse
         {
             keep_boundary_refined(mesh, m_tag);
         }

--- a/include/samurai/mr/adapt.hpp
+++ b/include/samurai/mr/adapt.hpp
@@ -5,6 +5,7 @@
 
 #include "../algorithm/graduation.hpp"
 #include "../algorithm/update.hpp"
+#include "../boundary.hpp"
 #include "../field.hpp"
 #include "../hdf5.hpp"
 #include "../static_algorithm.hpp"
@@ -194,6 +195,37 @@ namespace samurai
         }
     }
 
+    template <class Mesh>
+    void keep_boundary_refined(const Mesh& mesh, Field<Mesh, int, 1>& tag, const DirectionVector<Mesh::dim>& direction)
+    {
+        // Since the adaptation process starts at max_level, we just need to flag to `keep` the boundary cells at max_level only.
+        // There will never be boundary cells at lower levels.
+        auto bdry = boundary_layer(mesh, mesh.max_level(), direction, Mesh::config::max_stencil_width);
+        for_each_cell(mesh,
+                      bdry,
+                      [&](auto& cell)
+                      {
+                          tag[cell] = static_cast<int>(CellFlag::keep);
+                      });
+    }
+
+    template <class Mesh>
+    void keep_boundary_refined(const Mesh& mesh, Field<Mesh, int, 1>& tag)
+    {
+        constexpr std::size_t dim = Mesh::dim;
+
+        DirectionVector<dim> direction;
+        direction.fill(0);
+        for (std::size_t d = 0; d < dim; ++d)
+        {
+            direction(d) = 1;
+            keep_boundary_refined(mesh, tag, direction);
+            direction(d) = -1;
+            keep_boundary_refined(mesh, tag, direction);
+            direction(d) = 0;
+        }
+    }
+
     template <bool enlarge_, class TField, class... TFields>
     template <class... Fields>
     bool Adapt<enlarge_, TField, TFields...>::harten(std::size_t ite, double eps, double regularity, Fields&... other_fields)
@@ -240,6 +272,11 @@ namespace samurai
                                            (pow(2.0, regularity_to_use)) * eps_l,
                                            max_level)); // Refinement according to Harten
             update_tag_subdomains(level, m_tag, true);
+        }
+
+        if (args::refine_boundary)
+        {
+            keep_boundary_refined(mesh, m_tag);
         }
 
         for (std::size_t level = min_level; level <= max_level - ite; ++level)

--- a/include/samurai/schemes/fv/flux_based/flux_based_scheme.hpp
+++ b/include/samurai/schemes/fv/flux_based/flux_based_scheme.hpp
@@ -21,7 +21,8 @@ namespace samurai
     {
         using bdry_cfg = BoundaryConfigFV<cfg::stencil_size / 2>;
 
-        if (args::enable_max_level_flux && cfg::dim > 1 && cfg::stencil_size > 4) // cppcheck-suppress knownConditionTrueFalse
+        if (args::enable_max_level_flux && cfg::dim > 1 && cfg::stencil_size > 4 && !args::refine_boundary) // cppcheck-suppress
+                                                                                                            // knownConditionTrueFalse
         {
             std::cout << "Warning: for stencils larger than 4, computing fluxes at max_level may cause issues close to the boundary."
                       << std::endl;

--- a/include/samurai/schemes/fv/flux_based/flux_based_scheme.hpp
+++ b/include/samurai/schemes/fv/flux_based/flux_based_scheme.hpp
@@ -21,8 +21,8 @@ namespace samurai
     {
         using bdry_cfg = BoundaryConfigFV<cfg::stencil_size / 2>;
 
-        if (args::enable_max_level_flux && cfg::dim > 1 && cfg::stencil_size > 4 && !args::refine_boundary) // cppcheck-suppress
-                                                                                                            // knownConditionTrueFalse
+        // cppcheck-suppress knownConditionTrueFalse
+        if (args::enable_max_level_flux && cfg::dim > 1 && cfg::stencil_size > 4 && !args::refine_boundary)
         {
             std::cout << "Warning: for stencils larger than 4, computing fluxes at max_level may cause issues close to the boundary."
                       << std::endl;

--- a/include/samurai/schemes/fv/flux_based/flux_based_scheme__nonlin.hpp
+++ b/include/samurai/schemes/fv/flux_based/flux_based_scheme__nonlin.hpp
@@ -69,7 +69,7 @@ namespace samurai
 
         void enable_max_level_flux(bool enable)
         {
-            if (enable && dim > 1 && stencil_size > 4)
+            if (enable && dim > 1 && stencil_size > 4 && !args::refine_boundary)
             {
                 std::cout << "Warning: for stencils larger than 4, computing fluxes at max_level may cause issues close to the boundary."
                           << std::endl;

--- a/include/samurai/schemes/fv/flux_based/flux_based_scheme__nonlin.hpp
+++ b/include/samurai/schemes/fv/flux_based/flux_based_scheme__nonlin.hpp
@@ -69,7 +69,7 @@ namespace samurai
 
         void enable_max_level_flux(bool enable)
         {
-            if (enable && dim > 1 && stencil_size > 4 && !args::refine_boundary)
+            if (enable && dim > 1 && stencil_size > 4 && !args::refine_boundary) // cppcheck-suppress knownConditionTrueFalse
             {
                 std::cout << "Warning: for stencils larger than 4, computing fluxes at max_level may cause issues close to the boundary."
                           << std::endl;


### PR DESCRIPTION
## Description
Use the command line argument `--refine-boundary` to keep a layer of boundary cells refined at max_level. The layer width corresponds to `Mesh::config::max_stencil_width`, in order to make sure that no interior interface computes its flux with a stencil that is partially outside of the domain. That way, only boundary interfaces use outside ghosts.

## Related issue
Although this refinement is artificial, it solves two problems (until we can find proper solutions):
- Numerous bugs occur when a stencil around an interior interface is partially outside the domain. In that case, it is not clear how many ghosts must be created and how to fill them.

Typical bad situation:
```
   domain           |     outside
                    |
|====|====|----|----|----|----|                                
                    |
                    |
          |=========|---------|---------|---------|---------| 
```
- For the computation of fluxes at the finest level, it is also not clear how to predict the values used to compute the boundary flux. Even for interior interfaces, allowing jumps close to the boundary creates issues for large stencils, because we'll need to predict values outside of the domain, which requires filling outside diagonals in every directions, etc.

## Code of Conduct
By submitting this PR, you agree to follow our [Code of Conduct](https://github.com/hpc-maths/samurai/blob/master/docs/CODE_OF_CONDUCT.md)
- [x] I agree to follow this project's Code of Conduct
