### PR TITLE
build: PETSc headers

### DIFF
--- a/demos/FiniteVolume/CMakeLists.txt
+++ b/demos/FiniteVolume/CMakeLists.txt
@@ -2,6 +2,7 @@ include(FindPkgConfig)
 pkg_check_modules(PETSC PETSc)
 
 if(PETSC_FOUND)
+    include_directories(${PETSC_INCLUDE_DIRS})
     find_package(MPI)
 
     add_executable(finite-volume-heat heat.cpp)


### PR DESCRIPTION
## Description
From the **Issue** https://github.com/hpc-maths/samurai/issues/271#issue-2868526250, the user cannot compile from source a test case using PETSc headers.

I fix this by editing the associated CMakeLists.txt file

- Previously, CMake failed to locate the PETSc headers
- Added include_directories to resolve this
- Now it works correclty (verified with Spack PM)

Now, PETSc header is correctly found and the test case compiles successfully.

## Related issue
https://github.com/hpc-maths/samurai/issues/271

## How has this been tested?
<!-- Give the list of files used to test this new implementation. -->

## Code of Conduct
By submitting this PR, you agree to follow our [Code of Conduct](https://github.com/hpc-maths/samurai/blob/master/docs/CODE_OF_CONDUCT.md)
- [x] I agree to follow this project's Code of Conduct
