### PR TITLE
fix: MPI for vector fields

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -270,8 +270,9 @@ jobs:
               shell: bash -l {0}
               run: |
                   cmake --build build --target finite-volume-advection-2d --parallel 4
+                  cmake --build build --target finite-volume-burgers --parallel 4
 
-            - name: MPI test
+            - name: MPI test finite-volume-advection-2d
               shell: bash -l {0}
               run: |
                   cd build
@@ -285,6 +286,21 @@ jobs:
                   python ../python/compare.py FV_advection_2d_size_1 FV_advection_2d_size_3
                   python ../python/compare.py FV_advection_2d_size_1 FV_advection_2d_size_4
                   python ../python/compare.py FV_advection_2d_size_1 FV_advection_2d_size_9
+
+            - name: MPI test finite-volume-burgers
+              shell: bash -l {0}
+              run: |
+                  cd build
+                  mpiexec -n 1 ./demos/FiniteVolume/finite-burgers --Tf 0.02 --nfiles 1 --max-level 7
+                  mpiexec -n 2 ./demos/FiniteVolume/finite-burgers --Tf 0.02 --nfiles 1 --max-level 7
+                  mpiexec -n 3 ./demos/FiniteVolume/finite-burgers --Tf 0.02 --nfiles 1 --max-level 7
+                  mpiexec -n 4 ./demos/FiniteVolume/finite-burgers --Tf 0.02 --nfiles 1 --max-level 7
+                  mpiexec -n 9 ./demos/FiniteVolume/finite-burgers --Tf 0.02 --nfiles 1 --max-level 7
+                  ls
+                  python ../python/compare.py burgers_2D_size_1 burgers_2D_size_2
+                  python ../python/compare.py burgers_2D_size_1 burgers_2D_size_3
+                  python ../python/compare.py burgers_2D_size_1 burgers_2D_size_4
+                  python ../python/compare.py burgers_2D_size_1 burgers_2D_size_9
 
     macos-mamba:
         needs: [pre-commit, cppcheck]

--- a/demos/FiniteVolume/burgers.cpp
+++ b/demos/FiniteVolume/burgers.cpp
@@ -37,7 +37,12 @@ void save(const fs::path& path, const std::string& filename, const Field& u, con
                                level_[cell] = cell.level;
                            });
 
+#ifdef SAMURAI_WITH_MPI
+    mpi::communicator world;
+    samurai::save(path, fmt::format("{}_size_{}{}", filename, world.size(), suffix), mesh, u, level_);
+#else
     samurai::save(path, fmt::format("{}{}", filename, suffix), mesh, u, level_);
+#endif
 }
 
 template <std::size_t dim, std::size_t field_size>

--- a/include/samurai/algorithm/update.hpp
+++ b/include/samurai/algorithm/update.hpp
@@ -212,9 +212,9 @@ namespace samurai
                     [&](const auto& i, const auto& index)
                     {
                         std::copy(to_recv.begin() + count,
-                                  to_recv.begin() + count + static_cast<ptrdiff_t>(i.size()),
+                                  to_recv.begin() + count + static_cast<ptrdiff_t>(i.size() * Field::size),
                                   field(level, i, index).begin());
-                        count += static_cast<ptrdiff_t>(i.size());
+                        count += static_cast<ptrdiff_t>(i.size() * Field::size);
                     });
             }
         }

--- a/include/samurai/boundary.hpp
+++ b/include/samurai/boundary.hpp
@@ -4,12 +4,12 @@
 namespace samurai
 {
     template <class Mesh, class Vector>
-    auto boundary_layer(const Mesh& mesh, std::size_t level, const Vector& direction, std::size_t layer_width)
+    auto
+    boundary_layer(const Mesh& mesh, const typename Mesh::lca_type& domain, std::size_t level, const Vector& direction, std::size_t layer_width)
     {
         using mesh_id_t = typename Mesh::mesh_id_t;
 
-        auto& cells  = mesh[mesh_id_t::cells][level];
-        auto& domain = mesh.subdomain();
+        auto& cells = mesh[mesh_id_t::cells][level];
 
         auto max_level    = domain.level(); // domain.level();//mesh[mesh_id_t::cells].max_level();
         auto one_interval = layer_width << (max_level - level);
@@ -18,9 +18,27 @@ namespace samurai
     }
 
     template <class Mesh, class Vector>
-    auto boundary(const Mesh& mesh, std::size_t level, const Vector& direction)
+    inline auto domain_boundary_layer(const Mesh& mesh, std::size_t level, const Vector& direction, std::size_t layer_width)
     {
-        return boundary_layer(mesh, level, direction, 1);
+        return boundary_layer(mesh, mesh.domain(), level, direction, layer_width);
+    }
+
+    template <class Mesh, class Vector>
+    inline auto subdomain_boundary_layer(const Mesh& mesh, std::size_t level, const Vector& direction, std::size_t layer_width)
+    {
+        return boundary_layer(mesh, mesh.subdomain(), level, direction, layer_width);
+    }
+
+    template <class Mesh, class Vector>
+    inline auto domain_boundary(const Mesh& mesh, std::size_t level, const Vector& direction)
+    {
+        return domain_boundary_layer(mesh, level, direction, 1);
+    }
+
+    template <class Mesh, class Vector>
+    inline auto subdomain_boundary(const Mesh& mesh, std::size_t level, const Vector& direction)
+    {
+        return subdomain_boundary_layer(mesh, level, direction, 1);
     }
 
     template <class Mesh, class Subset, std::size_t stencil_size, class GetCoeffsFunc, class Func>

--- a/include/samurai/interface.hpp
+++ b/include/samurai/interface.hpp
@@ -352,7 +352,7 @@ namespace samurai
         auto comput_stencil_it       = make_stencil_iterator(mesh, comput_stencil);
 #endif
 
-        auto bdry = boundary(mesh, level, direction);
+        auto bdry = subdomain_boundary(mesh, level, direction);
         for_each_meshinterval<mesh_interval_t, run_type>(bdry,
                                                          [&](auto mesh_interval)
                                                          {

--- a/include/samurai/mr/adapt.hpp
+++ b/include/samurai/mr/adapt.hpp
@@ -201,7 +201,7 @@ namespace samurai
     {
         // Since the adaptation process starts at max_level, we just need to flag to `keep` the boundary cells at max_level only.
         // There will never be boundary cells at lower levels.
-        auto bdry = boundary_layer(mesh, mesh.max_level(), direction, Mesh::config::max_stencil_width);
+        auto bdry = domain_boundary_layer(mesh, mesh.max_level(), direction, Mesh::config::max_stencil_width);
         for_each_cell(mesh,
                       bdry,
                       [&](auto& cell)


### PR DESCRIPTION
## Description
Management of vector fields in MPI.
Fix `--refine-boundary` in MPI.

## Related issue
Vector fields were not managed in MPI.
`--refine-boundary` also refined the boundaries between subdomains.

## How has this been tested?
Burgers demo.

## Code of Conduct
By submitting this PR, you agree to follow our [Code of Conduct](https://github.com/hpc-maths/samurai/blob/master/docs/CODE_OF_CONDUCT.md)
- [x] I agree to follow this project's Code of Conduct
