### PR TITLE
feat: min and max level can be changed

### DIFF
--- a/include/samurai/mesh.hpp
+++ b/include/samurai/mesh.hpp
@@ -91,7 +91,10 @@ namespace samurai
         const ca_type& operator[](mesh_id_t mesh_id) const;
 
         std::size_t max_level() const;
+        std::size_t& max_level();
         std::size_t min_level() const;
+        std::size_t& min_level();
+
         auto& origin_point() const;
         void set_origin_point(const coords_t& origin_point);
         double scaling_factor() const;
@@ -359,7 +362,19 @@ namespace samurai
     }
 
     template <class D, class Config>
+    inline std::size_t& Mesh_base<D, Config>::max_level()
+    {
+        return m_max_level;
+    }
+
+    template <class D, class Config>
     inline std::size_t Mesh_base<D, Config>::min_level() const
+    {
+        return m_min_level;
+    }
+
+    template <class D, class Config>
+    inline std::size_t& Mesh_base<D, Config>::min_level()
     {
         return m_min_level;
     }


### PR DESCRIPTION
## Description
When a mesh is created, the minimum and maximum levels can only be read. It can be interesting to be able to change these values during the computation. This PR adds a set method for both. 

## Code of Conduct
By submitting this PR, you agree to follow our [Code of Conduct](https://github.com/hpc-maths/samurai/blob/master/docs/CODE_OF_CONDUCT.md)
- [x] I agree to follow this project's Code of Conduct
