### PR TITLE
fix: remove include

### DIFF
--- a/demos/FiniteVolume/linear_convection.cpp
+++ b/demos/FiniteVolume/linear_convection.cpp
@@ -173,7 +173,6 @@ int main(int argc, char* argv[])
         save(path, filename, u, suffix);
     }
 
-#include <samurai/io/restart.hpp>
     while (t != Tf)
     {
         // Move to next timestep


### PR DESCRIPTION
 ## Description
This PR removes a wrong copy-paste of include in linear-convection example.

## Code of Conduct
By submitting this PR, you agree to follow our [Code of Conduct](https://github.com/hpc-maths/samurai/blob/master/docs/CODE_OF_CONDUCT.md)
- [x] I agree to follow this project's Code of Conduct
