### PR TITLE
build: cmake correction

### DIFF
--- a/demos/FiniteVolume/CMakeLists.txt
+++ b/demos/FiniteVolume/CMakeLists.txt
@@ -12,7 +12,7 @@ if(PETSC_FOUND)
     target_link_libraries(finite-volume-heat-heterogeneous samurai CLI11::CLI11 ${PETSC_LINK_LIBRARIES} ${MPI_LIBRARIES})
 
     add_executable(finite-volume-heat-nonlinear heat_nonlinear.cpp)
-    target_link_libraries(finite-volume-heat-nonlinear samurai CLI11::CLI11 ${PETSC_LIBRARIES} ${MPI_LIBRARIES})
+    target_link_libraries(finite-volume-heat-nonlinear samurai CLI11::CLI11 ${PETSC_LINK_LIBRARIES} ${MPI_LIBRARIES})
 
     add_executable(finite-volume-stokes-2d stokes_2d.cpp)
     target_link_libraries(finite-volume-stokes-2d samurai CLI11::CLI11 ${PETSC_LINK_LIBRARIES} ${MPI_LIBRARIES})

--- a/demos/highorder/CMakeLists.txt
+++ b/demos/highorder/CMakeLists.txt
@@ -1,9 +1,10 @@
 include(FindPkgConfig)
 pkg_check_modules(PETSC PETSc)
 if (PETSC_FOUND)
+    include_directories(${PETSC_INCLUDE_DIRS})	
     find_package(MPI)
 
     add_executable(highorder main.cpp)
 
-    target_link_libraries(highorder samurai ${PETSC_LINK_LIBRARIES} ${MPI_LIBRARIES})
+    target_link_libraries(highorder samurai CLI11::CLI11 ${PETSC_LINK_LIBRARIES} ${MPI_LIBRARIES})
 endif()

--- a/demos/highorder/CMakeLists.txt
+++ b/demos/highorder/CMakeLists.txt
@@ -1,7 +1,7 @@
 include(FindPkgConfig)
 pkg_check_modules(PETSC PETSc)
 if (PETSC_FOUND)
-    include_directories(${PETSC_INCLUDE_DIRS})	
+    include_directories(${PETSC_INCLUDE_DIRS})
     find_package(MPI)
 
     add_executable(highorder main.cpp)

--- a/demos/multigrid/CMakeLists.txt
+++ b/demos/multigrid/CMakeLists.txt
@@ -1,9 +1,10 @@
 include(FindPkgConfig)
 pkg_check_modules(PETSC PETSc)
+
 if (PETSC_FOUND)
+    include_directories(${PETSC_INCLUDE_DIRS})
     find_package(MPI)
 
     add_executable(multigrid main.cpp)
-
-    target_link_libraries(multigrid samurai ${PETSC_LINK_LIBRARIES} ${MPI_LIBRARIES})
+    target_link_libraries(multigrid samurai CLI11::CLI11 ${PETSC_LINK_LIBRARIES} ${MPI_LIBRARIES})
 endif()


### PR DESCRIPTION
## Description
<!-- A clear and concise description of what you have done in this PR. -->
- PETSC headers :
	-	Previously, petsc headers are not included in multigrid, highorder and one FiniteVolume Demo.
	-	Without conda-forge, we need to add it manually
- CLI11 linking :
	-	Previously, CLI11 was not included in the link
	
## Code of Conduct
By submitting this PR, you agree to follow our [Code of Conduct](https://github.com/hpc-maths/samurai/blob/master/docs/CODE_OF_CONDUCT.md)
- [x] I agree to follow this project's Code of Conduct
