### PR TITLE
perf: Avoid multiple serialization

### DIFF
--- a/include/samurai/mesh.hpp
+++ b/include/samurai/mesh.hpp
@@ -623,12 +623,16 @@ namespace samurai
         mpi::communicator world;
         std::vector<mpi::request> req;
 
+        boost::mpi::packed_oarchive::buffer_type buffer;
+        boost::mpi::packed_oarchive oa(world, buffer);
+        oa << derived_cast();
+
         std::transform(m_mpi_neighbourhood.cbegin(),
                        m_mpi_neighbourhood.cend(),
                        std::back_inserter(req),
                        [&](const auto& neighbour)
                        {
-                           return world.isend(neighbour.rank, neighbour.rank, derived_cast());
+                           return world.isend(neighbour.rank, neighbour.rank, buffer);
                        });
 
         for (auto& neighbour : m_mpi_neighbourhood)


### PR DESCRIPTION
## Description
- We send the mesh to the neighborhood with `boost::send` calls
- But currently, this `boost::send` serialize the mesh for **each** send, even if it is always the same mesh.
- But we can serialize the mesh once and send the buffer.
- It is only tested on advection-2d, with a performance gain

## Related issue
Performance issue when using MPI

## How has this been tested?
It has been tested on the advection-2d test case

## Code of Conduct
By submitting this PR, you agree to follow our [Code of Conduct](https://github.com/hpc-maths/samurai/blob/master/docs/CODE_OF_CONDUCT.md)
- [x] I agree to follow this project's Code of Conduct
