### PR TITLE
fix: Repare MPI in 1D

### DIFF
--- a/include/samurai/mesh.hpp
+++ b/include/samurai/mesh.hpp
@@ -783,14 +783,14 @@ namespace samurai
         this->m_cells[mesh_id_t::cells][start_level] = {start_level, subdomain_box};
         */
 
-        // in 1D
         int subdomain_start = -1;
         int subdomain_end   = -1;
         lcl_type subdomain_cells(start_level, m_domain.origin_point(), m_domain.scaling_factor());
+        // in 1D MPI, we need a specific partitioning
         if (dim == 1)
         {
             auto n_cells              = m_domain.nb_cells();
-            int n_cells_per_subdomain = (int)(n_cells / size);
+            int n_cells_per_subdomain = static_cast<int>(n_cells / size);
             subdomain_start           = n_cells_per_subdomain * rank;
             subdomain_end             = n_cells_per_subdomain * (rank + 1);
             // for the last rank, we have to take all the last cells;
@@ -801,9 +801,12 @@ namespace samurai
         }
         else
         {
-            auto subdomain_nb_intervals = m_domain.nb_intervals() / static_cast<std::size_t>(size);
-            subdomain_start             = static_cast<std::size_t>(rank) * subdomain_nb_intervals;
-            subdomain_end               = (static_cast<std::size_t>(rank) + 1) * subdomain_nb_intervals;
+            (dim > 1)
+            {
+                auto subdomain_nb_intervals = m_domain.nb_intervals() / static_cast<std::size_t>(size);
+                subdomain_start             = static_cast<std::size_t>(rank) * subdomain_nb_intervals;
+                subdomain_end               = (static_cast<std::size_t>(rank) + 1) * subdomain_nb_intervals;
+            }
         }
         std::size_t k = 0;
         for_each_meshinterval(m_domain,

--- a/include/samurai/mesh.hpp
+++ b/include/samurai/mesh.hpp
@@ -796,7 +796,7 @@ namespace samurai
             // for the last rank, we have to take all the last cells;
             if (rank == size - 1)
             {
-                subdomain_end = n_cells_per_subdomain;
+                subdomain_end = n_cells;
             }
         }
         else if (dim >= 2)

--- a/include/samurai/mesh.hpp
+++ b/include/samurai/mesh.hpp
@@ -799,14 +799,11 @@ namespace samurai
                 subdomain_end = n_cells_per_subdomain;
             }
         }
-        else
+        else if (dim >= 2)
         {
-            (dim > 1)
-            {
-                auto subdomain_nb_intervals = m_domain.nb_intervals() / static_cast<std::size_t>(size);
-                subdomain_start             = static_cast<std::size_t>(rank) * subdomain_nb_intervals;
-                subdomain_end               = (static_cast<std::size_t>(rank) + 1) * subdomain_nb_intervals;
-            }
+            auto subdomain_nb_intervals = m_domain.nb_intervals() / static_cast<std::size_t>(size);
+            subdomain_start             = static_cast<std::size_t>(rank) * subdomain_nb_intervals;
+            subdomain_end               = (static_cast<std::size_t>(rank) + 1) * subdomain_nb_intervals;
         }
         std::size_t k = 0;
         for_each_meshinterval(m_domain,

--- a/include/samurai/mesh.hpp
+++ b/include/samurai/mesh.hpp
@@ -789,16 +789,15 @@ namespace samurai
         // in 1D MPI, we need a specific partitioning
         if (dim == 1)
         {
-            auto n_cells              = m_domain.nb_cells();
-            int n_cells_per_subdomain = static_cast<int>(n_cells / size);
-            subdomain_start           = n_cells_per_subdomain * rank;
-            subdomain_end             = n_cells_per_subdomain * (rank + 1);
+            std::size_t n_cells               = m_domain.nb_cells();
+            std::size_t n_cells_per_subdomain = n_cells / static_cast<std::size_t>(size);
+            subdomain_start                   = n_cells_per_subdomain * static_cast<std::size_t>(rank);
+            subdomain_end                     = n_cells_per_subdomain * (static_cast<std::size_t>(rank) + 1);
             // for the last rank, we have to take all the last cells;
             if (rank == size - 1)
             {
                 subdomain_end = n_cells;
             }
-            std::size_t k = 0;
             for_each_meshinterval(m_domain,
                                   [&](auto mi)
                                   {

--- a/include/samurai/mesh.hpp
+++ b/include/samurai/mesh.hpp
@@ -815,7 +815,11 @@ namespace samurai
             auto subdomain_nb_intervals = m_domain.nb_intervals() / static_cast<std::size_t>(size);
             subdomain_start             = static_cast<std::size_t>(rank) * subdomain_nb_intervals;
             subdomain_end               = (static_cast<std::size_t>(rank) + 1) * subdomain_nb_intervals;
-            std::size_t k               = 0;
+            if (rank == size - 1)
+            {
+                subdomain_end = m_domain.nb_intervals();
+            }
+            std::size_t k = 0;
             for_each_meshinterval(m_domain,
                                   [&](auto mi)
                                   {


### PR DESCRIPTION
## Description
- Previously, in multirank MPI, m_cells was empty due to a bad n_cells per subdomains computation
- Then I add a specific partitioning for 1D MPI :
    - We compute the number of cells in the original mesh
    - Each subdomain gets a part of the nb_cells

## Related issue
Previously, in 1D, in multirank MPI, the mesh was constructed empty. 
see https://github.com/hpc-maths/samurai/issues/290#issue-2928445322

## How has this been tested?
advection_1d is runnin, butt we need more tests

## Code of Conduct
By submitting this PR, you agree to follow our [Code of Conduct](https://github.com/hpc-maths/samurai/blob/master/docs/CODE_OF_CONDUCT.md)
- [x] I agree to follow this project's Code of Conduct
