### PR TITLE
fix: Python script to read MPI meshes

### DIFF
--- a/python/read_mesh.py
+++ b/python/read_mesh.py
@@ -46,16 +46,21 @@ class Plot:
                 ax = plt.subplot(1, len(args.field), i + 1)
                 mesh = read_mesh(filename)
 
-                unknown_field = next((f for f in args.field if f not in mesh['fields']), None)
-
-                if unknown_field is not None:
-                    keys = ' '.join(mesh['fields'].keys())
-                    raise ValueError(f"file:{filename}> field:{unknown_field} not in available fields values: {keys}")
-
                 if 'points' in mesh:
+                    unknown_field = next((f for f in args.field if f not in mesh['fields']), None)
+
+                    if unknown_field is not None:
+                        keys = ' '.join(mesh['fields'].keys())
+                        raise ValueError(f"file:{filename}> field:{unknown_field} not in available fields values: {keys}")
+
                     self.plot(ax, mesh, f)
                 else:
                     for rank in mesh.keys():
+                        unknown_field = next((f for f in args.field if f not in mesh[rank]['fields']), None)
+
+                        if unknown_field is not None:
+                            keys = ' '.join(mesh[rank]['fields'].keys())
+                            raise ValueError(f"file:{filename}> field:{unknown_field} not in available fields values: {keys}")
                         self.plot(ax, mesh[rank], f)
                 ax.set_title(f)
                 self.ax.append(ax)


### PR DESCRIPTION
 ## Description
The actual `read_mesh.py` script used to read 1D meshes is broken for MPI field visualization. This PR fixes this issue.

## Code of Conduct
By submitting this PR, you agree to follow our [Code of Conduct](https://github.com/hpc-maths/samurai/blob/master/docs/CODE_OF_CONDUCT.md)
- [x] I agree to follow this project's Code of Conduct
