### PR TITLE
feat: add ScalarField and VectorField

### DIFF
--- a/demos/FiniteVolume/AMR_Burgers_Hat.cpp
+++ b/demos/FiniteVolume/AMR_Burgers_Hat.cpp
@@ -253,7 +253,7 @@ int main(int argc, char* argv[])
 
     auto phinp1 = samurai::make_field<double, 1>("phi", mesh);
 
-    auto tag = samurai::make_field<int, 1>("tag", mesh);
+    auto tag = samurai::make_field<int>("tag", mesh);
     const xt::xtensor_fixed<int, xt::xshape<2, 1>> stencil_grad{{1}, {-1}};
 
     const double dx      = mesh.cell_length(max_level);

--- a/demos/FiniteVolume/AMR_Burgers_Hat.cpp
+++ b/demos/FiniteVolume/AMR_Burgers_Hat.cpp
@@ -126,7 +126,7 @@ template <class Field>
 void save(const fs::path& path, const std::string& filename, const Field& u, const std::string& suffix = "")
 {
     auto mesh   = u.mesh();
-    auto level_ = samurai::make_field<std::size_t>("level", mesh);
+    auto level_ = samurai::make_scalar_field<std::size_t>("level", mesh);
 
     if (!fs::exists(path))
     {
@@ -237,7 +237,7 @@ int main(int argc, char* argv[])
 
     const samurai::Box<double, dim> box({left_box}, {right_box});
     samurai::amr::Mesh<Config> mesh;
-    auto phi = samurai::make_field<double>("phi", mesh);
+    auto phi = samurai::make_scalar_field<double>("phi", mesh);
 
     if (restart_file.empty())
     {
@@ -251,9 +251,9 @@ int main(int argc, char* argv[])
 
     samurai::make_bc<samurai::Neumann<1>>(phi, 0.);
 
-    auto phinp1 = samurai::make_field<double>("phi", mesh);
+    auto phinp1 = samurai::make_scalar_field<double>("phi", mesh);
 
-    auto tag = samurai::make_field<int>("tag", mesh);
+    auto tag = samurai::make_scalar_field<int>("tag", mesh);
     const xt::xtensor_fixed<int, xt::xshape<2, 1>> stencil_grad{{1}, {-1}};
 
     const double dx      = mesh.cell_length(max_level);

--- a/demos/FiniteVolume/AMR_Burgers_Hat.cpp
+++ b/demos/FiniteVolume/AMR_Burgers_Hat.cpp
@@ -126,7 +126,7 @@ template <class Field>
 void save(const fs::path& path, const std::string& filename, const Field& u, const std::string& suffix = "")
 {
     auto mesh   = u.mesh();
-    auto level_ = samurai::make_field<std::size_t, 1>("level", mesh);
+    auto level_ = samurai::make_field<std::size_t>("level", mesh);
 
     if (!fs::exists(path))
     {
@@ -237,7 +237,7 @@ int main(int argc, char* argv[])
 
     const samurai::Box<double, dim> box({left_box}, {right_box});
     samurai::amr::Mesh<Config> mesh;
-    auto phi = samurai::make_field<double, 1>("phi", mesh);
+    auto phi = samurai::make_field<double>("phi", mesh);
 
     if (restart_file.empty())
     {
@@ -251,7 +251,7 @@ int main(int argc, char* argv[])
 
     samurai::make_bc<samurai::Neumann<1>>(phi, 0.);
 
-    auto phinp1 = samurai::make_field<double, 1>("phi", mesh);
+    auto phinp1 = samurai::make_field<double>("phi", mesh);
 
     auto tag = samurai::make_field<int>("tag", mesh);
     const xt::xtensor_fixed<int, xt::xshape<2, 1>> stencil_grad{{1}, {-1}};

--- a/demos/FiniteVolume/BZ/bz_2d.cpp
+++ b/demos/FiniteVolume/BZ/bz_2d.cpp
@@ -49,7 +49,7 @@ auto init_field(Mesh& mesh, const double f = 1.6, const double q = 2.e-3)
     field[0] : 'b' in the model
     field[1] : 'c' in the model
     */
-    auto field = samurai::make_field<double, 2>("solution", mesh);
+    auto field = samurai::make_vector_field<double, 2>("solution", mesh);
 
     samurai::for_each_cell(mesh[mesh_id_t::reference],
                            [&](auto cell)

--- a/demos/FiniteVolume/BZ/bz_2d_AMR.cpp
+++ b/demos/FiniteVolume/BZ/bz_2d_AMR.cpp
@@ -138,7 +138,7 @@ auto init_field(Mesh& mesh, const double f = 1.6, const double q = 2.e-3)
     field[0] : 'b' in the model
     field[1] : 'c' in the model
     */
-    auto field = samurai::make_field<double, 2>("solution", mesh);
+    auto field = samurai::make_vector_field<double, 2>("solution", mesh);
 
     samurai::for_each_cell(mesh[mesh_id_t::reference],
                            [&](auto cell)
@@ -468,7 +468,7 @@ void AMR_criterion(Field& f, Func&& update_bc_for_level, Tag& tag, std::size_t i
     // which is then used to decide where to enlarge.
     // This problem was solved in multiresolution by adding the choice of
     // the flag enlarge, but to do this we should change other parts of the code
-    auto tag_tmp = samurai::make_field<int, 1>("tag", mesh);
+    auto tag_tmp = samurai::make_scalar_field<int>("tag", mesh);
     tag_tmp.fill(static_cast<int>(samurai::CellFlag::keep));
 
     for (std::size_t level = min_level; level <= max_level; ++level)
@@ -697,7 +697,7 @@ int main()
 
         while (true)
         {
-            auto tag = samurai::make_field<int, 1>("tag", mesh);
+            auto tag = samurai::make_scalar_field<int>("tag", mesh);
             AMR_criterion(field, update_bc_for_level, tag, idx);
             make_graduation(tag);
             if (update_mesh(field, tag))

--- a/demos/FiniteVolume/advection_1d.cpp
+++ b/demos/FiniteVolume/advection_1d.cpp
@@ -90,7 +90,7 @@ template <class Field>
 void save(const fs::path& path, const std::string& filename, const Field& u, const std::string& suffix = "")
 {
     auto mesh   = u.mesh();
-    auto level_ = samurai::make_field<std::size_t, 1>("level", mesh);
+    auto level_ = samurai::make_field<std::size_t>("level", mesh);
 
     if (!fs::exists(path))
     {
@@ -165,7 +165,7 @@ int main(int argc, char* argv[])
 
     const samurai::Box<double, dim> box({left_box}, {right_box});
     samurai::MRMesh<Config> mesh;
-    auto u = samurai::make_field<double, 1>("u", mesh);
+    auto u = samurai::make_field<double>("u", mesh);
 
     if (restart_file.empty())
     {
@@ -188,7 +188,7 @@ int main(int argc, char* argv[])
         // same as (just to test OnDirection instead of Everywhere)
         // samurai::make_bc<samurai::Dirichlet<1>>(u, 0.);
     }
-    auto unp1 = samurai::make_field<double, 1>("unp1", mesh);
+    auto unp1 = samurai::make_field<double>("unp1", mesh);
 
     auto MRadaptation = samurai::make_MRAdapt(u);
     MRadaptation(mr_epsilon, mr_regularity);

--- a/demos/FiniteVolume/advection_1d.cpp
+++ b/demos/FiniteVolume/advection_1d.cpp
@@ -90,7 +90,7 @@ template <class Field>
 void save(const fs::path& path, const std::string& filename, const Field& u, const std::string& suffix = "")
 {
     auto mesh   = u.mesh();
-    auto level_ = samurai::make_field<std::size_t>("level", mesh);
+    auto level_ = samurai::make_scalar_field<std::size_t>("level", mesh);
 
     if (!fs::exists(path))
     {
@@ -165,7 +165,7 @@ int main(int argc, char* argv[])
 
     const samurai::Box<double, dim> box({left_box}, {right_box});
     samurai::MRMesh<Config> mesh;
-    auto u = samurai::make_field<double>("u", mesh);
+    auto u = samurai::make_scalar_field<double>("u", mesh);
 
     if (restart_file.empty())
     {
@@ -188,7 +188,7 @@ int main(int argc, char* argv[])
         // same as (just to test OnDirection instead of Everywhere)
         // samurai::make_bc<samurai::Dirichlet<1>>(u, 0.);
     }
-    auto unp1 = samurai::make_field<double>("unp1", mesh);
+    auto unp1 = samurai::make_scalar_field<double>("unp1", mesh);
 
     auto MRadaptation = samurai::make_MRAdapt(u);
     MRadaptation(mr_epsilon, mr_regularity);

--- a/demos/FiniteVolume/advection_2d.cpp
+++ b/demos/FiniteVolume/advection_2d.cpp
@@ -147,7 +147,7 @@ template <class Field>
 void save(const fs::path& path, const std::string& filename, const Field& u, const std::string& suffix = "")
 {
     auto mesh   = u.mesh();
-    auto level_ = samurai::make_field<std::size_t, 1>("level", mesh);
+    auto level_ = samurai::make_field<std::size_t>("level", mesh);
 
     if (!fs::exists(path))
     {
@@ -226,7 +226,7 @@ int main(int argc, char* argv[])
 
     const samurai::Box<double, dim> box(min_corner, max_corner);
     samurai::MRMesh<Config> mesh;
-    auto u = samurai::make_field<double, 1>("u", mesh);
+    auto u = samurai::make_field<double>("u", mesh);
 
     if (restart_file.empty())
     {
@@ -242,7 +242,7 @@ int main(int argc, char* argv[])
     double dt            = cfl * mesh.cell_length(max_level);
     const double dt_save = Tf / static_cast<double>(nfiles);
 
-    auto unp1 = samurai::make_field<double, 1>("unp1", mesh);
+    auto unp1 = samurai::make_field<double>("unp1", mesh);
 
     auto MRadaptation = samurai::make_MRAdapt(u);
     MRadaptation(mr_epsilon, mr_regularity);

--- a/demos/FiniteVolume/advection_2d.cpp
+++ b/demos/FiniteVolume/advection_2d.cpp
@@ -147,7 +147,7 @@ template <class Field>
 void save(const fs::path& path, const std::string& filename, const Field& u, const std::string& suffix = "")
 {
     auto mesh   = u.mesh();
-    auto level_ = samurai::make_field<std::size_t>("level", mesh);
+    auto level_ = samurai::make_scalar_field<std::size_t>("level", mesh);
 
     if (!fs::exists(path))
     {
@@ -226,7 +226,7 @@ int main(int argc, char* argv[])
 
     const samurai::Box<double, dim> box(min_corner, max_corner);
     samurai::MRMesh<Config> mesh;
-    auto u = samurai::make_field<double>("u", mesh);
+    auto u = samurai::make_scalar_field<double>("u", mesh);
 
     if (restart_file.empty())
     {
@@ -242,7 +242,7 @@ int main(int argc, char* argv[])
     double dt            = cfl * mesh.cell_length(max_level);
     const double dt_save = Tf / static_cast<double>(nfiles);
 
-    auto unp1 = samurai::make_field<double>("unp1", mesh);
+    auto unp1 = samurai::make_scalar_field<double>("unp1", mesh);
 
     auto MRadaptation = samurai::make_MRAdapt(u);
     MRadaptation(mr_epsilon, mr_regularity);

--- a/demos/FiniteVolume/advection_2d_user_bc.cpp
+++ b/demos/FiniteVolume/advection_2d_user_bc.cpp
@@ -172,7 +172,7 @@ template <class Field>
 void save(const fs::path& path, const std::string& filename, const Field& u, const std::string& suffix = "")
 {
     auto mesh   = u.mesh();
-    auto level_ = samurai::make_field<std::size_t>("level", mesh);
+    auto level_ = samurai::make_scalar_field<std::size_t>("level", mesh);
 
     if (!fs::exists(path))
     {
@@ -247,7 +247,7 @@ int main(int argc, char* argv[])
 
     const samurai::Box<double, dim> box(min_corner, max_corner);
     samurai::MRMesh<Config> mesh;
-    auto u = samurai::make_field<double>("u", mesh);
+    auto u = samurai::make_scalar_field<double>("u", mesh);
 
     if (restart_file.empty())
     {
@@ -263,7 +263,7 @@ int main(int argc, char* argv[])
     double dt            = cfl * mesh.cell_length(max_level);
     const double dt_save = Tf / static_cast<double>(nfiles);
 
-    auto unp1 = samurai::make_field<double>("unp1", mesh);
+    auto unp1 = samurai::make_scalar_field<double>("unp1", mesh);
 
     auto MRadaptation = samurai::make_MRAdapt(u);
     MRadaptation(mr_epsilon, mr_regularity);

--- a/demos/FiniteVolume/advection_2d_user_bc.cpp
+++ b/demos/FiniteVolume/advection_2d_user_bc.cpp
@@ -172,7 +172,7 @@ template <class Field>
 void save(const fs::path& path, const std::string& filename, const Field& u, const std::string& suffix = "")
 {
     auto mesh   = u.mesh();
-    auto level_ = samurai::make_field<std::size_t, 1>("level", mesh);
+    auto level_ = samurai::make_field<std::size_t>("level", mesh);
 
     if (!fs::exists(path))
     {
@@ -247,7 +247,7 @@ int main(int argc, char* argv[])
 
     const samurai::Box<double, dim> box(min_corner, max_corner);
     samurai::MRMesh<Config> mesh;
-    auto u = samurai::make_field<double, 1>("u", mesh);
+    auto u = samurai::make_field<double>("u", mesh);
 
     if (restart_file.empty())
     {
@@ -263,7 +263,7 @@ int main(int argc, char* argv[])
     double dt            = cfl * mesh.cell_length(max_level);
     const double dt_save = Tf / static_cast<double>(nfiles);
 
-    auto unp1 = samurai::make_field<double, 1>("unp1", mesh);
+    auto unp1 = samurai::make_field<double>("unp1", mesh);
 
     auto MRadaptation = samurai::make_MRAdapt(u);
     MRadaptation(mr_epsilon, mr_regularity);

--- a/demos/FiniteVolume/burgers.cpp
+++ b/demos/FiniteVolume/burgers.cpp
@@ -25,7 +25,7 @@ template <class Field>
 void save(const fs::path& path, const std::string& filename, const Field& u, const std::string& suffix = "")
 {
     auto mesh   = u.mesh();
-    auto level_ = samurai::make_field<std::size_t>("level", mesh);
+    auto level_ = samurai::make_scalar_field<std::size_t>("level", mesh);
 
     if (!fs::exists(path))
     {
@@ -120,10 +120,10 @@ int main_dim(int argc, char* argv[])
     Box box(box_corner1, box_corner2);
     samurai::MRMesh<Config> mesh;
 
-    auto u    = samurai::make_field<n_comp>("u", mesh);
-    auto u1   = samurai::make_field<n_comp>("u1", mesh);
-    auto u2   = samurai::make_field<n_comp>("u2", mesh);
-    auto unp1 = samurai::make_field<n_comp>("unp1", mesh);
+    auto u    = samurai::make_vector_field<n_comp>("u", mesh);
+    auto u1   = samurai::make_vector_field<n_comp>("u1", mesh);
+    auto u2   = samurai::make_vector_field<n_comp>("u2", mesh);
+    auto unp1 = samurai::make_vector_field<n_comp>("unp1", mesh);
 
     if (restart_file.empty())
     {

--- a/demos/FiniteVolume/burgers.cpp
+++ b/demos/FiniteVolume/burgers.cpp
@@ -25,7 +25,7 @@ template <class Field>
 void save(const fs::path& path, const std::string& filename, const Field& u, const std::string& suffix = "")
 {
     auto mesh   = u.mesh();
-    auto level_ = samurai::make_field<std::size_t, 1>("level", mesh);
+    auto level_ = samurai::make_field<std::size_t>("level", mesh);
 
     if (!fs::exists(path))
     {

--- a/demos/FiniteVolume/burgers_mra.cpp
+++ b/demos/FiniteVolume/burgers_mra.cpp
@@ -50,7 +50,7 @@ template <class Field>
 void save(const fs::path& path, const std::string& filename, const Field& u, const std::string& suffix = "")
 {
     auto mesh   = u.mesh();
-    auto level_ = samurai::make_field<std::size_t, 1>("level", mesh);
+    auto level_ = samurai::make_field<std::size_t>("level", mesh);
 
     if (!fs::exists(path))
     {
@@ -283,11 +283,11 @@ int main(int argc, char* argv[])
     samurai::MRMesh<Config> mesh{box, min_level, max_level};
     samurai::MRMesh<Config> max_level_mesh{box, max_level, max_level};
 
-    auto u    = samurai::make_field<1>("u", mesh);
-    auto unp1 = samurai::make_field<1>("unp1", mesh);
+    auto u    = samurai::make_field<double>("u", mesh);
+    auto unp1 = samurai::make_field<double>("unp1", mesh);
 
-    auto u_max    = samurai::make_field<1>("u", max_level_mesh);
-    auto unp1_max = samurai::make_field<1>("unp1", max_level_mesh);
+    auto u_max    = samurai::make_field<double>("u", max_level_mesh);
+    auto unp1_max = samurai::make_field<double>("unp1", max_level_mesh);
 
     filename += "_" + init_sol;
 

--- a/demos/FiniteVolume/burgers_mra.cpp
+++ b/demos/FiniteVolume/burgers_mra.cpp
@@ -50,7 +50,7 @@ template <class Field>
 void save(const fs::path& path, const std::string& filename, const Field& u, const std::string& suffix = "")
 {
     auto mesh   = u.mesh();
-    auto level_ = samurai::make_field<std::size_t>("level", mesh);
+    auto level_ = samurai::make_scalar_field<std::size_t>("level", mesh);
 
     if (!fs::exists(path))
     {
@@ -283,11 +283,11 @@ int main(int argc, char* argv[])
     samurai::MRMesh<Config> mesh{box, min_level, max_level};
     samurai::MRMesh<Config> max_level_mesh{box, max_level, max_level};
 
-    auto u    = samurai::make_field<double>("u", mesh);
-    auto unp1 = samurai::make_field<double>("unp1", mesh);
+    auto u    = samurai::make_scalar_field<double>("u", mesh);
+    auto unp1 = samurai::make_scalar_field<double>("unp1", mesh);
 
-    auto u_max    = samurai::make_field<double>("u", max_level_mesh);
-    auto unp1_max = samurai::make_field<double>("unp1", max_level_mesh);
+    auto u_max    = samurai::make_scalar_field<double>("u", max_level_mesh);
+    auto unp1_max = samurai::make_scalar_field<double>("unp1", max_level_mesh);
 
     filename += "_" + init_sol;
 

--- a/demos/FiniteVolume/heat.cpp
+++ b/demos/FiniteVolume/heat.cpp
@@ -27,7 +27,7 @@ template <class Field>
 void save(const fs::path& path, const std::string& filename, const Field& u, const std::string& suffix = "")
 {
     auto mesh   = u.mesh();
-    auto level_ = samurai::make_field<std::size_t, 1>("level", mesh);
+    auto level_ = samurai::make_field<std::size_t>("level", mesh);
 
     if (!fs::exists(path))
     {
@@ -145,7 +145,7 @@ int main(int argc, char* argv[])
     Box box(box_corner1, box_corner2);
     samurai::MRMesh<Config> mesh;
 
-    auto u = samurai::make_field<1>("u", mesh);
+    auto u = samurai::make_field<>("u", mesh);
 
     if (restart_file.empty())
     {
@@ -180,7 +180,7 @@ int main(int argc, char* argv[])
         samurai::load(restart_file, mesh, u);
     }
 
-    auto unp1 = samurai::make_field<1>("unp1", mesh);
+    auto unp1 = samurai::make_field<>("unp1", mesh);
 
     samurai::make_bc<samurai::Neumann<1>>(u, 0.);
     samurai::make_bc<samurai::Neumann<1>>(unp1, 0.);

--- a/demos/FiniteVolume/heat.cpp
+++ b/demos/FiniteVolume/heat.cpp
@@ -145,7 +145,7 @@ int main(int argc, char* argv[])
     Box box(box_corner1, box_corner2);
     samurai::MRMesh<Config> mesh;
 
-    auto u = samurai::make_scalar_field("u", mesh);
+    auto u = samurai::make_scalar_field<double>("u", mesh);
 
     if (restart_file.empty())
     {
@@ -180,7 +180,7 @@ int main(int argc, char* argv[])
         samurai::load(restart_file, mesh, u);
     }
 
-    auto unp1 = samurai::make_scalar_field("unp1", mesh);
+    auto unp1 = samurai::make_scalar_field<double>("unp1", mesh);
 
     samurai::make_bc<samurai::Neumann<1>>(u, 0.);
     samurai::make_bc<samurai::Neumann<1>>(unp1, 0.);

--- a/demos/FiniteVolume/heat.cpp
+++ b/demos/FiniteVolume/heat.cpp
@@ -27,7 +27,7 @@ template <class Field>
 void save(const fs::path& path, const std::string& filename, const Field& u, const std::string& suffix = "")
 {
     auto mesh   = u.mesh();
-    auto level_ = samurai::make_field<std::size_t>("level", mesh);
+    auto level_ = samurai::make_scalar_field<std::size_t>("level", mesh);
 
     if (!fs::exists(path))
     {
@@ -145,7 +145,7 @@ int main(int argc, char* argv[])
     Box box(box_corner1, box_corner2);
     samurai::MRMesh<Config> mesh;
 
-    auto u = samurai::make_field<>("u", mesh);
+    auto u = samurai::make_scalar_field("u", mesh);
 
     if (restart_file.empty())
     {
@@ -180,7 +180,7 @@ int main(int argc, char* argv[])
         samurai::load(restart_file, mesh, u);
     }
 
-    auto unp1 = samurai::make_field<>("unp1", mesh);
+    auto unp1 = samurai::make_scalar_field("unp1", mesh);
 
     samurai::make_bc<samurai::Neumann<1>>(u, 0.);
     samurai::make_bc<samurai::Neumann<1>>(unp1, 0.);

--- a/demos/FiniteVolume/heat_heterogeneous.cpp
+++ b/demos/FiniteVolume/heat_heterogeneous.cpp
@@ -15,7 +15,7 @@ template <class Field>
 void save(const fs::path& path, const std::string& filename, const Field& u, const std::string& suffix = "")
 {
     auto mesh   = u.mesh();
-    auto level_ = samurai::make_field<std::size_t, 1>("level", mesh);
+    auto level_ = samurai::make_field<std::size_t>("level", mesh);
 
     if (!fs::exists(path))
     {
@@ -115,8 +115,8 @@ int main(int argc, char* argv[])
     Box box(box_corner1, box_corner2);
     samurai::MRMesh<Config> mesh;
 
-    auto u    = samurai::make_field<1>("u", mesh);
-    auto unp1 = samurai::make_field<1>("unp1", mesh);
+    auto u    = samurai::make_field<>("u", mesh);
+    auto unp1 = samurai::make_field<>("unp1", mesh);
 
     if (restart_file.empty())
     {
@@ -142,7 +142,7 @@ int main(int argc, char* argv[])
     samurai::make_bc<samurai::Neumann<1>>(u, 0.);
     samurai::make_bc<samurai::Neumann<1>>(unp1, 0.);
 
-    auto K = samurai::make_field<samurai::DiffCoeff<dim>, 1>("K", mesh);
+    auto K = samurai::make_field<samurai::DiffCoeff<dim>>("K", mesh);
 
     auto set_K_values = [&]()
     {

--- a/demos/FiniteVolume/heat_heterogeneous.cpp
+++ b/demos/FiniteVolume/heat_heterogeneous.cpp
@@ -15,7 +15,7 @@ template <class Field>
 void save(const fs::path& path, const std::string& filename, const Field& u, const std::string& suffix = "")
 {
     auto mesh   = u.mesh();
-    auto level_ = samurai::make_field<std::size_t>("level", mesh);
+    auto level_ = samurai::make_scalar_field<std::size_t>("level", mesh);
 
     if (!fs::exists(path))
     {
@@ -115,8 +115,8 @@ int main(int argc, char* argv[])
     Box box(box_corner1, box_corner2);
     samurai::MRMesh<Config> mesh;
 
-    auto u    = samurai::make_field<>("u", mesh);
-    auto unp1 = samurai::make_field<>("unp1", mesh);
+    auto u    = samurai::make_scalar_field("u", mesh);
+    auto unp1 = samurai::make_scalar_field("unp1", mesh);
 
     if (restart_file.empty())
     {
@@ -142,7 +142,7 @@ int main(int argc, char* argv[])
     samurai::make_bc<samurai::Neumann<1>>(u, 0.);
     samurai::make_bc<samurai::Neumann<1>>(unp1, 0.);
 
-    auto K = samurai::make_field<samurai::DiffCoeff<dim>>("K", mesh);
+    auto K = samurai::make_scalar_field<samurai::DiffCoeff<dim>>("K", mesh);
 
     auto set_K_values = [&]()
     {

--- a/demos/FiniteVolume/heat_heterogeneous.cpp
+++ b/demos/FiniteVolume/heat_heterogeneous.cpp
@@ -115,8 +115,8 @@ int main(int argc, char* argv[])
     Box box(box_corner1, box_corner2);
     samurai::MRMesh<Config> mesh;
 
-    auto u    = samurai::make_scalar_field("u", mesh);
-    auto unp1 = samurai::make_scalar_field("unp1", mesh);
+    auto u    = samurai::make_scalar_field<double>("u", mesh);
+    auto unp1 = samurai::make_scalar_field<double>("unp1", mesh);
 
     if (restart_file.empty())
     {

--- a/demos/FiniteVolume/heat_nonlinear.cpp
+++ b/demos/FiniteVolume/heat_nonlinear.cpp
@@ -14,7 +14,7 @@ template <class Field>
 void save(const fs::path& path, const std::string& filename, const Field& u, const std::string& suffix = "")
 {
     auto mesh   = u.mesh();
-    auto level_ = samurai::make_field<std::size_t, 1>("level", mesh);
+    auto level_ = samurai::make_field<std::size_t>("level", mesh);
 
     if (!fs::exists(path))
     {
@@ -186,24 +186,24 @@ int main(int argc, char* argv[])
     box_corner2.fill(right_box);
     Box box(box_corner1, box_corner2);
     samurai::MRMesh<Config> mesh;
-    auto u = samurai::make_field<1>("u", mesh);
+    auto u = samurai::make_field<double>("u", mesh);
 
     if (restart_file.empty())
     {
         mesh = {box, min_level, max_level};
-        u    = samurai::make_field<1>("u",
-                                   mesh,
-                                   [&](const auto& coords)
-                                   {
-                                       return exact_solution(coords, 0);
-                                   });
+        u    = samurai::make_field<double>("u",
+                                        mesh,
+                                        [&](const auto& coords)
+                                        {
+                                            return exact_solution(coords, 0);
+                                        });
     }
     else
     {
         samurai::load(restart_file, mesh, u);
     }
 
-    auto unp1 = samurai::make_field<1>("unp1", mesh);
+    auto unp1 = samurai::make_field<double>("unp1", mesh);
 
     samurai::make_bc<samurai::Dirichlet<1>>(u,
                                             [&](const auto&, const auto&, const auto& coords)

--- a/demos/FiniteVolume/heat_nonlinear.cpp
+++ b/demos/FiniteVolume/heat_nonlinear.cpp
@@ -14,7 +14,7 @@ template <class Field>
 void save(const fs::path& path, const std::string& filename, const Field& u, const std::string& suffix = "")
 {
     auto mesh   = u.mesh();
-    auto level_ = samurai::make_field<std::size_t>("level", mesh);
+    auto level_ = samurai::make_scalar_field<std::size_t>("level", mesh);
 
     if (!fs::exists(path))
     {
@@ -186,24 +186,24 @@ int main(int argc, char* argv[])
     box_corner2.fill(right_box);
     Box box(box_corner1, box_corner2);
     samurai::MRMesh<Config> mesh;
-    auto u = samurai::make_field<double>("u", mesh);
+    auto u = samurai::make_scalar_field<double>("u", mesh);
 
     if (restart_file.empty())
     {
         mesh = {box, min_level, max_level};
-        u    = samurai::make_field<double>("u",
-                                        mesh,
-                                        [&](const auto& coords)
-                                        {
-                                            return exact_solution(coords, 0);
-                                        });
+        u    = samurai::make_scalar_field<double>("u",
+                                               mesh,
+                                               [&](const auto& coords)
+                                               {
+                                                   return exact_solution(coords, 0);
+                                               });
     }
     else
     {
         samurai::load(restart_file, mesh, u);
     }
 
-    auto unp1 = samurai::make_field<double>("unp1", mesh);
+    auto unp1 = samurai::make_scalar_field<double>("unp1", mesh);
 
     samurai::make_bc<samurai::Dirichlet<1>>(u,
                                             [&](const auto&, const auto&, const auto& coords)

--- a/demos/FiniteVolume/level_set.cpp
+++ b/demos/FiniteVolume/level_set.cpp
@@ -313,7 +313,7 @@ int main(int argc, char* argv[])
     auto phinp1 = samurai::make_field<double, 1>("phi", mesh);
     auto phihat = samurai::make_field<double, 1>("phi", mesh);
     samurai::make_bc<samurai::Neumann<1>>(phihat, 0.);
-    auto tag = samurai::make_field<int, 1>("tag", mesh);
+    auto tag = samurai::make_field<int>("tag", mesh);
 
     const xt::xtensor_fixed<int, xt::xshape<4, 2>> stencil_grad{
         {1,  0 },

--- a/demos/FiniteVolume/level_set.cpp
+++ b/demos/FiniteVolume/level_set.cpp
@@ -231,7 +231,7 @@ template <class Field, class Phi>
 void save(const fs::path& path, const std::string& filename, const Field& u, const Phi& phi, const std::string& suffix = "")
 {
     auto mesh   = u.mesh();
-    auto level_ = samurai::make_field<std::size_t, 1>("level", mesh);
+    auto level_ = samurai::make_field<std::size_t>("level", mesh);
 
     if (!fs::exists(path))
     {
@@ -293,7 +293,7 @@ int main(int argc, char* argv[])
 
     const samurai::Box<double, dim> box(min_corner, max_corner);
     samurai::amr::Mesh<Config> mesh;
-    auto phi = samurai::make_field<double, 1>("phi", mesh);
+    auto phi = samurai::make_field<double>("phi", mesh);
 
     if (restart_file.empty())
     {
@@ -310,8 +310,8 @@ int main(int argc, char* argv[])
 
     auto u = init_velocity(mesh);
 
-    auto phinp1 = samurai::make_field<double, 1>("phi", mesh);
-    auto phihat = samurai::make_field<double, 1>("phi", mesh);
+    auto phinp1 = samurai::make_field<double>("phi", mesh);
+    auto phihat = samurai::make_field<double>("phi", mesh);
     samurai::make_bc<samurai::Neumann<1>>(phihat, 0.);
     auto tag = samurai::make_field<int>("tag", mesh);
 

--- a/demos/FiniteVolume/level_set.cpp
+++ b/demos/FiniteVolume/level_set.cpp
@@ -50,7 +50,7 @@ auto init_velocity(Mesh& mesh)
     using mesh_id_t = typename Mesh::mesh_id_t;
     const double PI = xt::numeric_constants<double>::PI;
 
-    auto u = samurai::make_field<double, 2>("u", mesh);
+    auto u = samurai::make_vector_field<double, 2>("u", mesh);
     u.fill(0);
 
     samurai::for_each_cell(mesh[mesh_id_t::cells_and_ghosts],
@@ -231,7 +231,7 @@ template <class Field, class Phi>
 void save(const fs::path& path, const std::string& filename, const Field& u, const Phi& phi, const std::string& suffix = "")
 {
     auto mesh   = u.mesh();
-    auto level_ = samurai::make_field<std::size_t>("level", mesh);
+    auto level_ = samurai::make_scalar_field<std::size_t>("level", mesh);
 
     if (!fs::exists(path))
     {
@@ -293,7 +293,7 @@ int main(int argc, char* argv[])
 
     const samurai::Box<double, dim> box(min_corner, max_corner);
     samurai::amr::Mesh<Config> mesh;
-    auto phi = samurai::make_field<double>("phi", mesh);
+    auto phi = samurai::make_scalar_field<double>("phi", mesh);
 
     if (restart_file.empty())
     {
@@ -310,10 +310,10 @@ int main(int argc, char* argv[])
 
     auto u = init_velocity(mesh);
 
-    auto phinp1 = samurai::make_field<double>("phi", mesh);
-    auto phihat = samurai::make_field<double>("phi", mesh);
+    auto phinp1 = samurai::make_scalar_field<double>("phi", mesh);
+    auto phihat = samurai::make_scalar_field<double>("phi", mesh);
     samurai::make_bc<samurai::Neumann<1>>(phihat, 0.);
-    auto tag = samurai::make_field<int>("tag", mesh);
+    auto tag = samurai::make_scalar_field<int>("tag", mesh);
 
     const xt::xtensor_fixed<int, xt::xshape<4, 2>> stencil_grad{
         {1,  0 },

--- a/demos/FiniteVolume/level_set_from_scratch.cpp
+++ b/demos/FiniteVolume/level_set_from_scratch.cpp
@@ -575,7 +575,7 @@ template <class Field, class Phi>
 void save(const fs::path& path, const std::string& filename, const Field& u, const Phi& phi, const std::string& suffix = "")
 {
     auto mesh   = u.mesh();
-    auto level_ = samurai::make_field<std::size_t, 1>("level", mesh);
+    auto level_ = samurai::make_field<std::size_t>("level", mesh);
 
     if (!fs::exists(path))
     {
@@ -638,7 +638,7 @@ int main(int argc, char* argv[])
     const samurai::Box<double, dim> box(min_corner, max_corner);
     AMRMesh<Config> mesh;
 
-    auto phi = samurai::make_field<double, 1>("phi", mesh);
+    auto phi = samurai::make_field<double>("phi", mesh);
 
     if (restart_file.empty())
     {
@@ -656,7 +656,7 @@ int main(int argc, char* argv[])
     // We initialize the level set function
     // We initialize the velocity field
 
-    auto phinp1 = samurai::make_field<double, 1>("phi", mesh);
+    auto phinp1 = samurai::make_field<double>("phi", mesh);
 
     auto u = init_velocity(mesh);
 
@@ -715,7 +715,7 @@ int main(int argc, char* argv[])
 
             // TVD-RK2
             update_ghosts(phi, u);
-            auto phihat = samurai::make_field<double, 1>("phi", mesh);
+            auto phihat = samurai::make_field<double>("phi", mesh);
             samurai::make_bc<samurai::Neumann<1>>(phihat, 0.);
             phihat = phi - dt_fict * H_wrap(phi, phi_0, max_level);
             update_ghosts(phihat, u);

--- a/demos/FiniteVolume/level_set_from_scratch.cpp
+++ b/demos/FiniteVolume/level_set_from_scratch.cpp
@@ -670,7 +670,7 @@ int main(int argc, char* argv[])
         while (true)
         {
             std::cout << "Mesh adaptation iteration " << ite++ << std::endl;
-            auto tag = samurai::make_field<int, 1>("tag", mesh);
+            auto tag = samurai::make_field<int>("tag", mesh);
             AMR_criteria(phi, tag);
             ::make_graduation(tag);
             update_ghosts(phi, u);

--- a/demos/FiniteVolume/level_set_from_scratch.cpp
+++ b/demos/FiniteVolume/level_set_from_scratch.cpp
@@ -174,7 +174,7 @@ auto init_velocity(Mesh& mesh)
     using mesh_id_t = typename Mesh::mesh_id_t;
     const double PI = xt::numeric_constants<double>::PI;
 
-    auto u = samurai::make_field<double, 2>("u", mesh);
+    auto u = samurai::make_vector_field<double, 2>("u", mesh);
     u.fill(0);
 
     samurai::for_each_cell(mesh[mesh_id_t::cells_and_ghosts],
@@ -575,7 +575,7 @@ template <class Field, class Phi>
 void save(const fs::path& path, const std::string& filename, const Field& u, const Phi& phi, const std::string& suffix = "")
 {
     auto mesh   = u.mesh();
-    auto level_ = samurai::make_field<std::size_t>("level", mesh);
+    auto level_ = samurai::make_scalar_field<std::size_t>("level", mesh);
 
     if (!fs::exists(path))
     {
@@ -638,7 +638,7 @@ int main(int argc, char* argv[])
     const samurai::Box<double, dim> box(min_corner, max_corner);
     AMRMesh<Config> mesh;
 
-    auto phi = samurai::make_field<double>("phi", mesh);
+    auto phi = samurai::make_scalar_field<double>("phi", mesh);
 
     if (restart_file.empty())
     {
@@ -656,7 +656,7 @@ int main(int argc, char* argv[])
     // We initialize the level set function
     // We initialize the velocity field
 
-    auto phinp1 = samurai::make_field<double>("phi", mesh);
+    auto phinp1 = samurai::make_scalar_field<double>("phi", mesh);
 
     auto u = init_velocity(mesh);
 
@@ -670,7 +670,7 @@ int main(int argc, char* argv[])
         while (true)
         {
             std::cout << "Mesh adaptation iteration " << ite++ << std::endl;
-            auto tag = samurai::make_field<int>("tag", mesh);
+            auto tag = samurai::make_scalar_field<int>("tag", mesh);
             AMR_criteria(phi, tag);
             ::make_graduation(tag);
             update_ghosts(phi, u);
@@ -715,7 +715,7 @@ int main(int argc, char* argv[])
 
             // TVD-RK2
             update_ghosts(phi, u);
-            auto phihat = samurai::make_field<double>("phi", mesh);
+            auto phihat = samurai::make_scalar_field<double>("phi", mesh);
             samurai::make_bc<samurai::Neumann<1>>(phihat, 0.);
             phihat = phi - dt_fict * H_wrap(phi, phi_0, max_level);
             update_ghosts(phihat, u);

--- a/demos/FiniteVolume/lid_driven_cavity.cpp
+++ b/demos/FiniteVolume/lid_driven_cavity.cpp
@@ -176,9 +176,9 @@ int main(int argc, char* argv[])
     auto mesh = Mesh(box, min_level, max_level);
 
     // Fields for the Navier-Stokes equations
-    auto velocity     = samurai::make_vector_field<dim, is_soa>("velocity", mesh);
-    auto velocity_np1 = samurai::make_vector_field<dim, is_soa>("velocity_np1", mesh);
-    auto pressure_np1 = samurai::make_scalar_field("pressure_np1", mesh);
+    auto velocity     = samurai::make_vector_field<double, dim, is_soa>("velocity", mesh);
+    auto velocity_np1 = samurai::make_vector_field<double, dim, is_soa>("velocity_np1", mesh);
+    auto pressure_np1 = samurai::make_scalar_field<double>("pressure_np1", mesh);
 
     using VelocityField = decltype(velocity);
     using PressureField = decltype(pressure_np1);
@@ -234,8 +234,8 @@ int main(int argc, char* argv[])
     // clang-format on
 
     // Fields for the right-hand side of the system
-    auto rhs  = samurai::make_vector_field<dim, is_soa>("rhs", mesh);
-    auto zero = samurai::make_scalar_field("zero", mesh);
+    auto rhs  = samurai::make_vector_field<double, dim, is_soa>("rhs", mesh);
+    auto zero = samurai::make_scalar_field<double>("zero", mesh);
 
     // Linear solver
     auto stokes_solver = samurai::petsc::make_solver<monolithic>(stokes);
@@ -252,8 +252,8 @@ int main(int argc, char* argv[])
     auto mesh2 = Mesh2(box, 1, max_level);
 
     // Ink data fields
-    auto ink     = samurai::make_scalar_field("ink", mesh2);
-    auto ink_np1 = samurai::make_scalar_field("ink_np1", mesh2);
+    auto ink     = samurai::make_scalar_field<double>("ink", mesh2);
+    auto ink_np1 = samurai::make_scalar_field<double>("ink_np1", mesh2);
     // Field to store the Navier-Stokes velocity transferred to the 2nd mesh
     auto velocity2 = samurai::make_vector_field<dim, is_soa>("velocity2", mesh2);
 
@@ -431,8 +431,8 @@ int main(int argc, char* argv[])
         } // end time loop
 
         // srand(time(NULL));
-        // auto x_velocity = samurai::make_vector_field<dim, is_soa>("x_velocity", mesh);
-        // auto x_pressure = samurai::make_scalar_field("x_pressure", mesh);
+        // auto x_velocity = samurai::make_vector_field<double, dim, is_soa>("x_velocity", mesh);
+        // auto x_pressure = samurai::make_scalar_field<double>("x_pressure", mesh);
         // samurai::for_each_cell(mesh[mesh_id_t::reference],
         //                        [&](auto cell)
         //                        {
@@ -446,8 +446,8 @@ int main(int argc, char* argv[])
         // monolithicAssembly.create_matrix(monolithicA);
         // monolithicAssembly.assemble_matrix(monolithicA);
         // Vec mono_x                = monolithicAssembly.create_applicable_vector(x); // copy
-        // auto result_velocity_mono = samurai::make_vector_field<dim, is_soa>("result_velocity", mesh);
-        // auto result_pressure_mono = samurai::make_scalar_field("result_pressure", mesh);
+        // auto result_velocity_mono = samurai::make_vector_field<double, dim, is_soa>("result_velocity", mesh);
+        // auto result_pressure_mono = samurai::make_scalar_field<double>("result_pressure", mesh);
         // auto result_mono          = stokes.tie_rhs(result_velocity_mono, result_pressure_mono);
         // Vec mono_result           = monolithicAssembly.create_rhs_vector(result_mono); // copy
         // MatMult(monolithicA, mono_x, mono_result);
@@ -458,8 +458,8 @@ int main(int argc, char* argv[])
         // nestedAssembly.create_matrix(nestedA);
         // nestedAssembly.assemble_matrix(nestedA);
         // Vec nest_x                = nestedAssembly.create_applicable_vector(x);
-        // auto result_velocity_nest = samurai::make_vector_field<dim, is_soa>("result_velocity", mesh);
-        // auto result_pressure_nest = samurai::make_scalar_field("result_pressure", mesh);
+        // auto result_velocity_nest = samurai::make_vector_field<double, dim, is_soa>("result_velocity", mesh);
+        // auto result_pressure_nest = samurai::make_scalar_field<double>("result_pressure", mesh);
         // auto result_nest          = stokes.tie_rhs(result_velocity_nest, result_pressure_nest);
         // Vec nest_result           = nestedAssembly.create_rhs_vector(result_nest);
         // MatMult(nestedA, nest_x, nest_result);

--- a/demos/FiniteVolume/lid_driven_cavity.cpp
+++ b/demos/FiniteVolume/lid_driven_cavity.cpp
@@ -176,9 +176,9 @@ int main(int argc, char* argv[])
     auto mesh = Mesh(box, min_level, max_level);
 
     // Fields for the Navier-Stokes equations
-    auto velocity     = samurai::make_field<dim, is_soa>("velocity", mesh);
-    auto velocity_np1 = samurai::make_field<dim, is_soa>("velocity_np1", mesh);
-    auto pressure_np1 = samurai::make_field<>("pressure_np1", mesh);
+    auto velocity     = samurai::make_vector_field<dim, is_soa>("velocity", mesh);
+    auto velocity_np1 = samurai::make_vector_field<dim, is_soa>("velocity_np1", mesh);
+    auto pressure_np1 = samurai::make_scalar_field("pressure_np1", mesh);
 
     using VelocityField = decltype(velocity);
     using PressureField = decltype(pressure_np1);
@@ -234,8 +234,8 @@ int main(int argc, char* argv[])
     // clang-format on
 
     // Fields for the right-hand side of the system
-    auto rhs  = samurai::make_field<dim, is_soa>("rhs", mesh);
-    auto zero = samurai::make_field<>("zero", mesh);
+    auto rhs  = samurai::make_vector_field<dim, is_soa>("rhs", mesh);
+    auto zero = samurai::make_scalar_field("zero", mesh);
 
     // Linear solver
     auto stokes_solver = samurai::petsc::make_solver<monolithic>(stokes);
@@ -252,10 +252,10 @@ int main(int argc, char* argv[])
     auto mesh2 = Mesh2(box, 1, max_level);
 
     // Ink data fields
-    auto ink     = samurai::make_field<>("ink", mesh2);
-    auto ink_np1 = samurai::make_field<>("ink_np1", mesh2);
+    auto ink     = samurai::make_scalar_field("ink", mesh2);
+    auto ink_np1 = samurai::make_scalar_field("ink_np1", mesh2);
     // Field to store the Navier-Stokes velocity transferred to the 2nd mesh
-    auto velocity2 = samurai::make_field<dim, is_soa>("velocity2", mesh2);
+    auto velocity2 = samurai::make_vector_field<dim, is_soa>("velocity2", mesh2);
 
     using InkField = decltype(ink);
 
@@ -431,8 +431,8 @@ int main(int argc, char* argv[])
         } // end time loop
 
         // srand(time(NULL));
-        // auto x_velocity = samurai::make_field<dim, is_soa>("x_velocity", mesh);
-        // auto x_pressure = samurai::make_field<1, is_soa>("x_pressure", mesh);
+        // auto x_velocity = samurai::make_vector_field<dim, is_soa>("x_velocity", mesh);
+        // auto x_pressure = samurai::make_scalar_field("x_pressure", mesh);
         // samurai::for_each_cell(mesh[mesh_id_t::reference],
         //                        [&](auto cell)
         //                        {
@@ -446,8 +446,8 @@ int main(int argc, char* argv[])
         // monolithicAssembly.create_matrix(monolithicA);
         // monolithicAssembly.assemble_matrix(monolithicA);
         // Vec mono_x                = monolithicAssembly.create_applicable_vector(x); // copy
-        // auto result_velocity_mono = samurai::make_field<dim, is_soa>("result_velocity", mesh);
-        // auto result_pressure_mono = samurai::make_field<1, is_soa>("result_pressure", mesh);
+        // auto result_velocity_mono = samurai::make_vector_field<dim, is_soa>("result_velocity", mesh);
+        // auto result_pressure_mono = samurai::make_scalar_field("result_pressure", mesh);
         // auto result_mono          = stokes.tie_rhs(result_velocity_mono, result_pressure_mono);
         // Vec mono_result           = monolithicAssembly.create_rhs_vector(result_mono); // copy
         // MatMult(monolithicA, mono_x, mono_result);
@@ -458,8 +458,8 @@ int main(int argc, char* argv[])
         // nestedAssembly.create_matrix(nestedA);
         // nestedAssembly.assemble_matrix(nestedA);
         // Vec nest_x                = nestedAssembly.create_applicable_vector(x);
-        // auto result_velocity_nest = samurai::make_field<dim, is_soa>("result_velocity", mesh);
-        // auto result_pressure_nest = samurai::make_field<1, is_soa>("result_pressure", mesh);
+        // auto result_velocity_nest = samurai::make_vector_field<dim, is_soa>("result_velocity", mesh);
+        // auto result_pressure_nest = samurai::make_scalar_field("result_pressure", mesh);
         // auto result_nest          = stokes.tie_rhs(result_velocity_nest, result_pressure_nest);
         // Vec nest_result           = nestedAssembly.create_rhs_vector(result_nest);
         // MatMult(nestedA, nest_x, nest_result);

--- a/demos/FiniteVolume/lid_driven_cavity.cpp
+++ b/demos/FiniteVolume/lid_driven_cavity.cpp
@@ -178,7 +178,7 @@ int main(int argc, char* argv[])
     // Fields for the Navier-Stokes equations
     auto velocity     = samurai::make_field<dim, is_soa>("velocity", mesh);
     auto velocity_np1 = samurai::make_field<dim, is_soa>("velocity_np1", mesh);
-    auto pressure_np1 = samurai::make_field<1, is_soa>("pressure_np1", mesh);
+    auto pressure_np1 = samurai::make_field<>("pressure_np1", mesh);
 
     using VelocityField = decltype(velocity);
     using PressureField = decltype(pressure_np1);
@@ -235,7 +235,7 @@ int main(int argc, char* argv[])
 
     // Fields for the right-hand side of the system
     auto rhs  = samurai::make_field<dim, is_soa>("rhs", mesh);
-    auto zero = samurai::make_field<1, is_soa>("zero", mesh);
+    auto zero = samurai::make_field<>("zero", mesh);
 
     // Linear solver
     auto stokes_solver = samurai::petsc::make_solver<monolithic>(stokes);
@@ -252,8 +252,8 @@ int main(int argc, char* argv[])
     auto mesh2 = Mesh2(box, 1, max_level);
 
     // Ink data fields
-    auto ink     = samurai::make_field<1, is_soa>("ink", mesh2);
-    auto ink_np1 = samurai::make_field<1, is_soa>("ink_np1", mesh2);
+    auto ink     = samurai::make_field<>("ink", mesh2);
+    auto ink_np1 = samurai::make_field<>("ink_np1", mesh2);
     // Field to store the Navier-Stokes velocity transferred to the 2nd mesh
     auto velocity2 = samurai::make_field<dim, is_soa>("velocity2", mesh2);
 

--- a/demos/FiniteVolume/linear_convection.cpp
+++ b/demos/FiniteVolume/linear_convection.cpp
@@ -104,7 +104,7 @@ int main(int argc, char* argv[])
     std::array<bool, dim> periodic;
     periodic.fill(true);
     samurai::MRMesh<Config> mesh;
-    auto u = samurai::make_scalar_field("u", mesh);
+    auto u = samurai::make_scalar_field<double>("u", mesh);
 
     if (restart_file.empty())
     {

--- a/demos/FiniteVolume/linear_convection.cpp
+++ b/demos/FiniteVolume/linear_convection.cpp
@@ -15,7 +15,7 @@ template <class Field>
 void save(const fs::path& path, const std::string& filename, const Field& u, const std::string& suffix = "")
 {
     auto mesh   = u.mesh();
-    auto level_ = samurai::make_field<std::size_t, 1>("level", mesh);
+    auto level_ = samurai::make_field<std::size_t>("level", mesh);
 
     if (!fs::exists(path))
     {
@@ -104,38 +104,38 @@ int main(int argc, char* argv[])
     std::array<bool, dim> periodic;
     periodic.fill(true);
     samurai::MRMesh<Config> mesh;
-    auto u = samurai::make_field<1>("u", mesh);
+    auto u = samurai::make_field<>("u", mesh);
 
     if (restart_file.empty())
     {
         mesh = {box, min_level, max_level, periodic};
         // Initial solution
-        u = samurai::make_field<1>("u",
-                                   mesh,
-                                   [](const auto& coords)
-                                   {
-                                       if constexpr (dim == 1)
-                                       {
-                                           const auto& x = coords(0);
-                                           return (x >= -0.8 && x <= -0.3) ? 1. : 0.;
-                                       }
-                                       else
-                                       {
-                                           const auto& x = coords(0);
-                                           const auto& y = coords(1);
-                                           return (x >= -0.8 && x <= -0.3 && y >= 0.3 && y <= 0.8) ? 1. : 0.;
-                                       }
-                                   });
+        u = samurai::make_field<double>("u",
+                                        mesh,
+                                        [](const auto& coords)
+                                        {
+                                            if constexpr (dim == 1)
+                                            {
+                                                const auto& x = coords(0);
+                                                return (x >= -0.8 && x <= -0.3) ? 1. : 0.;
+                                            }
+                                            else
+                                            {
+                                                const auto& x = coords(0);
+                                                const auto& y = coords(1);
+                                                return (x >= -0.8 && x <= -0.3 && y >= 0.3 && y <= 0.8) ? 1. : 0.;
+                                            }
+                                        });
     }
     else
     {
         samurai::load(restart_file, mesh, u);
     }
 
-    auto unp1 = samurai::make_field<1>("unp1", mesh);
+    auto unp1 = samurai::make_field<double>("unp1", mesh);
     // Intermediary fields for the RK3 scheme
-    auto u1 = samurai::make_field<1>("u1", mesh);
-    auto u2 = samurai::make_field<1>("u2", mesh);
+    auto u1 = samurai::make_field<double>("u1", mesh);
+    auto u2 = samurai::make_field<double>("u2", mesh);
 
     unp1.fill(0);
     u1.fill(0);

--- a/demos/FiniteVolume/linear_convection.cpp
+++ b/demos/FiniteVolume/linear_convection.cpp
@@ -15,7 +15,7 @@ template <class Field>
 void save(const fs::path& path, const std::string& filename, const Field& u, const std::string& suffix = "")
 {
     auto mesh   = u.mesh();
-    auto level_ = samurai::make_field<std::size_t>("level", mesh);
+    auto level_ = samurai::make_scalar_field<std::size_t>("level", mesh);
 
     if (!fs::exists(path))
     {
@@ -104,38 +104,38 @@ int main(int argc, char* argv[])
     std::array<bool, dim> periodic;
     periodic.fill(true);
     samurai::MRMesh<Config> mesh;
-    auto u = samurai::make_field<>("u", mesh);
+    auto u = samurai::make_scalar_field("u", mesh);
 
     if (restart_file.empty())
     {
         mesh = {box, min_level, max_level, periodic};
         // Initial solution
-        u = samurai::make_field<double>("u",
-                                        mesh,
-                                        [](const auto& coords)
-                                        {
-                                            if constexpr (dim == 1)
-                                            {
-                                                const auto& x = coords(0);
-                                                return (x >= -0.8 && x <= -0.3) ? 1. : 0.;
-                                            }
-                                            else
-                                            {
-                                                const auto& x = coords(0);
-                                                const auto& y = coords(1);
-                                                return (x >= -0.8 && x <= -0.3 && y >= 0.3 && y <= 0.8) ? 1. : 0.;
-                                            }
-                                        });
+        u = samurai::make_scalar_field<double>("u",
+                                               mesh,
+                                               [](const auto& coords)
+                                               {
+                                                   if constexpr (dim == 1)
+                                                   {
+                                                       const auto& x = coords(0);
+                                                       return (x >= -0.8 && x <= -0.3) ? 1. : 0.;
+                                                   }
+                                                   else
+                                                   {
+                                                       const auto& x = coords(0);
+                                                       const auto& y = coords(1);
+                                                       return (x >= -0.8 && x <= -0.3 && y >= 0.3 && y <= 0.8) ? 1. : 0.;
+                                                   }
+                                               });
     }
     else
     {
         samurai::load(restart_file, mesh, u);
     }
 
-    auto unp1 = samurai::make_field<double>("unp1", mesh);
+    auto unp1 = samurai::make_scalar_field<double>("unp1", mesh);
     // Intermediary fields for the RK3 scheme
-    auto u1 = samurai::make_field<double>("u1", mesh);
-    auto u2 = samurai::make_field<double>("u2", mesh);
+    auto u1 = samurai::make_scalar_field<double>("u1", mesh);
+    auto u2 = samurai::make_scalar_field<double>("u2", mesh);
 
     unp1.fill(0);
     u1.fill(0);

--- a/demos/FiniteVolume/manual_block_matrix_assembly.cpp
+++ b/demos/FiniteVolume/manual_block_matrix_assembly.cpp
@@ -206,8 +206,8 @@ int main(int argc, char* argv[])
     // Fields and auxiliary unknowns //
     //-------------------------------//
 
-    auto u_e = samurai::make_vector_field<1>("u_e", mesh_e, 0);
-    auto u_s = samurai::make_vector_field<1>("u_s", mesh_s, 1);
+    auto u_e = samurai::make_scalar_field<double>("u_e", mesh_e, 0);
+    auto u_s = samurai::make_scalar_field<double>("u_s", mesh_s, 1);
 
     // Count the number of cells at the interface between mesh_e and mesh_s
     std::size_t n_interface_cells = 0;

--- a/demos/FiniteVolume/manual_block_matrix_assembly.cpp
+++ b/demos/FiniteVolume/manual_block_matrix_assembly.cpp
@@ -206,8 +206,8 @@ int main(int argc, char* argv[])
     // Fields and auxiliary unknowns //
     //-------------------------------//
 
-    auto u_e = samurai::make_field<1>("u_e", mesh_e, 0);
-    auto u_s = samurai::make_field<1>("u_s", mesh_s, 1);
+    auto u_e = samurai::make_vector_field<1>("u_e", mesh_e, 0);
+    auto u_s = samurai::make_vector_field<1>("u_s", mesh_s, 1);
 
     // Count the number of cells at the interface between mesh_e and mesh_s
     std::size_t n_interface_cells = 0;

--- a/demos/FiniteVolume/nagumo.cpp
+++ b/demos/FiniteVolume/nagumo.cpp
@@ -157,7 +157,7 @@ int main(int argc, char* argv[])
         samurai::for_each_cell(mesh,
                                [&](auto& cell)
                                {
-                                   u[cell][0] = exact_solution(cell.center(0), 0);
+                                   u[cell] = exact_solution(cell.center(0), 0);
                                });
     }
     else

--- a/demos/FiniteVolume/nagumo.cpp
+++ b/demos/FiniteVolume/nagumo.cpp
@@ -157,9 +157,6 @@ int main(int argc, char* argv[])
         samurai::for_each_cell(mesh,
                                [&](auto& cell)
                                {
-                                   // static_assert(std::is_same_v<decltype(exact_solution(cell.center(0), 0)), void>);
-                                   // static_assert(std::is_same_v<decltype(u[cell]), void>);
-                                   std::cout << u[cell] << std::endl;
                                    u[cell][0] = exact_solution(cell.center(0), 0);
                                });
     }

--- a/demos/FiniteVolume/nagumo.cpp
+++ b/demos/FiniteVolume/nagumo.cpp
@@ -14,7 +14,7 @@ template <class Field>
 void save(const fs::path& path, const std::string& filename, const Field& u, const std::string& suffix = "")
 {
     auto mesh   = u.mesh();
-    auto level_ = samurai::make_field<std::size_t, 1>("level", mesh);
+    auto level_ = samurai::make_field<std::size_t>("level", mesh);
 
     if (!fs::exists(path))
     {

--- a/demos/FiniteVolume/nagumo.cpp
+++ b/demos/FiniteVolume/nagumo.cpp
@@ -133,7 +133,7 @@ int main(int argc, char* argv[])
     Box box(box_corner1, box_corner2);
     samurai::MRMesh<Config> mesh{box, min_level, max_level};
 
-    auto u = samurai::make_field<n_comp>("u", mesh);
+    auto u = samurai::make_field<double, n_comp>("u", mesh);
 
     double z0 = left_box / 5;    // wave initial position
     double c  = sqrt(k * D / 2); // wave velocity
@@ -157,7 +157,10 @@ int main(int argc, char* argv[])
         samurai::for_each_cell(mesh,
                                [&](auto& cell)
                                {
-                                   u[cell] = exact_solution(cell.center(0), 0);
+                                   // static_assert(std::is_same_v<decltype(exact_solution(cell.center(0), 0)), void>);
+                                   // static_assert(std::is_same_v<decltype(u[cell]), void>);
+                                   std::cout << u[cell] << std::endl;
+                                   u[cell][0] = exact_solution(cell.center(0), 0);
                                });
     }
     else
@@ -165,7 +168,7 @@ int main(int argc, char* argv[])
         samurai::load(restart_file, mesh, u);
     }
 
-    auto unp1 = samurai::make_field<n_comp>("unp1", mesh);
+    auto unp1 = samurai::make_field<double, n_comp>("unp1", mesh);
 
     samurai::make_bc<samurai::Neumann<1>>(u);
     samurai::make_bc<samurai::Neumann<1>>(unp1);
@@ -213,7 +216,7 @@ int main(int argc, char* argv[])
         save(path, filename, u, fmt::format("_ite_{}", nsave++));
     }
 
-    auto rhs = samurai::make_field<n_comp>("rhs", mesh);
+    auto rhs = samurai::make_field<double, n_comp>("rhs", mesh);
 
     while (t != Tf)
     {

--- a/demos/FiniteVolume/nagumo.cpp
+++ b/demos/FiniteVolume/nagumo.cpp
@@ -14,7 +14,7 @@ template <class Field>
 void save(const fs::path& path, const std::string& filename, const Field& u, const std::string& suffix = "")
 {
     auto mesh   = u.mesh();
-    auto level_ = samurai::make_field<std::size_t>("level", mesh);
+    auto level_ = samurai::make_scalar_field<std::size_t>("level", mesh);
 
     if (!fs::exists(path))
     {
@@ -133,7 +133,7 @@ int main(int argc, char* argv[])
     Box box(box_corner1, box_corner2);
     samurai::MRMesh<Config> mesh{box, min_level, max_level};
 
-    auto u = samurai::make_field<double, n_comp>("u", mesh);
+    auto u = samurai::make_vector_field<double, n_comp>("u", mesh);
 
     double z0 = left_box / 5;    // wave initial position
     double c  = sqrt(k * D / 2); // wave velocity
@@ -165,7 +165,7 @@ int main(int argc, char* argv[])
         samurai::load(restart_file, mesh, u);
     }
 
-    auto unp1 = samurai::make_field<double, n_comp>("unp1", mesh);
+    auto unp1 = samurai::make_vector_field<double, n_comp>("unp1", mesh);
 
     samurai::make_bc<samurai::Neumann<1>>(u);
     samurai::make_bc<samurai::Neumann<1>>(unp1);
@@ -213,7 +213,7 @@ int main(int argc, char* argv[])
         save(path, filename, u, fmt::format("_ite_{}", nsave++));
     }
 
-    auto rhs = samurai::make_field<double, n_comp>("rhs", mesh);
+    auto rhs = samurai::make_vector_field<double, n_comp>("rhs", mesh);
 
     while (t != Tf)
     {

--- a/demos/FiniteVolume/scalar_burgers_2d.cpp
+++ b/demos/FiniteVolume/scalar_burgers_2d.cpp
@@ -160,7 +160,7 @@ template <class Field>
 void save(const fs::path& path, const std::string& filename, const Field& u, const std::string& suffix = "")
 {
     auto mesh   = u.mesh();
-    auto level_ = samurai::make_field<std::size_t, 1>("level", mesh);
+    auto level_ = samurai::make_field<std::size_t>("level", mesh);
 
     if (!fs::exists(path))
     {
@@ -236,7 +236,7 @@ int main(int argc, char* argv[])
     const samurai::Box<double, dim> box(min_corner, max_corner);
     samurai::MRMesh<Config> mesh;
 
-    auto u = samurai::make_field<double, 1>("u", mesh);
+    auto u = samurai::make_field<double>("u", mesh);
 
     if (restart_file.empty())
     {
@@ -253,7 +253,7 @@ int main(int argc, char* argv[])
     double dt            = cfl * mesh.cell_length(max_level);
     const double dt_save = Tf / static_cast<double>(nfiles);
 
-    auto unp1 = samurai::make_field<double, 1>("unp1", mesh);
+    auto unp1 = samurai::make_field<double>("unp1", mesh);
 
     auto MRadaptation = samurai::make_MRAdapt(u);
     MRadaptation(mr_epsilon, mr_regularity);

--- a/demos/FiniteVolume/scalar_burgers_2d.cpp
+++ b/demos/FiniteVolume/scalar_burgers_2d.cpp
@@ -160,7 +160,7 @@ template <class Field>
 void save(const fs::path& path, const std::string& filename, const Field& u, const std::string& suffix = "")
 {
     auto mesh   = u.mesh();
-    auto level_ = samurai::make_field<std::size_t>("level", mesh);
+    auto level_ = samurai::make_scalar_field<std::size_t>("level", mesh);
 
     if (!fs::exists(path))
     {
@@ -236,7 +236,7 @@ int main(int argc, char* argv[])
     const samurai::Box<double, dim> box(min_corner, max_corner);
     samurai::MRMesh<Config> mesh;
 
-    auto u = samurai::make_field<double>("u", mesh);
+    auto u = samurai::make_scalar_field<double>("u", mesh);
 
     if (restart_file.empty())
     {
@@ -253,7 +253,7 @@ int main(int argc, char* argv[])
     double dt            = cfl * mesh.cell_length(max_level);
     const double dt_save = Tf / static_cast<double>(nfiles);
 
-    auto unp1 = samurai::make_field<double>("unp1", mesh);
+    auto unp1 = samurai::make_scalar_field<double>("unp1", mesh);
 
     auto MRadaptation = samurai::make_MRAdapt(u);
     MRadaptation(mr_epsilon, mr_regularity);

--- a/demos/FiniteVolume/stokes_2d.cpp
+++ b/demos/FiniteVolume/stokes_2d.cpp
@@ -231,8 +231,8 @@ int main(int argc, char* argv[])
         //       p = pressure
 
         // Unknowns
-        auto velocity = samurai::make_field<dim, is_soa>("velocity", mesh);
-        auto pressure = samurai::make_field<double>("pressure", mesh);
+        auto velocity = samurai::make_vector_field<dim, is_soa>("velocity", mesh);
+        auto pressure = samurai::make_scalar_field<double>("pressure", mesh);
 
         using VelocityField = decltype(velocity);
         using PressureField = decltype(pressure);
@@ -271,17 +271,17 @@ int main(int argc, char* argv[])
         // clang-format on
 
         // Right-hand side
-        auto f    = samurai::make_field<dim, is_soa>("f",
-                                                  mesh,
-                                                  [](const auto& coord)
-                                                  {
-                                                      const auto& x = coord[0];
-                                                      const auto& y = coord[1];
-                                                      double f_x    = 2 * sin(pi * (x + y)) + (1 / pi) * cos(pi * (x + y));
-                                                      double f_y    = -2 * sin(pi * (x + y)) + (1 / pi) * cos(pi * (x + y));
-                                                      return samurai::Array<double, dim, is_soa>{f_x, f_y};
-                                                  });
-        auto zero = samurai::make_field<double>("zero", mesh);
+        auto f    = samurai::make_vector_field<dim, is_soa>("f",
+                                                         mesh,
+                                                         [](const auto& coord)
+                                                         {
+                                                             const auto& x = coord[0];
+                                                             const auto& y = coord[1];
+                                                             double f_x    = 2 * sin(pi * (x + y)) + (1 / pi) * cos(pi * (x + y));
+                                                             double f_y    = -2 * sin(pi * (x + y)) + (1 / pi) * cos(pi * (x + y));
+                                                             return samurai::Array<double, dim, is_soa>{f_x, f_y};
+                                                         });
+        auto zero = samurai::make_scalar_field<double>("zero", mesh);
         zero.fill(0);
 
         // Linear solver
@@ -313,33 +313,33 @@ int main(int argc, char* argv[])
         samurai::save(path, filename, mesh, velocity);
         samurai::save(path, "pressure", mesh, pressure);
 
-        auto exact_velocity = samurai::make_field<dim, is_soa>("exact_velocity",
-                                                               mesh,
-                                                               [](const auto& coord)
-                                                               {
-                                                                   const auto& x = coord[0];
-                                                                   const auto& y = coord[1];
-                                                                   auto v_x      = 1 / (pi * pi) * sin(pi * (x + y));
-                                                                   auto v_y      = -v_x;
-                                                                   return samurai::Array<double, dim, is_soa>{v_x, v_y};
-                                                               });
+        auto exact_velocity = samurai::make_vector_field<dim, is_soa>("exact_velocity",
+                                                                      mesh,
+                                                                      [](const auto& coord)
+                                                                      {
+                                                                          const auto& x = coord[0];
+                                                                          const auto& y = coord[1];
+                                                                          auto v_x      = 1 / (pi * pi) * sin(pi * (x + y));
+                                                                          auto v_y      = -v_x;
+                                                                          return samurai::Array<double, dim, is_soa>{v_x, v_y};
+                                                                      });
         samurai::save(path, "exact_velocity", mesh, exact_velocity);
 
-        /*auto err = samurai::make_field<dim, is_soa>("error", mesh);
+        /*auto err = samurai::make_vector_field<dim, is_soa>("error", mesh);
         for_each_cell(err.mesh(), [&](const auto& cell)
             {
                 err[cell] = exact_velocity[cell] - velocity[cell];
             });
         samurai::save(path, "error_velocity", mesh, err);*/
 
-        auto exact_pressure = samurai::make_field<double>("exact_pressure",
-                                                          mesh,
-                                                          [](const auto& coord)
-                                                          {
-                                                              const auto& x = coord[0];
-                                                              const auto& y = coord[1];
-                                                              return 1 / (pi * pi) * sin(pi * (x + y));
-                                                          });
+        auto exact_pressure = samurai::make_scalar_field<double>("exact_pressure",
+                                                                 mesh,
+                                                                 [](const auto& coord)
+                                                                 {
+                                                                     const auto& x = coord[0];
+                                                                     const auto& y = coord[1];
+                                                                     return 1 / (pi * pi) * sin(pi * (x + y));
+                                                                 });
         samurai::save(path, "exact_pressure", mesh, exact_pressure);
     }
 
@@ -392,16 +392,16 @@ int main(int argc, char* argv[])
         };
 
         // Unknowns
-        auto velocity     = samurai::make_field<dim, is_soa>("velocity", mesh);
-        auto velocity_np1 = samurai::make_field<dim, is_soa>("velocity_np1", mesh);
-        auto pressure_np1 = samurai::make_field<double>("pressure_np1", mesh);
+        auto velocity     = samurai::make_vector_field<dim, is_soa>("velocity", mesh);
+        auto velocity_np1 = samurai::make_vector_field<dim, is_soa>("velocity_np1", mesh);
+        auto pressure_np1 = samurai::make_scalar_field<double>("pressure_np1", mesh);
 
         using VelocityField = decltype(velocity);
         using PressureField = decltype(pressure_np1);
 
         // Right-hand side
-        auto rhs  = samurai::make_field<dim, is_soa>("rhs", mesh);
-        auto zero = samurai::make_field<double>("zero", mesh);
+        auto rhs  = samurai::make_vector_field<dim, is_soa>("rhs", mesh);
+        auto zero = samurai::make_scalar_field<double>("zero", mesh);
 
         // Boundary conditions
         samurai::make_bc<samurai::Dirichlet<1>>(velocity_np1,
@@ -524,12 +524,12 @@ int main(int argc, char* argv[])
             // Solve the linear equation
             //                [I + dt*Diff] v_np1 + dt*p_np1 = v_n + dt*f
             //                         -Div v_np1            = 0
-            auto f = samurai::make_field<dim, is_soa>("f",
-                                                      mesh,
-                                                      [&](const auto& coord)
-                                                      {
-                                                          return analytic_f(t_n, coord);
-                                                      });
+            auto f = samurai::make_vector_field<dim, is_soa>("f",
+                                                             mesh,
+                                                             [&](const auto& coord)
+                                                             {
+                                                                 return analytic_f(t_n, coord);
+                                                             });
             rhs.fill(0);
             rhs = velocity + dt * f;
             zero.fill(0);

--- a/demos/FiniteVolume/stokes_2d.cpp
+++ b/demos/FiniteVolume/stokes_2d.cpp
@@ -232,7 +232,7 @@ int main(int argc, char* argv[])
 
         // Unknowns
         auto velocity = samurai::make_field<dim, is_soa>("velocity", mesh);
-        auto pressure = samurai::make_field<1, is_soa>("pressure", mesh);
+        auto pressure = samurai::make_field<double>("pressure", mesh);
 
         using VelocityField = decltype(velocity);
         using PressureField = decltype(pressure);
@@ -281,7 +281,7 @@ int main(int argc, char* argv[])
                                                       double f_y    = -2 * sin(pi * (x + y)) + (1 / pi) * cos(pi * (x + y));
                                                       return samurai::Array<double, dim, is_soa>{f_x, f_y};
                                                   });
-        auto zero = samurai::make_field<1, is_soa>("zero", mesh);
+        auto zero = samurai::make_field<double>("zero", mesh);
         zero.fill(0);
 
         // Linear solver
@@ -332,14 +332,14 @@ int main(int argc, char* argv[])
             });
         samurai::save(path, "error_velocity", mesh, err);*/
 
-        auto exact_pressure = samurai::make_field<1, is_soa>("exact_pressure",
-                                                             mesh,
-                                                             [](const auto& coord)
-                                                             {
-                                                                 const auto& x = coord[0];
-                                                                 const auto& y = coord[1];
-                                                                 return 1 / (pi * pi) * sin(pi * (x + y));
-                                                             });
+        auto exact_pressure = samurai::make_field<double>("exact_pressure",
+                                                          mesh,
+                                                          [](const auto& coord)
+                                                          {
+                                                              const auto& x = coord[0];
+                                                              const auto& y = coord[1];
+                                                              return 1 / (pi * pi) * sin(pi * (x + y));
+                                                          });
         samurai::save(path, "exact_pressure", mesh, exact_pressure);
     }
 
@@ -394,14 +394,14 @@ int main(int argc, char* argv[])
         // Unknowns
         auto velocity     = samurai::make_field<dim, is_soa>("velocity", mesh);
         auto velocity_np1 = samurai::make_field<dim, is_soa>("velocity_np1", mesh);
-        auto pressure_np1 = samurai::make_field<1, is_soa>("pressure_np1", mesh);
+        auto pressure_np1 = samurai::make_field<double>("pressure_np1", mesh);
 
         using VelocityField = decltype(velocity);
         using PressureField = decltype(pressure_np1);
 
         // Right-hand side
         auto rhs  = samurai::make_field<dim, is_soa>("rhs", mesh);
-        auto zero = samurai::make_field<1, is_soa>("zero", mesh);
+        auto zero = samurai::make_field<double>("zero", mesh);
 
         // Boundary conditions
         samurai::make_bc<samurai::Dirichlet<1>>(velocity_np1,

--- a/demos/LBM/D1Q222_Euler_Sod.cpp
+++ b/demos/LBM/D1Q222_Euler_Sod.cpp
@@ -147,7 +147,7 @@ auto init_f(samurai::MROMesh<Config>& mesh, const double lambda)
     using mesh_id_t            = typename samurai::MROMesh<Config>::mesh_id_t;
     constexpr std::size_t nvel = 6;
 
-    auto f = samurai::make_field<double, nvel>("f", mesh);
+    auto f = samurai::make_vector_field<double, nvel>("f", mesh);
     f.fill(0);
 
     double gamma = 1.4;
@@ -199,11 +199,11 @@ void one_time_step(Field& f, const Pred& pred_coeff, Func&& update_bc_for_level,
     samurai::update_ghost_mr(f, std::forward<Func>(update_bc_for_level));
     samurai::update_overleaves_mr(f, std::forward<Func>(update_bc_for_level));
 
-    auto new_f = samurai::make_field<double, nvel>("new_f", mesh);
+    auto new_f = samurai::make_vector_field<double, nvel>("new_f", mesh);
     new_f.fill(0.);
-    auto advected_f = samurai::make_field<double, nvel>("advected_f", mesh);
+    auto advected_f = samurai::make_vector_field<double, nvel>("advected_f", mesh);
     advected_f.fill(0.);
-    auto help_f = samurai::make_field<double, nvel>("help_f", mesh);
+    auto help_f = samurai::make_vector_field<double, nvel>("help_f", mesh);
     help_f.fill(0.);
 
     for (std::size_t level = 0; level <= max_level; ++level)
@@ -358,10 +358,10 @@ void save_solution(Field& f, double eps, std::size_t ite, std::string ext = "")
     std::stringstream str;
     str << "LBM_D1Q2_Vectorial_Euler_" << ext << "_lmin_" << min_level << "_lmax-" << max_level << "_eps-" << eps << "_ite-" << ite;
 
-    auto level_ = samurai::make_field<std::size_t>("level", mesh);
-    auto rho    = samurai::make_field<double>("rho", mesh);
-    auto q      = samurai::make_field<double>("q", mesh);
-    auto e      = samurai::make_field<double>("e", mesh);
+    auto level_ = samurai::make_scalar_field<std::size_t>("level", mesh);
+    auto rho    = samurai::make_scalar_field<double>("rho", mesh);
+    auto q      = samurai::make_scalar_field<double>("q", mesh);
+    auto e      = samurai::make_scalar_field<double>("e", mesh);
 
     samurai::for_each_cell(mesh[mesh_id_t::cells],
                            [&](auto& cell)

--- a/demos/LBM/D1Q222_Euler_Sod.cpp
+++ b/demos/LBM/D1Q222_Euler_Sod.cpp
@@ -358,10 +358,10 @@ void save_solution(Field& f, double eps, std::size_t ite, std::string ext = "")
     std::stringstream str;
     str << "LBM_D1Q2_Vectorial_Euler_" << ext << "_lmin_" << min_level << "_lmax-" << max_level << "_eps-" << eps << "_ite-" << ite;
 
-    auto level_ = samurai::make_field<std::size_t, 1>("level", mesh);
-    auto rho    = samurai::make_field<double, 1>("rho", mesh);
-    auto q      = samurai::make_field<double, 1>("q", mesh);
-    auto e      = samurai::make_field<double, 1>("e", mesh);
+    auto level_ = samurai::make_field<std::size_t>("level", mesh);
+    auto rho    = samurai::make_field<double>("rho", mesh);
+    auto q      = samurai::make_field<double>("q", mesh);
+    auto e      = samurai::make_field<double>("e", mesh);
 
     samurai::for_each_cell(mesh[mesh_id_t::cells],
                            [&](auto& cell)

--- a/demos/LBM/D1Q2_Advection_and_Burgers.cpp
+++ b/demos/LBM/D1Q2_Advection_and_Burgers.cpp
@@ -103,7 +103,7 @@ auto init_f(samurai::MROMesh<Config>& mesh, const double lambda)
     using mesh_id_t            = typename samurai::MROMesh<Config>::mesh_id_t;
     constexpr std::size_t nvel = 2;
 
-    auto f = samurai::make_field<double, nvel>("f", mesh);
+    auto f = samurai::make_vector_field<double, nvel>("f", mesh);
     f.fill(0);
 
     samurai::for_each_cell(mesh[mesh_id_t::cells],
@@ -205,11 +205,11 @@ void one_time_step_overleaves(Field& f, const Pred& pred_coeff, Func&& update_bc
     samurai::update_ghost_mr(f, std::forward<Func>(update_bc_for_level));
     samurai::update_overleaves_mr(f, std::forward<Func>(update_bc_for_level));
 
-    auto new_f = samurai::make_field<double, nvel>("new_f", mesh);
+    auto new_f = samurai::make_vector_field<double, nvel>("new_f", mesh);
     new_f.fill(0.);
-    auto advected_f = samurai::make_field<double, nvel>("advected_f", mesh);
+    auto advected_f = samurai::make_vector_field<double, nvel>("advected_f", mesh);
     advected_f.fill(0.);
-    auto help_f = samurai::make_field<double, nvel>("help_f", mesh);
+    auto help_f = samurai::make_vector_field<double, nvel>("help_f", mesh);
     help_f.fill(0.);
 
     for (std::size_t level = 0; level <= max_level; ++level)
@@ -393,8 +393,8 @@ void save_solution(Field& f, double eps, std::size_t ite, std::string ext = "")
     std::stringstream str;
     str << "LBM_D1Q2_Burgers_" << ext << "_lmin_" << min_level << "_lmax-" << max_level << "_eps-" << eps << "_ite-" << ite;
 
-    auto level_ = samurai::make_field<std::size_t, 1>("level", mesh);
-    auto u      = samurai::make_field<value_t, 1>("u", mesh);
+    auto level_ = samurai::make_scalar_field<std::size_t>("level", mesh);
+    auto u      = samurai::make_scalar_field<value_t>("u", mesh);
 
     samurai::for_each_cell(mesh[mesh_id_t::cells],
                            [&](auto& cell)
@@ -421,7 +421,7 @@ void save_reconstructed(Field& f, FullField& f_full, Func&& update_bc_for_level,
 
     samurai::update_ghost_mr(f, std::forward<Func>(update_bc_for_level));
 
-    auto frec = samurai::make_field<value_t, nvel>("f_reconstructed", init_mesh);
+    auto frec = samurai::make_vector_field<value_t, nvel>("f_reconstructed", init_mesh);
     frec.fill(0.);
 
     using interval_t = typename Field::interval_t; // Type in X
@@ -445,8 +445,8 @@ void save_reconstructed(Field& f, FullField& f_full, Func&& update_bc_for_level,
     std::stringstream str;
     str << "LBM_D1Q2_Burgers_reconstructed_" << ext << "_lmin_" << min_level << "_lmax-" << max_level << "_eps-" << eps << "_ite-" << ite;
 
-    auto u_rec  = samurai::make_field<value_t, 1>("u_reconstructed", init_mesh);
-    auto u_full = samurai::make_field<value_t, 1>("u_full", init_mesh);
+    auto u_rec  = samurai::make_scalar_field<value_t>("u_reconstructed", init_mesh);
+    auto u_full = samurai::make_scalar_field<value_t>("u_full", init_mesh);
 
     samurai::for_each_cell(init_mesh[mesh_id_t::cells],
                            [&](auto& cell)

--- a/demos/LBM/D1Q3_Shallow_Waters_Dam.cpp
+++ b/demos/LBM/D1Q3_Shallow_Waters_Dam.cpp
@@ -88,7 +88,7 @@ auto init_f(samurai::MROMesh<Config>& mesh, double t, const double lambda, const
 {
     using mesh_id_t            = typename samurai::MROMesh<Config>::mesh_id_t;
     constexpr std::size_t nvel = 3;
-    auto f                     = samurai::make_field<double, nvel>("f", mesh);
+    auto f                     = samurai::make_vector_field<double, nvel>("f", mesh);
     f.fill(0);
 
     samurai::for_each_cell(mesh[mesh_id_t::cells],
@@ -126,11 +126,11 @@ void one_time_step(Field& f, const Pred& pred_coeff, Func&& update_bc_for_level,
     samurai::update_ghost_mr(f, std::forward<Func>(update_bc_for_level));
     samurai::update_overleaves_mr(f, std::forward<Func>(update_bc_for_level));
 
-    auto new_f = samurai::make_field<double, nvel>("new_f", mesh);
+    auto new_f = samurai::make_vector_field<double, nvel>("new_f", mesh);
     new_f.fill(0.);
-    auto advected_f = samurai::make_field<double, nvel>("advected_f", mesh);
+    auto advected_f = samurai::make_vector_field<double, nvel>("advected_f", mesh);
     advected_f.fill(0.);
-    auto help_f = samurai::make_field<double, nvel>("help_f", mesh);
+    auto help_f = samurai::make_vector_field<double, nvel>("help_f", mesh);
     help_f.fill(0.);
 
     for (std::size_t level = 0; level <= max_level; ++level)
@@ -249,10 +249,10 @@ void save_solution(Field& f, double eps, std::size_t ite, const double lambda, s
     std::stringstream str;
     str << "LBM_D1Q3_ShallowWaters_" << ext << "_lmin_" << min_level << "_lmax-" << max_level << "_eps-" << eps << "_ite-" << ite;
 
-    auto level_ = samurai::make_field<std::size_t, 1>("level", mesh);
-    auto h      = samurai::make_field<value_t, 1>("h", mesh);
-    auto q      = samurai::make_field<value_t, 1>("q", mesh);
-    auto u      = samurai::make_field<value_t, 1>("u", mesh);
+    auto level_ = samurai::make_scalar_field<std::size_t>("level", mesh);
+    auto h      = samurai::make_scalar_field<value_t>("h", mesh);
+    auto q      = samurai::make_scalar_field<value_t>("q", mesh);
+    auto u      = samurai::make_scalar_field<value_t>("u", mesh);
 
     samurai::for_each_cell(mesh[mesh_id_t::cells],
                            [&](auto& cell)

--- a/demos/LBM/D1Q5_Shallow_Waters_Dam.cpp
+++ b/demos/LBM/D1Q5_Shallow_Waters_Dam.cpp
@@ -104,7 +104,7 @@ auto init_f(samurai::MROMesh<Config>& mesh, double t, const double lambda, const
 {
     using mesh_id_t            = typename samurai::MROMesh<Config>::mesh_id_t;
     constexpr std::size_t nvel = 5;
-    auto f                     = samurai::make_field<double, nvel>("f", mesh);
+    auto f                     = samurai::make_vector_field<double, nvel>("f", mesh);
     f.fill(0);
 
     samurai::for_each_cell(mesh[mesh_id_t::cells],
@@ -298,11 +298,11 @@ void one_time_step_overleaves(Field& f, const Pred& pred_coeff, Func&& update_bc
     samurai::update_ghost_mr(f, std::forward<Func>(update_bc_for_level));
     samurai::update_overleaves_mr(f, std::forward<Func>(update_bc_for_level));
 
-    auto new_f = samurai::make_field<double, nvel>("new_f", mesh);
+    auto new_f = samurai::make_vector_field<double, nvel>("new_f", mesh);
     new_f.fill(0.);
-    auto advected_f = samurai::make_field<double, nvel>("advected_f", mesh);
+    auto advected_f = samurai::make_vector_field<double, nvel>("advected_f", mesh);
     advected_f.fill(0.);
-    auto help_f = samurai::make_field<double, nvel>("help_f", mesh);
+    auto help_f = samurai::make_vector_field<double, nvel>("help_f", mesh);
     help_f.fill(0.);
 
     for (std::size_t level = 0; level <= max_level; ++level)
@@ -479,10 +479,10 @@ void save_solution(Field& f, double eps, std::size_t ite, const double lambda, s
     std::stringstream str;
     str << "LBM_D1Q5_ShallowWaters_" << ext << "_lmin_" << min_level << "_lmax-" << max_level << "_eps-" << eps << "_ite-" << ite;
 
-    auto level_ = samurai::make_field<std::size_t, 1>("level", mesh);
-    auto h      = samurai::make_field<value_t, 1>("h", mesh);
-    auto q      = samurai::make_field<value_t, 1>("q", mesh);
-    auto u      = samurai::make_field<value_t, 1>("u", mesh);
+    auto level_ = samurai::make_scalar_field<std::size_t>("level", mesh);
+    auto h      = samurai::make_scalar_field<value_t>("h", mesh);
+    auto q      = samurai::make_scalar_field<value_t>("q", mesh);
+    auto u      = samurai::make_scalar_field<value_t>("u", mesh);
 
     samurai::for_each_cell(mesh[mesh_id_t::cells],
                            [&](auto& cell)

--- a/demos/LBM/D2Q4444_Euler_Implosion.cpp
+++ b/demos/LBM/D2Q4444_Euler_Implosion.cpp
@@ -45,7 +45,7 @@ auto init_f(samurai::MROMesh<Config>& mesh,
     constexpr std::size_t nvel = 16;
     using mesh_id_t            = typename samurai::MROMesh<Config>::mesh_id_t;
 
-    auto f = samurai::make_field<double, nvel>("f", mesh);
+    auto f = samurai::make_vector_field<double, nvel>("f", mesh);
     f.fill(0);
 
     samurai::for_each_cell(
@@ -874,12 +874,12 @@ void save_solution(Field& f, double eps, std::size_t ite, const double gas_const
     std::stringstream str;
     str << "LBM_D2Q4_4_Implosion_" << ext << "_lmin_" << min_level << "_lmax-" << max_level << "_eps-" << eps << "_ite-" << ite;
 
-    auto level = samurai::make_field<std::size_t, 1>("level", mesh);
-    auto rho   = samurai::make_field<value_t, 1>("rho", mesh);
-    auto qx    = samurai::make_field<value_t, 1>("qx", mesh);
-    auto qy    = samurai::make_field<value_t, 1>("qy", mesh);
-    auto e     = samurai::make_field<value_t, 1>("e", mesh);
-    auto s     = samurai::make_field<value_t, 1>("entropy", mesh);
+    auto level = samurai::make_scalar_field<std::size_t>("level", mesh);
+    auto rho   = samurai::make_scalar_field<value_t>("rho", mesh);
+    auto qx    = samurai::make_scalar_field<value_t>("qx", mesh);
+    auto qy    = samurai::make_scalar_field<value_t>("qy", mesh);
+    auto e     = samurai::make_scalar_field<value_t>("e", mesh);
+    auto s     = samurai::make_scalar_field<value_t>("entropy", mesh);
 
     samurai::for_each_cell(mesh[mesh_id_t::cells],
                            [&](auto& cell)

--- a/demos/LBM/D2Q4444_Euler_Lax_Liu.cpp
+++ b/demos/LBM/D2Q4444_Euler_Lax_Liu.cpp
@@ -43,7 +43,7 @@ auto init_f(samurai::MROMesh<Config>& mesh, int config, double lambda)
     constexpr std::size_t nvel = 16;
     using mesh_id_t            = typename samurai::MROMesh<Config>::mesh_id_t;
 
-    auto f = samurai::make_field<double, nvel>("f", mesh);
+    auto f = samurai::make_vector_field<double, nvel>("f", mesh);
     f.fill(0);
 
     samurai::for_each_cell(
@@ -460,12 +460,12 @@ void save_solution(Field& f, double eps, std::size_t ite, std::string ext = "")
     std::stringstream str;
     str << "LBM_D2Q4_3_Euler_" << ext << "_lmin_" << min_level << "_lmax-" << max_level << "_eps-" << eps << "_ite-" << ite;
 
-    auto level = samurai::make_field<std::size_t, 1>("level", mesh);
-    auto rho   = samurai::make_field<value_t, 1>("rho", mesh);
-    auto qx    = samurai::make_field<value_t, 1>("qx", mesh);
-    auto qy    = samurai::make_field<value_t, 1>("qy", mesh);
-    auto e     = samurai::make_field<value_t, 1>("e", mesh);
-    auto s     = samurai::make_field<value_t, 1>("entropy", mesh);
+    auto level = samurai::make_scalar_field<std::size_t>("level", mesh);
+    auto rho   = samurai::make_scalar_field<value_t>("rho", mesh);
+    auto qx    = samurai::make_scalar_field<value_t>("qx", mesh);
+    auto qy    = samurai::make_scalar_field<value_t>("qy", mesh);
+    auto e     = samurai::make_scalar_field<value_t>("e", mesh);
+    auto s     = samurai::make_scalar_field<value_t>("entropy", mesh);
 
     samurai::for_each_cell(mesh[mesh_id_t::cells],
                            [&](auto& cell)
@@ -605,7 +605,7 @@ double compute_error(Field& f, FieldFull& f_full, Func&& update_bc_for_level)
 
     samurai::update_ghost_mr(f, std::forward<Func>(update_bc_for_level));
 
-    auto f_reconstructed = samurai::make_field<value_t, nvel>("f_reconstructed", init_mesh);
+    auto f_reconstructed = samurai::make_vector_field<value_t, nvel>("f_reconstructed", init_mesh);
     f_reconstructed.fill(0.);
 
     // For memoization
@@ -658,22 +658,22 @@ void save_reconstructed(Field& f, FieldFull& f_full, Func&& update_bc_for_level,
 
     samurai::update_ghost_mr(f, std::forward<Func>(update_bc_for_level));
 
-    auto f_reconstructed = samurai::make_field<value_t, nvel>("f_reconstructed", init_mesh); // To reconstruct all and
-                                                                                             // see entropy
+    auto f_reconstructed = samurai::make_vector_field<value_t, nvel>("f_reconstructed", init_mesh); // To reconstruct all and
+                                                                                                    // see entropy
     f_reconstructed.fill(0.);
 
-    auto rho_reconstructed = samurai::make_field<value_t, 1>("rho_reconstructed", init_mesh);
-    auto qx_reconstructed  = samurai::make_field<value_t, 1>("qx_reconstructed", init_mesh);
-    auto qy_reconstructed  = samurai::make_field<value_t, 1>("qy_reconstructed", init_mesh);
-    auto E_reconstructed   = samurai::make_field<value_t, 1>("E_reconstructed", init_mesh);
-    auto s_reconstructed   = samurai::make_field<value_t, 1>("s_reconstructed", init_mesh);
-    auto level_            = samurai::make_field<std::size_t, 1>("level", init_mesh);
+    auto rho_reconstructed = samurai::make_scalar_field<value_t>("rho_reconstructed", init_mesh);
+    auto qx_reconstructed  = samurai::make_scalar_field<value_t>("qx_reconstructed", init_mesh);
+    auto qy_reconstructed  = samurai::make_scalar_field<value_t>("qy_reconstructed", init_mesh);
+    auto E_reconstructed   = samurai::make_scalar_field<value_t>("E_reconstructed", init_mesh);
+    auto s_reconstructed   = samurai::make_scalar_field<value_t>("s_reconstructed", init_mesh);
+    auto level_            = samurai::make_scalar_field<std::size_t>("level", init_mesh);
 
-    auto rho = samurai::make_field<value_t, 1>("rho", init_mesh);
-    auto qx  = samurai::make_field<value_t, 1>("qx", init_mesh);
-    auto qy  = samurai::make_field<value_t, 1>("qy", init_mesh);
-    auto E   = samurai::make_field<value_t, 1>("E", init_mesh);
-    auto s   = samurai::make_field<value_t, 1>("s", init_mesh);
+    auto rho = samurai::make_scalar_field<value_t>("rho", init_mesh);
+    auto qx  = samurai::make_scalar_field<value_t>("qx", init_mesh);
+    auto qy  = samurai::make_scalar_field<value_t>("qy", init_mesh);
+    auto E   = samurai::make_scalar_field<value_t>("E", init_mesh);
+    auto s   = samurai::make_scalar_field<value_t>("s", init_mesh);
 
     // For memoization
     using interval_t  = typename Field::interval_t;   // Type in X

--- a/demos/LBM/D2Q4444_Euler_Lax_Liu_uniform.cpp
+++ b/demos/LBM/D2Q4444_Euler_Lax_Liu_uniform.cpp
@@ -39,7 +39,7 @@ auto init_f(Mesh& mesh, int config, double lambda)
     constexpr std::size_t nvel = 16;
     using mesh_id_t            = typename Mesh::mesh_id_t;
 
-    auto f = samurai::make_field<double, nvel>("f", mesh);
+    auto f = samurai::make_vector_field<double, nvel>("f", mesh);
     f.fill(0);
 
     samurai::for_each_cell(
@@ -312,11 +312,11 @@ void save_solution(Field& f, std::size_t ite, std::string ext = "")
     std::stringstream str;
     str << "LBM_D2Q4_3_Euler_Uniform_ite-" << ite;
 
-    auto rho = samurai::make_field<value_t, 1>("rho", mesh);
-    auto qx  = samurai::make_field<value_t, 1>("qx", mesh);
-    auto qy  = samurai::make_field<value_t, 1>("qy", mesh);
-    auto e   = samurai::make_field<value_t, 1>("e", mesh);
-    auto s   = samurai::make_field<value_t, 1>("entropy", mesh);
+    auto rho = samurai::make_scalar_field<value_t>("rho", mesh);
+    auto qx  = samurai::make_scalar_field<value_t>("qx", mesh);
+    auto qy  = samurai::make_scalar_field<value_t>("qy", mesh);
+    auto e   = samurai::make_scalar_field<value_t>("e", mesh);
+    auto s   = samurai::make_scalar_field<value_t>("entropy", mesh);
 
     samurai::for_each_cell(mesh[mesh_id_t::cells],
                            [&](auto& cell)

--- a/demos/LBM/D2Q5444_Euler_Rayleigh_Taylor.cpp
+++ b/demos/LBM/D2Q5444_Euler_Rayleigh_Taylor.cpp
@@ -45,7 +45,7 @@ auto init_f(samurai::MROMesh<Config>& mesh,
     constexpr std::size_t nvel = 17;
     using mesh_id_t            = typename samurai::MROMesh<Config>::mesh_id_t;
 
-    auto f = samurai::make_field<double, nvel>("f", mesh);
+    auto f = samurai::make_vector_field<double, nvel>("f", mesh);
     f.fill(0);
 
     samurai::for_each_cell(
@@ -1058,12 +1058,12 @@ void save_solution(Field& f, double eps, std::size_t ite, const double gas_const
     std::stringstream str;
     str << "LBM_D2Q5444_RayleighTaylor_" << ext << "_lmin_" << min_level << "_lmax-" << max_level << "_eps-" << eps << "_ite-" << ite;
 
-    auto level = samurai::make_field<std::size_t, 1>("level", mesh);
-    auto rho   = samurai::make_field<value_t, 1>("rho", mesh);
-    auto qx    = samurai::make_field<value_t, 1>("qx", mesh);
-    auto qy    = samurai::make_field<value_t, 1>("qy", mesh);
-    auto e     = samurai::make_field<value_t, 1>("e", mesh);
-    auto s     = samurai::make_field<value_t, 1>("entropy", mesh);
+    auto level = samurai::make_scalar_field<std::size_t>("level", mesh);
+    auto rho   = samurai::make_scalar_field<value_t>("rho", mesh);
+    auto qx    = samurai::make_scalar_field<value_t>("qx", mesh);
+    auto qy    = samurai::make_scalar_field<value_t>("qy", mesh);
+    auto e     = samurai::make_scalar_field<value_t>("e", mesh);
+    auto s     = samurai::make_scalar_field<value_t>("entropy", mesh);
 
     samurai::for_each_cell(mesh[mesh_id_t::cells],
                            [&](auto& cell)

--- a/demos/LBM/D2Q9_Navier_Stokes_von_Karman_street.cpp
+++ b/demos/LBM/D2Q9_Navier_Stokes_von_Karman_street.cpp
@@ -169,7 +169,7 @@ auto init_f(samurai::MROMesh<Config>& mesh, const double radius, double rho0, do
     using mesh_id_t            = typename samurai::MROMesh<Config>::mesh_id_t;
     constexpr std::size_t nvel = 9;
 
-    auto f = samurai::make_field<double, nvel>("f", mesh);
+    auto f = samurai::make_vector_field<double, nvel>("f", mesh);
     f.fill(0);
 
     samurai::for_each_cell(mesh[mesh_id_t::cells],
@@ -1317,11 +1317,11 @@ void save_solution(Field& f, double eps, std::size_t ite, double lambda, std::st
     std::stringstream str;
     str << "LBM_D2Q9_von_Karman_street_" << ext << "_lmin_" << min_level << "_lmax-" << max_level << "_eps-" << eps << "_ite-" << ite;
 
-    auto level_  = samurai::make_field<std::size_t, 1>("level", mesh);
-    auto rho     = samurai::make_field<value_t, 1>("rho", mesh);
-    auto qx      = samurai::make_field<value_t, 1>("qx", mesh);
-    auto qy      = samurai::make_field<value_t, 1>("qy", mesh);
-    auto vel_mod = samurai::make_field<value_t, 1>("vel_modulus", mesh);
+    auto level_  = samurai::make_scalar_field<std::size_t>("level", mesh);
+    auto rho     = samurai::make_scalar_field<value_t>("rho", mesh);
+    auto qx      = samurai::make_scalar_field<value_t>("qx", mesh);
+    auto qy      = samurai::make_scalar_field<value_t>("qy", mesh);
+    auto vel_mod = samurai::make_scalar_field<value_t>("vel_modulus", mesh);
 
     samurai::for_each_cell(mesh[mesh_id_t::cells],
                            [&](auto& cell)

--- a/demos/LBM/test_D1Q2.cpp
+++ b/demos/LBM/test_D1Q2.cpp
@@ -135,7 +135,7 @@ template <class Mesh>
 auto init_f(Mesh& mesh, double t, double ad_vel, double lambda, int test_number)
 {
     using mesh_id_t = typename Mesh::mesh_id_t;
-    auto f          = samurai::make_field<double, 2>("f", mesh);
+    auto f          = samurai::make_vector_field<double, 2>("f", mesh);
 
     samurai::for_each_cell(mesh[mesh_id_t::cells],
                            [&](auto& cell)
@@ -167,7 +167,7 @@ void one_time_step(Field& f, Func&& update_bc_for_level, double s_rel, double la
 
     samurai::update_ghost_mr(f, std::forward<Func>(update_bc_for_level));
 
-    auto new_f = samurai::make_field<double, nvel>("new_f", mesh);
+    auto new_f = samurai::make_vector_field<double, nvel>("new_f", mesh);
     samurai::for_each_interval(mesh[mesh_id_t::cells][max_level],
                                [&](std::size_t level, auto& i, auto&)
                                {

--- a/demos/LBM/test_D1Q222.cpp
+++ b/demos/LBM/test_D1Q222.cpp
@@ -146,7 +146,7 @@ auto init_f(samurai::MROMesh<Config>& mesh, const double lambda)
     using mesh_id_t            = typename samurai::MROMesh<Config>::mesh_id_t;
     constexpr std::size_t nvel = 6;
 
-    auto f = samurai::make_field<double, nvel>("f", mesh);
+    auto f = samurai::make_vector_field<double, nvel>("f", mesh);
     f.fill(0);
 
     double gamma = 1.4;
@@ -198,11 +198,11 @@ void one_time_step(Field& f, const Pred& pred_coeff, Func&& update_bc_for_level,
     samurai::update_ghost_mr(f, std::forward<Func>(update_bc_for_level));
     samurai::update_overleaves_mr(f, std::forward<Func>(update_bc_for_level));
 
-    auto new_f = samurai::make_field<double, nvel>("new_f", mesh);
+    auto new_f = samurai::make_vector_field<double, nvel>("new_f", mesh);
     new_f.fill(0.);
-    auto advected_f = samurai::make_field<double, nvel>("advected_f", mesh);
+    auto advected_f = samurai::make_vector_field<double, nvel>("advected_f", mesh);
     advected_f.fill(0.);
-    auto help_f = samurai::make_field<double, nvel>("help_f", mesh);
+    auto help_f = samurai::make_vector_field<double, nvel>("help_f", mesh);
     help_f.fill(0.);
 
     for (std::size_t level = 0; level <= max_level; ++level)

--- a/demos/LBM/test_D1Q3.cpp
+++ b/demos/LBM/test_D1Q3.cpp
@@ -89,7 +89,7 @@ auto init_f(samurai::MROMesh<Config>& mesh, double t, const double lambda, const
 {
     using mesh_id_t            = typename samurai::MROMesh<Config>::mesh_id_t;
     constexpr std::size_t nvel = 3;
-    auto f                     = samurai::make_field<double, nvel>("f", mesh);
+    auto f                     = samurai::make_vector_field<double, nvel>("f", mesh);
     f.fill(0);
 
     samurai::for_each_cell(mesh[mesh_id_t::cells],
@@ -127,11 +127,11 @@ void one_time_step(Field& f, const Pred& pred_coeff, Func&& update_bc_for_level,
     samurai::update_ghost_mr(f, std::forward<Func>(update_bc_for_level));
     samurai::update_overleaves_mr(f, std::forward<Func>(update_bc_for_level));
 
-    auto new_f = samurai::make_field<double, nvel>("new_f", mesh);
+    auto new_f = samurai::make_vector_field<double, nvel>("new_f", mesh);
     new_f.fill(0.);
-    auto advected_f = samurai::make_field<double, nvel>("advected_f", mesh);
+    auto advected_f = samurai::make_vector_field<double, nvel>("advected_f", mesh);
     advected_f.fill(0.);
-    auto help_f = samurai::make_field<double, nvel>("help_f", mesh);
+    auto help_f = samurai::make_vector_field<double, nvel>("help_f", mesh);
     help_f.fill(0.);
 
     for (std::size_t level = 0; level <= max_level; ++level)

--- a/demos/LBM/test_D1Q5.cpp
+++ b/demos/LBM/test_D1Q5.cpp
@@ -106,7 +106,7 @@ auto init_f(samurai::MROMesh<Config>& mesh, double t, const double lambda, const
 {
     using mesh_id_t            = typename samurai::MROMesh<Config>::mesh_id_t;
     constexpr std::size_t nvel = 5;
-    auto f                     = samurai::make_field<double, nvel>("f", mesh);
+    auto f                     = samurai::make_vector_field<double, nvel>("f", mesh);
     f.fill(0);
 
     samurai::for_each_cell(mesh[mesh_id_t::cells],
@@ -299,11 +299,11 @@ void one_time_step_overleaves(Field& f, const Pred& pred_coeff, Func&& update_bc
     samurai::update_ghost_mr(f, std::forward<Func>(update_bc_for_level));
     samurai::update_overleaves_mr(f, std::forward<Func>(update_bc_for_level));
 
-    auto new_f = samurai::make_field<double, nvel>("new_f", mesh);
+    auto new_f = samurai::make_vector_field<double, nvel>("new_f", mesh);
     new_f.fill(0.);
-    auto advected_f = samurai::make_field<double, nvel>("advected_f", mesh);
+    auto advected_f = samurai::make_vector_field<double, nvel>("advected_f", mesh);
     advected_f.fill(0.);
-    auto help_f = samurai::make_field<double, nvel>("help_f", mesh);
+    auto help_f = samurai::make_vector_field<double, nvel>("help_f", mesh);
     help_f.fill(0.);
 
     for (std::size_t level = 0; level <= max_level; ++level)

--- a/demos/Weno/VF_level_set_houc5_amr.cpp
+++ b/demos/Weno/VF_level_set_houc5_amr.cpp
@@ -18,7 +18,7 @@ template <class Mesh>
 auto init_field(Mesh& mesh)
 {
     using mesh_id_t = typename Mesh::mesh_id_t;
-    auto field      = samurai::make_field<double>("sol", mesh);
+    auto field      = samurai::make_scalar_field<double>("sol", mesh);
 
     samurai::for_each_cell(mesh[mesh_id_t::cells_and_ghosts],
                            [&](auto& cell)
@@ -36,7 +36,7 @@ auto init_velocity(Mesh& mesh)
 {
     using mesh_id_t = typename Mesh::mesh_id_t;
 
-    auto u = samurai::make_field<double, 2>("u", mesh);
+    auto u = samurai::make_vector_field<double, 2>("u", mesh);
     u.fill(0);
 
     samurai::for_each_cell(mesh[mesh_id_t::cells_and_ghosts],
@@ -297,7 +297,7 @@ int main()
         {
             std::cout << "\tmesh adaptation: " << ite_adapt++ << std::endl;
             samurai::update_ghost(update_bc, field);
-            auto tag = samurai::make_field<int>("tag", mesh);
+            auto tag = samurai::make_scalar_field<int>("tag", mesh);
             AMR_criteria(field, tag);
             samurai::graduation(tag, stencil_graduation::call(samurai::Dim<dim>{}));
             if (samurai::update_field(tag, field))
@@ -307,7 +307,7 @@ int main()
         }
 
         auto vel       = init_velocity(mesh);
-        auto field_np1 = samurai::make_field<double>("sol", mesh);
+        auto field_np1 = samurai::make_scalar_field<double>("sol", mesh);
         field_np1.fill(0.);
 
         // Euler --> unstable on uniform mesh
@@ -315,9 +315,9 @@ int main()
         // field_np1 = field - dt*houc5(field, vel);
 
         // TVD-RK3 (SSPRK3)
-        auto field1 = samurai::make_field<double>("sol", mesh);
+        auto field1 = samurai::make_scalar_field<double>("sol", mesh);
         field1.fill(0.);
-        auto field2 = samurai::make_field<double>("sol", mesh);
+        auto field2 = samurai::make_scalar_field<double>("sol", mesh);
         field2.fill(0.);
 
         samurai::update_ghost(update_bc, field);

--- a/demos/Weno/VF_level_set_houc5_amr.cpp
+++ b/demos/Weno/VF_level_set_houc5_amr.cpp
@@ -18,7 +18,7 @@ template <class Mesh>
 auto init_field(Mesh& mesh)
 {
     using mesh_id_t = typename Mesh::mesh_id_t;
-    auto field      = samurai::make_field<double, 1>("sol", mesh);
+    auto field      = samurai::make_field<double>("sol", mesh);
 
     samurai::for_each_cell(mesh[mesh_id_t::cells_and_ghosts],
                            [&](auto& cell)
@@ -297,7 +297,7 @@ int main()
         {
             std::cout << "\tmesh adaptation: " << ite_adapt++ << std::endl;
             samurai::update_ghost(update_bc, field);
-            auto tag = samurai::make_field<int, 1>("tag", mesh);
+            auto tag = samurai::make_field<int>("tag", mesh);
             AMR_criteria(field, tag);
             samurai::graduation(tag, stencil_graduation::call(samurai::Dim<dim>{}));
             if (samurai::update_field(tag, field))
@@ -307,7 +307,7 @@ int main()
         }
 
         auto vel       = init_velocity(mesh);
-        auto field_np1 = samurai::make_field<double, 1>("sol", mesh);
+        auto field_np1 = samurai::make_field<double>("sol", mesh);
         field_np1.fill(0.);
 
         // Euler --> unstable on uniform mesh
@@ -315,9 +315,9 @@ int main()
         // field_np1 = field - dt*houc5(field, vel);
 
         // TVD-RK3 (SSPRK3)
-        auto field1 = samurai::make_field<double, 1>("sol", mesh);
+        auto field1 = samurai::make_field<double>("sol", mesh);
         field1.fill(0.);
-        auto field2 = samurai::make_field<double, 1>("sol", mesh);
+        auto field2 = samurai::make_field<double>("sol", mesh);
         field2.fill(0.);
 
         samurai::update_ghost(update_bc, field);

--- a/demos/Weno/VF_level_set_os5_amr.cpp
+++ b/demos/Weno/VF_level_set_os5_amr.cpp
@@ -18,7 +18,7 @@ template <class Mesh>
 auto init_field(Mesh& mesh)
 {
     using mesh_id_t = typename Mesh::mesh_id_t;
-    auto field      = samurai::make_field<double, 1>("sol", mesh);
+    auto field      = samurai::make_field<double>("sol", mesh);
 
     samurai::for_each_cell(mesh[mesh_id_t::cells_and_ghosts],
                            [&](auto& cell)
@@ -293,8 +293,8 @@ int main()
 
     auto field = init_field(mesh);
 
-    auto field_np1 = samurai::make_field<double, 1>("sol", mesh);
-    auto tag       = samurai::make_field<int, 1>("tag", mesh);
+    auto field_np1 = samurai::make_field<double>("sol", mesh);
+    auto tag       = samurai::make_field<int>("tag", mesh);
 
     auto update_bc = [](std::size_t level, auto& field)
     {

--- a/demos/Weno/VF_level_set_os5_amr.cpp
+++ b/demos/Weno/VF_level_set_os5_amr.cpp
@@ -18,7 +18,7 @@ template <class Mesh>
 auto init_field(Mesh& mesh)
 {
     using mesh_id_t = typename Mesh::mesh_id_t;
-    auto field      = samurai::make_field<double>("sol", mesh);
+    auto field      = samurai::make_scalar_field<double>("sol", mesh);
 
     samurai::for_each_cell(mesh[mesh_id_t::cells_and_ghosts],
                            [&](auto& cell)
@@ -36,7 +36,7 @@ auto init_velocity(Mesh& mesh)
 {
     using mesh_id_t = typename Mesh::mesh_id_t;
 
-    auto u = samurai::make_field<double, 2>("u", mesh);
+    auto u = samurai::make_vector_field<double, 2>("u", mesh);
     u.fill(0);
 
     samurai::for_each_cell(mesh[mesh_id_t::cells_and_ghosts],
@@ -293,8 +293,8 @@ int main()
 
     auto field = init_field(mesh);
 
-    auto field_np1 = samurai::make_field<double>("sol", mesh);
-    auto tag       = samurai::make_field<int>("tag", mesh);
+    auto field_np1 = samurai::make_scalar_field<double>("sol", mesh);
+    auto tag       = samurai::make_scalar_field<int>("tag", mesh);
 
     auto update_bc = [](std::size_t level, auto& field)
     {

--- a/demos/Weno/heat_weno5_amr.cpp
+++ b/demos/Weno/heat_weno5_amr.cpp
@@ -20,7 +20,7 @@ struct init_field
     static auto call(samurai::Dim<2>, Mesh& mesh)
     {
         using mesh_id_t = typename Mesh::mesh_id_t;
-        auto field      = samurai::make_field<double>("sol", mesh);
+        auto field      = samurai::make_scalar_field<double>("sol", mesh);
 
         samurai::for_each_cell(mesh[mesh_id_t::cells_and_ghosts],
                                [&](auto& cell)
@@ -39,7 +39,7 @@ struct init_field
     static auto call(samurai::Dim<3>, Mesh& mesh)
     {
         using mesh_id_t = typename Mesh::mesh_id_t;
-        auto field      = samurai::make_field<double>("sol", mesh);
+        auto field      = samurai::make_scalar_field<double>("sol", mesh);
 
         samurai::for_each_cell(mesh[mesh_id_t::cells_and_ghosts],
                                [&](auto& cell)
@@ -62,7 +62,7 @@ auto init_velocity(Mesh& mesh)
 {
     using mesh_id_t = typename Mesh::mesh_id_t;
 
-    auto u = samurai::make_field<double, dim>("u", mesh);
+    auto u = samurai::make_vector_field<double, dim>("u", mesh);
     u.fill(0);
 
     samurai::for_each_cell(mesh[mesh_id_t::cells_and_ghosts],
@@ -83,7 +83,7 @@ auto init_phys(Mesh& mesh)
 {
     using mesh_id_t = typename Mesh::mesh_id_t;
 
-    auto nu = samurai::make_field<double>("nu", mesh);
+    auto nu = samurai::make_scalar_field<double>("nu", mesh);
     nu.fill(0);
 
     samurai::for_each_cell(mesh[mesh_id_t::cells_and_ghosts],
@@ -756,7 +756,7 @@ int main()
         {
             std::cout << "\tmesh adaptation: " << ite_adapt++ << std::endl;
             samurai::update_ghost(update_bc, field);
-            auto tag = samurai::make_field<int>("tag", mesh);
+            auto tag = samurai::make_scalar_field<int>("tag", mesh);
             AMR_criteria(field, tag);
             samurai::graduation(tag, stencil_graduation::call(samurai::Dim<dim>{}));
             if (samurai::update_field(tag, field))
@@ -815,7 +815,7 @@ int main()
 
         /* Integration */
 
-        auto field_np1 = samurai::make_field<double>("sol", mesh);
+        auto field_np1 = samurai::make_scalar_field<double>("sol", mesh);
         field_np1.fill(0.);
 
         /* Covection */

--- a/demos/Weno/heat_weno5_amr.cpp
+++ b/demos/Weno/heat_weno5_amr.cpp
@@ -20,7 +20,7 @@ struct init_field
     static auto call(samurai::Dim<2>, Mesh& mesh)
     {
         using mesh_id_t = typename Mesh::mesh_id_t;
-        auto field      = samurai::make_field<double, 1>("sol", mesh);
+        auto field      = samurai::make_field<double>("sol", mesh);
 
         samurai::for_each_cell(mesh[mesh_id_t::cells_and_ghosts],
                                [&](auto& cell)
@@ -39,7 +39,7 @@ struct init_field
     static auto call(samurai::Dim<3>, Mesh& mesh)
     {
         using mesh_id_t = typename Mesh::mesh_id_t;
-        auto field      = samurai::make_field<double, 1>("sol", mesh);
+        auto field      = samurai::make_field<double>("sol", mesh);
 
         samurai::for_each_cell(mesh[mesh_id_t::cells_and_ghosts],
                                [&](auto& cell)
@@ -83,7 +83,7 @@ auto init_phys(Mesh& mesh)
 {
     using mesh_id_t = typename Mesh::mesh_id_t;
 
-    auto nu = samurai::make_field<double, 1>("nu", mesh);
+    auto nu = samurai::make_field<double>("nu", mesh);
     nu.fill(0);
 
     samurai::for_each_cell(mesh[mesh_id_t::cells_and_ghosts],
@@ -756,7 +756,7 @@ int main()
         {
             std::cout << "\tmesh adaptation: " << ite_adapt++ << std::endl;
             samurai::update_ghost(update_bc, field);
-            auto tag = samurai::make_field<int, 1>("tag", mesh);
+            auto tag = samurai::make_field<int>("tag", mesh);
             AMR_criteria(field, tag);
             samurai::graduation(tag, stencil_graduation::call(samurai::Dim<dim>{}));
             if (samurai::update_field(tag, field))
@@ -815,7 +815,7 @@ int main()
 
         /* Integration */
 
-        auto field_np1 = samurai::make_field<double, 1>("sol", mesh);
+        auto field_np1 = samurai::make_field<double>("sol", mesh);
         field_np1.fill(0.);
 
         /* Covection */

--- a/demos/Weno/weno5.cpp
+++ b/demos/Weno/weno5.cpp
@@ -100,7 +100,7 @@ template <class Mesh>
 auto init_field(Mesh& mesh)
 {
     using mesh_id_t = typename Mesh::mesh_id_t;
-    auto field      = samurai::make_field<double>("sol", mesh);
+    auto field      = samurai::make_scalar_field<double>("sol", mesh);
 
     samurai::for_each_cell(mesh[mesh_id_t::cells_and_ghosts],
                            [&](auto& cell)
@@ -118,7 +118,7 @@ auto init_velocity(Mesh& mesh)
 {
     using mesh_id_t = typename Mesh::mesh_id_t;
 
-    auto u = samurai::make_field<double, 2>("u", mesh);
+    auto u = samurai::make_vector_field<double, 2>("u", mesh);
     u.fill(0);
 
     samurai::for_each_cell(mesh[mesh_id_t::cells_and_ghosts],
@@ -371,7 +371,7 @@ int main()
     auto field = init_field(mesh);
     auto vel   = init_velocity(mesh);
 
-    auto field_np1 = samurai::make_field<double>("sol", mesh);
+    auto field_np1 = samurai::make_scalar_field<double>("sol", mesh);
 
     double dt           = 0.5 / (1 << start_level);
     std::size_t max_ite = 50;

--- a/demos/Weno/weno5.cpp
+++ b/demos/Weno/weno5.cpp
@@ -100,7 +100,7 @@ template <class Mesh>
 auto init_field(Mesh& mesh)
 {
     using mesh_id_t = typename Mesh::mesh_id_t;
-    auto field      = samurai::make_field<double, 1>("sol", mesh);
+    auto field      = samurai::make_field<double>("sol", mesh);
 
     samurai::for_each_cell(mesh[mesh_id_t::cells_and_ghosts],
                            [&](auto& cell)
@@ -371,7 +371,7 @@ int main()
     auto field = init_field(mesh);
     auto vel   = init_velocity(mesh);
 
-    auto field_np1 = samurai::make_field<double, 1>("sol", mesh);
+    auto field_np1 = samurai::make_field<double>("sol", mesh);
 
     double dt           = 0.5 / (1 << start_level);
     std::size_t max_ite = 50;

--- a/demos/Weno/weno5_amr.cpp
+++ b/demos/Weno/weno5_amr.cpp
@@ -20,7 +20,7 @@ struct init_field
     static auto call(samurai::Dim<2>, Mesh& mesh)
     {
         using mesh_id_t = typename Mesh::mesh_id_t;
-        auto field      = samurai::make_field<double>("sol", mesh);
+        auto field      = samurai::make_scalar_field<double>("sol", mesh);
 
         samurai::for_each_cell(mesh[mesh_id_t::cells_and_ghosts],
                                [&](auto& cell)
@@ -37,7 +37,7 @@ struct init_field
     static auto call(samurai::Dim<3>, Mesh& mesh)
     {
         using mesh_id_t = typename Mesh::mesh_id_t;
-        auto field      = samurai::make_field<double>("sol", mesh);
+        auto field      = samurai::make_scalar_field<double>("sol", mesh);
 
         samurai::for_each_cell(mesh[mesh_id_t::cells_and_ghosts],
                                [&](auto& cell)
@@ -95,7 +95,7 @@ auto init_velocity(Mesh& mesh)
 {
     using mesh_id_t = typename Mesh::mesh_id_t;
 
-    auto u = samurai::make_field<double, dim>("u", mesh);
+    auto u = samurai::make_vector_field<double, dim>("u", mesh);
     u.fill(0);
 
     samurai::for_each_cell(mesh[mesh_id_t::cells_and_ghosts],
@@ -471,7 +471,7 @@ int main()
         {
             std::cout << "\tmesh adaptation: " << ite_adapt++ << std::endl;
             samurai::update_ghost(update_bc, field);
-            auto tag = samurai::make_field<int>("tag", mesh);
+            auto tag = samurai::make_scalar_field<int>("tag", mesh);
             AMR_criteria(field, tag);
             samurai::graduation(tag, stencil_graduation::call(samurai::Dim<dim>{}));
             if (samurai::update_field(tag, field))
@@ -483,7 +483,7 @@ int main()
         samurai::update_ghost(update_bc, field);
 
         auto vel       = init_velocity<dim>(mesh);
-        auto field_np1 = samurai::make_field<double>("sol", mesh);
+        auto field_np1 = samurai::make_scalar_field<double>("sol", mesh);
         field_np1.fill(0.);
 
         field_np1 = field - dt * weno5(field, vel);

--- a/demos/Weno/weno5_amr.cpp
+++ b/demos/Weno/weno5_amr.cpp
@@ -20,7 +20,7 @@ struct init_field
     static auto call(samurai::Dim<2>, Mesh& mesh)
     {
         using mesh_id_t = typename Mesh::mesh_id_t;
-        auto field      = samurai::make_field<double, 1>("sol", mesh);
+        auto field      = samurai::make_field<double>("sol", mesh);
 
         samurai::for_each_cell(mesh[mesh_id_t::cells_and_ghosts],
                                [&](auto& cell)
@@ -37,7 +37,7 @@ struct init_field
     static auto call(samurai::Dim<3>, Mesh& mesh)
     {
         using mesh_id_t = typename Mesh::mesh_id_t;
-        auto field      = samurai::make_field<double, 1>("sol", mesh);
+        auto field      = samurai::make_field<double>("sol", mesh);
 
         samurai::for_each_cell(mesh[mesh_id_t::cells_and_ghosts],
                                [&](auto& cell)
@@ -471,7 +471,7 @@ int main()
         {
             std::cout << "\tmesh adaptation: " << ite_adapt++ << std::endl;
             samurai::update_ghost(update_bc, field);
-            auto tag = samurai::make_field<int, 1>("tag", mesh);
+            auto tag = samurai::make_field<int>("tag", mesh);
             AMR_criteria(field, tag);
             samurai::graduation(tag, stencil_graduation::call(samurai::Dim<dim>{}));
             if (samurai::update_field(tag, field))
@@ -483,7 +483,7 @@ int main()
         samurai::update_ghost(update_bc, field);
 
         auto vel       = init_velocity<dim>(mesh);
-        auto field_np1 = samurai::make_field<double, 1>("sol", mesh);
+        auto field_np1 = samurai::make_field<double>("sol", mesh);
         field_np1.fill(0.);
 
         field_np1 = field - dt * weno5(field, vel);

--- a/demos/from_obj/main.cpp
+++ b/demos/from_obj/main.cpp
@@ -11,7 +11,7 @@ namespace fs = std::filesystem;
 template <class Mesh>
 void save_mesh(const fs::path& path, const std::string& filename, const Mesh& mesh)
 {
-    auto level = samurai::make_field<std::size_t, 1>("level", mesh);
+    auto level = samurai::make_scalar_field<std::size_t>("level", mesh);
 
     if (!fs::exists(path))
     {

--- a/demos/highorder/main.cpp
+++ b/demos/highorder/main.cpp
@@ -168,23 +168,23 @@ int main(int argc, char* argv[])
     PetscInitialize(&argc, &argv, 0, nullptr);
     PetscOptionsSetValue(NULL, "-options_left", "off");
 
-    auto adapt_field = samurai::make_field<double, 1>("adapt_field",
-                                                      init_mesh,
-                                                      [](const auto& coord)
-                                                      {
-                                                          const auto& x = coord[0];
-                                                          const auto& y = coord[1];
-                                                          double radius = 0.4;
-                                                          if ((x - 0.5) * (x - 0.5) + (y - 0.5) * (y - 0.5) < radius * radius)
-                                                          {
-                                                              samurai::finalize();
-                                                              return 0;
-                                                          }
-                                                          else
-                                                          {
-                                                              return 1;
-                                                          }
-                                                      });
+    auto adapt_field = samurai::make_field<double>("adapt_field",
+                                                   init_mesh,
+                                                   [](const auto& coord)
+                                                   {
+                                                       const auto& x = coord[0];
+                                                       const auto& y = coord[1];
+                                                       double radius = 0.4;
+                                                       if ((x - 0.5) * (x - 0.5) + (y - 0.5) * (y - 0.5) < radius * radius)
+                                                       {
+                                                           samurai::finalize();
+                                                           return 0;
+                                                       }
+                                                       else
+                                                       {
+                                                           return 1;
+                                                       }
+                                                   });
 
     auto MRadaptation = samurai::make_MRAdapt(adapt_field);
     MRadaptation(mr_epsilon, mr_regularity);
@@ -218,17 +218,17 @@ int main(int argc, char* argv[])
 
         // Equation: -Lap u = f   in [0, 1]^2
         //            f(x,y) = 2(y(1-y) + x(1-x))
-        auto f = samurai::make_field<double, 1>("f",
-                                                mesh,
-                                                [](const auto& coord)
-                                                {
-                                                    const auto& x = coord[0];
-                                                    const auto& y = coord[1];
-                                                    // return 2 * (y*(1 - y) + x * (1 - x));
-                                                    // return 2 * pow(4 * M_PI, 2) * sin(4 * M_PI * x)*sin(4 * M_PI *
-                                                    // y);
-                                                    return (-pow(y, 4) - 2 * x * (1 + 2 * x * y * y)) * exp(x * y * y);
-                                                });
+        auto f = samurai::make_field<double>("f",
+                                             mesh,
+                                             [](const auto& coord)
+                                             {
+                                                 const auto& x = coord[0];
+                                                 const auto& y = coord[1];
+                                                 // return 2 * (y*(1 - y) + x * (1 - x));
+                                                 // return 2 * pow(4 * M_PI, 2) * sin(4 * M_PI * x)*sin(4 * M_PI *
+                                                 // y);
+                                                 return (-pow(y, 4) - 2 * x * (1 + 2 * x * y * y)) * exp(x * y * y);
+                                             });
 
         // samurai::for_each_cell(mesh[mesh_id_t::reference], [&](auto& cell)
         // {
@@ -241,8 +241,8 @@ int main(int argc, char* argv[])
         // auto set = samurai::intersection(mesh[mesh_id_t::cells][level],
         // mesh[mesh_id_t::reference][level-1]).on(level-1);
         // set.apply_op(samurai::projection(f));
-        // auto f_recons = samurai::make_field<double, 1>("f_recons", mesh);
-        // auto error_f = samurai::make_field<double, 1>("error", mesh);
+        // auto f_recons = samurai::make_field<double>("f_recons", mesh);
+        // auto error_f = samurai::make_field<double>("error", mesh);
         // set.apply_op(samurai::prediction<prediction_order, true>(f_recons, f));
         // samurai::for_each_interval(mesh[mesh_id_t::cells], [&](std::size_t level,
         // const auto& i, const auto& index)
@@ -313,7 +313,7 @@ int main(int argc, char* argv[])
         }
         std::cout << std::endl;
 
-        auto error_field = samurai::make_field<double, 1>("error", mesh);
+        auto error_field = samurai::make_field<double>("error", mesh);
         samurai::for_each_cell(mesh,
                                [&](const auto& cell)
                                {

--- a/demos/highorder/main.cpp
+++ b/demos/highorder/main.cpp
@@ -168,23 +168,23 @@ int main(int argc, char* argv[])
     PetscInitialize(&argc, &argv, 0, nullptr);
     PetscOptionsSetValue(NULL, "-options_left", "off");
 
-    auto adapt_field = samurai::make_field<double>("adapt_field",
-                                                   init_mesh,
-                                                   [](const auto& coord)
-                                                   {
-                                                       const auto& x = coord[0];
-                                                       const auto& y = coord[1];
-                                                       double radius = 0.4;
-                                                       if ((x - 0.5) * (x - 0.5) + (y - 0.5) * (y - 0.5) < radius * radius)
-                                                       {
-                                                           samurai::finalize();
-                                                           return 0;
-                                                       }
-                                                       else
-                                                       {
-                                                           return 1;
-                                                       }
-                                                   });
+    auto adapt_field = samurai::make_scalar_field<double>("adapt_field",
+                                                          init_mesh,
+                                                          [](const auto& coord)
+                                                          {
+                                                              const auto& x = coord[0];
+                                                              const auto& y = coord[1];
+                                                              double radius = 0.4;
+                                                              if ((x - 0.5) * (x - 0.5) + (y - 0.5) * (y - 0.5) < radius * radius)
+                                                              {
+                                                                  samurai::finalize();
+                                                                  return 0;
+                                                              }
+                                                              else
+                                                              {
+                                                                  return 1;
+                                                              }
+                                                          });
 
     auto MRadaptation = samurai::make_MRAdapt(adapt_field);
     MRadaptation(mr_epsilon, mr_regularity);
@@ -218,17 +218,17 @@ int main(int argc, char* argv[])
 
         // Equation: -Lap u = f   in [0, 1]^2
         //            f(x,y) = 2(y(1-y) + x(1-x))
-        auto f = samurai::make_field<double>("f",
-                                             mesh,
-                                             [](const auto& coord)
-                                             {
-                                                 const auto& x = coord[0];
-                                                 const auto& y = coord[1];
-                                                 // return 2 * (y*(1 - y) + x * (1 - x));
-                                                 // return 2 * pow(4 * M_PI, 2) * sin(4 * M_PI * x)*sin(4 * M_PI *
-                                                 // y);
-                                                 return (-pow(y, 4) - 2 * x * (1 + 2 * x * y * y)) * exp(x * y * y);
-                                             });
+        auto f = samurai::make_scalar_field<double>("f",
+                                                    mesh,
+                                                    [](const auto& coord)
+                                                    {
+                                                        const auto& x = coord[0];
+                                                        const auto& y = coord[1];
+                                                        // return 2 * (y*(1 - y) + x * (1 - x));
+                                                        // return 2 * pow(4 * M_PI, 2) * sin(4 * M_PI * x)*sin(4 * M_PI *
+                                                        // y);
+                                                        return (-pow(y, 4) - 2 * x * (1 + 2 * x * y * y)) * exp(x * y * y);
+                                                    });
 
         // samurai::for_each_cell(mesh[mesh_id_t::reference], [&](auto& cell)
         // {
@@ -241,8 +241,8 @@ int main(int argc, char* argv[])
         // auto set = samurai::intersection(mesh[mesh_id_t::cells][level],
         // mesh[mesh_id_t::reference][level-1]).on(level-1);
         // set.apply_op(samurai::projection(f));
-        // auto f_recons = samurai::make_field<double>("f_recons", mesh);
-        // auto error_f = samurai::make_field<double>("error", mesh);
+        // auto f_recons = samurai::make_scalar_field<double>("f_recons", mesh);
+        // auto error_f = samurai::make_scalar_field<double>("error", mesh);
         // set.apply_op(samurai::prediction<prediction_order, true>(f_recons, f));
         // samurai::for_each_interval(mesh[mesh_id_t::cells], [&](std::size_t level,
         // const auto& i, const auto& index)
@@ -254,7 +254,7 @@ int main(int argc, char* argv[])
         // samurai::save("test_pred", mesh, f, f_recons, error_f);
         // samurai::finalize();
 
-        auto u = samurai::make_field<double>("u", mesh);
+        auto u = samurai::make_scalar_field<double>("u", mesh);
         samurai::make_bc<samurai::Dirichlet<2>>(u,
                                                 [](const auto&, const auto&, const auto& coord)
                                                 {
@@ -313,7 +313,7 @@ int main(int argc, char* argv[])
         }
         std::cout << std::endl;
 
-        auto error_field = samurai::make_field<double>("error", mesh);
+        auto error_field = samurai::make_scalar_field<double>("error", mesh);
         samurai::for_each_cell(mesh,
                                [&](const auto& cell)
                                {

--- a/demos/highorder/main.cpp
+++ b/demos/highorder/main.cpp
@@ -254,7 +254,7 @@ int main(int argc, char* argv[])
         // samurai::save("test_pred", mesh, f, f_recons, error_f);
         // samurai::finalize();
 
-        auto u = samurai::make_field<double, 1>("u", mesh);
+        auto u = samurai::make_field<double>("u", mesh);
         samurai::make_bc<samurai::Dirichlet<2>>(u,
                                                 [](const auto&, const auto&, const auto& coord)
                                                 {

--- a/demos/multigrid/main.cpp
+++ b/demos/multigrid/main.cpp
@@ -218,8 +218,8 @@ int main(int argc, char* argv[])
     // Create problem //
     //----------------//
 
-    auto source   = samurai::make_field<double, n_comp, is_soa>("source", mesh, test_case->source());
-    auto solution = samurai::make_field<double, n_comp, is_soa>("solution", mesh);
+    auto source   = samurai::make_vector_field<double, n_comp, is_soa>("source", mesh, test_case->source());
+    auto solution = samurai::make_vector_field<double, n_comp, is_soa>("solution", mesh);
 
     // Boundary conditions
     samurai::make_bc<samurai::Dirichlet<1>>(solution, test_case->dirichlet());
@@ -277,7 +277,7 @@ int main(int argc, char* argv[])
     std::cout << "Elapsed time: " << total_timer.Elapsed() << std::endl;
     std::cout << std::endl;
 
-    /*auto right_fluxes = samurai::make_field<double, n_comp, is_soa>("fluxes", mesh);
+    /*auto right_fluxes = samurai::make_vector_field<double, n_comp, is_soa>("fluxes", mesh);
     samurai::DirectionVector<dim> right = {1, 0};
     samurai::Stencil<2, dim> comput_stencil = {{0, 0}, {1, 0}};
     samurai::for_each_interface(mesh, right, comput_stencil,

--- a/demos/multigrid/main.cpp
+++ b/demos/multigrid/main.cpp
@@ -127,7 +127,7 @@ int main(int argc, char* argv[])
     // using Mesh = samurai::MRMesh<Config>;
     constexpr unsigned int n_comp = 1;
     constexpr bool is_soa         = true;
-    using Field                   = samurai::Field<Mesh, double, n_comp, is_soa>;
+    using Field                   = samurai::VectorField<Mesh, double, n_comp, is_soa>;
 
     //------------------//
     // Petsc initialize //
@@ -238,7 +238,7 @@ int main(int argc, char* argv[])
     // Solve linear system //
     //---------------------//
 
-    auto diff   = samurai::make_diffusion_order2<decltype(solution), samurai::DirichletEnforcement::Equation>();
+    auto diff   = samurai::make_diffusion_old<decltype(solution), samurai::DirichletEnforcement::Equation>();
     auto solver = samurai::petsc::make_solver(diff);
     solver.set_unknown(solution);
 

--- a/demos/multigrid/samurai_new/multigrid/petsc/intergrid_operators.hpp
+++ b/demos/multigrid/samurai_new/multigrid/petsc/intergrid_operators.hpp
@@ -497,7 +497,7 @@ namespace samurai_new
                 auto& cm = coarse_mesh[mesh_id_t::cells];
                 auto& fm = fine_mesh[mesh_id_t::cells];
 
-                auto fine_field = samurai::make_field<double, 1>("fine", fine_mesh);
+                auto fine_field = samurai::make_scalar_field<double>("fine", fine_mesh);
                 fine_field.fill(0);
 
                 for (std::size_t level = fine_mesh.min_level(); level <= fine_mesh.max_level(); ++level)
@@ -936,7 +936,7 @@ namespace samurai_new
                 auto& cm = coarse_mesh[mesh_id_t::cells];
                 auto& fm = fine_mesh[mesh_id_t::cells];
 
-                auto coarse_field = samurai::make_field<double, 1>("coarse", coarse_mesh);
+                auto coarse_field = samurai::make_scalar_field<double>("coarse", coarse_mesh);
                 coarse_field.fill(0);
 
                 for (std::size_t level = coarse_mesh.min_level(); level <= coarse_mesh.max_level(); ++level)

--- a/demos/multigrid/test_cases.hpp
+++ b/demos/multigrid/test_cases.hpp
@@ -49,7 +49,7 @@ class TestCase
         }
         return [](const auto&, const cell_t&, const coords_t&)
         {
-            if constexpr (Field::n_comp == 1)
+            if constexpr (Field::is_scalar)
             {
                 return 0.;
             }
@@ -109,7 +109,7 @@ class PolynomialTestCase : public TestCase<Field>
                 const auto& x = coord[0];
                 const auto& y = coord[1];
                 double value  = x * (1 - x) * y * (1 - y);
-                if constexpr (Field::n_comp == 1)
+                if constexpr (Field::is_scalar)
                 {
                     return value;
                 }
@@ -129,7 +129,7 @@ class PolynomialTestCase : public TestCase<Field>
                 const auto& y = coord[1];
                 const auto& z = coord[2];
                 double value  = x * (1 - x) * y * (1 - y) * z * (1 - z);
-                if constexpr (Field::n_comp == 1)
+                if constexpr (Field::is_scalar)
                 {
                     return value;
                 }
@@ -152,7 +152,7 @@ class PolynomialTestCase : public TestCase<Field>
     {
         return [](const auto&, const cell_t&, const coords_t&)
         {
-            if constexpr (Field::n_comp == 1)
+            if constexpr (Field::is_scalar)
             {
                 return 0.;
             }
@@ -202,7 +202,7 @@ class PolynomialTestCase : public TestCase<Field>
                 {
                     assert(false);
                 }
-                if constexpr (Field::n_comp == 1)
+                if constexpr (Field::is_scalar)
                 {
                     return value;
                 }
@@ -237,7 +237,7 @@ class PolynomialTestCase : public TestCase<Field>
                 const auto& x = coord[0];
                 const auto& y = coord[1];
                 double value  = 2 * (y * (1 - y) + x * (1 - x));
-                if constexpr (Field::n_comp == 1)
+                if constexpr (Field::is_scalar)
                 {
                     return value;
                 }
@@ -257,7 +257,7 @@ class PolynomialTestCase : public TestCase<Field>
                 const auto& y = coord[1];
                 const auto& z = coord[2];
                 double value  = 2 * ((y * (1 - y) * z * (1 - z) + x * (1 - x) * z * (1 - z) + x * (1 - x) * y * (1 - y)));
-                if constexpr (Field::n_comp == 1)
+                if constexpr (Field::is_scalar)
                 {
                     return value;
                 }
@@ -306,7 +306,7 @@ class ExponentialTestCase : public TestCase<Field>
                 const auto& x = coord[0];
                 const auto& y = coord[1];
                 double value  = exp(x * y * y);
-                if constexpr (Field::n_comp == 1)
+                if constexpr (Field::is_scalar)
                 {
                     return value;
                 }
@@ -326,7 +326,7 @@ class ExponentialTestCase : public TestCase<Field>
                 const auto& y = coord[1];
                 const auto& z = coord[2];
                 double value  = exp(x * y * y * z * z * z);
-                if constexpr (Field::n_comp == 1)
+                if constexpr (Field::is_scalar)
                 {
                     return value;
                 }
@@ -357,7 +357,7 @@ class ExponentialTestCase : public TestCase<Field>
                 const auto& x = coord[0];
                 const auto& y = coord[1];
                 double value  = (-pow(y, 4) - 2 * x * (1 + 2 * x * y * y)) * exp(x * y * y);
-                if constexpr (Field::n_comp == 1)
+                if constexpr (Field::is_scalar)
                 {
                     return value;
                 }
@@ -379,7 +379,7 @@ class ExponentialTestCase : public TestCase<Field>
                 double value  = -(pow(y, 4) * pow(z, 6) + 2 * x * pow(z, 3) + 4 * x * x * y * y * pow(z, 6) + 6 * x * y * y * z
                                  + 9 * x * x * pow(y, 4) * pow(z, 4))
                              * exp(x * y * y * z * z * z);
-                if constexpr (Field::n_comp == 1)
+                if constexpr (Field::is_scalar)
                 {
                     return value;
                 }

--- a/demos/p4est/simple_2d.cpp
+++ b/demos/p4est/simple_2d.cpp
@@ -42,7 +42,7 @@ void refine_1(mesh_t& mesh, std::size_t max_level)
 
     for (std::size_t ite = 0; ite < max_level; ++ite)
     {
-        auto cell_tag = samurai::make_field<bool, 1>("tag", mesh);
+        auto cell_tag = samurai::make_field<bool>("tag", mesh);
         cell_tag.fill(false);
 
         samurai::for_each_cell(mesh,

--- a/demos/p4est/simple_2d.cpp
+++ b/demos/p4est/simple_2d.cpp
@@ -42,7 +42,7 @@ void refine_1(mesh_t& mesh, std::size_t max_level)
 
     for (std::size_t ite = 0; ite < max_level; ++ite)
     {
-        auto cell_tag = samurai::make_field<bool>("tag", mesh);
+        auto cell_tag = samurai::make_scalar_field<bool>("tag", mesh);
         cell_tag.fill(false);
 
         samurai::for_each_cell(mesh,
@@ -100,7 +100,7 @@ void refine_2(mesh_t& mesh, std::size_t max_level)
 
     for (std::size_t ite = 0; ite < max_level; ++ite)
     {
-        auto cell_tag = samurai::make_field<int>("tag", mesh);
+        auto cell_tag = samurai::make_scalar_field<int>("tag", mesh);
         cell_tag.fill(0);
 
         samurai::for_each_cell(mesh,
@@ -253,7 +253,7 @@ int main(int argc, char* argv[])
     auto mem = samurai::memory_usage(mesh_2, /*verbose*/ true);
     std::cout << "Total: " << mem << std::endl;
 
-    auto level = samurai::make_field<std::size_t>("level", mesh_2);
+    auto level = samurai::make_scalar_field<std::size_t>("level", mesh_2);
     samurai::for_each_cell(mesh_2,
                            [&](auto cell)
                            {

--- a/demos/p4est/simple_2d.cpp
+++ b/demos/p4est/simple_2d.cpp
@@ -100,7 +100,7 @@ void refine_2(mesh_t& mesh, std::size_t max_level)
 
     for (std::size_t ite = 0; ite < max_level; ++ite)
     {
-        auto cell_tag = samurai::make_field<int, 1>("tag", mesh);
+        auto cell_tag = samurai::make_field<int>("tag", mesh);
         cell_tag.fill(0);
 
         samurai::for_each_cell(mesh,
@@ -253,7 +253,7 @@ int main(int argc, char* argv[])
     auto mem = samurai::memory_usage(mesh_2, /*verbose*/ true);
     std::cout << "Total: " << mem << std::endl;
 
-    auto level = samurai::make_field<std::size_t, 1>("level", mesh_2);
+    auto level = samurai::make_field<std::size_t>("level", mesh_2);
     samurai::for_each_cell(mesh_2,
                            [&](auto cell)
                            {

--- a/demos/pablo/bubble_2d.cpp
+++ b/demos/pablo/bubble_2d.cpp
@@ -121,7 +121,7 @@ void remove_intersection(samurai::CellArray<dim>& ca)
 
     while (true)
     {
-        auto tag = samurai::make_field<bool, 1>("tag", ca);
+        auto tag = samurai::make_field<bool>("tag", ca);
         tag.fill(false);
 
         for (std::size_t level = min_level + 1; level <= max_level; ++level)
@@ -179,7 +179,7 @@ void make_graduation(samurai::CellArray<dim>& ca)
     };
     while (true)
     {
-        auto tag = samurai::make_field<bool, 1>("tag", ca);
+        auto tag = samurai::make_field<bool>("tag", ca);
         tag.fill(false);
 
         for (std::size_t level = min_level + 2; level <= max_level; ++level)

--- a/demos/pablo/bubble_2d.cpp
+++ b/demos/pablo/bubble_2d.cpp
@@ -30,7 +30,7 @@ void update_mesh(Mesh& mesh,
     constexpr std::size_t dim = Mesh::dim;
     std::size_t nb_bubbles    = bb_xcenter.shape(0);
 
-    auto tag = samurai::make_field<int>("tag", mesh);
+    auto tag = samurai::make_scalar_field<int>("tag", mesh);
     tag.fill(static_cast<int>(samurai::CellFlag::keep));
 
     samurai::for_each_cell(
@@ -121,7 +121,7 @@ void remove_intersection(samurai::CellArray<dim>& ca)
 
     while (true)
     {
-        auto tag = samurai::make_field<bool>("tag", ca);
+        auto tag = samurai::make_scalar_field<bool>("tag", ca);
         tag.fill(false);
 
         for (std::size_t level = min_level + 1; level <= max_level; ++level)
@@ -179,7 +179,7 @@ void make_graduation(samurai::CellArray<dim>& ca)
     };
     while (true)
     {
-        auto tag = samurai::make_field<bool>("tag", ca);
+        auto tag = samurai::make_scalar_field<bool>("tag", ca);
         tag.fill(false);
 
         for (std::size_t level = min_level + 2; level <= max_level; ++level)

--- a/demos/pablo/bubble_2d.cpp
+++ b/demos/pablo/bubble_2d.cpp
@@ -30,7 +30,7 @@ void update_mesh(Mesh& mesh,
     constexpr std::size_t dim = Mesh::dim;
     std::size_t nb_bubbles    = bb_xcenter.shape(0);
 
-    auto tag = samurai::make_field<int, 1>("tag", mesh);
+    auto tag = samurai::make_field<int>("tag", mesh);
     tag.fill(static_cast<int>(samurai::CellFlag::keep));
 
     samurai::for_each_cell(

--- a/demos/tutorial/AMR_1D_Burgers/step_1/init_sol.hpp
+++ b/demos/tutorial/AMR_1D_Burgers/step_1/init_sol.hpp
@@ -9,7 +9,7 @@ template <class Mesh>
 auto init_sol(Mesh& mesh)
 {
     // create a field from the mesh
-    auto phi = samurai::make_field<double>("phi", mesh);
+    auto phi = samurai::make_scalar_field<double>("phi", mesh);
 
     samurai::for_each_cell(mesh,
                            [&](auto& cell)

--- a/demos/tutorial/AMR_1D_Burgers/step_1/init_sol.hpp
+++ b/demos/tutorial/AMR_1D_Burgers/step_1/init_sol.hpp
@@ -9,7 +9,7 @@ template <class Mesh>
 auto init_sol(Mesh& mesh)
 {
     // create a field from the mesh
-    auto phi = samurai::make_field<double, 1>("phi", mesh);
+    auto phi = samurai::make_field<double>("phi", mesh);
 
     samurai::for_each_cell(mesh,
                            [&](auto& cell)

--- a/demos/tutorial/AMR_1D_Burgers/step_2/main.cpp
+++ b/demos/tutorial/AMR_1D_Burgers/step_2/main.cpp
@@ -67,7 +67,7 @@ int main(int argc, char* argv[])
     std::size_t nsave = 1;
     std::size_t nt    = 0;
 
-    auto phi_np1 = samurai::make_field<double>("phi", mesh);
+    auto phi_np1 = samurai::make_scalar_field<double>("phi", mesh);
     phi_np1.fill(0.);
 
     while (t != Tf)

--- a/demos/tutorial/AMR_1D_Burgers/step_2/main.cpp
+++ b/demos/tutorial/AMR_1D_Burgers/step_2/main.cpp
@@ -67,7 +67,7 @@ int main(int argc, char* argv[])
     std::size_t nsave = 1;
     std::size_t nt    = 0;
 
-    auto phi_np1 = samurai::make_field<double, 1>("phi", mesh);
+    auto phi_np1 = samurai::make_field<double>("phi", mesh);
     phi_np1.fill(0.);
 
     while (t != Tf)

--- a/demos/tutorial/AMR_1D_Burgers/step_3/init_sol.hpp
+++ b/demos/tutorial/AMR_1D_Burgers/step_3/init_sol.hpp
@@ -10,7 +10,7 @@ template <class Mesh>
 auto init_sol(Mesh& mesh)
 {
     using mesh_id_t = typename Mesh::mesh_id_t; // <-----------------
-    auto phi        = samurai::make_field<double, 1>("phi", mesh);
+    auto phi        = samurai::make_field<double>("phi", mesh);
     phi.fill(0.);
 
     samurai::for_each_cell(mesh[mesh_id_t::cells_and_ghosts],

--- a/demos/tutorial/AMR_1D_Burgers/step_3/init_sol.hpp
+++ b/demos/tutorial/AMR_1D_Burgers/step_3/init_sol.hpp
@@ -10,7 +10,7 @@ template <class Mesh>
 auto init_sol(Mesh& mesh)
 {
     using mesh_id_t = typename Mesh::mesh_id_t; // <-----------------
-    auto phi        = samurai::make_field<double>("phi", mesh);
+    auto phi        = samurai::make_scalar_field<double>("phi", mesh);
     phi.fill(0.);
 
     samurai::for_each_cell(mesh[mesh_id_t::cells_and_ghosts],

--- a/demos/tutorial/AMR_1D_Burgers/step_3/main.cpp
+++ b/demos/tutorial/AMR_1D_Burgers/step_3/main.cpp
@@ -69,7 +69,7 @@ int main(int argc, char* argv[])
     std::size_t nsave = 1;
     std::size_t nt    = 0;
 
-    auto phi_np1 = samurai::make_field<double>("phi", mesh);
+    auto phi_np1 = samurai::make_scalar_field<double>("phi", mesh);
     phi_np1.fill(0.);
 
     while (t != Tf)

--- a/demos/tutorial/AMR_1D_Burgers/step_3/main.cpp
+++ b/demos/tutorial/AMR_1D_Burgers/step_3/main.cpp
@@ -69,7 +69,7 @@ int main(int argc, char* argv[])
     std::size_t nsave = 1;
     std::size_t nt    = 0;
 
-    auto phi_np1 = samurai::make_field<double, 1>("phi", mesh);
+    auto phi_np1 = samurai::make_field<double>("phi", mesh);
     phi_np1.fill(0.);
 
     while (t != Tf)

--- a/demos/tutorial/AMR_1D_Burgers/step_4/main.cpp
+++ b/demos/tutorial/AMR_1D_Burgers/step_4/main.cpp
@@ -75,7 +75,7 @@ int main(int argc, char* argv[])
         };
     }
 
-    auto level = samurai::make_field<std::size_t, 1>("level", mesh);
+    auto level = samurai::make_field<std::size_t>("level", mesh);
     samurai::for_each_interval(mesh[MeshID::cells],
                                [&](std::size_t lvl, const auto& i, auto)
                                {

--- a/demos/tutorial/AMR_1D_Burgers/step_4/main.cpp
+++ b/demos/tutorial/AMR_1D_Burgers/step_4/main.cpp
@@ -63,7 +63,7 @@ int main(int argc, char* argv[])
     std::size_t i_adapt = 0;
     while (i_adapt < (max_level - min_level + 1))
     {
-        auto tag = samurai::make_field<std::size_t, 1>("tag", mesh);
+        auto tag = samurai::make_field<std::size_t>("tag", mesh);
 
         AMR_criterion(phi, tag);
 

--- a/demos/tutorial/AMR_1D_Burgers/step_4/main.cpp
+++ b/demos/tutorial/AMR_1D_Burgers/step_4/main.cpp
@@ -63,7 +63,7 @@ int main(int argc, char* argv[])
     std::size_t i_adapt = 0;
     while (i_adapt < (max_level - min_level + 1))
     {
-        auto tag = samurai::make_field<std::size_t>("tag", mesh);
+        auto tag = samurai::make_scalar_field<std::size_t>("tag", mesh);
 
         AMR_criterion(phi, tag);
 
@@ -75,7 +75,7 @@ int main(int argc, char* argv[])
         };
     }
 
-    auto level = samurai::make_field<std::size_t>("level", mesh);
+    auto level = samurai::make_scalar_field<std::size_t>("level", mesh);
     samurai::for_each_interval(mesh[MeshID::cells],
                                [&](std::size_t lvl, const auto& i, auto)
                                {

--- a/demos/tutorial/AMR_1D_Burgers/step_5/main.cpp
+++ b/demos/tutorial/AMR_1D_Burgers/step_5/main.cpp
@@ -64,7 +64,7 @@ int main(int argc, char* argv[])
     std::size_t i_adapt = 0;
     while (i_adapt < (max_level - min_level + 1))
     {
-        auto tag = samurai::make_field<std::size_t>("tag", mesh);
+        auto tag = samurai::make_scalar_field<std::size_t>("tag", mesh);
 
         update_ghost(phi); // <--------------------------------
         AMR_criterion(phi, tag);
@@ -78,7 +78,7 @@ int main(int argc, char* argv[])
         };
     }
 
-    auto level = samurai::make_field<std::size_t>("level", mesh);
+    auto level = samurai::make_scalar_field<std::size_t>("level", mesh);
     samurai::for_each_interval(mesh[MeshID::cells],
                                [&](std::size_t lvl, const auto& i, auto)
                                {

--- a/demos/tutorial/AMR_1D_Burgers/step_5/main.cpp
+++ b/demos/tutorial/AMR_1D_Burgers/step_5/main.cpp
@@ -78,7 +78,7 @@ int main(int argc, char* argv[])
         };
     }
 
-    auto level = samurai::make_field<std::size_t, 1>("level", mesh);
+    auto level = samurai::make_field<std::size_t>("level", mesh);
     samurai::for_each_interval(mesh[MeshID::cells],
                                [&](std::size_t lvl, const auto& i, auto)
                                {

--- a/demos/tutorial/AMR_1D_Burgers/step_5/main.cpp
+++ b/demos/tutorial/AMR_1D_Burgers/step_5/main.cpp
@@ -64,7 +64,7 @@ int main(int argc, char* argv[])
     std::size_t i_adapt = 0;
     while (i_adapt < (max_level - min_level + 1))
     {
-        auto tag = samurai::make_field<std::size_t, 1>("tag", mesh);
+        auto tag = samurai::make_field<std::size_t>("tag", mesh);
 
         update_ghost(phi); // <--------------------------------
         AMR_criterion(phi, tag);

--- a/demos/tutorial/AMR_1D_Burgers/step_6/main.cpp
+++ b/demos/tutorial/AMR_1D_Burgers/step_6/main.cpp
@@ -95,7 +95,7 @@ int main(int argc, char* argv[])
         std::size_t i_adapt = 0;
         while (i_adapt < (max_level - min_level + 1))
         {
-            auto tag = samurai::make_field<std::size_t, 1>("tag", mesh);
+            auto tag = samurai::make_field<std::size_t>("tag", mesh);
 
             fmt::print("adaptation iteration : {:4d}\n", i_adapt++);
             update_ghost(phi);

--- a/demos/tutorial/AMR_1D_Burgers/step_6/main.cpp
+++ b/demos/tutorial/AMR_1D_Burgers/step_6/main.cpp
@@ -95,7 +95,7 @@ int main(int argc, char* argv[])
         std::size_t i_adapt = 0;
         while (i_adapt < (max_level - min_level + 1))
         {
-            auto tag = samurai::make_field<std::size_t>("tag", mesh);
+            auto tag = samurai::make_scalar_field<std::size_t>("tag", mesh);
 
             fmt::print("adaptation iteration : {:4d}\n", i_adapt++);
             update_ghost(phi);
@@ -109,13 +109,13 @@ int main(int argc, char* argv[])
         }
 
         update_ghost(phi);
-        auto phi_np1 = samurai::make_field<double>("phi", mesh);
+        auto phi_np1 = samurai::make_scalar_field<double>("phi", mesh);
 
         update_sol(dt, phi, phi_np1);
 
         if (t >= static_cast<double>(nsave + 1) * dt_save || t == Tf)
         {
-            auto level = samurai::make_field<std::size_t>("level", mesh);
+            auto level = samurai::make_scalar_field<std::size_t>("level", mesh);
             samurai::for_each_interval(mesh[MeshID::cells],
                                        [&](std::size_t lvl, const auto& i, auto)
                                        {

--- a/demos/tutorial/AMR_1D_Burgers/step_6/main.cpp
+++ b/demos/tutorial/AMR_1D_Burgers/step_6/main.cpp
@@ -109,13 +109,13 @@ int main(int argc, char* argv[])
         }
 
         update_ghost(phi);
-        auto phi_np1 = samurai::make_field<double, 1>("phi", mesh);
+        auto phi_np1 = samurai::make_field<double>("phi", mesh);
 
         update_sol(dt, phi, phi_np1);
 
         if (t >= static_cast<double>(nsave + 1) * dt_save || t == Tf)
         {
-            auto level = samurai::make_field<std::size_t, 1>("level", mesh);
+            auto level = samurai::make_field<std::size_t>("level", mesh);
             samurai::for_each_interval(mesh[MeshID::cells],
                                        [&](std::size_t lvl, const auto& i, auto)
                                        {

--- a/demos/tutorial/graduation_case_1.cpp
+++ b/demos/tutorial/graduation_case_1.cpp
@@ -110,7 +110,7 @@ int main(int argc, char* argv[])
 
     while (true)
     {
-        auto tag = samurai::make_field<bool>("tag", ca);
+        auto tag = samurai::make_scalar_field<bool>("tag", ca);
         tag.fill(false);
 
         for (std::size_t level = min_level + 2; level <= max_level; ++level)

--- a/demos/tutorial/graduation_case_1.cpp
+++ b/demos/tutorial/graduation_case_1.cpp
@@ -110,7 +110,7 @@ int main(int argc, char* argv[])
 
     while (true)
     {
-        auto tag = samurai::make_field<bool, 1>("tag", ca);
+        auto tag = samurai::make_field<bool>("tag", ca);
         tag.fill(false);
 
         for (std::size_t level = min_level + 2; level <= max_level; ++level)

--- a/demos/tutorial/graduation_case_2.cpp
+++ b/demos/tutorial/graduation_case_2.cpp
@@ -70,7 +70,7 @@ int main(int argc, char* argv[])
     while (true)
     {
         std::cout << "Iteration for remove intersection: " << ite++ << "\n";
-        auto tag = samurai::make_field<bool, 1>("tag", ca);
+        auto tag = samurai::make_field<bool>("tag", ca);
         tag.fill(false);
 
         for (std::size_t level = ca.min_level() + 1; level <= ca.max_level(); ++level)
@@ -138,7 +138,7 @@ int main(int argc, char* argv[])
     while (true)
     {
         std::cout << "Iteration for graduation: " << ite++ << "\n";
-        auto tag = samurai::make_field<bool, 1>("tag", ca);
+        auto tag = samurai::make_field<bool>("tag", ca);
         tag.fill(false);
 
         for (std::size_t level = ca.min_level() + 2; level <= ca.max_level(); ++level)

--- a/demos/tutorial/graduation_case_2.cpp
+++ b/demos/tutorial/graduation_case_2.cpp
@@ -70,7 +70,7 @@ int main(int argc, char* argv[])
     while (true)
     {
         std::cout << "Iteration for remove intersection: " << ite++ << "\n";
-        auto tag = samurai::make_field<bool>("tag", ca);
+        auto tag = samurai::make_scalar_field<bool>("tag", ca);
         tag.fill(false);
 
         for (std::size_t level = ca.min_level() + 1; level <= ca.max_level(); ++level)
@@ -138,7 +138,7 @@ int main(int argc, char* argv[])
     while (true)
     {
         std::cout << "Iteration for graduation: " << ite++ << "\n";
-        auto tag = samurai::make_field<bool>("tag", ca);
+        auto tag = samurai::make_scalar_field<bool>("tag", ca);
         tag.fill(false);
 
         for (std::size_t level = ca.min_level() + 2; level <= ca.max_level(); ++level)

--- a/demos/tutorial/graduation_case_3.cpp
+++ b/demos/tutorial/graduation_case_3.cpp
@@ -61,7 +61,7 @@ int main(int argc, char* argv[])
     {
         std::cout << "Iteration for remove intersection: " << ite++ << "\n";
 
-        auto tag = samurai::make_field<bool>("tag", ca);
+        auto tag = samurai::make_scalar_field<bool>("tag", ca);
         tag.fill(false);
 
         samurai::for_each_cell(ca,

--- a/demos/tutorial/graduation_case_3.cpp
+++ b/demos/tutorial/graduation_case_3.cpp
@@ -61,7 +61,7 @@ int main(int argc, char* argv[])
     {
         std::cout << "Iteration for remove intersection: " << ite++ << "\n";
 
-        auto tag = samurai::make_field<bool, 1>("tag", ca);
+        auto tag = samurai::make_field<bool>("tag", ca);
         tag.fill(false);
 
         samurai::for_each_cell(ca,

--- a/demos/tutorial/proj_on_mesh.cpp
+++ b/demos/tutorial/proj_on_mesh.cpp
@@ -12,7 +12,7 @@ template <class Mesh>
 auto init_field(Mesh& mesh, double dec)
 {
     static constexpr std::size_t dim = Mesh::dim;
-    auto f                           = samurai::make_field<double, 1>("u", mesh);
+    auto f                           = samurai::make_field<double>("u", mesh);
     f.fill(0.);
     samurai::for_each_cell(
         mesh,

--- a/demos/tutorial/proj_on_mesh.cpp
+++ b/demos/tutorial/proj_on_mesh.cpp
@@ -12,7 +12,7 @@ template <class Mesh>
 auto init_field(Mesh& mesh, double dec)
 {
     static constexpr std::size_t dim = Mesh::dim;
-    auto f                           = samurai::make_field<double>("u", mesh);
+    auto f                           = samurai::make_scalar_field<double>("u", mesh);
     f.fill(0.);
     samurai::for_each_cell(
         mesh,

--- a/demos/tutorial/reconstruction_1d.cpp
+++ b/demos/tutorial/reconstruction_1d.cpp
@@ -29,7 +29,7 @@ auto init(Mesh& mesh, Case& c)
 {
     using mesh_id_t = typename Mesh::mesh_id_t;
 
-    auto u = samurai::make_field<double>("u", mesh);
+    auto u = samurai::make_scalar_field<double>("u", mesh);
 
     samurai::for_each_interval(mesh[mesh_id_t::cells],
                                [&](std::size_t level, const auto& i, const auto&)
@@ -117,7 +117,7 @@ int main(int argc, char* argv[])
     auto MRadaptation = samurai::make_MRAdapt(u);
     MRadaptation(mr_epsilon, mr_regularity);
 
-    auto level_ = samurai::make_field<std::size_t>("level", mrmesh);
+    auto level_ = samurai::make_scalar_field<std::size_t>("level", mrmesh);
     samurai::for_each_cell(mrmesh[mrmesh_id_t::cells],
                            [&](const auto& cell)
                            {
@@ -130,7 +130,7 @@ int main(int argc, char* argv[])
     auto t2            = std::chrono::high_resolution_clock::now();
     std::cout << "execution time " << std::chrono::duration_cast<std::chrono::microseconds>(t2 - t1).count() << std::endl;
 
-    auto error = samurai::make_field<double>("error", u_reconstruct.mesh());
+    auto error = samurai::make_scalar_field<double>("error", u_reconstruct.mesh());
     samurai::for_each_interval(u_reconstruct.mesh(),
                                [&](std::size_t level, const auto& i, const auto&)
                                {

--- a/demos/tutorial/reconstruction_1d.cpp
+++ b/demos/tutorial/reconstruction_1d.cpp
@@ -29,7 +29,7 @@ auto init(Mesh& mesh, Case& c)
 {
     using mesh_id_t = typename Mesh::mesh_id_t;
 
-    auto u = samurai::make_field<double, 1>("u", mesh);
+    auto u = samurai::make_field<double>("u", mesh);
 
     samurai::for_each_interval(mesh[mesh_id_t::cells],
                                [&](std::size_t level, const auto& i, const auto&)
@@ -117,7 +117,7 @@ int main(int argc, char* argv[])
     auto MRadaptation = samurai::make_MRAdapt(u);
     MRadaptation(mr_epsilon, mr_regularity);
 
-    auto level_ = samurai::make_field<std::size_t, 1>("level", mrmesh);
+    auto level_ = samurai::make_field<std::size_t>("level", mrmesh);
     samurai::for_each_cell(mrmesh[mrmesh_id_t::cells],
                            [&](const auto& cell)
                            {
@@ -130,7 +130,7 @@ int main(int argc, char* argv[])
     auto t2            = std::chrono::high_resolution_clock::now();
     std::cout << "execution time " << std::chrono::duration_cast<std::chrono::microseconds>(t2 - t1).count() << std::endl;
 
-    auto error = samurai::make_field<double, 1>("error", u_reconstruct.mesh());
+    auto error = samurai::make_field<double>("error", u_reconstruct.mesh());
     samurai::for_each_interval(u_reconstruct.mesh(),
                                [&](std::size_t level, const auto& i, const auto&)
                                {

--- a/demos/tutorial/reconstruction_2d.cpp
+++ b/demos/tutorial/reconstruction_2d.cpp
@@ -30,7 +30,7 @@ auto init(Mesh& mesh, Case& c)
 {
     using mesh_id_t = typename Mesh::mesh_id_t;
 
-    auto u = samurai::make_field<double, 1>("u", mesh);
+    auto u = samurai::make_field<double>("u", mesh);
 
     samurai::for_each_interval(mesh[mesh_id_t::cells],
                                [&](std::size_t level, const auto& i, const auto& index)
@@ -146,7 +146,7 @@ int main(int argc, char* argv[])
     auto MRadaptation = samurai::make_MRAdapt(u);
     MRadaptation(mr_epsilon, mr_regularity);
 
-    auto level_ = samurai::make_field<std::size_t, 1>("level", mrmesh);
+    auto level_ = samurai::make_field<std::size_t>("level", mrmesh);
     samurai::for_each_cell(mrmesh[mrmesh_id_t::cells],
                            [&](const auto& cell)
                            {
@@ -159,7 +159,7 @@ int main(int argc, char* argv[])
     auto t2            = std::chrono::high_resolution_clock::now();
     std::cout << "execution time " << std::chrono::duration_cast<std::chrono::microseconds>(t2 - t1).count() << std::endl;
 
-    auto error = samurai::make_field<double, 1>("error", u_reconstruct.mesh());
+    auto error = samurai::make_field<double>("error", u_reconstruct.mesh());
     samurai::for_each_interval(u_reconstruct.mesh(),
                                [&](std::size_t level, const auto& i, const auto& index)
                                {

--- a/demos/tutorial/reconstruction_2d.cpp
+++ b/demos/tutorial/reconstruction_2d.cpp
@@ -30,7 +30,7 @@ auto init(Mesh& mesh, Case& c)
 {
     using mesh_id_t = typename Mesh::mesh_id_t;
 
-    auto u = samurai::make_field<double>("u", mesh);
+    auto u = samurai::make_scalar_field<double>("u", mesh);
 
     samurai::for_each_interval(mesh[mesh_id_t::cells],
                                [&](std::size_t level, const auto& i, const auto& index)
@@ -146,7 +146,7 @@ int main(int argc, char* argv[])
     auto MRadaptation = samurai::make_MRAdapt(u);
     MRadaptation(mr_epsilon, mr_regularity);
 
-    auto level_ = samurai::make_field<std::size_t>("level", mrmesh);
+    auto level_ = samurai::make_scalar_field<std::size_t>("level", mrmesh);
     samurai::for_each_cell(mrmesh[mrmesh_id_t::cells],
                            [&](const auto& cell)
                            {
@@ -159,7 +159,7 @@ int main(int argc, char* argv[])
     auto t2            = std::chrono::high_resolution_clock::now();
     std::cout << "execution time " << std::chrono::duration_cast<std::chrono::microseconds>(t2 - t1).count() << std::endl;
 
-    auto error = samurai::make_field<double>("error", u_reconstruct.mesh());
+    auto error = samurai::make_scalar_field<double>("error", u_reconstruct.mesh());
     samurai::for_each_interval(u_reconstruct.mesh(),
                                [&](std::size_t level, const auto& i, const auto& index)
                                {

--- a/demos/tutorial/reconstruction_3d.cpp
+++ b/demos/tutorial/reconstruction_3d.cpp
@@ -29,7 +29,7 @@ auto init(Mesh& mesh, Case& c)
 {
     using mesh_id_t = typename Mesh::mesh_id_t;
 
-    auto u = samurai::make_field<double, 1>("u", mesh);
+    auto u = samurai::make_field<double>("u", mesh);
 
     samurai::for_each_interval(mesh[mesh_id_t::cells],
                                [&](std::size_t level, const auto& i, const auto& index)
@@ -151,7 +151,7 @@ int main(int argc, char* argv[])
     auto MRadaptation = samurai::make_MRAdapt(u);
     MRadaptation(mr_epsilon, mr_regularity);
 
-    auto level_ = samurai::make_field<std::size_t, 1>("level", mrmesh);
+    auto level_ = samurai::make_field<std::size_t>("level", mrmesh);
     samurai::for_each_cell(mrmesh[mrmesh_id_t::cells],
                            [&](const auto& cell)
                            {
@@ -164,7 +164,7 @@ int main(int argc, char* argv[])
     auto t2            = std::chrono::high_resolution_clock::now();
     std::cout << "execution time " << std::chrono::duration_cast<std::chrono::microseconds>(t2 - t1).count() << std::endl;
 
-    auto error = samurai::make_field<double, 1>("error", u_reconstruct.mesh());
+    auto error = samurai::make_field<double>("error", u_reconstruct.mesh());
     samurai::for_each_interval(u_reconstruct.mesh(),
                                [&](std::size_t level, const auto& i, const auto& index)
                                {

--- a/demos/tutorial/reconstruction_3d.cpp
+++ b/demos/tutorial/reconstruction_3d.cpp
@@ -29,7 +29,7 @@ auto init(Mesh& mesh, Case& c)
 {
     using mesh_id_t = typename Mesh::mesh_id_t;
 
-    auto u = samurai::make_field<double>("u", mesh);
+    auto u = samurai::make_scalar_field<double>("u", mesh);
 
     samurai::for_each_interval(mesh[mesh_id_t::cells],
                                [&](std::size_t level, const auto& i, const auto& index)
@@ -151,7 +151,7 @@ int main(int argc, char* argv[])
     auto MRadaptation = samurai::make_MRAdapt(u);
     MRadaptation(mr_epsilon, mr_regularity);
 
-    auto level_ = samurai::make_field<std::size_t>("level", mrmesh);
+    auto level_ = samurai::make_scalar_field<std::size_t>("level", mrmesh);
     samurai::for_each_cell(mrmesh[mrmesh_id_t::cells],
                            [&](const auto& cell)
                            {
@@ -164,7 +164,7 @@ int main(int argc, char* argv[])
     auto t2            = std::chrono::high_resolution_clock::now();
     std::cout << "execution time " << std::chrono::duration_cast<std::chrono::microseconds>(t2 - t1).count() << std::endl;
 
-    auto error = samurai::make_field<double>("error", u_reconstruct.mesh());
+    auto error = samurai::make_scalar_field<double>("error", u_reconstruct.mesh());
     samurai::for_each_interval(u_reconstruct.mesh(),
                                [&](std::size_t level, const auto& i, const auto& index)
                                {

--- a/demos/tutorial/set_operator.cpp
+++ b/demos/tutorial/set_operator.cpp
@@ -90,7 +90,7 @@ int main()
             std::cout << "difference found in " << i << std::endl;
         });
 
-    auto u = samurai::make_field<double>("u", ca);
+    auto u = samurai::make_scalar_field<double>("u", ca);
     u.fill(0);
     samurai::for_each_cell(ca[1],
                            [&](auto cell)

--- a/demos/tutorial/set_operator.cpp
+++ b/demos/tutorial/set_operator.cpp
@@ -90,7 +90,7 @@ int main()
             std::cout << "difference found in " << i << std::endl;
         });
 
-    auto u = samurai::make_field<double, 1>("u", ca);
+    auto u = samurai::make_field<double>("u", ca);
     u.fill(0);
     samurai::for_each_cell(ca[1],
                            [&](auto cell)

--- a/docs/source/reference/snippet/subset_1d.cpp
+++ b/docs/source/reference/snippet/subset_1d.cpp
@@ -17,7 +17,7 @@ int main()
     samurai::CellArray<dim> ca{cl};
 
     // Initialize field u on this mesh
-    auto u = samurai::make_field<double, 1>("u", ca);
+    auto u = samurai::make_field<double>("u", ca);
     samurai::for_each_cell(ca,
                            [&](auto cell)
                            {

--- a/docs/source/reference/snippet/subset_1d.cpp
+++ b/docs/source/reference/snippet/subset_1d.cpp
@@ -17,7 +17,7 @@ int main()
     samurai::CellArray<dim> ca{cl};
 
     // Initialize field u on this mesh
-    auto u = samurai::make_field<double>("u", ca);
+    auto u = samurai::make_scalar_field<double>("u", ca);
     samurai::for_each_cell(ca,
                            [&](auto cell)
                            {

--- a/include/samurai/bc.hpp
+++ b/include/samurai/bc.hpp
@@ -95,10 +95,10 @@ namespace samurai
     struct BcValue
     {
         static constexpr std::size_t dim = Field::dim;
-        using value_t                    = CollapsArray<typename Field::value_type, Field::n_comp, detail::is_soa_v<Field>>;
-        using coords_t                   = xt::xtensor_fixed<double, xt::xshape<dim>>;
-        using direction_t                = DirectionVector<dim>;
-        using cell_t                     = typename Field::cell_t;
+        using value_t     = CollapsArray<typename Field::value_type, Field::n_comp, detail::is_soa_v<Field>, Field::is_scalar>;
+        using coords_t    = xt::xtensor_fixed<double, xt::xshape<dim>>;
+        using direction_t = DirectionVector<dim>;
+        using cell_t      = typename Field::cell_t;
 
         virtual ~BcValue()                 = default;
         BcValue(const BcValue&)            = delete;

--- a/include/samurai/bc.hpp
+++ b/include/samurai/bc.hpp
@@ -1123,7 +1123,15 @@ namespace samurai
                     static constexpr std::size_t in  = 0;
                     static constexpr std::size_t out = 1;
 
-                    double dx     = f.mesh().cell_length(cells[out].level);
+                    double dx = f.mesh().cell_length(cells[out].level);
+                    // static_assert(std::is_same_v<decltype(f), void>);
+                    // static_assert(std::is_same_v<decltype(cells[out]), void>);
+                    // static_assert(std::is_same_v<decltype(f[cells[out]]), void>);
+                    // static_assert(std::is_same_v<decltype(f[cells[in]]), void>);
+                    // static_assert(std::is_same_v<decltype(value), void>);
+                    std::cout << "f[cells[out]] " << f[cells[out]] << std::endl;
+                    std::cout << "f[cells[in]]  " << f[cells[in]] << std::endl;
+                    std::cout << "value         " << value << std::endl;
                     f[cells[out]] = dx * value + f[cells[in]];
                 }
                 else

--- a/include/samurai/bc.hpp
+++ b/include/samurai/bc.hpp
@@ -14,6 +14,7 @@
 #include "static_algorithm.hpp"
 #include "stencil.hpp"
 #include "storage/containers.hpp"
+#include "utils.hpp"
 
 #define APPLY_AND_STENCIL_FUNCTIONS(STENCIL_SIZE)                                                                                         \
     using apply_function_##STENCIL_SIZE = std::function<void(Field&, const std::array<cell_t, STENCIL_SIZE>&, const value_t&)>;           \
@@ -82,7 +83,10 @@ namespace samurai
     class UniformMesh;
 
     template <class mesh_t, class value_t, std::size_t size, bool SOA>
-    class Field;
+    class VectorField;
+
+    template <class mesh_t, class value_t>
+    class ScalarField;
 
     ////////////////////////
     // BcValue definition //
@@ -91,7 +95,7 @@ namespace samurai
     struct BcValue
     {
         static constexpr std::size_t dim = Field::dim;
-        using value_t                    = CollapsArray<typename Field::value_type, Field::n_comp, Field::is_soa>;
+        using value_t                    = CollapsArray<typename Field::value_type, Field::n_comp, detail::is_soa_v<Field>>;
         using coords_t                   = xt::xtensor_fixed<double, xt::xshape<dim>>;
         using direction_t                = DirectionVector<dim>;
         using cell_t                     = typename Field::cell_t;

--- a/include/samurai/bc.hpp
+++ b/include/samurai/bc.hpp
@@ -1123,15 +1123,7 @@ namespace samurai
                     static constexpr std::size_t in  = 0;
                     static constexpr std::size_t out = 1;
 
-                    double dx = f.mesh().cell_length(cells[out].level);
-                    // static_assert(std::is_same_v<decltype(f), void>);
-                    // static_assert(std::is_same_v<decltype(cells[out]), void>);
-                    // static_assert(std::is_same_v<decltype(f[cells[out]]), void>);
-                    // static_assert(std::is_same_v<decltype(f[cells[in]]), void>);
-                    // static_assert(std::is_same_v<decltype(value), void>);
-                    std::cout << "f[cells[out]] " << f[cells[out]] << std::endl;
-                    std::cout << "f[cells[in]]  " << f[cells[in]] << std::endl;
-                    std::cout << "value         " << value << std::endl;
+                    double dx     = f.mesh().cell_length(cells[out].level);
                     f[cells[out]] = dx * value + f[cells[in]];
                 }
                 else

--- a/include/samurai/field.hpp
+++ b/include/samurai/field.hpp
@@ -360,7 +360,7 @@ namespace samurai
 
         static constexpr size_type n_comp = n_comp_;
         static constexpr bool is_soa      = SOA;
-        static constexpr bool is_scalar   = detail::is_scalar_field_type_v<self_type>;
+        static constexpr bool is_scalar   = false;
         using inner_types::static_layout;
 
         VectorField() = default;
@@ -971,7 +971,7 @@ namespace samurai
         using const_reverse_iterator = Field_reverse_iterator<const_iterator>;
 
         static constexpr size_type n_comp = 1;
-        static constexpr bool is_scalar   = detail::is_scalar_field_type_v<self_type>;
+        static constexpr bool is_scalar   = true;
         using inner_types::static_layout;
 
         ScalarField() = default;

--- a/include/samurai/field.hpp
+++ b/include/samurai/field.hpp
@@ -760,8 +760,54 @@ namespace samurai
 
     // VectorField helper functions -------------------------------------------
 
+    /**
+     * @brief Creates a VectorField.
+     * @param name Name of the returned Field.
+     * @param f Continuous function.
+     * @param gl Gauss Legendre polynomial
+     */
+    template <class value_t, std::size_t n_comp, bool SOA = false, class mesh_t, class Func, std::size_t polynomial_degree>
+    [[deprecated("Use make_vector_field() instead")]] auto
+    make_field(std::string name, mesh_t& mesh, Func&& f, const GaussLegendre<polynomial_degree>& gl)
+    {
+        return make_vector_field<value_t, n_comp, SOA>(name, mesh, std::forward<Func>(f), gl);
+    }
+
+    template <std::size_t n_comp, bool SOA = false, class mesh_t, class Func, std::size_t polynomial_degree>
+    [[deprecated("Use make_vector_field() instead")]] auto
+    make_field(std::string name, mesh_t& mesh, Func&& f, const GaussLegendre<polynomial_degree>& gl)
+    {
+        return make_vector_field<n_comp, SOA>(name, mesh, std::forward<Func>(f), gl);
+    }
+
+    /**
+     * @brief Creates a VectorField.
+     * @param name Name of the returned Field.
+     * @param f Continuous function.
+     */
+    template <class value_t,
+              std::size_t n_comp,
+              bool SOA = false,
+              class mesh_t,
+              class Func,
+              typename = std::enable_if_t<std::is_invocable_v<Func, typename Cell<mesh_t::dim, typename mesh_t::interval_t>::coords_t>>>
+    [[deprecated("Use make_vector_field() instead")]] auto make_field(std::string name, mesh_t& mesh, Func&& f)
+    {
+        return make_vector_field<value_t, n_comp, SOA>(name, mesh, std::forward<Func>(f));
+    }
+
+    template <std::size_t n_comp,
+              bool SOA = false,
+              class mesh_t,
+              class Func,
+              typename = std::enable_if_t<std::is_invocable_v<Func, typename Cell<mesh_t::dim, typename mesh_t::interval_t>::coords_t>>>
+    [[deprecated("Use make_vector_field() instead")]] auto make_field(std::string name, mesh_t& mesh, Func&& f)
+    {
+        return make_vector_field<n_comp, SOA>(name, mesh, std::forward<Func>(f));
+    }
+
     template <class value_t, std::size_t n_comp, bool SOA = false, class mesh_t>
-    auto make_field(std::string name, mesh_t& mesh)
+    auto make_vector_field(std::string name, mesh_t& mesh)
     {
         using field_t = VectorField<mesh_t, value_t, n_comp, SOA>;
         field_t f(name, mesh);
@@ -775,7 +821,7 @@ namespace samurai
     }
 
     template <class value_t, std::size_t n_comp, bool SOA = false, class mesh_t>
-    auto make_field(std::string name, mesh_t& mesh, value_t init_value)
+    auto make_vector_field(std::string name, mesh_t& mesh, value_t init_value)
     {
         using field_t = VectorField<mesh_t, value_t, n_comp, SOA>;
         auto field    = field_t(name, mesh);
@@ -784,29 +830,29 @@ namespace samurai
     }
 
     template <std::size_t n_comp, bool SOA = false, class mesh_t>
-    auto make_field(std::string name, mesh_t& mesh)
+    auto make_vector_field(std::string name, mesh_t& mesh)
     {
         using default_value_t = double;
-        return make_field<default_value_t, n_comp, SOA>(name, mesh);
+        return make_vector_field<default_value_t, n_comp, SOA>(name, mesh);
     }
 
     template <std::size_t n_comp, bool SOA = false, class mesh_t>
-    auto make_field(std::string name, mesh_t& mesh, double init_value)
+    auto make_vector_field(std::string name, mesh_t& mesh, double init_value)
     {
         using default_value_t = double;
-        return make_field<default_value_t, n_comp, SOA>(name, mesh, init_value);
+        return make_vector_field<default_value_t, n_comp, SOA>(name, mesh, init_value);
     }
 
     /**
-     * @brief Creates a field.
+     * @brief Creates a VectorField.
      * @param name Name of the returned Field.
      * @param f Continuous function.
      * @param gl Gauss Legendre polynomial
      */
     template <class value_t, std::size_t n_comp, bool SOA = false, class mesh_t, class Func, std::size_t polynomial_degree>
-    auto make_field(std::string name, mesh_t& mesh, Func&& f, const GaussLegendre<polynomial_degree>& gl)
+    auto make_vector_field(std::string name, mesh_t& mesh, Func&& f, const GaussLegendre<polynomial_degree>& gl)
     {
-        auto field = make_field<value_t, n_comp, SOA, mesh_t>(name, mesh);
+        auto field = make_vector_field<value_t, n_comp, SOA, mesh_t>(name, mesh);
 #ifdef SAMURAI_CHECK_NAN
         f.fill(std::nan(""));
 #else
@@ -823,14 +869,14 @@ namespace samurai
     }
 
     template <std::size_t n_comp, bool SOA = false, class mesh_t, class Func, std::size_t polynomial_degree>
-    auto make_field(std::string name, mesh_t& mesh, Func&& f, const GaussLegendre<polynomial_degree>& gl)
+    auto make_vector_field(std::string name, mesh_t& mesh, Func&& f, const GaussLegendre<polynomial_degree>& gl)
     {
         using default_value_t = double;
-        return make_field<default_value_t, n_comp, SOA>(name, mesh, std::forward<Func>(f), gl);
+        return make_vector_field<default_value_t, n_comp, SOA>(name, mesh, std::forward<Func>(f), gl);
     }
 
     /**
-     * @brief Creates a field.
+     * @brief Creates a VectorField.
      * @param name Name of the returned Field.
      * @param f Continuous function.
      */
@@ -840,9 +886,9 @@ namespace samurai
               class mesh_t,
               class Func,
               typename = std::enable_if_t<std::is_invocable_v<Func, typename Cell<mesh_t::dim, typename mesh_t::interval_t>::coords_t>>>
-    auto make_field(std::string name, mesh_t& mesh, Func&& f)
+    auto make_vector_field(std::string name, mesh_t& mesh, Func&& f)
     {
-        auto field = make_field<value_t, n_comp, SOA, mesh_t>(name, mesh);
+        auto field = make_vector_field<value_t, n_comp, SOA, mesh_t>(name, mesh);
 #ifdef SAMURAI_CHECK_NAN
         field.fill(std::nan(""));
 #else
@@ -862,10 +908,34 @@ namespace samurai
               class mesh_t,
               class Func,
               typename = std::enable_if_t<std::is_invocable_v<Func, typename Cell<mesh_t::dim, typename mesh_t::interval_t>::coords_t>>>
-    auto make_field(std::string name, mesh_t& mesh, Func&& f)
+    auto make_vector_field(std::string name, mesh_t& mesh, Func&& f)
     {
         using default_value_t = double;
-        return make_field<default_value_t, n_comp, SOA>(name, mesh, std::forward<Func>(f));
+        return make_vector_field<default_value_t, n_comp, SOA>(name, mesh, std::forward<Func>(f));
+    }
+
+    template <class value_t, std::size_t n_comp, bool SOA = false, class mesh_t>
+    [[deprecated("Use make_vector_field() instead")]] auto make_field(std::string name, mesh_t& mesh)
+    {
+        return make_vector_field<value_t, n_comp>(name, mesh);
+    }
+
+    template <class value_t, std::size_t n_comp, bool SOA = false, class mesh_t>
+    [[deprecated("Use make_vector_field() instead")]] auto make_field(std::string name, mesh_t& mesh, value_t init_value)
+    {
+        return make_vector_field<value_t, n_comp>(name, mesh, init_value);
+    }
+
+    template <std::size_t n_comp, bool SOA = false, class mesh_t>
+    [[deprecated("Use make_vector_field() instead")]] auto make_field(std::string name, mesh_t& mesh)
+    {
+        return make_vector_field<n_comp>(name, mesh);
+    }
+
+    template <std::size_t n_comp, bool SOA = false, class mesh_t>
+    [[deprecated("Use make_vector_field() instead")]] auto make_field(std::string name, mesh_t& mesh, double init_value)
+    {
+        return make_vector_field<n_comp>(name, mesh, init_value);
     }
 
     // ------------------------------------------------------------------------
@@ -1301,8 +1371,50 @@ namespace samurai
 
     // ScalarField helper functions -------------------------------------------
 
+    /**
+     * @brief Creates a ScalarField.
+     * @param name Name of the returned Field.
+     * @param f Continuous function.
+     * @param gl Gauss Legendre polynomial
+     */
+    template <class value_t, class mesh_t, class Func, std::size_t polynomial_degree>
+    [[deprecated("Use make_scalar_field() instead")]] auto
+    make_field(std::string name, mesh_t& mesh, Func&& f, const GaussLegendre<polynomial_degree>& gl)
+    {
+        return make_scalar_field<value_t>(name, mesh, std::forward<Func>(f), gl);
+    }
+
+    template <class mesh_t, class Func, std::size_t polynomial_degree>
+    [[deprecated("Use make_scalar_field() instead")]] auto
+    make_field(std::string name, mesh_t& mesh, Func&& f, const GaussLegendre<polynomial_degree>& gl)
+    {
+        return make_scalar_field<double>(name, mesh, std::forward<Func>(f), gl);
+    }
+
+    /**
+     * @brief Creates a ScalarField.
+     * @param name Name of the returned Field.
+     * @param f Continuous function.
+     */
+    template <class value_t,
+              class mesh_t,
+              class Func,
+              typename = std::enable_if_t<std::is_invocable_v<Func, typename Cell<mesh_t::dim, typename mesh_t::interval_t>::coords_t>>>
+    [[deprecated("Use make_scalar_field() instead")]] auto make_field(std::string name, mesh_t& mesh, Func&& f)
+    {
+        return make_scalar_field<value_t>(name, mesh, std::forward<Func>(f));
+    }
+
+    template <class mesh_t,
+              class Func,
+              typename = std::enable_if_t<std::is_invocable_v<Func, typename Cell<mesh_t::dim, typename mesh_t::interval_t>::coords_t>>>
+    [[deprecated("Use make_scalar_field() instead")]] auto make_field(std::string name, mesh_t& mesh, Func&& f)
+    {
+        return make_scalar_field<double>(name, mesh, std::forward<Func>(f));
+    }
+
     template <class value_t, class mesh_t>
-    auto make_field(std::string name, mesh_t& mesh)
+    auto make_scalar_field(std::string name, mesh_t& mesh)
     {
         using field_t = ScalarField<mesh_t, value_t>;
         field_t f(name, mesh);
@@ -1316,7 +1428,7 @@ namespace samurai
     }
 
     template <class value_t, class mesh_t>
-    auto make_field(std::string name, mesh_t& mesh, value_t init_value)
+    auto make_scalar_field(std::string name, mesh_t& mesh, value_t init_value)
     {
         using field_t = ScalarField<mesh_t, value_t>;
         auto field    = field_t(name, mesh);
@@ -1325,29 +1437,29 @@ namespace samurai
     }
 
     template <class mesh_t>
-    auto make_field(std::string name, mesh_t& mesh)
+    auto make_scalar_field(std::string name, mesh_t& mesh)
     {
         using default_value_t = double;
-        return make_field<default_value_t>(name, mesh);
+        return make_scalar_field<default_value_t>(name, mesh);
     }
 
     template <class mesh_t>
-    auto make_field(std::string name, mesh_t& mesh, double init_value)
+    auto make_scalar_field(std::string name, mesh_t& mesh, double init_value)
     {
         using default_value_t = double;
-        return make_field<default_value_t>(name, mesh, init_value);
+        return make_scalar_field<default_value_t>(name, mesh, init_value);
     }
 
     /**
-     * @brief Creates a field.
+     * @brief Creates a ScalarField.
      * @param name Name of the returned Field.
      * @param f Continuous function.
      * @param gl Gauss Legendre polynomial
      */
     template <class value_t, class mesh_t, class Func, std::size_t polynomial_degree>
-    auto make_field(std::string name, mesh_t& mesh, Func&& f, const GaussLegendre<polynomial_degree>& gl)
+    auto make_scalar_field(std::string name, mesh_t& mesh, Func&& f, const GaussLegendre<polynomial_degree>& gl)
     {
-        auto field = make_field<value_t, mesh_t>(name, mesh);
+        auto field = make_scalar_field<value_t, mesh_t>(name, mesh);
 #ifdef SAMURAI_CHECK_NAN
         f.fill(std::nan(""));
 #else
@@ -1364,14 +1476,14 @@ namespace samurai
     }
 
     template <class mesh_t, class Func, std::size_t polynomial_degree>
-    auto make_field(std::string name, mesh_t& mesh, Func&& f, const GaussLegendre<polynomial_degree>& gl)
+    auto make_scalar_field(std::string name, mesh_t& mesh, Func&& f, const GaussLegendre<polynomial_degree>& gl)
     {
         using default_value_t = double;
-        return make_field<default_value_t>(name, mesh, std::forward<Func>(f), gl);
+        return make_scalar_field<default_value_t>(name, mesh, std::forward<Func>(f), gl);
     }
 
     /**
-     * @brief Creates a field.
+     * @brief Creates a ScalarField.
      * @param name Name of the returned Field.
      * @param f Continuous function.
      */
@@ -1379,9 +1491,9 @@ namespace samurai
               class mesh_t,
               class Func,
               typename = std::enable_if_t<std::is_invocable_v<Func, typename Cell<mesh_t::dim, typename mesh_t::interval_t>::coords_t>>>
-    auto make_field(std::string name, mesh_t& mesh, Func&& f)
+    auto make_scalar_field(std::string name, mesh_t& mesh, Func&& f)
     {
-        auto field = make_field<value_t, mesh_t>(name, mesh);
+        auto field = make_scalar_field<value_t, mesh_t>(name, mesh);
 #ifdef SAMURAI_CHECK_NAN
         field.fill(std::nan(""));
 #else
@@ -1399,10 +1511,34 @@ namespace samurai
     template <class mesh_t,
               class Func,
               typename = std::enable_if_t<std::is_invocable_v<Func, typename Cell<mesh_t::dim, typename mesh_t::interval_t>::coords_t>>>
-    auto make_field(std::string name, mesh_t& mesh, Func&& f)
+    auto make_scalar_field(std::string name, mesh_t& mesh, Func&& f)
     {
         using default_value_t = double;
-        return make_field<default_value_t>(name, mesh, std::forward<Func>(f));
+        return make_scalar_field<default_value_t>(name, mesh, std::forward<Func>(f));
+    }
+
+    template <class value_t, class mesh_t>
+    [[deprecated("Use make_scalar_field() instead")]] auto make_field(std::string name, mesh_t& mesh)
+    {
+        return make_scalar_field<value_t>(name, mesh);
+    }
+
+    template <class value_t, class mesh_t>
+    [[deprecated("Use make_scalar_field() instead")]] auto make_field(std::string name, mesh_t& mesh, value_t init_value)
+    {
+        return make_scalar_field<value_t>(name, mesh, init_value);
+    }
+
+    template <class mesh_t>
+    [[deprecated("Use make_scalar_field() instead")]] auto make_field(std::string name, mesh_t& mesh)
+    {
+        return make_scalar_field<double>(name, mesh);
+    }
+
+    template <class mesh_t>
+    [[deprecated("Use make_scalar_field() instead")]] auto make_field(std::string name, mesh_t& mesh, double init_value)
+    {
+        return make_scalar_field<double>(name, mesh, init_value);
     }
 
     // ------------------------------------------------------------------------

--- a/include/samurai/field.hpp
+++ b/include/samurai/field.hpp
@@ -768,14 +768,14 @@ namespace samurai
      */
     template <class value_t, std::size_t n_comp, bool SOA = false, class mesh_t, class Func, std::size_t polynomial_degree>
     [[deprecated("Use make_vector_field() instead")]] auto
-    make_field(std::string name, mesh_t& mesh, Func&& f, const GaussLegendre<polynomial_degree>& gl)
+    make_field(std::string const& name, mesh_t& mesh, Func&& f, const GaussLegendre<polynomial_degree>& gl)
     {
         return make_vector_field<value_t, n_comp, SOA>(name, mesh, std::forward<Func>(f), gl);
     }
 
     template <std::size_t n_comp, bool SOA = false, class mesh_t, class Func, std::size_t polynomial_degree>
     [[deprecated("Use make_vector_field() instead")]] auto
-    make_field(std::string name, mesh_t& mesh, Func&& f, const GaussLegendre<polynomial_degree>& gl)
+    make_field(std::string const& name, mesh_t& mesh, Func&& f, const GaussLegendre<polynomial_degree>& gl)
     {
         return make_vector_field<n_comp, SOA>(name, mesh, std::forward<Func>(f), gl);
     }
@@ -791,7 +791,7 @@ namespace samurai
               class mesh_t,
               class Func,
               typename = std::enable_if_t<std::is_invocable_v<Func, typename Cell<mesh_t::dim, typename mesh_t::interval_t>::coords_t>>>
-    [[deprecated("Use make_vector_field() instead")]] auto make_field(std::string name, mesh_t& mesh, Func&& f)
+    [[deprecated("Use make_vector_field() instead")]] auto make_field(std::string const& name, mesh_t& mesh, Func&& f)
     {
         return make_vector_field<value_t, n_comp, SOA>(name, mesh, std::forward<Func>(f));
     }
@@ -801,13 +801,13 @@ namespace samurai
               class mesh_t,
               class Func,
               typename = std::enable_if_t<std::is_invocable_v<Func, typename Cell<mesh_t::dim, typename mesh_t::interval_t>::coords_t>>>
-    [[deprecated("Use make_vector_field() instead")]] auto make_field(std::string name, mesh_t& mesh, Func&& f)
+    [[deprecated("Use make_vector_field() instead")]] auto make_field(std::string const& name, mesh_t& mesh, Func&& f)
     {
         return make_vector_field<n_comp, SOA>(name, mesh, std::forward<Func>(f));
     }
 
     template <class value_t, std::size_t n_comp, bool SOA = false, class mesh_t>
-    auto make_vector_field(std::string name, mesh_t& mesh)
+    auto make_vector_field(std::string const& name, mesh_t& mesh)
     {
         using field_t = VectorField<mesh_t, value_t, n_comp, SOA>;
         field_t f(name, mesh);
@@ -821,7 +821,7 @@ namespace samurai
     }
 
     template <class value_t, std::size_t n_comp, bool SOA = false, class mesh_t>
-    auto make_vector_field(std::string name, mesh_t& mesh, value_t init_value)
+    auto make_vector_field(std::string const& name, mesh_t& mesh, value_t init_value)
     {
         using field_t = VectorField<mesh_t, value_t, n_comp, SOA>;
         auto field    = field_t(name, mesh);
@@ -830,14 +830,14 @@ namespace samurai
     }
 
     template <std::size_t n_comp, bool SOA = false, class mesh_t>
-    auto make_vector_field(std::string name, mesh_t& mesh)
+    auto make_vector_field(std::string const& name, mesh_t& mesh)
     {
         using default_value_t = double;
         return make_vector_field<default_value_t, n_comp, SOA>(name, mesh);
     }
 
     template <std::size_t n_comp, bool SOA = false, class mesh_t>
-    auto make_vector_field(std::string name, mesh_t& mesh, double init_value)
+    auto make_vector_field(std::string const& name, mesh_t& mesh, double init_value)
     {
         using default_value_t = double;
         return make_vector_field<default_value_t, n_comp, SOA>(name, mesh, init_value);
@@ -850,7 +850,7 @@ namespace samurai
      * @param gl Gauss Legendre polynomial
      */
     template <class value_t, std::size_t n_comp, bool SOA = false, class mesh_t, class Func, std::size_t polynomial_degree>
-    auto make_vector_field(std::string name, mesh_t& mesh, Func&& f, const GaussLegendre<polynomial_degree>& gl)
+    auto make_vector_field(std::string const& name, mesh_t& mesh, Func&& f, const GaussLegendre<polynomial_degree>& gl)
     {
         auto field = make_vector_field<value_t, n_comp, SOA, mesh_t>(name, mesh);
 #ifdef SAMURAI_CHECK_NAN
@@ -869,7 +869,7 @@ namespace samurai
     }
 
     template <std::size_t n_comp, bool SOA = false, class mesh_t, class Func, std::size_t polynomial_degree>
-    auto make_vector_field(std::string name, mesh_t& mesh, Func&& f, const GaussLegendre<polynomial_degree>& gl)
+    auto make_vector_field(std::string const& name, mesh_t& mesh, Func&& f, const GaussLegendre<polynomial_degree>& gl)
     {
         using default_value_t = double;
         return make_vector_field<default_value_t, n_comp, SOA>(name, mesh, std::forward<Func>(f), gl);
@@ -886,7 +886,7 @@ namespace samurai
               class mesh_t,
               class Func,
               typename = std::enable_if_t<std::is_invocable_v<Func, typename Cell<mesh_t::dim, typename mesh_t::interval_t>::coords_t>>>
-    auto make_vector_field(std::string name, mesh_t& mesh, Func&& f)
+    auto make_vector_field(std::string const& name, mesh_t& mesh, Func&& f)
     {
         auto field = make_vector_field<value_t, n_comp, SOA, mesh_t>(name, mesh);
 #ifdef SAMURAI_CHECK_NAN
@@ -908,32 +908,32 @@ namespace samurai
               class mesh_t,
               class Func,
               typename = std::enable_if_t<std::is_invocable_v<Func, typename Cell<mesh_t::dim, typename mesh_t::interval_t>::coords_t>>>
-    auto make_vector_field(std::string name, mesh_t& mesh, Func&& f)
+    auto make_vector_field(std::string const& name, mesh_t& mesh, Func&& f)
     {
         using default_value_t = double;
         return make_vector_field<default_value_t, n_comp, SOA>(name, mesh, std::forward<Func>(f));
     }
 
     template <class value_t, std::size_t n_comp, bool SOA = false, class mesh_t>
-    [[deprecated("Use make_vector_field() instead")]] auto make_field(std::string name, mesh_t& mesh)
+    [[deprecated("Use make_vector_field() instead")]] auto make_field(std::string const& name, mesh_t& mesh)
     {
         return make_vector_field<value_t, n_comp>(name, mesh);
     }
 
     template <class value_t, std::size_t n_comp, bool SOA = false, class mesh_t>
-    [[deprecated("Use make_vector_field() instead")]] auto make_field(std::string name, mesh_t& mesh, value_t init_value)
+    [[deprecated("Use make_vector_field() instead")]] auto make_field(std::string const& name, mesh_t& mesh, value_t init_value)
     {
         return make_vector_field<value_t, n_comp>(name, mesh, init_value);
     }
 
     template <std::size_t n_comp, bool SOA = false, class mesh_t>
-    [[deprecated("Use make_vector_field() instead")]] auto make_field(std::string name, mesh_t& mesh)
+    [[deprecated("Use make_vector_field() instead")]] auto make_field(std::string const& name, mesh_t& mesh)
     {
         return make_vector_field<n_comp>(name, mesh);
     }
 
     template <std::size_t n_comp, bool SOA = false, class mesh_t>
-    [[deprecated("Use make_vector_field() instead")]] auto make_field(std::string name, mesh_t& mesh, double init_value)
+    [[deprecated("Use make_vector_field() instead")]] auto make_field(std::string const& name, mesh_t& mesh, double init_value)
     {
         return make_vector_field<n_comp>(name, mesh, init_value);
     }
@@ -1379,14 +1379,14 @@ namespace samurai
      */
     template <class value_t, class mesh_t, class Func, std::size_t polynomial_degree>
     [[deprecated("Use make_scalar_field() instead")]] auto
-    make_field(std::string name, mesh_t& mesh, Func&& f, const GaussLegendre<polynomial_degree>& gl)
+    make_field(std::string const& name, mesh_t& mesh, Func&& f, const GaussLegendre<polynomial_degree>& gl)
     {
         return make_scalar_field<value_t>(name, mesh, std::forward<Func>(f), gl);
     }
 
     template <class mesh_t, class Func, std::size_t polynomial_degree>
     [[deprecated("Use make_scalar_field() instead")]] auto
-    make_field(std::string name, mesh_t& mesh, Func&& f, const GaussLegendre<polynomial_degree>& gl)
+    make_field(std::string const& name, mesh_t& mesh, Func&& f, const GaussLegendre<polynomial_degree>& gl)
     {
         return make_scalar_field<double>(name, mesh, std::forward<Func>(f), gl);
     }
@@ -1400,7 +1400,7 @@ namespace samurai
               class mesh_t,
               class Func,
               typename = std::enable_if_t<std::is_invocable_v<Func, typename Cell<mesh_t::dim, typename mesh_t::interval_t>::coords_t>>>
-    [[deprecated("Use make_scalar_field() instead")]] auto make_field(std::string name, mesh_t& mesh, Func&& f)
+    [[deprecated("Use make_scalar_field() instead")]] auto make_field(std::string const& name, mesh_t& mesh, Func&& f)
     {
         return make_scalar_field<value_t>(name, mesh, std::forward<Func>(f));
     }
@@ -1408,13 +1408,13 @@ namespace samurai
     template <class mesh_t,
               class Func,
               typename = std::enable_if_t<std::is_invocable_v<Func, typename Cell<mesh_t::dim, typename mesh_t::interval_t>::coords_t>>>
-    [[deprecated("Use make_scalar_field() instead")]] auto make_field(std::string name, mesh_t& mesh, Func&& f)
+    [[deprecated("Use make_scalar_field() instead")]] auto make_field(std::string const& name, mesh_t& mesh, Func&& f)
     {
         return make_scalar_field<double>(name, mesh, std::forward<Func>(f));
     }
 
     template <class value_t, class mesh_t>
-    auto make_scalar_field(std::string name, mesh_t& mesh)
+    auto make_scalar_field(std::string const& name, mesh_t& mesh)
     {
         using field_t = ScalarField<mesh_t, value_t>;
         field_t f(name, mesh);
@@ -1428,7 +1428,7 @@ namespace samurai
     }
 
     template <class value_t, class mesh_t>
-    auto make_scalar_field(std::string name, mesh_t& mesh, value_t init_value)
+    auto make_scalar_field(std::string const& name, mesh_t& mesh, value_t init_value)
     {
         using field_t = ScalarField<mesh_t, value_t>;
         auto field    = field_t(name, mesh);
@@ -1437,14 +1437,14 @@ namespace samurai
     }
 
     template <class mesh_t>
-    auto make_scalar_field(std::string name, mesh_t& mesh)
+    auto make_scalar_field(std::string const& name, mesh_t& mesh)
     {
         using default_value_t = double;
         return make_scalar_field<default_value_t>(name, mesh);
     }
 
     template <class mesh_t>
-    auto make_scalar_field(std::string name, mesh_t& mesh, double init_value)
+    auto make_scalar_field(std::string const& name, mesh_t& mesh, double init_value)
     {
         using default_value_t = double;
         return make_scalar_field<default_value_t>(name, mesh, init_value);
@@ -1457,7 +1457,7 @@ namespace samurai
      * @param gl Gauss Legendre polynomial
      */
     template <class value_t, class mesh_t, class Func, std::size_t polynomial_degree>
-    auto make_scalar_field(std::string name, mesh_t& mesh, Func&& f, const GaussLegendre<polynomial_degree>& gl)
+    auto make_scalar_field(std::string const& name, mesh_t& mesh, Func&& f, const GaussLegendre<polynomial_degree>& gl)
     {
         auto field = make_scalar_field<value_t, mesh_t>(name, mesh);
 #ifdef SAMURAI_CHECK_NAN
@@ -1476,7 +1476,7 @@ namespace samurai
     }
 
     template <class mesh_t, class Func, std::size_t polynomial_degree>
-    auto make_scalar_field(std::string name, mesh_t& mesh, Func&& f, const GaussLegendre<polynomial_degree>& gl)
+    auto make_scalar_field(std::string const& name, mesh_t& mesh, Func&& f, const GaussLegendre<polynomial_degree>& gl)
     {
         using default_value_t = double;
         return make_scalar_field<default_value_t>(name, mesh, std::forward<Func>(f), gl);
@@ -1491,7 +1491,7 @@ namespace samurai
               class mesh_t,
               class Func,
               typename = std::enable_if_t<std::is_invocable_v<Func, typename Cell<mesh_t::dim, typename mesh_t::interval_t>::coords_t>>>
-    auto make_scalar_field(std::string name, mesh_t& mesh, Func&& f)
+    auto make_scalar_field(std::string const& name, mesh_t& mesh, Func&& f)
     {
         auto field = make_scalar_field<value_t, mesh_t>(name, mesh);
 #ifdef SAMURAI_CHECK_NAN
@@ -1511,32 +1511,32 @@ namespace samurai
     template <class mesh_t,
               class Func,
               typename = std::enable_if_t<std::is_invocable_v<Func, typename Cell<mesh_t::dim, typename mesh_t::interval_t>::coords_t>>>
-    auto make_scalar_field(std::string name, mesh_t& mesh, Func&& f)
+    auto make_scalar_field(std::string const& name, mesh_t& mesh, Func&& f)
     {
         using default_value_t = double;
         return make_scalar_field<default_value_t>(name, mesh, std::forward<Func>(f));
     }
 
     template <class value_t, class mesh_t>
-    [[deprecated("Use make_scalar_field() instead")]] auto make_field(std::string name, mesh_t& mesh)
+    [[deprecated("Use make_scalar_field() instead")]] auto make_field(std::string const& name, mesh_t& mesh)
     {
         return make_scalar_field<value_t>(name, mesh);
     }
 
     template <class value_t, class mesh_t>
-    [[deprecated("Use make_scalar_field() instead")]] auto make_field(std::string name, mesh_t& mesh, value_t init_value)
+    [[deprecated("Use make_scalar_field() instead")]] auto make_field(std::string const& name, mesh_t& mesh, value_t init_value)
     {
         return make_scalar_field<value_t>(name, mesh, init_value);
     }
 
     template <class mesh_t>
-    [[deprecated("Use make_scalar_field() instead")]] auto make_field(std::string name, mesh_t& mesh)
+    [[deprecated("Use make_scalar_field() instead")]] auto make_field(std::string const& name, mesh_t& mesh)
     {
         return make_scalar_field<double>(name, mesh);
     }
 
     template <class mesh_t>
-    [[deprecated("Use make_scalar_field() instead")]] auto make_field(std::string name, mesh_t& mesh, double init_value)
+    [[deprecated("Use make_scalar_field() instead")]] auto make_field(std::string const& name, mesh_t& mesh, double init_value)
     {
         return make_scalar_field<double>(name, mesh, init_value);
     }

--- a/include/samurai/field.hpp
+++ b/include/samurai/field.hpp
@@ -901,8 +901,8 @@ namespace samurai
         using const_reverse_iterator = Field_reverse_iterator<const_iterator>;
 
         static constexpr size_type n_comp = 1;
-        // static constexpr bool is_soa      = SOA;
-        static constexpr bool is_scalar = detail::is_scalar_field_type_v<self_type>;
+        static constexpr bool is_soa      = false;
+        static constexpr bool is_scalar   = detail::is_scalar_field_type_v<self_type>;
         using inner_types::static_layout;
 
         ScalarField() = default;

--- a/include/samurai/field.hpp
+++ b/include/samurai/field.hpp
@@ -35,84 +35,6 @@ namespace samurai
     template <class mesh_t, class value_t>
     class ScalarField;
 
-    /**
-     * @brief test if template parameter is a samurai field (ScalarField or VectorField)
-     *
-     * @tparam T type to test
-     */
-    template <class T>
-    struct is_field_type : std::false_type
-    {
-    };
-
-    // specialization for VectorField
-    template <class Mesh, class value_t, std::size_t n_comp, bool SOA>
-    struct is_field_type<VectorField<Mesh, value_t, n_comp, SOA>> : std::true_type
-    {
-    };
-
-    // specialization for ScalarField
-    template <class Mesh, class value_t>
-    struct is_field_type<ScalarField<Mesh, value_t>> : std::true_type
-    {
-    };
-
-    /**
-     * @brief helper to get value of is_field_type
-     *
-     * @tparam T type to test
-     */
-    template <class T>
-    inline constexpr bool is_field_type_v = is_field_type<std::decay_t<T>>::value;
-
-    /**
-     * @brief test if template parameter is a VectorField
-     *
-     * @tparam T type to test
-     */
-    template <class T>
-    struct is_vector_field_type : std::false_type
-    {
-    };
-
-    // specialization for VectorField
-    template <class Mesh, class value_t, std::size_t n_comp, bool SOA>
-    struct is_vector_field_type<VectorField<Mesh, value_t, n_comp, SOA>> : std::true_type
-    {
-    };
-
-    /**
-     * @brief helper to get value of is_vector_field
-     *
-     * @tparam T type to test
-     */
-    template <class T>
-    inline constexpr bool is_vector_field_type_v = is_vector_field_type<std::decay_t<T>>::value;
-
-    /**
-     * @brief test if template parameter is a ScalarField
-     *
-     * @tparam T type to test
-     */
-    template <class T>
-    struct is_scalar_field_type : std::false_type
-    {
-    };
-
-    // specialization for ScalarField
-    template <class Mesh, class value_t>
-    struct is_scalar_field_type<ScalarField<Mesh, value_t>> : std::true_type
-    {
-    };
-
-    /**
-     * @brief helper to get value of is_scalar_field
-     *
-     * @tparam T type to test
-     */
-    template <class T>
-    inline constexpr bool is_scalar_field_type_v = is_scalar_field_type<std::decay_t<T>>::value;
-
     template <class Field, bool is_const>
     class Field_iterator;
 
@@ -169,7 +91,7 @@ namespace samurai
             using interval_value_t              = typename interval_t::value_t;
             using cell_t                        = Cell<dim, interval_t>;
             using data_type                     = field_data_storage_t<value_t, 1>;
-            using local_data_type               = local_field_data_t<value_t, 1>;
+            using local_data_type               = local_field_data_t<value_t, 1, false, true>;
             using size_type                     = typename data_type::size_type;
             static constexpr auto static_layout = data_type::static_layout;
 
@@ -289,7 +211,7 @@ namespace samurai
             using index_t                    = typename interval_t::index_t;
             using cell_t                     = Cell<dim, interval_t>;
             using data_type                  = field_data_storage_t<value_t, n_comp, SOA>;
-            using local_data_type            = local_field_data_t<value_t, n_comp, SOA>;
+            using local_data_type            = local_field_data_t<value_t, n_comp, SOA, false>;
             using size_type                  = typename data_type::size_type;
 
             static constexpr auto static_layout = data_type::static_layout;
@@ -408,7 +330,7 @@ namespace samurai
     // class VectorField
     // ------------------------------------------------------------------------
 
-    template <class mesh_t_, class value_t = double, std::size_t n_comp_, bool SOA>
+    template <class mesh_t_, class value_t, std::size_t n_comp_, bool SOA>
     class VectorField : public field_expression<VectorField<mesh_t_, value_t, n_comp_, SOA>>,
                         public inner_mesh_type<mesh_t_>,
                         public detail::inner_field_types<VectorField<mesh_t_, value_t, n_comp_, SOA>>
@@ -438,6 +360,7 @@ namespace samurai
 
         static constexpr size_type n_comp = n_comp_;
         static constexpr bool is_soa      = SOA;
+        static constexpr bool is_scalar   = detail::is_scalar_field_type_v<self_type>;
         using inner_types::static_layout;
 
         VectorField() = default;
@@ -979,6 +902,7 @@ namespace samurai
 
         static constexpr size_type n_comp = 1;
         // static constexpr bool is_soa      = SOA;
+        static constexpr bool is_scalar = detail::is_scalar_field_type_v<self_type>;
         using inner_types::static_layout;
 
         ScalarField() = default;

--- a/include/samurai/field.hpp
+++ b/include/samurai/field.hpp
@@ -210,7 +210,7 @@ namespace samurai
             using interval_t                 = typename mesh_t::interval_t;
             using index_t                    = typename interval_t::index_t;
             using cell_t                     = Cell<dim, interval_t>;
-            using data_type                  = field_data_storage_t<value_t, n_comp, SOA>;
+            using data_type                  = field_data_storage_t<value_t, n_comp, SOA, false>;
             using local_data_type            = local_field_data_t<value_t, n_comp, SOA, false>;
             using size_type                  = typename data_type::size_type;
 

--- a/include/samurai/field.hpp
+++ b/include/samurai/field.hpp
@@ -971,7 +971,6 @@ namespace samurai
         using const_reverse_iterator = Field_reverse_iterator<const_iterator>;
 
         static constexpr size_type n_comp = 1;
-        static constexpr bool is_soa      = false;
         static constexpr bool is_scalar   = detail::is_scalar_field_type_v<self_type>;
         using inner_types::static_layout;
 

--- a/include/samurai/field.hpp
+++ b/include/samurai/field.hpp
@@ -29,21 +29,89 @@ namespace fs = std::filesystem;
 
 namespace samurai
 {
-    template <class mesh_t, class value_t, std::size_t n_comp = 1, bool SOA = false>
-    class Field;
+    template <class mesh_t, class value_t, std::size_t n_comp, bool SOA>
+    class VectorField;
 
+    template <class mesh_t, class value_t>
+    class ScalarField;
+
+    /**
+     * @brief test if template parameter is a samurai field (ScalarField or VectorField)
+     *
+     * @tparam T type to test
+     */
     template <class T>
     struct is_field_type : std::false_type
     {
     };
 
+    // specialization for VectorField
     template <class Mesh, class value_t, std::size_t n_comp, bool SOA>
-    struct is_field_type<Field<Mesh, value_t, n_comp, SOA>> : std::true_type
+    struct is_field_type<VectorField<Mesh, value_t, n_comp, SOA>> : std::true_type
     {
     };
 
+    // specialization for ScalarField
+    template <class Mesh, class value_t>
+    struct is_field_type<ScalarField<Mesh, value_t>> : std::true_type
+    {
+    };
+
+    /**
+     * @brief helper to get value of is_field_type
+     *
+     * @tparam T type to test
+     */
     template <class T>
     inline constexpr bool is_field_type_v = is_field_type<std::decay_t<T>>::value;
+
+    /**
+     * @brief test if template parameter is a VectorField
+     *
+     * @tparam T type to test
+     */
+    template <class T>
+    struct is_vector_field_type : std::false_type
+    {
+    };
+
+    // specialization for VectorField
+    template <class Mesh, class value_t, std::size_t n_comp, bool SOA>
+    struct is_vector_field_type<VectorField<Mesh, value_t, n_comp, SOA>> : std::true_type
+    {
+    };
+
+    /**
+     * @brief helper to get value of is_vector_field
+     *
+     * @tparam T type to test
+     */
+    template <class T>
+    inline constexpr bool is_vector_field_type_v = is_vector_field_type<std::decay_t<T>>::value;
+
+    /**
+     * @brief test if template parameter is a ScalarField
+     *
+     * @tparam T type to test
+     */
+    template <class T>
+    struct is_scalar_field_type : std::false_type
+    {
+    };
+
+    // specialization for ScalarField
+    template <class Mesh, class value_t>
+    struct is_scalar_field_type<ScalarField<Mesh, value_t>> : std::true_type
+    {
+    };
+
+    /**
+     * @brief helper to get value of is_scalar_field
+     *
+     * @tparam T type to test
+     */
+    template <class T>
+    inline constexpr bool is_scalar_field_type_v = is_scalar_field_type<std::decay_t<T>>::value;
 
     template <class Field, bool is_const>
     class Field_iterator;
@@ -87,8 +155,13 @@ namespace samurai
             }
         };
 
-        template <class mesh_t, class value_t, bool SOA>
-        struct inner_field_types<Field<mesh_t, value_t, 1, SOA>> : public crtp_field<Field<mesh_t, value_t, 1, SOA>>
+        // ------------------------------------------------------------------------
+        // struct inner_field_types
+        // ------------------------------------------------------------------------
+
+        // ScalarField specialization ---------------------------------------------
+        template <class mesh_t, class value_t>
+        struct inner_field_types<ScalarField<mesh_t, value_t>> : public crtp_field<ScalarField<mesh_t, value_t>>
         {
             static constexpr std::size_t dim    = mesh_t::dim;
             using interval_t                    = typename mesh_t::interval_t;
@@ -206,9 +279,10 @@ namespace samurai
             data_type m_storage;
         };
 
+        // VectorField specialization ---------------------------------------------
+
         template <class mesh_t, class value_t, std::size_t n_comp, bool SOA>
-        struct inner_field_types<Field<mesh_t, value_t, n_comp, SOA>, std::enable_if_t<(n_comp > 1)>>
-            : public crtp_field<Field<mesh_t, value_t, n_comp, SOA>>
+        struct inner_field_types<VectorField<mesh_t, value_t, n_comp, SOA>> : public crtp_field<VectorField<mesh_t, value_t, n_comp, SOA>>
         {
             static constexpr std::size_t dim = mesh_t::dim;
             using interval_t                 = typename mesh_t::interval_t;
@@ -330,24 +404,28 @@ namespace samurai
     template <class Field, bool is_const>
     class Field_iterator;
 
+    // ------------------------------------------------------------------------
+    // class VectorField
+    // ------------------------------------------------------------------------
+
     template <class mesh_t_, class value_t = double, std::size_t n_comp_, bool SOA>
-    class Field : public field_expression<Field<mesh_t_, value_t, n_comp_, SOA>>,
-                  public inner_mesh_type<mesh_t_>,
-                  public detail::inner_field_types<Field<mesh_t_, value_t, n_comp_, SOA>>
+    class VectorField : public field_expression<VectorField<mesh_t_, value_t, n_comp_, SOA>>,
+                        public inner_mesh_type<mesh_t_>,
+                        public detail::inner_field_types<VectorField<mesh_t_, value_t, n_comp_, SOA>>
     {
       public:
 
-        using self_type    = Field<mesh_t_, value_t, n_comp_, SOA>;
+        using self_type    = VectorField<mesh_t_, value_t, n_comp_, SOA>;
         using inner_mesh_t = inner_mesh_type<mesh_t_>;
         using mesh_t       = mesh_t_;
 
         using value_type      = value_t;
-        using inner_types     = detail::inner_field_types<Field<mesh_t, value_t, n_comp_, SOA>>;
+        using inner_types     = detail::inner_field_types<self_type>;
         using data_type       = typename inner_types::data_type::container_t;
         using local_data_type = typename inner_types::local_data_type;
         using size_type       = typename inner_types::size_type;
         using inner_types::operator();
-        using bc_container = std::vector<std::unique_ptr<Bc<Field>>>;
+        using bc_container = std::vector<std::unique_ptr<Bc<self_type>>>;
 
         using inner_types::dim;
         using interval_t = typename mesh_t::interval_t;
@@ -362,23 +440,23 @@ namespace samurai
         static constexpr bool is_soa      = SOA;
         using inner_types::static_layout;
 
-        Field() = default;
+        VectorField() = default;
 
-        Field(std::string name, mesh_t& mesh);
-
-        template <class E>
-        Field(const field_expression<E>& e);
-
-        Field(const Field&);
-        Field& operator=(const Field&);
-
-        Field(Field&&) noexcept            = default;
-        Field& operator=(Field&&) noexcept = default;
-
-        ~Field() = default;
+        VectorField(std::string name, mesh_t& mesh);
 
         template <class E>
-        Field& operator=(const field_expression<E>& e);
+        VectorField(const field_expression<E>& e);
+
+        VectorField(const VectorField&);
+        VectorField& operator=(const VectorField&);
+
+        VectorField(VectorField&&) noexcept            = default;
+        VectorField& operator=(VectorField&&) noexcept = default;
+
+        ~VectorField() = default;
+
+        template <class E>
+        VectorField& operator=(const field_expression<E>& e);
 
         void fill(value_type v);
 
@@ -394,7 +472,7 @@ namespace samurai
         auto attach_bc(const Bc_derived& bc);
         auto& get_bc();
         const auto& get_bc() const;
-        void copy_bc_from(const Field& other);
+        void copy_bc_from(const VectorField& other);
 
         iterator begin();
         const_iterator begin() const;
@@ -424,116 +502,13 @@ namespace samurai
 
         bc_container p_bc;
 
-        friend struct detail::inner_field_types<Field<mesh_t, value_t, n_comp_, SOA>>;
+        friend struct detail::inner_field_types<VectorField<mesh_t, value_t, n_comp_, SOA>>;
     };
 
-    template <class Field, bool is_const>
-    class Field_iterator : public xtl::xrandom_access_iterator_base3<Field_iterator<Field, is_const>,
-                                                                     CellArray_iterator<const typename Field::mesh_t::ca_type, true>>
-    {
-      public:
-
-        using self_type   = Field_iterator<Field, is_const>;
-        using ca_iterator = CellArray_iterator<const typename Field::mesh_t::ca_type, true>;
-
-        using reference       = default_view_t<typename Field::data_type>;
-        using difference_type = typename ca_iterator::difference_type;
-
-        Field_iterator(Field* field, const ca_iterator& ca_it);
-
-        self_type& operator++();
-        self_type& operator--();
-
-        self_type& operator+=(difference_type n);
-        self_type& operator-=(difference_type n);
-
-        auto operator*() const;
-
-        bool equal(const self_type& rhs) const;
-        bool less_than(const self_type& rhs) const;
-
-      private:
-
-        Field* p_field;
-        ca_iterator m_ca_it;
-    };
-
-    template <class Field, bool is_const>
-    Field_iterator<Field, is_const>::Field_iterator(Field* field, const ca_iterator& ca_it)
-        : p_field(field)
-        , m_ca_it(ca_it)
-    {
-    }
-
-    template <class Field, bool is_const>
-    inline auto Field_iterator<Field, is_const>::operator++() -> self_type&
-    {
-        ++m_ca_it;
-        return *this;
-    }
-
-    template <class Field, bool is_const>
-    inline auto Field_iterator<Field, is_const>::operator--() -> self_type&
-    {
-        --m_ca_it;
-        return *this;
-    }
-
-    template <class Field, bool is_const>
-    inline auto Field_iterator<Field, is_const>::operator+=(difference_type n) -> self_type&
-    {
-        m_ca_it += n;
-        return *this;
-    }
-
-    template <class Field, bool is_const>
-    inline auto Field_iterator<Field, is_const>::operator-=(difference_type n) -> self_type&
-    {
-        m_ca_it -= n;
-        return *this;
-    }
-
-    template <class Field, bool is_const>
-    inline auto Field_iterator<Field, is_const>::operator*() const
-    {
-        std::size_t level = m_ca_it.level();
-        auto& index       = m_ca_it.index();
-        return (*p_field)(level, *m_ca_it, index);
-    }
-
-    template <class Field, bool is_const>
-    inline bool Field_iterator<Field, is_const>::equal(const self_type& rhs) const
-    {
-        return m_ca_it.equal(rhs.m_ca_it);
-    }
-
-    template <class Field, bool is_const>
-    inline bool Field_iterator<Field, is_const>::less_than(const self_type& rhs) const
-    {
-        return m_ca_it.less_than(rhs.m_ca_it);
-    }
-
-    template <class Field, bool is_const>
-    inline bool operator==(const Field_iterator<Field, is_const>& it1, const Field_iterator<Field, is_const>& it2)
-    {
-        return it1.equal(it2);
-    }
-
-    template <class Field, bool is_const>
-    inline bool operator<(const Field_iterator<Field, is_const>& it1, const Field_iterator<Field, is_const>& it2)
-    {
-        return it1.less_than(it2);
-    }
+    // VectorField constructors -----------------------------------------------
 
     template <class mesh_t, class value_t, std::size_t n_comp_, bool SOA>
-    inline void Field<mesh_t, value_t, n_comp_, SOA>::fill(value_type v)
-
-    {
-        this->m_storage.data().fill(v);
-    }
-
-    template <class mesh_t, class value_t, std::size_t n_comp_, bool SOA>
-    inline Field<mesh_t, value_t, n_comp_, SOA>::Field(std::string name, mesh_t& mesh)
+    inline VectorField<mesh_t, value_t, n_comp_, SOA>::VectorField(std::string name, mesh_t& mesh)
         : inner_mesh_t(mesh)
         , inner_types()
         , m_name(std::move(name))
@@ -543,7 +518,7 @@ namespace samurai
 
     template <class mesh_t, class value_t, std::size_t n_comp_, bool SOA>
     template <class E>
-    inline Field<mesh_t, value_t, n_comp_, SOA>::Field(const field_expression<E>& e)
+    inline VectorField<mesh_t, value_t, n_comp_, SOA>::VectorField(const field_expression<E>& e)
         : inner_mesh_t(detail::extract_mesh(e.derived_cast()))
     {
         this->resize();
@@ -551,7 +526,7 @@ namespace samurai
     }
 
     template <class mesh_t, class value_t, std::size_t n_comp_, bool SOA>
-    inline Field<mesh_t, value_t, n_comp_, SOA>::Field(const Field& field)
+    inline VectorField<mesh_t, value_t, n_comp_, SOA>::VectorField(const VectorField& field)
         : inner_mesh_t(field.mesh())
         , inner_types(field)
         , m_name(field.m_name)
@@ -559,8 +534,10 @@ namespace samurai
         copy_bc_from(field);
     }
 
+    // VectorField operators --------------------------------------------------
+
     template <class mesh_t, class value_t, std::size_t n_comp_, bool SOA>
-    inline auto Field<mesh_t, value_t, n_comp_, SOA>::operator=(const Field& field) -> Field&
+    inline auto VectorField<mesh_t, value_t, n_comp_, SOA>::operator=(const VectorField& field) -> VectorField&
     {
         times::timers.start("field expressions");
         inner_mesh_t::operator=(field.mesh());
@@ -582,7 +559,7 @@ namespace samurai
 
     template <class mesh_t, class value_t, std::size_t n_comp_, bool SOA>
     template <class E>
-    inline auto Field<mesh_t, value_t, n_comp_, SOA>::operator=(const field_expression<E>& e) -> Field&
+    inline auto VectorField<mesh_t, value_t, n_comp_, SOA>::operator=(const field_expression<E>& e) -> VectorField&
     {
         times::timers.start("field expressions");
         for_each_interval(this->mesh(),
@@ -594,11 +571,15 @@ namespace samurai
         return *this;
     }
 
+    // VectorField methods ----------------------------------------------------
+
+    // --- element access -----------------------------------------------------
+
     template <class mesh_t, class value_t, std::size_t n_comp_, bool SOA>
     template <class... T>
-    inline auto Field<mesh_t, value_t, n_comp_, SOA>::get_interval(std::size_t level,
-                                                                   const interval_t& interval,
-                                                                   const T... index) const -> const interval_t&
+    inline auto VectorField<mesh_t, value_t, n_comp_, SOA>::get_interval(std::size_t level,
+                                                                         const interval_t& interval,
+                                                                         const T... index) const -> const interval_t&
     {
         const interval_t& interval_tmp = this->mesh().get_interval(level, interval, index...);
 
@@ -629,10 +610,10 @@ namespace samurai
     }
 
     template <class mesh_t, class value_t, std::size_t n_comp_, bool SOA>
-    inline auto
-    Field<mesh_t, value_t, n_comp_, SOA>::get_interval(std::size_t level,
-                                                       const interval_t& interval,
-                                                       const xt::xtensor_fixed<value_t, xt::xshape<dim - 1>>& index) const -> const interval_t&
+    inline auto VectorField<mesh_t, value_t, n_comp_, SOA>::get_interval(std::size_t level,
+                                                                         const interval_t& interval,
+                                                                         const xt::xtensor_fixed<value_t, xt::xshape<dim - 1>>& index) const
+        -> const interval_t&
     {
         const interval_t& interval_tmp = this->mesh().get_interval(level, interval, index);
 
@@ -645,31 +626,117 @@ namespace samurai
     }
 
     template <class mesh_t, class value_t, std::size_t n_comp_, bool SOA>
-    inline auto Field<mesh_t, value_t, n_comp_, SOA>::array() const -> const data_type&
+    inline auto VectorField<mesh_t, value_t, n_comp_, SOA>::array() const -> const data_type&
     {
         return this->m_storage.data();
     }
 
     template <class mesh_t, class value_t, std::size_t n_comp_, bool SOA>
-    inline auto Field<mesh_t, value_t, n_comp_, SOA>::array() -> data_type&
+    inline auto VectorField<mesh_t, value_t, n_comp_, SOA>::array() -> data_type&
     {
         return this->m_storage.data();
     }
 
     template <class mesh_t, class value_t, std::size_t n_comp_, bool SOA>
-    inline const std::string& Field<mesh_t, value_t, n_comp_, SOA>::name() const
+    inline const std::string& VectorField<mesh_t, value_t, n_comp_, SOA>::name() const
     {
         return m_name;
     }
 
     template <class mesh_t, class value_t, std::size_t n_comp_, bool SOA>
-    inline std::string& Field<mesh_t, value_t, n_comp_, SOA>::name()
+    inline std::string& VectorField<mesh_t, value_t, n_comp_, SOA>::name()
     {
         return m_name;
     }
 
+    // --- iterators ----------------------------------------------------------
+
     template <class mesh_t, class value_t, std::size_t n_comp_, bool SOA>
-    inline void Field<mesh_t, value_t, n_comp_, SOA>::to_stream(std::ostream& os) const
+    inline auto VectorField<mesh_t, value_t, n_comp_, SOA>::begin() -> iterator
+    {
+        using mesh_id_t = typename mesh_t::mesh_id_t;
+        return iterator(this, this->mesh()[mesh_id_t::cells].begin());
+    }
+
+    template <class mesh_t, class value_t, std::size_t n_comp_, bool SOA>
+    inline auto VectorField<mesh_t, value_t, n_comp_, SOA>::end() -> iterator
+    {
+        using mesh_id_t = typename mesh_t::mesh_id_t;
+        return iterator(this, this->mesh()[mesh_id_t::cells].end());
+    }
+
+    template <class mesh_t, class value_t, std::size_t n_comp_, bool SOA>
+    inline auto VectorField<mesh_t, value_t, n_comp_, SOA>::begin() const -> const_iterator
+    {
+        return cbegin();
+    }
+
+    template <class mesh_t, class value_t, std::size_t n_comp_, bool SOA>
+    inline auto VectorField<mesh_t, value_t, n_comp_, SOA>::end() const -> const_iterator
+    {
+        return cend();
+    }
+
+    template <class mesh_t, class value_t, std::size_t n_comp_, bool SOA>
+    inline auto VectorField<mesh_t, value_t, n_comp_, SOA>::cbegin() const -> const_iterator
+    {
+        using mesh_id_t = typename mesh_t::mesh_id_t;
+        return const_iterator(this, this->mesh()[mesh_id_t::cells].cbegin());
+    }
+
+    template <class mesh_t, class value_t, std::size_t n_comp_, bool SOA>
+    inline auto VectorField<mesh_t, value_t, n_comp_, SOA>::cend() const -> const_iterator
+    {
+        using mesh_id_t = typename mesh_t::mesh_id_t;
+        return const_iterator(this, this->mesh()[mesh_id_t::cells].cend());
+    }
+
+    template <class mesh_t, class value_t, std::size_t n_comp_, bool SOA>
+    inline auto VectorField<mesh_t, value_t, n_comp_, SOA>::rbegin() -> reverse_iterator
+    {
+        return reverse_iterator(end());
+    }
+
+    template <class mesh_t, class value_t, std::size_t n_comp_, bool SOA>
+    inline auto VectorField<mesh_t, value_t, n_comp_, SOA>::rend() -> reverse_iterator
+    {
+        return reverse_iterator(begin());
+    }
+
+    template <class mesh_t, class value_t, std::size_t n_comp_, bool SOA>
+    inline auto VectorField<mesh_t, value_t, n_comp_, SOA>::rbegin() const -> const_reverse_iterator
+    {
+        return rcbegin();
+    }
+
+    template <class mesh_t, class value_t, std::size_t n_comp_, bool SOA>
+    inline auto VectorField<mesh_t, value_t, n_comp_, SOA>::rend() const -> const_reverse_iterator
+    {
+        return rcend();
+    }
+
+    template <class mesh_t, class value_t, std::size_t n_comp_, bool SOA>
+    inline auto VectorField<mesh_t, value_t, n_comp_, SOA>::rcbegin() const -> const_reverse_iterator
+    {
+        return const_reverse_iterator(cend());
+    }
+
+    template <class mesh_t, class value_t, std::size_t n_comp_, bool SOA>
+    inline auto VectorField<mesh_t, value_t, n_comp_, SOA>::rcend() const -> const_reverse_iterator
+    {
+        return const_reverse_iterator(cbegin());
+    }
+
+    // --- others -------------------------------------------------------------
+
+    template <class mesh_t, class value_t, std::size_t n_comp_, bool SOA>
+    inline void VectorField<mesh_t, value_t, n_comp_, SOA>::fill(value_type v)
+    {
+        this->m_storage.data().fill(v);
+    }
+
+    template <class mesh_t, class value_t, std::size_t n_comp_, bool SOA>
+    inline void VectorField<mesh_t, value_t, n_comp_, SOA>::to_stream(std::ostream& os) const
     {
         os << "Field " << m_name << "\n";
 
@@ -686,35 +753,28 @@ namespace samurai
                       });
     }
 
-    template <class mesh_t, class T, std::size_t N, bool SOA>
-    inline std::ostream& operator<<(std::ostream& out, const Field<mesh_t, T, N, SOA>& field)
-    {
-        field.to_stream(out);
-        return out;
-    }
-
     template <class mesh_t, class value_t, std::size_t n_comp_, bool SOA>
     template <class Bc_derived>
-    inline auto Field<mesh_t, value_t, n_comp_, SOA>::attach_bc(const Bc_derived& bc)
+    inline auto VectorField<mesh_t, value_t, n_comp_, SOA>::attach_bc(const Bc_derived& bc)
     {
         p_bc.push_back(bc.clone());
         return p_bc.back().get();
     }
 
     template <class mesh_t, class value_t, std::size_t n_comp_, bool SOA>
-    inline auto& Field<mesh_t, value_t, n_comp_, SOA>::get_bc()
+    inline auto& VectorField<mesh_t, value_t, n_comp_, SOA>::get_bc()
     {
         return p_bc;
     }
 
     template <class mesh_t, class value_t, std::size_t n_comp_, bool SOA>
-    inline const auto& Field<mesh_t, value_t, n_comp_, SOA>::get_bc() const
+    inline const auto& VectorField<mesh_t, value_t, n_comp_, SOA>::get_bc() const
     {
         return p_bc;
     }
 
     template <class mesh_t, class value_t, std::size_t n_comp_, bool SOA>
-    void Field<mesh_t, value_t, n_comp_, SOA>::copy_bc_from(const Field<mesh_t, value_t, n_comp_, SOA>& other)
+    void VectorField<mesh_t, value_t, n_comp_, SOA>::copy_bc_from(const VectorField<mesh_t, value_t, n_comp_, SOA>& other)
     {
         std::transform(other.get_bc().cbegin(),
                        other.get_bc().cend(),
@@ -725,86 +785,62 @@ namespace samurai
                        });
     }
 
+    // VectorField extern operators -------------------------------------------
+
     template <class mesh_t, class value_t, std::size_t n_comp_, bool SOA>
-    inline auto Field<mesh_t, value_t, n_comp_, SOA>::begin() -> iterator
+    inline std::ostream& operator<<(std::ostream& out, const VectorField<mesh_t, value_t, n_comp_, SOA>& field)
+    {
+        field.to_stream(out);
+        return out;
+    }
+
+    template <class mesh_t, class value_t, std::size_t n_comp_, bool SOA>
+    inline bool operator==(const VectorField<mesh_t, value_t, n_comp_, SOA>& field1, const VectorField<mesh_t, value_t, n_comp_, SOA>& field2)
     {
         using mesh_id_t = typename mesh_t::mesh_id_t;
-        return iterator(this, this->mesh()[mesh_id_t::cells].begin());
+
+        if (field1.mesh() != field2.mesh())
+        {
+            std::cout << "mesh different" << std::endl;
+            return false;
+        }
+
+        auto& mesh   = field1.mesh();
+        bool is_same = true;
+        for_each_cell(mesh[mesh_id_t::cells],
+                      [&](const auto& cell)
+                      {
+                          if constexpr (std::is_integral_v<value_t>)
+                          {
+                              if (field1[cell] != field2[cell])
+                              {
+                                  is_same = false;
+                              }
+                          }
+                          else
+                          {
+                              if (std::abs(field1[cell] - field2[cell]) > 1e-15)
+                              {
+                                  is_same = false;
+                              }
+                          }
+                      });
+
+        return is_same;
     }
 
     template <class mesh_t, class value_t, std::size_t n_comp_, bool SOA>
-    inline auto Field<mesh_t, value_t, n_comp_, SOA>::end() -> iterator
+    inline bool operator!=(const VectorField<mesh_t, value_t, n_comp_, SOA>& field1, const VectorField<mesh_t, value_t, n_comp_, SOA>& field2)
     {
-        using mesh_id_t = typename mesh_t::mesh_id_t;
-        return iterator(this, this->mesh()[mesh_id_t::cells].end());
+        return !(field1 == field2);
     }
 
-    template <class mesh_t, class value_t, std::size_t n_comp_, bool SOA>
-    inline auto Field<mesh_t, value_t, n_comp_, SOA>::begin() const -> const_iterator
-    {
-        return cbegin();
-    }
-
-    template <class mesh_t, class value_t, std::size_t n_comp_, bool SOA>
-    inline auto Field<mesh_t, value_t, n_comp_, SOA>::end() const -> const_iterator
-    {
-        return cend();
-    }
-
-    template <class mesh_t, class value_t, std::size_t n_comp_, bool SOA>
-    inline auto Field<mesh_t, value_t, n_comp_, SOA>::cbegin() const -> const_iterator
-    {
-        using mesh_id_t = typename mesh_t::mesh_id_t;
-        return const_iterator(this, this->mesh()[mesh_id_t::cells].cbegin());
-    }
-
-    template <class mesh_t, class value_t, std::size_t n_comp_, bool SOA>
-    inline auto Field<mesh_t, value_t, n_comp_, SOA>::cend() const -> const_iterator
-    {
-        using mesh_id_t = typename mesh_t::mesh_id_t;
-        return const_iterator(this, this->mesh()[mesh_id_t::cells].cend());
-    }
-
-    template <class mesh_t, class value_t, std::size_t n_comp_, bool SOA>
-    inline auto Field<mesh_t, value_t, n_comp_, SOA>::rbegin() -> reverse_iterator
-    {
-        return reverse_iterator(end());
-    }
-
-    template <class mesh_t, class value_t, std::size_t n_comp_, bool SOA>
-    inline auto Field<mesh_t, value_t, n_comp_, SOA>::rend() -> reverse_iterator
-    {
-        return reverse_iterator(begin());
-    }
-
-    template <class mesh_t, class value_t, std::size_t n_comp_, bool SOA>
-    inline auto Field<mesh_t, value_t, n_comp_, SOA>::rbegin() const -> const_reverse_iterator
-    {
-        return rcbegin();
-    }
-
-    template <class mesh_t, class value_t, std::size_t n_comp_, bool SOA>
-    inline auto Field<mesh_t, value_t, n_comp_, SOA>::rend() const -> const_reverse_iterator
-    {
-        return rcend();
-    }
-
-    template <class mesh_t, class value_t, std::size_t n_comp_, bool SOA>
-    inline auto Field<mesh_t, value_t, n_comp_, SOA>::rcbegin() const -> const_reverse_iterator
-    {
-        return const_reverse_iterator(cend());
-    }
-
-    template <class mesh_t, class value_t, std::size_t n_comp_, bool SOA>
-    inline auto Field<mesh_t, value_t, n_comp_, SOA>::rcend() const -> const_reverse_iterator
-    {
-        return const_reverse_iterator(cbegin());
-    }
+    // VectorField helper functions -------------------------------------------
 
     template <class value_t, std::size_t n_comp, bool SOA = false, class mesh_t>
     auto make_field(std::string name, mesh_t& mesh)
     {
-        using field_t = Field<mesh_t, value_t, n_comp, SOA>;
+        using field_t = VectorField<mesh_t, value_t, n_comp, SOA>;
         field_t f(name, mesh);
 #ifdef SAMURAI_CHECK_NAN
         if constexpr (std::is_floating_point_v<value_t>)
@@ -818,7 +854,7 @@ namespace samurai
     template <class value_t, std::size_t n_comp, bool SOA = false, class mesh_t>
     auto make_field(std::string name, mesh_t& mesh, value_t init_value)
     {
-        using field_t = Field<mesh_t, value_t, n_comp, SOA>;
+        using field_t = VectorField<mesh_t, value_t, n_comp, SOA>;
         auto field    = field_t(name, mesh);
         field.fill(init_value);
         return field;
@@ -909,8 +945,397 @@ namespace samurai
         return make_field<default_value_t, n_comp, SOA>(name, mesh, std::forward<Func>(f));
     }
 
-    template <class mesh_t, class value_t, std::size_t n_comp_, bool SOA>
-    inline bool operator==(const Field<mesh_t, value_t, n_comp_, SOA>& field1, const Field<mesh_t, value_t, n_comp_, SOA>& field2)
+    // ------------------------------------------------------------------------
+    // class ScalarField
+    // ------------------------------------------------------------------------
+
+    template <class mesh_t_, class value_t = double>
+    class ScalarField : public field_expression<ScalarField<mesh_t_, value_t>>,
+                        public inner_mesh_type<mesh_t_>,
+                        public detail::inner_field_types<ScalarField<mesh_t_, value_t>>
+    {
+      public:
+
+        using self_type    = ScalarField<mesh_t_, value_t>;
+        using inner_mesh_t = inner_mesh_type<mesh_t_>;
+        using mesh_t       = mesh_t_;
+
+        using value_type      = value_t;
+        using inner_types     = detail::inner_field_types<self_type>;
+        using data_type       = typename inner_types::data_type::container_t;
+        using local_data_type = typename inner_types::local_data_type;
+        using size_type       = typename inner_types::size_type;
+        using inner_types::operator();
+        using bc_container = std::vector<std::unique_ptr<Bc<self_type>>>;
+
+        using inner_types::dim;
+        using interval_t = typename mesh_t::interval_t;
+        using cell_t     = typename inner_types::cell_t;
+
+        using iterator               = Field_iterator<self_type, false>;
+        using const_iterator         = Field_iterator<const self_type, true>;
+        using reverse_iterator       = Field_reverse_iterator<iterator>;
+        using const_reverse_iterator = Field_reverse_iterator<const_iterator>;
+
+        static constexpr size_type n_comp = 1;
+        // static constexpr bool is_soa      = SOA;
+        using inner_types::static_layout;
+
+        ScalarField() = default;
+
+        ScalarField(std::string name, mesh_t& mesh);
+
+        template <class E>
+        ScalarField(const field_expression<E>& e);
+
+        ScalarField(const ScalarField&);
+        ScalarField& operator=(const ScalarField&);
+
+        ScalarField(ScalarField&&) noexcept            = default;
+        ScalarField& operator=(ScalarField&&) noexcept = default;
+
+        ~ScalarField() = default;
+
+        template <class E>
+        ScalarField& operator=(const field_expression<E>& e);
+
+        void fill(value_type v);
+
+        const data_type& array() const;
+        data_type& array();
+
+        const std::string& name() const;
+        std::string& name();
+
+        void to_stream(std::ostream& os) const;
+
+        template <class Bc_derived>
+        auto attach_bc(const Bc_derived& bc);
+        auto& get_bc();
+        const auto& get_bc() const;
+        void copy_bc_from(const ScalarField& other);
+
+        iterator begin();
+        const_iterator begin() const;
+        const_iterator cbegin() const;
+
+        reverse_iterator rbegin();
+        const_reverse_iterator rbegin() const;
+        const_reverse_iterator rcbegin() const;
+
+        iterator end();
+        const_iterator end() const;
+        const_iterator cend() const;
+
+        reverse_iterator rend();
+        const_reverse_iterator rend() const;
+        const_reverse_iterator rcend() const;
+
+      private:
+
+        template <class... T>
+        const interval_t& get_interval(std::size_t level, const interval_t& interval, const T... index) const;
+
+        const interval_t&
+        get_interval(std::size_t level, const interval_t& interval, const xt::xtensor_fixed<value_t, xt::xshape<dim - 1>>& index) const;
+
+        std::string m_name;
+
+        bc_container p_bc;
+
+        friend struct detail::inner_field_types<ScalarField<mesh_t, value_t>>;
+    };
+
+    // ScalarField constructors -----------------------------------------------
+
+    template <class mesh_t, class value_t>
+    inline ScalarField<mesh_t, value_t>::ScalarField(std::string name, mesh_t& mesh)
+        : inner_mesh_t(mesh)
+        , inner_types()
+        , m_name(std::move(name))
+    {
+        this->resize();
+    }
+
+    template <class mesh_t, class value_t>
+    template <class E>
+    inline ScalarField<mesh_t, value_t>::ScalarField(const field_expression<E>& e)
+        : inner_mesh_t(detail::extract_mesh(e.derived_cast()))
+    {
+        this->resize();
+        *this = e;
+    }
+
+    template <class mesh_t, class value_t>
+    inline ScalarField<mesh_t, value_t>::ScalarField(const ScalarField& field)
+        : inner_mesh_t(field.mesh())
+        , inner_types(field)
+        , m_name(field.m_name)
+    {
+        copy_bc_from(field);
+    }
+
+    // ScalarField operators --------------------------------------------------
+
+    template <class mesh_t, class value_t>
+    inline auto ScalarField<mesh_t, value_t>::operator=(const ScalarField& field) -> ScalarField&
+    {
+        times::timers.start("field expressions");
+        inner_mesh_t::operator=(field.mesh());
+        m_name = field.m_name;
+        inner_types::operator=(field);
+
+        bc_container tmp;
+        std::transform(field.p_bc.cbegin(),
+                       field.p_bc.cend(),
+                       std::back_inserter(tmp),
+                       [](const auto& v)
+                       {
+                           return v->clone();
+                       });
+        std::swap(p_bc, tmp);
+        times::timers.stop("field expressions");
+        return *this;
+    }
+
+    template <class mesh_t, class value_t>
+    template <class E>
+    inline auto ScalarField<mesh_t, value_t>::operator=(const field_expression<E>& e) -> ScalarField&
+    {
+        times::timers.start("field expressions");
+        for_each_interval(this->mesh(),
+                          [&](std::size_t level, const auto& i, const auto& index)
+                          {
+                              noalias((*this)(level, i, index)) = e.derived_cast()(level, i, index);
+                          });
+        times::timers.stop("field expressions");
+        return *this;
+    }
+
+    // ScalarField methods ----------------------------------------------------
+
+    // --- element access -----------------------------------------------------
+
+    template <class mesh_t, class value_t>
+    template <class... T>
+    inline auto
+    ScalarField<mesh_t, value_t>::get_interval(std::size_t level, const interval_t& interval, const T... index) const -> const interval_t&
+    {
+        const interval_t& interval_tmp = this->mesh().get_interval(level, interval, index...);
+
+        if ((interval_tmp.end - interval_tmp.step < interval.end - interval.step) || (interval_tmp.start > interval.start))
+        {
+            // using mesh_id_t  = typename mesh_t::mesh_id_t;
+            // auto coords      = make_field<int, dim, false>("coordinates", this->mesh());
+            // auto level_field = make_field<std::size_t, 1, false>("level", this->mesh());
+            // for_each_cell(this->mesh()[mesh_id_t::reference],
+            //               [&](auto& cell)
+            //               {
+            //                   if constexpr (dim == 1)
+            //                   {
+            //                       coords[cell] = cell.indices[0];
+            //                   }
+            //                   else
+            //                   {
+            //                       coords[cell] = cell.indices;
+            //                   }
+            //                   level_field[cell] = cell.level;
+            //               });
+            // save(fs::current_path(), "mesh_throw", {true, true}, this->mesh(), coords, level_field);
+            (std::cout << ... << index) << std::endl;
+            throw std::out_of_range(fmt::format("FIELD ERROR on level {}: try to find interval {}", level, interval));
+        }
+
+        return interval_tmp;
+    }
+
+    template <class mesh_t, class value_t>
+    inline auto
+    ScalarField<mesh_t, value_t>::get_interval(std::size_t level,
+                                               const interval_t& interval,
+                                               const xt::xtensor_fixed<value_t, xt::xshape<dim - 1>>& index) const -> const interval_t&
+    {
+        const interval_t& interval_tmp = this->mesh().get_interval(level, interval, index);
+
+        if ((interval_tmp.end - interval_tmp.step < interval.end - interval.step) || (interval_tmp.start > interval.start))
+        {
+            throw std::out_of_range(fmt::format("FIELD ERROR on level {}: try to find interval {}", level, interval));
+        }
+
+        return interval_tmp;
+    }
+
+    template <class mesh_t, class value_t>
+    inline auto ScalarField<mesh_t, value_t>::array() const -> const data_type&
+    {
+        return this->m_storage.data();
+    }
+
+    template <class mesh_t, class value_t>
+    inline auto ScalarField<mesh_t, value_t>::array() -> data_type&
+    {
+        return this->m_storage.data();
+    }
+
+    template <class mesh_t, class value_t>
+    inline const std::string& ScalarField<mesh_t, value_t>::name() const
+    {
+        return m_name;
+    }
+
+    template <class mesh_t, class value_t>
+    inline std::string& ScalarField<mesh_t, value_t>::name()
+    {
+        return m_name;
+    }
+
+    // --- iterators ----------------------------------------------------------
+
+    template <class mesh_t, class value_t>
+    inline auto ScalarField<mesh_t, value_t>::begin() -> iterator
+    {
+        using mesh_id_t = typename mesh_t::mesh_id_t;
+        return iterator(this, this->mesh()[mesh_id_t::cells].begin());
+    }
+
+    template <class mesh_t, class value_t>
+    inline auto ScalarField<mesh_t, value_t>::end() -> iterator
+    {
+        using mesh_id_t = typename mesh_t::mesh_id_t;
+        return iterator(this, this->mesh()[mesh_id_t::cells].end());
+    }
+
+    template <class mesh_t, class value_t>
+    inline auto ScalarField<mesh_t, value_t>::begin() const -> const_iterator
+    {
+        return cbegin();
+    }
+
+    template <class mesh_t, class value_t>
+    inline auto ScalarField<mesh_t, value_t>::end() const -> const_iterator
+    {
+        return cend();
+    }
+
+    template <class mesh_t, class value_t>
+    inline auto ScalarField<mesh_t, value_t>::cbegin() const -> const_iterator
+    {
+        using mesh_id_t = typename mesh_t::mesh_id_t;
+        return const_iterator(this, this->mesh()[mesh_id_t::cells].cbegin());
+    }
+
+    template <class mesh_t, class value_t>
+    inline auto ScalarField<mesh_t, value_t>::cend() const -> const_iterator
+    {
+        using mesh_id_t = typename mesh_t::mesh_id_t;
+        return const_iterator(this, this->mesh()[mesh_id_t::cells].cend());
+    }
+
+    template <class mesh_t, class value_t>
+    inline auto ScalarField<mesh_t, value_t>::rbegin() -> reverse_iterator
+    {
+        return reverse_iterator(end());
+    }
+
+    template <class mesh_t, class value_t>
+    inline auto ScalarField<mesh_t, value_t>::rend() -> reverse_iterator
+    {
+        return reverse_iterator(begin());
+    }
+
+    template <class mesh_t, class value_t>
+    inline auto ScalarField<mesh_t, value_t>::rbegin() const -> const_reverse_iterator
+    {
+        return rcbegin();
+    }
+
+    template <class mesh_t, class value_t>
+    inline auto ScalarField<mesh_t, value_t>::rend() const -> const_reverse_iterator
+    {
+        return rcend();
+    }
+
+    template <class mesh_t, class value_t>
+    inline auto ScalarField<mesh_t, value_t>::rcbegin() const -> const_reverse_iterator
+    {
+        return const_reverse_iterator(cend());
+    }
+
+    template <class mesh_t, class value_t>
+    inline auto ScalarField<mesh_t, value_t>::rcend() const -> const_reverse_iterator
+    {
+        return const_reverse_iterator(cbegin());
+    }
+
+    // --- others -------------------------------------------------------------
+
+    template <class mesh_t, class value_t>
+    inline void ScalarField<mesh_t, value_t>::fill(value_type v)
+    {
+        this->m_storage.data().fill(v);
+    }
+
+    template <class mesh_t, class value_t>
+    inline void ScalarField<mesh_t, value_t>::to_stream(std::ostream& os) const
+    {
+        os << "Field " << m_name << "\n";
+
+#ifdef SAMURAI_CHECK_NAN
+        using mesh_id_t = typename Field::mesh_t::mesh_id_t;
+        for_each_cell(this->mesh()[mesh_id_t::reference],
+#else
+        for_each_cell(this->mesh(),
+#endif
+                      [&](auto& cell)
+                      {
+                          os << "\tlevel: " << cell.level << " coords: " << cell.center() << " index: " << cell.index
+                             << ", value: " << this->operator[](cell) << "\n";
+                      });
+    }
+
+    template <class mesh_t, class value_t>
+    template <class Bc_derived>
+    inline auto ScalarField<mesh_t, value_t>::attach_bc(const Bc_derived& bc)
+    {
+        p_bc.push_back(bc.clone());
+        return p_bc.back().get();
+    }
+
+    template <class mesh_t, class value_t>
+    inline auto& ScalarField<mesh_t, value_t>::get_bc()
+    {
+        return p_bc;
+    }
+
+    template <class mesh_t, class value_t>
+    inline const auto& ScalarField<mesh_t, value_t>::get_bc() const
+    {
+        return p_bc;
+    }
+
+    template <class mesh_t, class value_t>
+    void ScalarField<mesh_t, value_t>::copy_bc_from(const ScalarField<mesh_t, value_t>& other)
+    {
+        std::transform(other.get_bc().cbegin(),
+                       other.get_bc().cend(),
+                       std::back_inserter(p_bc),
+                       [](const auto& v)
+                       {
+                           return v->clone();
+                       });
+    }
+
+    // ScalarField extern operators -------------------------------------------
+
+    template <class mesh_t, class value_t>
+    inline std::ostream& operator<<(std::ostream& out, const ScalarField<mesh_t, value_t>& field)
+    {
+        field.to_stream(out);
+        return out;
+    }
+
+    template <class mesh_t, class value_t>
+    inline bool operator==(const ScalarField<mesh_t, value_t>& field1, const ScalarField<mesh_t, value_t>& field2)
     {
         using mesh_id_t = typename mesh_t::mesh_id_t;
 
@@ -944,11 +1369,231 @@ namespace samurai
         return is_same;
     }
 
-    template <class mesh_t, class value_t, std::size_t n_comp_, bool SOA>
-    inline bool operator!=(const Field<mesh_t, value_t, n_comp_, SOA>& field1, const Field<mesh_t, value_t, n_comp_, SOA>& field2)
+    template <class mesh_t, class value_t>
+    inline bool operator!=(const ScalarField<mesh_t, value_t>& field1, const ScalarField<mesh_t, value_t>& field2)
     {
         return !(field1 == field2);
     }
+
+    // ScalarField helper functions -------------------------------------------
+
+    template <class value_t, class mesh_t>
+    auto make_field(std::string name, mesh_t& mesh)
+    {
+        using field_t = ScalarField<mesh_t, value_t>;
+        field_t f(name, mesh);
+#ifdef SAMURAI_CHECK_NAN
+        if constexpr (std::is_floating_point_v<value_t>)
+        {
+            f.fill(static_cast<value_t>(std::nan("")));
+        }
+#endif
+        return f;
+    }
+
+    template <class value_t, class mesh_t>
+    auto make_field(std::string name, mesh_t& mesh, value_t init_value)
+    {
+        using field_t = ScalarField<mesh_t, value_t>;
+        auto field    = field_t(name, mesh);
+        field.fill(init_value);
+        return field;
+    }
+
+    template <class mesh_t>
+    auto make_field(std::string name, mesh_t& mesh)
+    {
+        using default_value_t = double;
+        return make_field<default_value_t>(name, mesh);
+    }
+
+    template <class mesh_t>
+    auto make_field(std::string name, mesh_t& mesh, double init_value)
+    {
+        using default_value_t = double;
+        return make_field<default_value_t>(name, mesh, init_value);
+    }
+
+    /**
+     * @brief Creates a field.
+     * @param name Name of the returned Field.
+     * @param f Continuous function.
+     * @param gl Gauss Legendre polynomial
+     */
+    template <class value_t, class mesh_t, class Func, std::size_t polynomial_degree>
+    auto make_field(std::string name, mesh_t& mesh, Func&& f, const GaussLegendre<polynomial_degree>& gl)
+    {
+        auto field = make_field<value_t, mesh_t>(name, mesh);
+#ifdef SAMURAI_CHECK_NAN
+        f.fill(std::nan(""));
+#else
+        field.fill(0);
+#endif
+
+        for_each_cell(mesh,
+                      [&](const auto& cell)
+                      {
+                          const double& h = cell.length;
+                          field[cell]     = gl.template quadrature<1>(cell, f) / pow(h, mesh_t::dim);
+                      });
+        return field;
+    }
+
+    template <class mesh_t, class Func, std::size_t polynomial_degree>
+    auto make_field(std::string name, mesh_t& mesh, Func&& f, const GaussLegendre<polynomial_degree>& gl)
+    {
+        using default_value_t = double;
+        return make_field<default_value_t>(name, mesh, std::forward<Func>(f), gl);
+    }
+
+    /**
+     * @brief Creates a field.
+     * @param name Name of the returned Field.
+     * @param f Continuous function.
+     */
+    template <class value_t,
+              class mesh_t,
+              class Func,
+              typename = std::enable_if_t<std::is_invocable_v<Func, typename Cell<mesh_t::dim, typename mesh_t::interval_t>::coords_t>>>
+    auto make_field(std::string name, mesh_t& mesh, Func&& f)
+    {
+        auto field = make_field<value_t, mesh_t>(name, mesh);
+#ifdef SAMURAI_CHECK_NAN
+        field.fill(std::nan(""));
+#else
+        field.fill(0);
+#endif
+
+        for_each_cell(mesh,
+                      [&](const auto& cell)
+                      {
+                          field[cell] = f(cell.center());
+                      });
+        return field;
+    }
+
+    template <class mesh_t,
+              class Func,
+              typename = std::enable_if_t<std::is_invocable_v<Func, typename Cell<mesh_t::dim, typename mesh_t::interval_t>::coords_t>>>
+    auto make_field(std::string name, mesh_t& mesh, Func&& f)
+    {
+        using default_value_t = double;
+        return make_field<default_value_t>(name, mesh, std::forward<Func>(f));
+    }
+
+    // ------------------------------------------------------------------------
+    // class Field_iterator
+    // ------------------------------------------------------------------------
+
+    template <class Field, bool is_const>
+    class Field_iterator : public xtl::xrandom_access_iterator_base3<Field_iterator<Field, is_const>,
+                                                                     CellArray_iterator<const typename Field::mesh_t::ca_type, true>>
+    {
+      public:
+
+        using self_type   = Field_iterator<Field, is_const>;
+        using ca_iterator = CellArray_iterator<const typename Field::mesh_t::ca_type, true>;
+
+        using reference       = default_view_t<typename Field::data_type>;
+        using difference_type = typename ca_iterator::difference_type;
+
+        Field_iterator(Field* field, const ca_iterator& ca_it);
+
+        self_type& operator++();
+        self_type& operator--();
+
+        self_type& operator+=(difference_type n);
+        self_type& operator-=(difference_type n);
+
+        auto operator*() const;
+
+        bool equal(const self_type& rhs) const;
+        bool less_than(const self_type& rhs) const;
+
+      private:
+
+        Field* p_field;
+        ca_iterator m_ca_it;
+    };
+
+    // Field_iterator constructors --------------------------------------------
+
+    template <class Field, bool is_const>
+    Field_iterator<Field, is_const>::Field_iterator(Field* field, const ca_iterator& ca_it)
+        : p_field(field)
+        , m_ca_it(ca_it)
+    {
+    }
+
+    // Field_iterator operators -----------------------------------------------
+
+    template <class Field, bool is_const>
+    inline auto Field_iterator<Field, is_const>::operator++() -> self_type&
+    {
+        ++m_ca_it;
+        return *this;
+    }
+
+    template <class Field, bool is_const>
+    inline auto Field_iterator<Field, is_const>::operator--() -> self_type&
+    {
+        --m_ca_it;
+        return *this;
+    }
+
+    template <class Field, bool is_const>
+    inline auto Field_iterator<Field, is_const>::operator+=(difference_type n) -> self_type&
+    {
+        m_ca_it += n;
+        return *this;
+    }
+
+    template <class Field, bool is_const>
+    inline auto Field_iterator<Field, is_const>::operator-=(difference_type n) -> self_type&
+    {
+        m_ca_it -= n;
+        return *this;
+    }
+
+    template <class Field, bool is_const>
+    inline auto Field_iterator<Field, is_const>::operator*() const
+    {
+        std::size_t level = m_ca_it.level();
+        auto& index       = m_ca_it.index();
+        return (*p_field)(level, *m_ca_it, index);
+    }
+
+    // Field_iterator methods -------------------------------------------------
+
+    template <class Field, bool is_const>
+    inline bool Field_iterator<Field, is_const>::equal(const self_type& rhs) const
+    {
+        return m_ca_it.equal(rhs.m_ca_it);
+    }
+
+    template <class Field, bool is_const>
+    inline bool Field_iterator<Field, is_const>::less_than(const self_type& rhs) const
+    {
+        return m_ca_it.less_than(rhs.m_ca_it);
+    }
+
+    // Field_iterator extern operators ----------------------------------------
+
+    template <class Field, bool is_const>
+    inline bool operator==(const Field_iterator<Field, is_const>& it1, const Field_iterator<Field, is_const>& it2)
+    {
+        return it1.equal(it2);
+    }
+
+    template <class Field, bool is_const>
+    inline bool operator<(const Field_iterator<Field, is_const>& it1, const Field_iterator<Field, is_const>& it2)
+    {
+        return it1.less_than(it2);
+    }
+
+    // ------------------------------------------------------------------------
+    // class Field_tuple
+    // ------------------------------------------------------------------------
 
     template <class TField, class... TFields>
     class Field_tuple

--- a/include/samurai/io/from_geometry.hpp
+++ b/include/samurai/io/from_geometry.hpp
@@ -11,7 +11,6 @@
 #include "../field.hpp"
 #include "../graduation.hpp"
 #include "../subset/node.hpp"
-#include "../utils.hpp"
 #include "cgal.hpp"
 
 namespace samurai

--- a/include/samurai/io/from_geometry.hpp
+++ b/include/samurai/io/from_geometry.hpp
@@ -53,7 +53,7 @@ namespace samurai
         std::size_t current_level = start_level;
         while (current_level != max_level + 1)
         {
-            auto tag = make_field<int>("tag", mesh);
+            auto tag = make_scalar_field<int>("tag", mesh);
             tag.fill(0);
 
             for (std::size_t level = mesh.min_level(); level < current_level; ++level)

--- a/include/samurai/io/from_geometry.hpp
+++ b/include/samurai/io/from_geometry.hpp
@@ -11,6 +11,7 @@
 #include "../field.hpp"
 #include "../graduation.hpp"
 #include "../subset/node.hpp"
+#include "../utils.hpp"
 #include "cgal.hpp"
 
 namespace samurai
@@ -52,7 +53,7 @@ namespace samurai
         std::size_t current_level = start_level;
         while (current_level != max_level + 1)
         {
-            auto tag = make_field<int, 1>("tag", mesh);
+            auto tag = make_field<int>("tag", mesh);
             tag.fill(0);
 
             for (std::size_t level = mesh.min_level(); level < current_level; ++level)

--- a/include/samurai/io/util.hpp
+++ b/include/samurai/io/util.hpp
@@ -18,7 +18,7 @@ namespace samurai
             for_each_cell(submesh,
                           [&](auto cell)
                           {
-                              if constexpr (Field::n_comp == 1)
+                              if constexpr (Field::is_scalar)
                               {
                                   data(index, 0) = field[cell];
                               }

--- a/include/samurai/mr/adapt.hpp
+++ b/include/samurai/mr/adapt.hpp
@@ -77,7 +77,9 @@ namespace samurai
         {
             using fields_t = TField&;
             using mesh_t   = typename TField::mesh_t;
-            using detail_t = VectorField<mesh_t, typename TField::value_type, TField::n_comp, detail::is_soa_v<TField>>;
+            using detail_t = std::conditional_t<TField::is_scalar,
+                                                ScalarField<mesh_t, typename TField::value_type>,
+                                                VectorField<mesh_t, typename TField::value_type, TField::n_comp, detail::is_soa_v<TField>>>;
         };
     }
 

--- a/include/samurai/mr/adapt.hpp
+++ b/include/samurai/mr/adapt.hpp
@@ -69,7 +69,7 @@ namespace samurai
             using fields_t = Field_tuple<TFields...>;
             using mesh_t   = typename fields_t::mesh_t;
             using common_t = typename fields_t::common_t;
-            using detail_t = Field<mesh_t, common_t, detail::compute_n_comp<TFields...>()>;
+            using detail_t = VectorField<mesh_t, common_t, detail::compute_n_comp<TFields...>()>;
         };
 
         template <class TField>
@@ -77,7 +77,7 @@ namespace samurai
         {
             using fields_t = TField&;
             using mesh_t   = typename TField::mesh_t;
-            using detail_t = Field<mesh_t, typename TField::value_type, TField::n_comp, TField::is_soa>;
+            using detail_t = VectorField<mesh_t, typename TField::value_type, TField::n_comp, detail::is_soa_v<TField>>;
         };
     }
 
@@ -98,7 +98,7 @@ namespace samurai
         using mesh_t            = typename inner_fields_type::mesh_t;
         using mesh_id_t         = typename mesh_t::mesh_id_t;
         using detail_t          = typename inner_fields_type::detail_t;
-        using tag_t             = Field<mesh_t, int, 1>;
+        using tag_t             = ScalarField<mesh_t, int>;
 
         static constexpr std::size_t dim = mesh_t::dim;
         static constexpr bool enlarge_v  = enlarge_;
@@ -194,7 +194,7 @@ namespace samurai
     }
 
     template <class Mesh>
-    void keep_boundary_refined(const Mesh& mesh, Field<Mesh, int, 1>& tag, const DirectionVector<Mesh::dim>& direction)
+    void keep_boundary_refined(const Mesh& mesh, ScalarField<Mesh, int>& tag, const DirectionVector<Mesh::dim>& direction)
     {
         // Since the adaptation process starts at max_level, we just need to flag to `keep` the boundary cells at max_level only.
         // There will never be boundary cells at lower levels.
@@ -208,7 +208,7 @@ namespace samurai
     }
 
     template <class Mesh>
-    void keep_boundary_refined(const Mesh& mesh, Field<Mesh, int, 1>& tag)
+    void keep_boundary_refined(const Mesh& mesh, ScalarField<Mesh, int>& tag)
     {
         constexpr std::size_t dim = Mesh::dim;
 

--- a/include/samurai/mr/criteria.hpp
+++ b/include/samurai/mr/criteria.hpp
@@ -5,6 +5,7 @@
 
 #include "../cell_flag.hpp"
 #include "../operators_base.hpp"
+#include "../utils.hpp"
 
 namespace samurai
 {
@@ -20,17 +21,15 @@ namespace samurai
         // inline void operator()(Dim<1>, const T1& detail, const T3&
         // max_detail, T2 &tag, double eps, std::size_t min_lev) const
         inline void operator()(Dim<1>, const T1& detail, T2& tag, double eps, std::size_t min_lev) const
-
         {
             using namespace math;
-            constexpr auto n_comp  = T1::n_comp;
             std::size_t fine_level = level + 1;
 
             if (fine_level > min_lev)
             {
                 // auto maxd = xt::view(max_detail, level);
 
-                if constexpr (n_comp == 1)
+                if constexpr (T1::is_scalar)
                 {
                     // auto mask = abs(detail(level, 2*i))/maxd < eps;
                     auto mask = abs(detail(fine_level, 2 * i)) < eps; // NO normalization
@@ -44,6 +43,8 @@ namespace samurai
                 }
                 else
                 {
+                    constexpr auto n_comp = T1::n_comp;
+
                     // auto mask = xt::sum((abs(detail(level, 2*i))/maxd <
                     // eps), {1}) > (n_comp-1);
                     constexpr std::size_t axis = detail::static_size_first_v<n_comp, T1::is_soa, T1::static_layout> ? 0 : 1;
@@ -65,12 +66,11 @@ namespace samurai
         {
             using namespace math;
 
-            constexpr auto n_comp  = T1::n_comp;
             std::size_t fine_level = level + 1;
 
             if (fine_level > min_lev)
             {
-                if constexpr (n_comp == 1)
+                if constexpr (T1::is_scalar)
                 {
                     auto mask = (abs(detail(fine_level, 2 * i, 2 * j)) < eps) && (abs(detail(fine_level, 2 * i + 1, 2 * j)) < eps)
                              && (abs(detail(fine_level, 2 * i, 2 * j + 1)) < eps) && (abs(detail(fine_level, 2 * i + 1, 2 * j + 1)) < eps);
@@ -95,6 +95,8 @@ namespace samurai
                 }
                 else
                 {
+                    constexpr auto n_comp = T1::n_comp;
+
                     // auto mask = xt::sum((abs(detail(level, 2*i  ,
                     // 2*j))/maxd < eps) &&
                     //                     (abs(detail(level, 2*i+1,
@@ -135,14 +137,13 @@ namespace samurai
         {
             using namespace math;
 
-            constexpr auto n_comp  = T1::n_comp;
             std::size_t fine_level = level + 1;
 
             if (fine_level > min_lev)
             {
                 // auto maxd = xt::view(max_detail, level);
 
-                if constexpr (n_comp == 1)
+                if constexpr (T1::is_scalar)
                 {
                     // auto mask = (abs(detail(level, 2*i  ,   2*j))/maxd <
                     // eps) and
@@ -175,6 +176,8 @@ namespace samurai
                 }
                 else
                 {
+                    constexpr auto n_comp = T1::n_comp;
+
                     // auto mask = xt::sum((abs(detail(level, 2*i  ,
                     // 2*j))/maxd < eps) and
                     //                     (abs(detail(level, 2*i+1,

--- a/include/samurai/mr/criteria.hpp
+++ b/include/samurai/mr/criteria.hpp
@@ -47,7 +47,9 @@ namespace samurai
 
                     // auto mask = xt::sum((abs(detail(level, 2*i))/maxd <
                     // eps), {1}) > (n_comp-1);
-                    constexpr std::size_t axis = detail::static_size_first_v<n_comp, T1::is_soa, T1::is_scalar, T1::static_layout> ? 0 : 1;
+                    constexpr std::size_t axis = detail::static_size_first_v<n_comp, detail::is_soa_v<T1>, T1::is_scalar, T1::static_layout>
+                                                   ? 0
+                                                   : 1;
 
                     auto mask = sum<axis>((abs(detail(fine_level, 2 * i)) < eps)) > (n_comp - 1); // No normalization
 
@@ -105,7 +107,9 @@ namespace samurai
                     //                     2*j+1))/maxd < eps) &&
                     //                     (abs(detail(level, 2*i+1,
                     //                     2*j+1))/maxd < eps), {1}) > (n_comp-1);
-                    constexpr std::size_t axis = detail::static_size_first_v<n_comp, T1::is_soa, T1::is_scalar, T1::static_layout> ? 0 : 1;
+                    constexpr std::size_t axis = detail::static_size_first_v<n_comp, detail::is_soa_v<T1>, T1::is_scalar, T1::static_layout>
+                                                   ? 0
+                                                   : 1;
 
                     auto mask = all_true<axis, n_comp>(
                         (abs(detail(fine_level, 2 * i, 2 * j)) < eps) && (abs(detail(fine_level, 2 * i + 1, 2 * j)) < eps)
@@ -187,7 +191,9 @@ namespace samurai
                     //                     (abs(detail(level, 2*i+1,
                     //                     2*j+1))/maxd < eps), {1}) > (n_comp-1);
 
-                    constexpr std::size_t axis = detail::static_size_first_v<n_comp, T1::is_soa, T1::is_scalar, T1::static_layout> ? 0 : 1;
+                    constexpr std::size_t axis = detail::static_size_first_v<n_comp, detail::is_soa_v<T1>, T1::is_scalar, T1::static_layout>
+                                                   ? 0
+                                                   : 1;
 
                     auto mask = sum<axis>((abs(detail(fine_level, 2 * i, 2 * j, 2 * k)) < eps)
                                           && (abs(detail(fine_level, 2 * i + 1, 2 * j, 2 * k)) < eps)
@@ -252,7 +258,7 @@ namespace samurai
             constexpr auto n_comp  = T1::n_comp;
             std::size_t fine_level = level + 1;
 
-            auto mask_ghost = get_mask<n_comp, T1::is_soa>(detail(fine_level - 1, i, index), eps / (1 << dim));
+            auto mask_ghost = get_mask<n_comp, detail::is_soa_v<T1>>(detail(fine_level - 1, i, index), eps / (1 << dim));
 
             apply_on_masked(mask_ghost,
                             [&](auto imask)
@@ -272,7 +278,7 @@ namespace samurai
                     {
                         for (int ii = 0; ii < 2; ++ii)
                         {
-                            auto mask = get_mask<n_comp, T1::is_soa>(detail(fine_level, 2 * i + ii, 2 * index + stencil), eps);
+                            auto mask = get_mask<n_comp, detail::is_soa_v<T1>>(detail(fine_level, 2 * i + ii, 2 * index + stencil), eps);
 
                             apply_on_masked(tag(fine_level, 2 * i + ii, 2 * index + stencil),
                                             mask,

--- a/include/samurai/mr/criteria.hpp
+++ b/include/samurai/mr/criteria.hpp
@@ -47,7 +47,7 @@ namespace samurai
 
                     // auto mask = xt::sum((abs(detail(level, 2*i))/maxd <
                     // eps), {1}) > (n_comp-1);
-                    constexpr std::size_t axis = detail::static_size_first_v<n_comp, T1::is_soa, T1::static_layout> ? 0 : 1;
+                    constexpr std::size_t axis = detail::static_size_first_v<n_comp, T1::is_soa, T1::is_scalar, T1::static_layout> ? 0 : 1;
 
                     auto mask = sum<axis>((abs(detail(fine_level, 2 * i)) < eps)) > (n_comp - 1); // No normalization
 
@@ -105,7 +105,7 @@ namespace samurai
                     //                     2*j+1))/maxd < eps) &&
                     //                     (abs(detail(level, 2*i+1,
                     //                     2*j+1))/maxd < eps), {1}) > (n_comp-1);
-                    constexpr std::size_t axis = detail::static_size_first_v<n_comp, T1::is_soa, T1::static_layout> ? 0 : 1;
+                    constexpr std::size_t axis = detail::static_size_first_v<n_comp, T1::is_soa, T1::is_scalar, T1::static_layout> ? 0 : 1;
 
                     auto mask = all_true<axis, n_comp>(
                         (abs(detail(fine_level, 2 * i, 2 * j)) < eps) && (abs(detail(fine_level, 2 * i + 1, 2 * j)) < eps)
@@ -187,7 +187,7 @@ namespace samurai
                     //                     (abs(detail(level, 2*i+1,
                     //                     2*j+1))/maxd < eps), {1}) > (n_comp-1);
 
-                    constexpr std::size_t axis = detail::static_size_first_v<n_comp, T1::is_soa, T1::static_layout> ? 0 : 1;
+                    constexpr std::size_t axis = detail::static_size_first_v<n_comp, T1::is_soa, T1::is_scalar, T1::static_layout> ? 0 : 1;
 
                     auto mask = sum<axis>((abs(detail(fine_level, 2 * i, 2 * j, 2 * k)) < eps)
                                           && (abs(detail(fine_level, 2 * i + 1, 2 * j, 2 * k)) < eps)
@@ -240,7 +240,7 @@ namespace samurai
             }
             else
             {
-                constexpr std::size_t axis = detail::static_size_first_v<n_comp, is_soa, SAMURAI_DEFAULT_LAYOUT> ? 0 : 1;
+                constexpr std::size_t axis = detail::static_size_first_v<n_comp, is_soa, false, SAMURAI_DEFAULT_LAYOUT> ? 0 : 1;
                 return eval(sum<axis>(abs(detail_view) > eps) > 0);
             }
         }

--- a/include/samurai/mr/operators.hpp
+++ b/include/samurai/mr/operators.hpp
@@ -384,7 +384,7 @@ namespace samurai
 
             static constexpr std::size_t dim    = Field::dim;
             static constexpr std::size_t n_comp = Field::n_comp;
-            static constexpr bool is_soa        = Field::is_soa;
+            static constexpr bool is_soa        = detail::is_soa_v<Field>;
 
             using interval_t    = typename Field::interval_t;
             using coord_index_t = typename interval_t::coord_index_t;

--- a/include/samurai/mr/operators.hpp
+++ b/include/samurai/mr/operators.hpp
@@ -11,6 +11,7 @@
 #include "../field.hpp"
 #include "../numeric/prediction.hpp"
 #include "../operators_base.hpp"
+#include "../utils.hpp"
 
 namespace samurai
 {
@@ -288,7 +289,7 @@ namespace samurai
                 auto qs_ij = Qs_ij<order>(field, level, i, j);
 
 #ifdef SAMURAI_CHECK_NAN
-                if constexpr (T1::n_comp == 1)
+                if constexpr (T1::is_scalar)
                 {
                     for (std::size_t ii = 0; ii < i.size(); ++ii)
                     {
@@ -368,7 +369,7 @@ namespace samurai
         }
     };
 
-    template <class T1, class T2, std::enable_if_t<is_field_type_v<T2>, int> = 0>
+    template <class T1, class T2, std::enable_if_t<detail::is_field_type_v<T2>, int> = 0>
     inline auto compute_detail(T1&& detail, T2&& field)
     {
         return make_field_operator_function<compute_detail_op>(std::forward<T1>(detail), std::forward<T2>(field));

--- a/include/samurai/numeric/prediction.hpp
+++ b/include/samurai/numeric/prediction.hpp
@@ -368,7 +368,7 @@ namespace samurai
         template <class T, class QS>
         auto qs_view_even(QS& qs, int dec)
         {
-            if constexpr (detail::static_size_first_v<T::n_comp, detail::is_soa_v<T>, T::static_layout>)
+            if constexpr (detail::static_size_first_v<T::n_comp, detail::is_soa_v<T>, T::is_scalar, T::static_layout>)
             {
                 return view(qs, placeholders::all(), range(dec, shape(qs, 1)));
             }
@@ -381,7 +381,7 @@ namespace samurai
         template <class T, class QS>
         auto qs_view_odd(QS& qs, int dec)
         {
-            if constexpr (detail::static_size_first_v<T::n_comp, detail::is_soa_v<T>, T::static_layout>)
+            if constexpr (detail::static_size_first_v<T::n_comp, detail::is_soa_v<T>, T::is_scalar, T::static_layout>)
             {
                 return view(qs, placeholders::all(), range(0, safe_subs<int>(shape(qs, 1), dec)));
             }

--- a/include/samurai/numeric/prediction.hpp
+++ b/include/samurai/numeric/prediction.hpp
@@ -368,7 +368,7 @@ namespace samurai
         template <class T, class QS>
         auto qs_view_even(QS& qs, int dec)
         {
-            if constexpr (detail::static_size_first_v<T::n_comp, T::is_soa, T::static_layout>)
+            if constexpr (detail::static_size_first_v<T::n_comp, detail::is_soa_v<T>, T::static_layout>)
             {
                 return view(qs, placeholders::all(), range(dec, shape(qs, 1)));
             }
@@ -381,7 +381,7 @@ namespace samurai
         template <class T, class QS>
         auto qs_view_odd(QS& qs, int dec)
         {
-            if constexpr (detail::static_size_first_v<T::n_comp, T::is_soa, T::static_layout>)
+            if constexpr (detail::static_size_first_v<T::n_comp, detail::is_soa_v<T>, T::static_layout>)
             {
                 return view(qs, placeholders::all(), range(0, safe_subs<int>(shape(qs, 1), dec)));
             }

--- a/include/samurai/petsc/fv/FV_scheme_assembly.hpp
+++ b/include/samurai/petsc/fv/FV_scheme_assembly.hpp
@@ -5,8 +5,6 @@
 #include "../../schemes/fv/scheme_operators.hpp"
 #include "../matrix_assembly.hpp"
 
-#include <type_traits>
-
 namespace samurai
 {
     namespace petsc

--- a/include/samurai/petsc/fv/FV_scheme_assembly.hpp
+++ b/include/samurai/petsc/fv/FV_scheme_assembly.hpp
@@ -210,7 +210,7 @@ namespace samurai
                 {
                     return m_col_shift + cell_index;
                 }
-                else if constexpr (field_t::is_soa)
+                else if constexpr (detail::is_soa_v<field_t>)
                 {
                     return m_col_shift + static_cast<PetscInt>(field_j * m_n_cells) + cell_index;
                 }
@@ -226,7 +226,7 @@ namespace samurai
                 {
                     return m_row_shift + cell_index;
                 }
-                else if constexpr (field_t::is_soa)
+                else if constexpr (detail::is_soa_v<field_t>)
                 {
                     return m_row_shift + static_cast<PetscInt>(field_i * m_n_cells) + cell_index;
                 }

--- a/include/samurai/petsc/fv/FV_scheme_assembly.hpp
+++ b/include/samurai/petsc/fv/FV_scheme_assembly.hpp
@@ -5,6 +5,8 @@
 #include "../../schemes/fv/scheme_operators.hpp"
 #include "../matrix_assembly.hpp"
 
+#include <type_traits>
+
 namespace samurai
 {
     namespace petsc
@@ -204,7 +206,7 @@ namespace samurai
             // Global data index
             inline PetscInt col_index(PetscInt cell_index, [[maybe_unused]] unsigned int field_j) const
             {
-                if constexpr (n_comp == 1)
+                if constexpr (field_t::is_scalar)
                 {
                     return m_col_shift + cell_index;
                 }
@@ -247,7 +249,7 @@ namespace samurai
             template <class Coeffs>
             inline double rhs_coeff(const Coeffs& coeffs, [[maybe_unused]] unsigned int field_i, [[maybe_unused]] unsigned int field_j) const
             {
-                if constexpr (n_comp == 1 && output_n_comp == 1)
+                if constexpr (field_t::is_scalar && output_n_comp == 1)
                 {
                     return coeffs;
                 }
@@ -569,7 +571,7 @@ namespace samurai
                         assert(coeff != 0);
 
                         double bc_value;
-                        if constexpr (n_comp == 1)
+                        if constexpr (field_t::is_scalar)
                         {
                             bc_value = bc->value({}, {}, boundary_point);
                         }

--- a/include/samurai/petsc/fv/cell_based_scheme_assembly.hpp
+++ b/include/samurai/petsc/fv/cell_based_scheme_assembly.hpp
@@ -54,7 +54,7 @@ namespace samurai
                 {
                     return cell_local_index;
                 }
-                else if constexpr (field_t::is_soa)
+                else if constexpr (detail::is_soa_v<field_t>)
                 {
                     return field_j * stencil_size + cell_local_index;
                 }
@@ -70,7 +70,7 @@ namespace samurai
                 {
                     return cell_local_index;
                 }
-                else if constexpr (field_t::is_soa)
+                else if constexpr (detail::is_soa_v<field_t>)
                 {
                     return field_i * stencil_size + cell_local_index;
                 }

--- a/include/samurai/petsc/nonlinear_local_solvers.hpp
+++ b/include/samurai/petsc/nonlinear_local_solvers.hpp
@@ -238,7 +238,7 @@ namespace samurai
                 // In this case, jac = B, but Petsc recommends we assemble B for more general cases.
                 auto jac_stencil_coeffs = scheme.scheme_definition().local_jacobian_function(cell, x_field);
                 auto& jac_coeffs        = jac_stencil_coeffs[0]; // local stencil (of size 1)
-                if constexpr (field_t::n_comp == 1)
+                if constexpr (field_t::is_scalar)
                 {
                     MatSetValue(B, 0, 0, jac_coeffs, INSERT_VALUES);
                 }

--- a/include/samurai/petsc/nonlinear_local_solvers.hpp
+++ b/include/samurai/petsc/nonlinear_local_solvers.hpp
@@ -155,7 +155,7 @@ namespace samurai
                                             Vec x;
                                             Vec b;
 
-                                            if constexpr (n > 1 && field_t::is_soa)
+                                            if constexpr (n > 1 && detail::is_soa_v<field_t>)
                                             {
                                                 VecCreateSeq(PETSC_COMM_SELF, n, &x);
                                                 copy(unknown(), cell, x);
@@ -176,7 +176,7 @@ namespace samurai
 
                                             solve_system(snes, b, x);
 
-                                            if constexpr (n > 1 && field_t::is_soa)
+                                            if constexpr (n > 1 && detail::is_soa_v<field_t>)
                                             {
                                                 copy(x, unknown(), cell);
                                             }

--- a/include/samurai/petsc/utils.hpp
+++ b/include/samurai/petsc/utils.hpp
@@ -142,7 +142,7 @@ namespace samurai
             double* v_data;
             VecGetArray(v, &v_data);
 
-            if constexpr (Field::n_comp == 1)
+            if constexpr (Field::is_scalar)
             {
                 v_data[0] = f[cell];
             }
@@ -160,7 +160,7 @@ namespace samurai
         template <class Field>
         Vec create_petsc_vector_from(Field& f, const typename Field::cell_t& cell)
         {
-            static_assert(Field::n_comp == 1 || !Field::is_soa);
+            static_assert(Field::is_scalar || !detail::is_soa_v<Field>);
 
             Vec v;
             auto vec_size        = static_cast<PetscInt>(Field::n_comp);
@@ -179,7 +179,7 @@ namespace samurai
             const double* v_data;
             VecGetArrayRead(v, &v_data);
 
-            if constexpr (Field::n_comp == 1)
+            if constexpr (Field::is_scalar)
             {
                 f[cell] = v_data[0];
             }

--- a/include/samurai/reconstruction.hpp
+++ b/include/samurai/reconstruction.hpp
@@ -407,11 +407,11 @@ namespace samurai
         {
             if constexpr (Field::is_scalar)
             {
-                return make_field<typename Field::value_type>(name, mesh);
+                return make_scalar_field<typename Field::value_type>(name, mesh);
             }
             else
             {
-                return make_field<typename Field::value_type, Field::n_comp, detail::is_soa_v<Field>>(name, mesh);
+                return make_vector_field<typename Field::value_type, Field::n_comp, detail::is_soa_v<Field>>(name, mesh);
             }
         };
 

--- a/include/samurai/reconstruction.hpp
+++ b/include/samurai/reconstruction.hpp
@@ -410,7 +410,7 @@ namespace samurai
         reconstruct_mesh.update_index();
 
         auto m                 = holder(reconstruct_mesh);
-        auto reconstruct_field = make_field<typename Field::value_type, Field::n_comp, Field::is_soa>(field.name(), m);
+        auto reconstruct_field = make_field<typename Field::value_type, Field::n_comp, detail::is_soa_v<Field>>(field.name(), m);
         reconstruct_field.fill(0.);
 
         std::size_t min_level = mesh[mesh_id_t::cells].min_level();
@@ -1153,7 +1153,7 @@ namespace samurai
                         {
                             auto i_dst = static_cast<size_type>(((i.start + ii) >> static_cast<value_t>(shift))
                                                                 - (i.start >> static_cast<value_t>(shift)));
-                            if constexpr (Field_src::is_soa && Field_src::n_comp > 1)
+                            if constexpr (detail::is_soa_v<Field_src> && !Field_src::is_scalar)
                             {
                                 view(dst, placeholders::all(), i_dst) += view(src, placeholders::all(), static_cast<size_type>(ii))
                                                                        / (1 << shift * dim);
@@ -1161,7 +1161,7 @@ namespace samurai
                             else
                             {
 #if defined(SAMURAI_FIELD_CONTAINER_EIGEN3)
-                                static_assert(Field_src::is_soa && Field_src::n_comp > 1,
+                                static_assert(detail::is_soa_v<Field_src> && !Field_src::is_scalar,
                                               "transfer() is not implemented with Eigen for scalar fields and vectorial fields in AOS.");
                             // In the lid-driven-cavity demo, the following line of code does not compile with Eigen.
 #else

--- a/include/samurai/reconstruction.hpp
+++ b/include/samurai/reconstruction.hpp
@@ -403,14 +403,27 @@ namespace samurai
         using mesh_id_t = typename mesh_t::mesh_id_t;
         using ca_type   = typename mesh_t::ca_type;
 
+        auto make_field_like = [](std::string const& name, auto& mesh)
+        {
+            if constexpr (Field::is_scalar)
+            {
+                return make_field<typename Field::value_type>(name, mesh);
+            }
+            else
+            {
+                return make_field<typename Field::value_type, Field::n_comp, detail::is_soa_v<Field>>(name, mesh);
+            }
+        };
+
         auto& mesh = field.mesh();
         ca_type reconstruct_mesh;
         std::size_t reconstruct_level       = mesh.domain().level();
         reconstruct_mesh[reconstruct_level] = mesh.domain();
         reconstruct_mesh.update_index();
 
-        auto m                 = holder(reconstruct_mesh);
-        auto reconstruct_field = make_field<typename Field::value_type, Field::n_comp, detail::is_soa_v<Field>>(field.name(), m);
+        auto m = holder(reconstruct_mesh);
+        // auto reconstruct_field = make_field<typename Field::value_type, Field::n_comp, detail::is_soa_v<Field>>(field.name(), m);
+        auto reconstruct_field = make_field_like(field.name(), m);
         reconstruct_field.fill(0.);
 
         std::size_t min_level = mesh[mesh_id_t::cells].min_level();

--- a/include/samurai/schemes/fv/FV_scheme.hpp
+++ b/include/samurai/schemes/fv/FV_scheme.hpp
@@ -31,7 +31,7 @@ namespace samurai
     {
         static constexpr std::size_t n_comp = Field::n_comp;
         using field_value_type              = typename Field::value_type;
-        using coeffs_t                      = CollapsMatrix<field_value_type, output_n_comp, n_comp>;
+        using coeffs_t                      = CollapsMatrix<field_value_type, output_n_comp, n_comp, Field::is_scalar>;
 
         using stencil_coeffs_t = std::array<coeffs_t, bdry_stencil_size>;
         using rhs_coeffs_t     = coeffs_t;
@@ -110,7 +110,9 @@ namespace samurai
         static constexpr std::size_t bdry_stencil_size        = bdry_cfg::stencil_size;
         static constexpr std::size_t nb_bdry_ghosts           = bdry_cfg::nb_ghosts;
 
-        using output_field_t = Field<mesh_t, field_value_type, output_n_comp, input_field_t::is_soa>;
+        using output_field_t = std::conditional_t<input_field_t::is_scalar && output_n_comp == 1,
+                                                  ScalarField<mesh_t, field_value_type>,
+                                                  VectorField<mesh_t, field_value_type, output_n_comp, detail::is_soa_v<input_field_t>>>;
 
         using dirichlet_t = DirichletImpl<nb_bdry_ghosts, field_t>;
         using neumann_t   = NeumannImpl<nb_bdry_ghosts, field_t>;
@@ -210,7 +212,7 @@ namespace samurai
                                            [[maybe_unused]] size_type field_i,
                                            [[maybe_unused]] size_type field_j) const
         {
-            if constexpr (n_comp == 1 && output_n_comp == 1)
+            if constexpr (field_t::is_scalar && output_n_comp == 1)
             {
                 return coeffs[cell_number_in_stencil];
             }
@@ -225,7 +227,7 @@ namespace samurai
                                                 [[maybe_unused]] size_type field_i,
                                                 [[maybe_unused]] size_type field_j) const
         {
-            if constexpr (n_comp == 1 && output_n_comp == 1)
+            if constexpr (field_t::is_scalar && output_n_comp == 1)
             {
                 return coeffs[cell_number_in_stencil];
             }

--- a/include/samurai/schemes/fv/cell_based/algebraic_operators.hpp
+++ b/include/samurai/schemes/fv/cell_based/algebraic_operators.hpp
@@ -157,7 +157,7 @@ namespace samurai
 
                 auto h      = cell.length;
                 auto coeffs = lin_scheme.coefficients(h);
-                value += mat_vec<field_t::is_soa, can_collapse>(coeffs[0], field[cell]);
+                value += mat_vec<detail::is_soa_v<field_t>, can_collapse>(coeffs[0], field[cell]);
                 return value;
             };
 
@@ -170,7 +170,7 @@ namespace samurai
 
                     auto h      = cell.length;
                     auto coeffs = lin_scheme.coefficients(h);
-                    value += mat_vec<field_t::is_soa, can_collapse>(coeffs[0], field[cell]);
+                    value += mat_vec<detail::is_soa_v<field_t>, can_collapse>(coeffs[0], field[cell]);
                     return value;
                 };
             }

--- a/include/samurai/schemes/fv/cell_based/algebraic_operators.hpp
+++ b/include/samurai/schemes/fv/cell_based/algebraic_operators.hpp
@@ -144,6 +144,8 @@ namespace samurai
         using stencil_cells_t = typename CellBasedScheme<nonlin_cfg, bdry_cfg>::stencil_cells_t;
         using field_t         = typename CellBasedScheme<nonlin_cfg, bdry_cfg>::field_t;
 
+        static constexpr bool can_collapse = lin_cfg::input_field_t::is_scalar && lin_cfg::output_n_comp == 1;
+
         CellBasedScheme<nonlin_cfg, bdry_cfg> addition_scheme(nonlin_scheme); // copy
 
         addition_scheme.set_name(lin_scheme.name() + " + " + nonlin_scheme.name());
@@ -155,7 +157,7 @@ namespace samurai
 
                 auto h      = cell.length;
                 auto coeffs = lin_scheme.coefficients(h);
-                value += mat_vec<field_t::is_soa>(coeffs[0], field[cell]);
+                value += mat_vec<field_t::is_soa, can_collapse>(coeffs[0], field[cell]);
                 return value;
             };
 
@@ -168,7 +170,7 @@ namespace samurai
 
                     auto h      = cell.length;
                     auto coeffs = lin_scheme.coefficients(h);
-                    value += mat_vec<field_t::is_soa>(coeffs[0], field[cell]);
+                    value += mat_vec<field_t::is_soa, can_collapse>(coeffs[0], field[cell]);
                     return value;
                 };
             }

--- a/include/samurai/schemes/fv/cell_based/cell_based_scheme__nonlin.hpp
+++ b/include/samurai/schemes/fv/cell_based/cell_based_scheme__nonlin.hpp
@@ -134,7 +134,7 @@ namespace samurai
 
         inline field_value_type contrib_cmpnent(const SchemeValue<cfg>& coeffs, [[maybe_unused]] size_type field_i) const
         {
-            if constexpr (cfg::output_n_comp == 1)
+            if constexpr (input_field_t::is_scalar && cfg::output_n_comp == 1)
             {
                 return coeffs;
             }

--- a/include/samurai/schemes/fv/cell_based/cell_based_scheme_definition.hpp
+++ b/include/samurai/schemes/fv/cell_based/cell_based_scheme_definition.hpp
@@ -77,7 +77,10 @@ namespace samurai
     };
 
     template <class cfg>
-    using SchemeValue = CollapsArray<typename cfg::input_field_t::value_type, cfg::output_n_comp, cfg::input_field_t::is_soa, cfg::input_field_t::is_scalar>;
+    using SchemeValue = CollapsArray<typename cfg::input_field_t::value_type,
+                                     cfg::output_n_comp,
+                                     detail::is_soa_v<typename cfg::input_field_t>,
+                                     cfg::input_field_t::is_scalar>;
 
     /**
      * Specialization of @class CellBasedSchemeDefinition.

--- a/include/samurai/schemes/fv/cell_based/cell_based_scheme_definition.hpp
+++ b/include/samurai/schemes/fv/cell_based/cell_based_scheme_definition.hpp
@@ -77,7 +77,7 @@ namespace samurai
     };
 
     template <class cfg>
-    using SchemeValue = CollapsArray<typename cfg::input_field_t::value_type, cfg::output_n_comp, cfg::input_field_t::is_soa>;
+    using SchemeValue = CollapsArray<typename cfg::input_field_t::value_type, cfg::output_n_comp, cfg::input_field_t::is_soa, cfg::input_field_t::is_scalar>;
 
     /**
      * Specialization of @class CellBasedSchemeDefinition.

--- a/include/samurai/schemes/fv/cell_based/local_field.hpp
+++ b/include/samurai/schemes/fv/cell_based/local_field.hpp
@@ -12,7 +12,7 @@ namespace samurai
      * Implementation when number of components of field = 1
      */
     template <class field_t>
-    class LocalField<field_t, std::enable_if_t<field_t::n_comp == 1>>
+    class LocalField<field_t, std::enable_if_t<field_t::is_scalar>>
     {
         using field_value_type = typename field_t::value_type;
         using cell_t           = typename field_t::cell_t;
@@ -41,7 +41,7 @@ namespace samurai
      * Implementation when number of components of field > 1
      */
     template <class field_t>
-    class LocalField<field_t, std::enable_if_t<field_t::n_comp != 1>>
+    class LocalField<field_t, std::enable_if_t<!field_t::is_scalar>>
     {
         using field_value_type    = typename field_t::value_type;
         using cell_t              = typename field_t::cell_t;

--- a/include/samurai/schemes/fv/flux_based/flux_based_scheme__nonlin.hpp
+++ b/include/samurai/schemes/fv/flux_based/flux_based_scheme__nonlin.hpp
@@ -24,6 +24,7 @@ namespace samurai
         using typename base_class::input_field_t;
         using typename base_class::mesh_id_t;
         using typename base_class::mesh_t;
+        using typename base_class::output_field_t;
 
         using interval_t       = typename mesh_t::interval_t;
         using interval_value_t = typename interval_t::value_t;
@@ -101,7 +102,7 @@ namespace samurai
 
         inline field_value_type flux_value_cmpnent(const FluxValue<cfg>& flux_value, [[maybe_unused]] size_type field_i) const
         {
-            if constexpr (output_n_comp == 1)
+            if constexpr (output_field_t::is_scalar)
             {
                 return flux_value;
             }
@@ -160,7 +161,7 @@ namespace samurai
                                   const std::size_t delta_l,
                                   const cell_indices_t& fine_cell_indices)
         {
-            if constexpr (n_comp == 1)
+            if constexpr (input_field_t::is_scalar)
             {
                 predicted_value = portion(field, level, coarse_cell_indices, delta_l, fine_cell_indices)[0];
             }

--- a/include/samurai/schemes/fv/flux_based/flux_definition.hpp
+++ b/include/samurai/schemes/fv/flux_based/flux_definition.hpp
@@ -63,8 +63,7 @@ namespace samurai
     //----------------------------------//
 
     template <class cfg>
-    using FluxValue = CollapsFluxArray<typename cfg::input_field_t::value_type, cfg::output_n_comp>; //,
-                                                                                                     // cfg::input_field_t::is_soa>;
+    using FluxValue = CollapsFluxArray<typename cfg::input_field_t::value_type, cfg::output_n_comp, cfg::input_field_t::is_scalar>;
 
     template <class cfg>
     using FluxValuePair = StdArrayWrapper<FluxValue<cfg>, 2>;

--- a/include/samurai/schemes/fv/operators/convection_lin.hpp
+++ b/include/samurai/schemes/fv/operators/convection_lin.hpp
@@ -92,7 +92,7 @@ namespace samurai
 
         static constexpr std::size_t dim           = Field::dim;
         static constexpr std::size_t n_comp        = Field::n_comp;
-        static constexpr bool is_soa               = Field::is_soa;
+        static constexpr bool is_soa               = detail::is_soa_v<Field>;
         static constexpr std::size_t output_n_comp = n_comp;
         static constexpr std::size_t stencil_size  = 6;
 
@@ -220,7 +220,7 @@ namespace samurai
 
         static constexpr std::size_t dim           = Field::dim;
         static constexpr std::size_t n_comp        = Field::n_comp;
-        static constexpr bool is_soa               = Field::is_soa;
+        static constexpr bool is_soa               = detail::is_soa_v<Field>;
         static constexpr std::size_t output_n_comp = n_comp;
         static constexpr std::size_t stencil_size  = 6;
 

--- a/include/samurai/schemes/fv/operators/convection_nonlin.hpp
+++ b/include/samurai/schemes/fv/operators/convection_nonlin.hpp
@@ -43,7 +43,7 @@ namespace samurai
 
                 auto f = [](auto u) -> FluxValue<cfg>
                 {
-                    if constexpr (n_comp == 1)
+                    if constexpr (Field::is_scalar)
                     {
                         return u * u;
                     }
@@ -59,7 +59,7 @@ namespace samurai
                     static constexpr std::size_t right = 1;
 
                     field_value_t v;
-                    if constexpr (n_comp == 1)
+                    if constexpr (Field::is_scalar)
                     {
                         v = field[left];
                     }
@@ -103,7 +103,7 @@ namespace samurai
 
                 auto f = [](auto u) -> FluxValue<cfg>
                 {
-                    if constexpr (n_comp == 1)
+                    if constexpr (Field::is_scalar)
                     {
                         return u * u;
                     }
@@ -120,7 +120,7 @@ namespace samurai
                     static constexpr std::size_t stencil_center = 2;
 
                     field_value_t v;
-                    if constexpr (n_comp == 1)
+                    if constexpr (Field::is_scalar)
                     {
                         v = u[stencil_center];
                     }

--- a/include/samurai/schemes/fv/operators/diffusion.hpp
+++ b/include/samurai/schemes/fv/operators/diffusion.hpp
@@ -2,7 +2,6 @@
 #include "../flux_based/flux_based_scheme__lin_het.hpp"
 #include "../flux_based/flux_based_scheme__lin_hom.hpp"
 #include "divergence.hpp"
-#
 
 namespace samurai
 {

--- a/include/samurai/schemes/fv/operators/diffusion.hpp
+++ b/include/samurai/schemes/fv/operators/diffusion.hpp
@@ -2,6 +2,7 @@
 #include "../flux_based/flux_based_scheme__lin_het.hpp"
 #include "../flux_based/flux_based_scheme__lin_hom.hpp"
 #include "divergence.hpp"
+#
 
 namespace samurai
 {
@@ -151,7 +152,7 @@ namespace samurai
                     // Return value: 2 matrices (left, right) of size output_n_comp x n_comp.
                     // In this case, of size n_comp x n_comp.
                     FluxStencilCoeffs<cfg> coeffs;
-                    if constexpr (n_comp == 1)
+                    if constexpr (Field::is_scalar)
                     {
                         coeffs[left]  = -1 / h;
                         coeffs[right] = 1 / h;
@@ -205,7 +206,7 @@ namespace samurai
                     // Return value: 2 matrices (left, right) of size output_n_comp x n_comp.
                     // In this case, of size n_comp x n_comp.
                     FluxStencilCoeffs<cfg> coeffs;
-                    if constexpr (n_comp == 1)
+                    if constexpr (Field::is_scalar)
                     {
                         coeffs[left]  = -1 / h;
                         coeffs[right] = 1 / h;
@@ -221,7 +222,7 @@ namespace samurai
                         }
                     }
                     // Minus sign because we want -Laplacian
-                    if constexpr (n_comp == 1)
+                    if constexpr (Field::is_scalar)
                     {
                         coeffs[left] *= -K(0);
                         coeffs[right] *= -K(0);
@@ -268,7 +269,7 @@ namespace samurai
 
     template <class field_t,
               class DiffTensorField,
-              std::enable_if_t<DiffTensorField::n_comp == 1 && std::is_same_v<typename DiffTensorField::value_type, DiffCoeff<field_t::dim>>, bool> = true>
+              std::enable_if_t<DiffTensorField::is_scalar && std::is_same_v<typename DiffTensorField::value_type, DiffCoeff<field_t::dim>>, bool> = true>
     auto make_diffusion_order2(const DiffTensorField& K)
     {
         static constexpr std::size_t dim           = field_t::dim;
@@ -298,7 +299,7 @@ namespace samurai
                     // Return value: 2 matrices (left, right) of size output_n_comp x n_comp.
                     // In this case, of size n_comp x n_comp.
                     FluxStencilCoeffs<cfg> coeffs;
-                    if constexpr (n_comp == 1)
+                    if constexpr (field_t::is_scalar)
                     {
                         coeffs[left]  = -k_left(d) / h;
                         coeffs[right] = k_left(d) / h;

--- a/include/samurai/schemes/fv/operators/diffusion_old.hpp
+++ b/include/samurai/schemes/fv/operators/diffusion_old.hpp
@@ -33,7 +33,7 @@ namespace samurai
             this->stencil()           = star_stencil<dim>();
             this->coefficients_func() = [](double h)
             {
-                auto Identity = eye<field_value_type, n_comp, n_comp>();
+                auto Identity = eye<field_value_type, n_comp, n_comp, Field::is_scalar>();
                 StencilCoeffs<cfg> coeffs;
                 for (unsigned int i = 0; i < cfg::stencil_size; ++i)
                 {

--- a/include/samurai/schemes/fv/operators/divergence.hpp
+++ b/include/samurai/schemes/fv/operators/divergence.hpp
@@ -30,7 +30,7 @@ namespace samurai
                     // Return value: 2 matrices (left, right) of size output_n_comp x n_comp.
                     // In this case, of size 1 x dim, i.e. a row vector of size dim.
                     FluxStencilCoeffs<cfg> coeffs;
-                    if constexpr (n_comp == 1)
+                    if constexpr (Field::is_scalar)
                     {
                         coeffs[left]  = 0.5;
                         coeffs[right] = 0.5;

--- a/include/samurai/schemes/fv/operators/identity.hpp
+++ b/include/samurai/schemes/fv/operators/identity.hpp
@@ -17,7 +17,7 @@ namespace samurai
         {
             // return {eye<field_value_type, n_comp, n_comp>()};
             StencilCoeffs<cfg> sc;
-            sc(0) = eye<field_value_type, n_comp, n_comp>();
+            sc(0) = eye<field_value_type, n_comp, n_comp, Field::is_scalar>();
             return sc;
         };
         identity.is_symmetric(true);

--- a/include/samurai/schemes/fv/operators/zero_operator.hpp
+++ b/include/samurai/schemes/fv/operators/zero_operator.hpp
@@ -17,7 +17,7 @@ namespace samurai
         {
             // return {zeros<field_value_type, output_n_comp, n_comp>()};
             StencilCoeffs<cfg> sc;
-            sc(0) = zeros<field_value_type, output_n_comp, n_comp>();
+            sc(0) = zeros<field_value_type, output_n_comp, n_comp, Field::is_scalar>();
             return sc;
         };
         zero.is_symmetric(true);

--- a/include/samurai/schemes/fv/utils.hpp
+++ b/include/samurai/schemes/fv/utils.hpp
@@ -12,13 +12,13 @@ namespace samurai
     };
 
     template <class cfg>
-    using StencilCells = CollapsStdArray<typename cfg::input_field_t::cell_t, cfg::stencil_size>;
+    using StencilCells = CollapsStdArray<typename cfg::input_field_t::cell_t, cfg::stencil_size, true>;
 
     template <class cfg>
-    using StencilValues = CollapsStdArray<typename cfg::input_field_t::local_data_type, cfg::stencil_size>;
+    using StencilValues = CollapsStdArray<typename cfg::input_field_t::local_data_type, cfg::stencil_size, cfg::input_field_t::is_scalar>;
 
     template <class cfg>
-    using JacobianMatrix = CollapsMatrix<typename cfg::input_field_t::value_type, cfg::output_n_comp, cfg::input_field_t::n_comp>;
+    using JacobianMatrix = CollapsMatrix<typename cfg::input_field_t::value_type, cfg::output_n_comp, cfg::input_field_t::n_comp, cfg::input_field_t::is_scalar>;
 
     template <class cfg>
     using StencilJacobian = StdArrayWrapper<JacobianMatrix<cfg>, cfg::stencil_size>;

--- a/include/samurai/storage/collapsable.hpp
+++ b/include/samurai/storage/collapsable.hpp
@@ -15,7 +15,7 @@ namespace samurai
     namespace detail
     {
 
-        template <class MatrixType, class value_type, std::size_t rows, std::size_t cols>
+        template <class MatrixType, class value_type, std::size_t rows, std::size_t cols, bool can_collapse>
         struct CollapsableMatrix
         {
             using Type = MatrixType;
@@ -23,14 +23,14 @@ namespace samurai
 
         // Template specialization: if rows=cols=1, then just a scalar coefficient
         template <class MatrixType, class value_type>
-        struct CollapsableMatrix<MatrixType, value_type, 1, 1>
+        struct CollapsableMatrix<MatrixType, value_type, 1, 1, true>
         {
             using Type = value_type;
         };
     }
 
-    template <class MatrixType, class value_type, std::size_t rows, std::size_t cols>
-    using CollapsableMatrix = typename detail::CollapsableMatrix<MatrixType, value_type, rows, cols>::Type;
+    template <class MatrixType, class value_type, std::size_t rows, std::size_t cols, bool can_collapse>
+    using CollapsableMatrix = typename detail::CollapsableMatrix<MatrixType, value_type, rows, cols, can_collapse>::Type;
 
     //----------------------------------------------------------------//
     // CollapsableArray:                                              //
@@ -38,7 +38,7 @@ namespace samurai
     //----------------------------------------------------------------//
     namespace detail
     {
-        template <class ArrayType, class value_type, std::size_t size>
+        template <class ArrayType, class value_type, std::size_t size, bool can_collapse>
         struct CollapsableArray
         {
             using Type = ArrayType;
@@ -46,18 +46,18 @@ namespace samurai
 
         // Template specialization: if size=1, then just a scalar coefficient
         template <class ArrayType, class value_type>
-        struct CollapsableArray<ArrayType, value_type, 1>
+        struct CollapsableArray<ArrayType, value_type, 1, true>
         {
             using Type = value_type;
         };
     }
 
-    template <class ArrayType, class value_type, std::size_t size>
-    using CollapsableArray = typename detail::CollapsableArray<ArrayType, value_type, size>::Type;
+    template <class ArrayType, class value_type, std::size_t size, bool can_collapse>
+    using CollapsableArray = typename detail::CollapsableArray<ArrayType, value_type, size, can_collapse>::Type;
 
     // Collapsable std::array
-    template <class value_type, std::size_t size>
-    using CollapsStdArray = typename detail::CollapsableArray<std::array<value_type, size>, value_type, size>::Type;
+    template <class value_type, std::size_t size, bool can_collapse>
+    using CollapsStdArray = typename detail::CollapsableArray<std::array<value_type, size>, value_type, size, can_collapse>::Type;
 
     template <class value_type>
     void fill(value_type& scalar, value_type value)

--- a/include/samurai/storage/collapsable_linear_algebra.hpp
+++ b/include/samurai/storage/collapsable_linear_algebra.hpp
@@ -37,10 +37,10 @@ namespace samurai
         }
     }
 
-    template <class value_type, std::size_t rows, std::size_t cols>
+    template <class value_type, std::size_t rows, std::size_t cols, bool can_collapse>
     auto zeros()
     {
-        using matrix_type = CollapsMatrix<value_type, rows, cols>;
+        using matrix_type = CollapsMatrix<value_type, rows, cols, can_collapse>;
         return zeros<matrix_type>();
     }
 
@@ -80,10 +80,10 @@ namespace samurai
     //     return xt::eye(s[0]);
     // }
 
-    template <class value_type, std::size_t rows, std::size_t cols>
+    template <class value_type, std::size_t rows, std::size_t cols, bool can_collapse>
     auto eye()
     {
-        using matrix_type = CollapsMatrix<value_type, rows, cols>;
+        using matrix_type = CollapsMatrix<value_type, rows, cols, can_collapse>;
         return eye<matrix_type>();
         // matrix_type e;
         // if constexpr (rows == 1 && cols == 1)
@@ -106,12 +106,12 @@ namespace samurai
         return A * x;
     }
 
-    template <bool SOA, class value_type, std::size_t rows, std::size_t cols, class vector_type>
+    template <bool SOA, bool can_collapse, class value_type, std::size_t rows, std::size_t cols, class vector_type>
     auto mat_vec(const Matrix<value_type, rows, cols>& A, const vector_type& x)
     {
         // 'vector_type' can be an xt::view or a CollapsArray
 
-        CollapsArray<value_type, rows, SOA> res = zeros<CollapsMatrix<value_type, rows, cols>>();
+        CollapsArray<value_type, rows, SOA, can_collapse> res = zeros<CollapsMatrix<value_type, rows, cols, can_collapse>>();
         if constexpr (rows == 1 && cols == 1)
         {
             res = A * x;

--- a/include/samurai/storage/collapsable_linear_algebra.hpp
+++ b/include/samurai/storage/collapsable_linear_algebra.hpp
@@ -112,7 +112,7 @@ namespace samurai
         // 'vector_type' can be an xt::view or a CollapsArray
 
         CollapsArray<value_type, rows, SOA, can_collapse> res = zeros<CollapsMatrix<value_type, rows, cols, can_collapse>>();
-        if constexpr (rows == 1 && cols == 1)
+        if constexpr (rows == 1 && cols == 1 && can_collapse)
         {
             res = A * x;
         }

--- a/include/samurai/storage/containers_config.hpp
+++ b/include/samurai/storage/containers_config.hpp
@@ -32,18 +32,18 @@ namespace samurai
 
 #if defined(SAMURAI_FIELD_CONTAINER_EIGEN3)
 
-    template <class value_type, std::size_t size = 1, bool SOA = false>
-    using field_data_storage_t = eigen_container<value_type, size, SOA>;
+    template <class value_type, std::size_t size = 1, bool SOA = false, bool can_collapse = true>
+    using field_data_storage_t = eigen_container<value_type, size, SOA, can_collapse>;
 
-    template <class value_type, std::size_t size, bool SOA = false>
-    using local_field_data_t = eigen_collapsable_static_array<value_type, size, SOA>;
+    template <class value_type, std::size_t size, bool SOA = false, bool can_collapse = true>
+    using local_field_data_t = eigen_collapsable_static_array<value_type, size, SOA, can_collapse>;
 
     template <class T>
     using default_view_t = Eigen::IndexedView<T, Eigen::internal::ArithmeticSequenceRange<16777215, -1, 16777215>, Eigen::internal::SingleRange<0>>;
 #else // SAMURAI_FIELD_CONTAINER_XTENSOR
 
-    template <class value_type, std::size_t size = 1, bool SOA = false>
-    using field_data_storage_t = xtensor_container<value_type, size, SOA>;
+    template <class value_type, std::size_t size = 1, bool SOA = false, bool can_collapse = true>
+    using field_data_storage_t = xtensor_container<value_type, size, SOA, can_collapse>;
 
     template <class value_type, std::size_t size, bool SOA = false, bool can_collapse = true>
     using local_field_data_t = xtensor_collapsable_static_array<value_type, size, can_collapse>;

--- a/include/samurai/storage/containers_config.hpp
+++ b/include/samurai/storage/containers_config.hpp
@@ -45,8 +45,8 @@ namespace samurai
     template <class value_type, std::size_t size = 1, bool SOA = false>
     using field_data_storage_t = xtensor_container<value_type, size, SOA>;
 
-    template <class value_type, std::size_t size, bool SOA = false>
-    using local_field_data_t = xtensor_collapsable_static_array<value_type, size>;
+    template <class value_type, std::size_t size, bool SOA = false, bool can_collapse = true>
+    using local_field_data_t = xtensor_collapsable_static_array<value_type, size, can_collapse>;
 
     template <class T>
     using default_view_t = xt::xview<T&, xt::xstepped_range<long>>;
@@ -63,8 +63,8 @@ namespace samurai
     using Array = xtensor_static_array<value_type, size>;
 #endif
 
-    template <class value_type, std::size_t size, bool SOA = false>
-    using CollapsArray = CollapsableArray<Array<value_type, size, SOA>, value_type, size>;
+    template <class value_type, std::size_t size, bool SOA = false, bool can_collapse = true>
+    using CollapsArray = CollapsableArray<Array<value_type, size, SOA>, value_type, size, can_collapse>;
 
     //----------------//
     // Flux container //
@@ -82,8 +82,8 @@ namespace samurai
     using flux_index_type = std::size_t;
 #endif
 
-    template <class value_type, std::size_t size>
-    using CollapsFluxArray = CollapsableArray<flux_array_t<value_type, size>, value_type, size>;
+    template <class value_type, std::size_t size, bool can_collapse>
+    using CollapsFluxArray = CollapsableArray<flux_array_t<value_type, size>, value_type, size, can_collapse>;
 
     //---------------//
     // Static matrix //
@@ -101,7 +101,7 @@ namespace samurai
     using Matrix = xtensor_static_matrix<value_type, rows, cols>;
 #endif
 
-    template <class value_type, std::size_t rows, std::size_t cols>
-    using CollapsMatrix = CollapsableMatrix<Matrix<value_type, rows, cols>, value_type, rows, cols>;
+    template <class value_type, std::size_t rows, std::size_t cols, bool can_collapse>
+    using CollapsMatrix = CollapsableMatrix<Matrix<value_type, rows, cols>, value_type, rows, cols, can_collapse>;
 
 }

--- a/include/samurai/storage/eigen/eigen_static.hpp
+++ b/include/samurai/storage/eigen/eigen_static.hpp
@@ -41,8 +41,8 @@ namespace samurai
     template <class value_type, std::size_t rows, std::size_t cols>
     using eigen_static_matrix = Eigen::Matrix<value_type, rows, cols>;
 
-    template <class value_type, std::size_t size, bool SOA>
-    using eigen_collapsable_static_array = CollapsableArray<eigen_static_array<value_type, size, SOA>, value_type, size>;
+    template <class value_type, std::size_t size, bool SOA, bool can_collapse>
+    using eigen_collapsable_static_array = CollapsableArray<eigen_static_array<value_type, size, SOA>, value_type, size, can_collapse>;
 
     template <class value_type, std::size_t rows, std::size_t cols>
     using eigen_collapsable_static_matrix = CollapsableMatrix<eigen_static_matrix<value_type, rows, cols>, value_type, rows, cols>;

--- a/include/samurai/storage/std/algebraic_array.hpp
+++ b/include/samurai/storage/std/algebraic_array.hpp
@@ -360,7 +360,7 @@ namespace samurai
         return std::pow(base, exponent);
     }
 
-    template <class value_type, std::size_t size>
-    using collapsable_algebraic_std_array = CollapsableArray<StdArrayWrapper<value_type, size>, value_type, size>;
+    template <class value_type, std::size_t size, bool can_collapse>
+    using collapsable_algebraic_std_array = CollapsableArray<StdArrayWrapper<value_type, size>, value_type, size, can_collapse>;
 
 } // end namespace samurai

--- a/include/samurai/storage/utils.hpp
+++ b/include/samurai/storage/utils.hpp
@@ -9,25 +9,30 @@ namespace samurai
 {
     namespace detail
     {
-        template <std::size_t size, bool SOA, layout_type L>
+        template <std::size_t size, bool SOA, bool can_collapse, layout_type L>
         struct static_size_first : std::false_type
         {
         };
 
-        template <std::size_t size>
+        template <std::size_t size, bool can_collapse>
             requires(size > 1)
-        struct static_size_first<size, true, layout_type::row_major> : std::true_type
+        struct static_size_first<size, true, can_collapse, layout_type::row_major> : std::true_type
         {
         };
 
-        template <std::size_t size>
+        template <std::size_t size, bool can_collapse>
             requires(size > 1)
-        struct static_size_first<size, false, layout_type::column_major> : std::true_type
+        struct static_size_first<size, false, can_collapse, layout_type::column_major> : std::true_type
         {
         };
 
-        template <std::size_t size, bool SOA, layout_type L>
-        static constexpr bool static_size_first_v = static_size_first<size, SOA, L>::value;
+        template <bool SOA, layout_type L>
+        struct static_size_first<1, SOA, false, L> : std::true_type
+        {
+        };
+
+        template <std::size_t size, bool SOA, bool can_collapse, layout_type L>
+        static constexpr bool static_size_first_v = static_size_first<size, SOA, can_collapse, L>::value;
     }
 
     template <class T>

--- a/include/samurai/storage/xtensor/xtensor_static.hpp
+++ b/include/samurai/storage/xtensor/xtensor_static.hpp
@@ -18,11 +18,11 @@ namespace samurai
     template <class value_type, std::size_t rows, std::size_t cols>
     using xtensor_static_matrix = xt::xtensor_fixed<value_type, xt::xshape<rows, cols>>;
 
-    template <class value_type, std::size_t size>
-    using xtensor_collapsable_static_array = CollapsableArray<xtensor_static_array<value_type, size>, value_type, size>;
+    template <class value_type, std::size_t size, bool can_collapse>
+    using xtensor_collapsable_static_array = CollapsableArray<xtensor_static_array<value_type, size>, value_type, size, can_collapse>;
 
-    template <class value_type, std::size_t rows, std::size_t cols>
-    using xtensor_collapsable_static_matrix = CollapsableMatrix<xtensor_static_matrix<value_type, rows, cols>, value_type, rows, cols>;
+    template <class value_type, std::size_t rows, std::size_t cols, bool can_collapse>
+    using xtensor_collapsable_static_matrix = CollapsableMatrix<xtensor_static_matrix<value_type, rows, cols>, value_type, rows, cols, can_collapse>;
 
     // is_xtensor_matrix //
     template <typename>

--- a/include/samurai/utils.hpp
+++ b/include/samurai/utils.hpp
@@ -94,7 +94,7 @@ namespace samurai
     template <template <std::size_t dim, class T> class OP, class... CT>
     class field_operator_function;
 
-    template <class mesh_t, class value_t, std::size_t n_comp = 1, bool SOA = false>
+    template <class mesh_t, class value_t, std::size_t n_comp, bool SOA = false>
     class VectorField;
 
     template <class mesh_t, class value_t>
@@ -310,18 +310,108 @@ namespace samurai
             return do_min(v0 < v1 ? v0 : v1, rest...);
         }
 
+        /**
+         * @brief test if template parameter is SOA of AOS Field (false by default like VectorField)
+         *
+         * @tparam T type to test
+         */
         template <class T>
         struct is_soa : std::false_type
         {
         };
 
+        // specialization for VectorField
         template <class Mesh, class value_t, std::size_t n_comp, bool SOA>
         struct is_soa<VectorField<Mesh, value_t, n_comp, SOA>> : std::bool_constant<SOA>
         {
         };
 
+        /**
+         * @brief helper to get value of is_soa
+         *
+         * @tparam T type to test
+         */
         template <class T>
         inline constexpr bool is_soa_v = is_soa<std::decay_t<T>>::value;
+
+        /**
+         * @brief test if template parameter is a samurai field (ScalarField or VectorField)
+         *
+         * @tparam T type to test
+         */
+        template <class T>
+        struct is_field_type : std::false_type
+        {
+        };
+
+        // specialization for VectorField
+        template <class Mesh, class value_t, std::size_t n_comp, bool SOA>
+        struct is_field_type<VectorField<Mesh, value_t, n_comp, SOA>> : std::true_type
+        {
+        };
+
+        // specialization for ScalarField
+        template <class Mesh, class value_t>
+        struct is_field_type<ScalarField<Mesh, value_t>> : std::true_type
+        {
+        };
+
+        /**
+         * @brief helper to get value of is_field_type
+         *
+         * @tparam T type to test
+         */
+        template <class T>
+        inline constexpr bool is_field_type_v = is_field_type<std::decay_t<T>>::value;
+
+        /**
+         * @brief test if template parameter is a VectorField
+         *
+         * @tparam T type to test
+         */
+        template <class T>
+        struct is_vector_field_type : std::false_type
+        {
+        };
+
+        // specialization for VectorField
+        template <class Mesh, class value_t, std::size_t n_comp, bool SOA>
+        struct is_vector_field_type<VectorField<Mesh, value_t, n_comp, SOA>> : std::true_type
+        {
+        };
+
+        /**
+         * @brief helper to get value of is_vector_field
+         *
+         * @tparam T type to test
+         */
+        template <class T>
+        inline constexpr bool is_vector_field_type_v = is_vector_field_type<std::decay_t<T>>::value;
+
+        /**
+         * @brief test if template parameter is a ScalarField
+         *
+         * @tparam T type to test
+         */
+        template <class T>
+        struct is_scalar_field_type : std::false_type
+        {
+        };
+
+        // specialization for ScalarField
+        template <class Mesh, class value_t>
+        struct is_scalar_field_type<ScalarField<Mesh, value_t>> : std::true_type
+        {
+        };
+
+        /**
+         * @brief helper to get value of is_scalar_field
+         *
+         * @tparam T type to test
+         */
+        template <class T>
+        inline constexpr bool is_scalar_field_type_v = is_scalar_field_type<std::decay_t<T>>::value;
+
     } // namespace detail
 
     template <class R, class T1, class T2>
@@ -340,7 +430,7 @@ namespace samurai
     inline auto& field_value(Field& f, const typename Field::index_t& cell_index, [[maybe_unused]] index_t field_i)
     {
         using size_type = typename Field::size_type;
-        if constexpr (Field::n_comp == 1)
+        if constexpr (Field::is_scalar)
         {
             return f[static_cast<size_type>(cell_index)];
         }
@@ -354,13 +444,13 @@ namespace samurai
     // inline auto&
     // field_value(typename Field::value_type* data, const typename Field::index_t& cell_index, [[maybe_unused]] std::size_t field_i)
     // {
-    //     if constexpr (Field::n_comp == 1)
+    //     if constexpr (Field::is_scalar)
     //     {
     //         return *data[cell_index];
     //     }
-    //     else if constexpr (Field::is_soa)
+    //     else if constexpr (detail::is_soa_v<Field>)
     //     {
-    //         static_assert(Field::n_comp == 1 || !Field::is_soa, "field_value() is not implemented for SOA fields");
+    //         static_assert(Field::is_scalar || !detail::is_soa_v<Field>, "field_value() is not implemented for SOA fields");
     //         return *data[field_i /*  *n_cells */ + cell_index];
     //     }
     //     else

--- a/include/samurai/utils.hpp
+++ b/include/samurai/utils.hpp
@@ -364,54 +364,6 @@ namespace samurai
         template <class T>
         inline constexpr bool is_field_type_v = is_field_type<std::decay_t<T>>::value;
 
-        /**
-         * @brief test if template parameter is a VectorField
-         *
-         * @tparam T type to test
-         */
-        template <class T>
-        struct is_vector_field_type : std::false_type
-        {
-        };
-
-        // specialization for VectorField
-        template <class Mesh, class value_t, std::size_t n_comp, bool SOA>
-        struct is_vector_field_type<VectorField<Mesh, value_t, n_comp, SOA>> : std::true_type
-        {
-        };
-
-        /**
-         * @brief helper to get value of is_vector_field
-         *
-         * @tparam T type to test
-         */
-        template <class T>
-        inline constexpr bool is_vector_field_type_v = is_vector_field_type<std::decay_t<T>>::value;
-
-        /**
-         * @brief test if template parameter is a ScalarField
-         *
-         * @tparam T type to test
-         */
-        template <class T>
-        struct is_scalar_field_type : std::false_type
-        {
-        };
-
-        // specialization for ScalarField
-        template <class Mesh, class value_t>
-        struct is_scalar_field_type<ScalarField<Mesh, value_t>> : std::true_type
-        {
-        };
-
-        /**
-         * @brief helper to get value of is_scalar_field
-         *
-         * @tparam T type to test
-         */
-        template <class T>
-        inline constexpr bool is_scalar_field_type_v = is_scalar_field_type<std::decay_t<T>>::value;
-
     } // namespace detail
 
     template <class R, class T1, class T2>

--- a/include/samurai/utils.hpp
+++ b/include/samurai/utils.hpp
@@ -94,6 +94,12 @@ namespace samurai
     template <template <std::size_t dim, class T> class OP, class... CT>
     class field_operator_function;
 
+    template <class mesh_t, class value_t, std::size_t n_comp = 1, bool SOA = false>
+    class VectorField;
+
+    template <class mesh_t, class value_t>
+    class ScalarField;
+
     namespace detail
     {
 
@@ -303,6 +309,19 @@ namespace samurai
         {
             return do_min(v0 < v1 ? v0 : v1, rest...);
         }
+
+        template <class T>
+        struct is_soa : std::false_type
+        {
+        };
+
+        template <class Mesh, class value_t, std::size_t n_comp, bool SOA>
+        struct is_soa<VectorField<Mesh, value_t, n_comp, SOA>> : std::bool_constant<SOA>
+        {
+        };
+
+        template <class T>
+        inline constexpr bool is_soa_v = is_soa<std::decay_t<T>>::value;
     } // namespace detail
 
     template <class R, class T1, class T2>

--- a/tests/test_adapt.cpp
+++ b/tests/test_adapt.cpp
@@ -32,7 +32,7 @@ namespace samurai
         static constexpr std::size_t dim = TypeParam::value;
         using config                     = MRConfig<dim>;
         auto mesh                        = MRMesh<config>({xt::zeros<double>({dim}), xt::ones<double>({dim})}, 2, 4);
-        auto u_1                         = make_field<double, 1>("u_1", mesh);
+        auto u_1                         = make_field<double>("u_1", mesh);
         auto u_2                         = make_field<double, 3, true>("u_2", mesh);
         auto u_3                         = make_field<double, 2>("u_3", mesh);
 

--- a/tests/test_adapt.cpp
+++ b/tests/test_adapt.cpp
@@ -32,9 +32,9 @@ namespace samurai
         static constexpr std::size_t dim = TypeParam::value;
         using config                     = MRConfig<dim>;
         auto mesh                        = MRMesh<config>({xt::zeros<double>({dim}), xt::ones<double>({dim})}, 2, 4);
-        auto u_1                         = make_field<double>("u_1", mesh);
-        auto u_2                         = make_field<double, 3, true>("u_2", mesh);
-        auto u_3                         = make_field<double, 2>("u_3", mesh);
+        auto u_1                         = make_scalar_field<double>("u_1", mesh);
+        auto u_2                         = make_vector_field<double, 3, true>("u_2", mesh);
+        auto u_3                         = make_vector_field<double, 2>("u_3", mesh);
 
         auto adapt = make_MRAdapt(u_1, u_2, u_3);
         adapt(1e-4, 2);

--- a/tests/test_bc.cpp
+++ b/tests/test_bc.cpp
@@ -13,7 +13,7 @@ namespace samurai
         static constexpr std::size_t dim = 1;
         using config                     = UniformConfig<dim>;
         auto mesh                        = UniformMesh<config>({{0}, {1}}, 4);
-        auto u                           = make_field<double, 1>("u", mesh);
+        auto u                           = make_field<double>("u", mesh);
 
         make_bc<Dirichlet<1>>(u);
         EXPECT_EQ(u.get_bc()[0]->constant_value(), 0.);
@@ -35,7 +35,7 @@ namespace samurai
         static constexpr std::size_t dim = 1;
         using config                     = UniformConfig<dim>;
         auto mesh                        = UniformMesh<config>({{0}, {1}}, 4);
-        auto u                           = make_field<double, 1>("u", mesh);
+        auto u                           = make_field<double>("u", mesh);
 
         make_bc<Dirichlet<1>>(u, 2);
         EXPECT_EQ(u.get_bc()[0]->constant_value(), 2);
@@ -60,7 +60,7 @@ namespace samurai
 
         Box<double, dim> box = {{0}, {1}};
         auto mesh            = MRMesh<config>(box, 2, 4);
-        auto u               = make_field<double, 1>("u", mesh);
+        auto u               = make_field<double>("u", mesh);
 
         make_bc<Dirichlet<1>>(u,
                               [](const auto&, const auto&, const auto&)

--- a/tests/test_bc.cpp
+++ b/tests/test_bc.cpp
@@ -13,7 +13,7 @@ namespace samurai
         static constexpr std::size_t dim = 1;
         using config                     = UniformConfig<dim>;
         auto mesh                        = UniformMesh<config>({{0}, {1}}, 4);
-        auto u                           = make_field<double>("u", mesh);
+        auto u                           = make_scalar_field<double>("u", mesh);
 
         make_bc<Dirichlet<1>>(u);
         EXPECT_EQ(u.get_bc()[0]->constant_value(), 0.);
@@ -24,7 +24,7 @@ namespace samurai
         static constexpr std::size_t dim = 1;
         using config                     = UniformConfig<dim>;
         auto mesh                        = UniformMesh<config>({{0}, {1}}, 4);
-        auto u                           = make_field<double, 4>("u", mesh);
+        auto u                           = make_vector_field<double, 4>("u", mesh);
 
         make_bc<Dirichlet<1>>(u);
         EXPECT_TRUE(compare(u.get_bc()[0]->constant_value(), zeros<double>(4)));
@@ -35,7 +35,7 @@ namespace samurai
         static constexpr std::size_t dim = 1;
         using config                     = UniformConfig<dim>;
         auto mesh                        = UniformMesh<config>({{0}, {1}}, 4);
-        auto u                           = make_field<double>("u", mesh);
+        auto u                           = make_scalar_field<double>("u", mesh);
 
         make_bc<Dirichlet<1>>(u, 2);
         EXPECT_EQ(u.get_bc()[0]->constant_value(), 2);
@@ -46,7 +46,7 @@ namespace samurai
         static constexpr std::size_t dim = 1;
         using config                     = UniformConfig<dim>;
         auto mesh                        = UniformMesh<config>({{0}, {1}}, 4);
-        auto u                           = make_field<double, 4>("u", mesh);
+        auto u                           = make_vector_field<double, 4>("u", mesh);
 
         make_bc<Dirichlet<1>>(u, 1., 2., 3., 4.);
         samurai::Array<double, 4, false> expected({1, 2, 3, 4});
@@ -60,7 +60,7 @@ namespace samurai
 
         Box<double, dim> box = {{0}, {1}};
         auto mesh            = MRMesh<config>(box, 2, 4);
-        auto u               = make_field<double>("u", mesh);
+        auto u               = make_scalar_field<double>("u", mesh);
 
         make_bc<Dirichlet<1>>(u,
                               [](const auto&, const auto&, const auto&)

--- a/tests/test_field.cpp
+++ b/tests/test_field.cpp
@@ -18,7 +18,7 @@ namespace samurai
         using Config = UniformConfig<1>;
         auto mesh    = UniformMesh<Config>(box, 3);
 
-        auto u = make_field<double, 1>("u", mesh);
+        auto u = make_field<double>("u", mesh);
         u.fill(1.);
         using field_t = decltype(u);
         field_t ue    = 5 + u;
@@ -35,7 +35,7 @@ namespace samurai
         Box<double, 1> box{{0}, {1}};
         using Config       = UniformConfig<1>;
         auto mesh          = UniformMesh<Config>(box, 3);
-        const auto u_const = make_field<double, 1>("uc", mesh, 1.);
+        const auto u_const = make_field<double>("uc", mesh, 1.);
 
         auto u = u_const;
         EXPECT_EQ(u.name(), u_const.name());
@@ -44,7 +44,7 @@ namespace samurai
         EXPECT_EQ(&(u.mesh()), &(u_const.mesh()));
 
         auto m              = holder(mesh);
-        const auto u_const1 = make_field<double, 1>("uc", m, 1.);
+        const auto u_const1 = make_field<double>("uc", m, 1.);
         auto u1             = u_const1;
         EXPECT_EQ(u1.name(), u_const1.name());
         EXPECT_TRUE(compare(u1.array(), u_const1.array()));
@@ -57,18 +57,18 @@ namespace samurai
         using Config       = UniformConfig<1>;
         auto mesh1         = UniformMesh<Config>(box, 5);
         auto mesh2         = UniformMesh<Config>(box, 3);
-        const auto u_const = make_field<double, 1>("uc",
-                                                   mesh1,
-                                                   [](const auto& coords)
-                                                   {
-                                                       return coords[0];
-                                                   });
-        auto u             = make_field<double, 1>("u",
-                                       mesh2,
-                                       [](const auto& coords)
-                                       {
-                                           return coords[0];
-                                       });
+        const auto u_const = make_field<double>("uc",
+                                                mesh1,
+                                                [](const auto& coords)
+                                                {
+                                                    return coords[0];
+                                                });
+        auto u             = make_field<double>("u",
+                                    mesh2,
+                                    [](const auto& coords)
+                                    {
+                                        return coords[0];
+                                    });
 
         u = u_const;
         EXPECT_EQ(u.name(), u_const.name());
@@ -78,18 +78,18 @@ namespace samurai
 
         auto m1             = holder(mesh1);
         auto m2             = holder(mesh2);
-        const auto u_const1 = make_field<double, 1>("uc",
-                                                    m1,
-                                                    [](const auto& coords)
-                                                    {
-                                                        return coords[0];
-                                                    });
-        auto u1             = make_field<double, 1>("u",
-                                        m2,
-                                        [](const auto& coords)
-                                        {
-                                            return coords[0];
-                                        });
+        const auto u_const1 = make_field<double>("uc",
+                                                 m1,
+                                                 [](const auto& coords)
+                                                 {
+                                                     return coords[0];
+                                                 });
+        auto u1             = make_field<double>("u",
+                                     m2,
+                                     [](const auto& coords)
+                                     {
+                                         return coords[0];
+                                     });
         u1                  = u_const1;
         EXPECT_EQ(u1.name(), u_const1.name());
         EXPECT_TRUE(compare(u1.array(), u_const1.array()));
@@ -105,7 +105,7 @@ namespace samurai
         cl[2][{0}].add_interval({4, 8});
 
         auto mesh  = MRMesh<config>(cl, 1, 2);
-        auto field = make_field<std::size_t, 1>("u", mesh);
+        auto field = make_field<std::size_t>("u", mesh);
 
         std::size_t index = 0;
         for_each_cell(mesh,
@@ -134,7 +134,7 @@ namespace samurai
         Box<double, 1> box{{0}, {1}};
         using Config = UniformConfig<1>;
         auto mesh    = UniformMesh<Config>(box, 5);
-        auto u       = make_field<double, 1>("u", mesh);
+        auto u       = make_field<double>("u", mesh);
 
         EXPECT_EQ(u.name(), "u");
         u.name() = "new_name";

--- a/tests/test_field.cpp
+++ b/tests/test_field.cpp
@@ -18,7 +18,7 @@ namespace samurai
         using Config = UniformConfig<1>;
         auto mesh    = UniformMesh<Config>(box, 3);
 
-        auto u = make_field<double>("u", mesh);
+        auto u = make_scalar_field<double>("u", mesh);
         u.fill(1.);
         using field_t = decltype(u);
         field_t ue    = 5 + u;
@@ -35,7 +35,7 @@ namespace samurai
         Box<double, 1> box{{0}, {1}};
         using Config       = UniformConfig<1>;
         auto mesh          = UniformMesh<Config>(box, 3);
-        const auto u_const = make_field<double>("uc", mesh, 1.);
+        const auto u_const = make_scalar_field<double>("uc", mesh, 1.);
 
         auto u = u_const;
         EXPECT_EQ(u.name(), u_const.name());
@@ -44,7 +44,7 @@ namespace samurai
         EXPECT_EQ(&(u.mesh()), &(u_const.mesh()));
 
         auto m              = holder(mesh);
-        const auto u_const1 = make_field<double>("uc", m, 1.);
+        const auto u_const1 = make_scalar_field<double>("uc", m, 1.);
         auto u1             = u_const1;
         EXPECT_EQ(u1.name(), u_const1.name());
         EXPECT_TRUE(compare(u1.array(), u_const1.array()));
@@ -57,18 +57,18 @@ namespace samurai
         using Config       = UniformConfig<1>;
         auto mesh1         = UniformMesh<Config>(box, 5);
         auto mesh2         = UniformMesh<Config>(box, 3);
-        const auto u_const = make_field<double>("uc",
-                                                mesh1,
-                                                [](const auto& coords)
-                                                {
-                                                    return coords[0];
-                                                });
-        auto u             = make_field<double>("u",
-                                    mesh2,
-                                    [](const auto& coords)
-                                    {
-                                        return coords[0];
-                                    });
+        const auto u_const = make_scalar_field<double>("uc",
+                                                       mesh1,
+                                                       [](const auto& coords)
+                                                       {
+                                                           return coords[0];
+                                                       });
+        auto u             = make_scalar_field<double>("u",
+                                           mesh2,
+                                           [](const auto& coords)
+                                           {
+                                               return coords[0];
+                                           });
 
         u = u_const;
         EXPECT_EQ(u.name(), u_const.name());
@@ -78,18 +78,18 @@ namespace samurai
 
         auto m1             = holder(mesh1);
         auto m2             = holder(mesh2);
-        const auto u_const1 = make_field<double>("uc",
-                                                 m1,
-                                                 [](const auto& coords)
-                                                 {
-                                                     return coords[0];
-                                                 });
-        auto u1             = make_field<double>("u",
-                                     m2,
-                                     [](const auto& coords)
-                                     {
-                                         return coords[0];
-                                     });
+        const auto u_const1 = make_scalar_field<double>("uc",
+                                                        m1,
+                                                        [](const auto& coords)
+                                                        {
+                                                            return coords[0];
+                                                        });
+        auto u1             = make_scalar_field<double>("u",
+                                            m2,
+                                            [](const auto& coords)
+                                            {
+                                                return coords[0];
+                                            });
         u1                  = u_const1;
         EXPECT_EQ(u1.name(), u_const1.name());
         EXPECT_TRUE(compare(u1.array(), u_const1.array()));
@@ -105,7 +105,7 @@ namespace samurai
         cl[2][{0}].add_interval({4, 8});
 
         auto mesh  = MRMesh<config>(cl, 1, 2);
-        auto field = make_field<std::size_t>("u", mesh);
+        auto field = make_scalar_field<std::size_t>("u", mesh);
 
         std::size_t index = 0;
         for_each_cell(mesh,
@@ -134,7 +134,7 @@ namespace samurai
         Box<double, 1> box{{0}, {1}};
         using Config = UniformConfig<1>;
         auto mesh    = UniformMesh<Config>(box, 5);
-        auto u       = make_field<double>("u", mesh);
+        auto u       = make_scalar_field<double>("u", mesh);
 
         EXPECT_EQ(u.name(), "u");
         u.name() = "new_name";

--- a/tests/test_find.cpp
+++ b/tests/test_find.cpp
@@ -22,14 +22,14 @@ namespace samurai
 
         Mesh mesh{box, min_level, max_level};
 
-        auto u = samurai::make_field<1>("u",
-                                        mesh,
-                                        [](const auto& coords)
-                                        {
-                                            const auto& x = coords(0);
-                                            const auto& y = coords(1);
-                                            return (x >= -0.8 && x <= -0.3 && y >= 0.3 && y <= 0.8) ? 1. : 0.;
-                                        });
+        auto u = samurai::make_field<double>("u",
+                                             mesh,
+                                             [](const auto& coords)
+                                             {
+                                                 const auto& x = coords(0);
+                                                 const auto& y = coords(1);
+                                                 return (x >= -0.8 && x <= -0.3 && y >= 0.3 && y <= 0.8) ? 1. : 0.;
+                                             });
 
         auto MRadaptation = samurai::make_MRAdapt(u);
         MRadaptation(1e-3, 1);

--- a/tests/test_find.cpp
+++ b/tests/test_find.cpp
@@ -22,14 +22,14 @@ namespace samurai
 
         Mesh mesh{box, min_level, max_level};
 
-        auto u = samurai::make_field<double>("u",
-                                             mesh,
-                                             [](const auto& coords)
-                                             {
-                                                 const auto& x = coords(0);
-                                                 const auto& y = coords(1);
-                                                 return (x >= -0.8 && x <= -0.3 && y >= 0.3 && y <= 0.8) ? 1. : 0.;
-                                             });
+        auto u = samurai::make_scalar_field<double>("u",
+                                                    mesh,
+                                                    [](const auto& coords)
+                                                    {
+                                                        const auto& x = coords(0);
+                                                        const auto& y = coords(1);
+                                                        return (x >= -0.8 && x <= -0.3 && y >= 0.3 && y <= 0.8) ? 1. : 0.;
+                                                    });
 
         auto MRadaptation = samurai::make_MRAdapt(u);
         MRadaptation(1e-3, 1);

--- a/tests/test_periodic.cpp
+++ b/tests/test_periodic.cpp
@@ -24,7 +24,7 @@ namespace samurai
     auto init(Mesh& mesh)
     {
         double dx = mesh.cell_length(mesh.max_level());
-        auto u    = make_field<double, 1>("u", mesh);
+        auto u    = make_field<double>("u", mesh);
         u.fill(0.);
 
         for_each_cell(mesh,
@@ -68,7 +68,7 @@ namespace samurai
         double t  = 0.;
 
         auto u    = init(mesh);
-        auto unp1 = make_field<double, 1>("unp1", mesh);
+        auto unp1 = make_field<double>("unp1", mesh);
         unp1.fill(0);
 
         auto MRadaptation = make_MRAdapt(u);

--- a/tests/test_periodic.cpp
+++ b/tests/test_periodic.cpp
@@ -24,7 +24,7 @@ namespace samurai
     auto init(Mesh& mesh)
     {
         double dx = mesh.cell_length(mesh.max_level());
-        auto u    = make_field<double>("u", mesh);
+        auto u    = make_scalar_field<double>("u", mesh);
         u.fill(0.);
 
         for_each_cell(mesh,
@@ -68,7 +68,7 @@ namespace samurai
         double t  = 0.;
 
         auto u    = init(mesh);
-        auto unp1 = make_field<double>("unp1", mesh);
+        auto unp1 = make_scalar_field<double>("unp1", mesh);
         unp1.fill(0);
 
         auto MRadaptation = make_MRAdapt(u);

--- a/tests/test_portion.cpp
+++ b/tests/test_portion.cpp
@@ -11,7 +11,7 @@ namespace samurai
     auto init(Mesh& mesh)
     {
         using mesh_id_t = typename Mesh::mesh_id_t;
-        auto u          = make_field<double>("u", mesh);
+        auto u          = make_scalar_field<double>("u", mesh);
         for_each_cell(mesh[mesh_id_t::cells],
                       [&](const auto& cell)
                       {

--- a/tests/test_portion.cpp
+++ b/tests/test_portion.cpp
@@ -11,7 +11,7 @@ namespace samurai
     auto init(Mesh& mesh)
     {
         using mesh_id_t = typename Mesh::mesh_id_t;
-        auto u          = make_field<double, 1>("u", mesh);
+        auto u          = make_field<double>("u", mesh);
         for_each_cell(mesh[mesh_id_t::cells],
                       [&](const auto& cell)
                       {

--- a/tests/test_restart.cpp
+++ b/tests/test_restart.cpp
@@ -107,12 +107,12 @@ namespace samurai
     TEST(restart, restart_field)
     {
         auto mesh = create_mesh<2>(1);
-        auto u    = make_field<double, 1>("u", mesh);
+        auto u    = make_field<double>("u", mesh);
         u.fill(1.);
         dump("mesh", mesh, u);
 
         auto mesh2 = create_mesh<2>(10);
-        auto u2    = make_field<double, 1>("u", mesh2);
+        auto u2    = make_field<double>("u", mesh2);
         load("mesh", mesh2, u2);
         EXPECT_TRUE(u == u2);
     }
@@ -120,13 +120,13 @@ namespace samurai
     TEST(restart, restart_multiple_fields)
     {
         auto mesh = create_mesh<2>(1);
-        auto u    = make_field<double, 1>("u", mesh);
+        auto u    = make_field<double>("u", mesh);
         u.fill(1.);
         auto v = make_field<int, 2>("v", mesh);
         v.fill(2);
         dump("mesh", mesh, u, v);
         auto mesh2 = create_mesh<2>(10);
-        auto u2    = make_field<double, 1>("u", mesh2);
+        auto u2    = make_field<double>("u", mesh2);
         auto v2    = make_field<int, 2>("v", mesh2);
         load("mesh", mesh2, u2, v2);
         EXPECT_TRUE(u == u2);

--- a/tests/test_restart.cpp
+++ b/tests/test_restart.cpp
@@ -107,12 +107,12 @@ namespace samurai
     TEST(restart, restart_field)
     {
         auto mesh = create_mesh<2>(1);
-        auto u    = make_field<double>("u", mesh);
+        auto u    = make_scalar_field<double>("u", mesh);
         u.fill(1.);
         dump("mesh", mesh, u);
 
         auto mesh2 = create_mesh<2>(10);
-        auto u2    = make_field<double>("u", mesh2);
+        auto u2    = make_scalar_field<double>("u", mesh2);
         load("mesh", mesh2, u2);
         EXPECT_TRUE(u == u2);
     }
@@ -120,14 +120,14 @@ namespace samurai
     TEST(restart, restart_multiple_fields)
     {
         auto mesh = create_mesh<2>(1);
-        auto u    = make_field<double>("u", mesh);
+        auto u    = make_scalar_field<double>("u", mesh);
         u.fill(1.);
-        auto v = make_field<int, 2>("v", mesh);
+        auto v = make_vector_field<int, 2>("v", mesh);
         v.fill(2);
         dump("mesh", mesh, u, v);
         auto mesh2 = create_mesh<2>(10);
-        auto u2    = make_field<double>("u", mesh2);
-        auto v2    = make_field<int, 2>("v", mesh2);
+        auto u2    = make_scalar_field<double>("u", mesh2);
+        auto v2    = make_vector_field<int, 2>("v", mesh2);
         load("mesh", mesh2, u2, v2);
         EXPECT_TRUE(u == u2);
         EXPECT_TRUE(v == v2);

--- a/tests/test_utils.cpp
+++ b/tests/test_utils.cpp
@@ -16,7 +16,7 @@ namespace samurai
         using Config = UniformConfig<1>;
         auto mesh    = UniformMesh<Config>(box, 3);
 
-        auto u = make_field<double>("u", mesh);
+        auto u = make_scalar_field<double>("u", mesh);
 
         static_assert(detail::is_field_function<decltype(5 + u)>::value);
         static_assert(detail::is_field_function<decltype(upwind(1, u))>::value);
@@ -28,8 +28,8 @@ namespace samurai
         using Config = UniformConfig<1>;
         auto mesh    = UniformMesh<Config>(box, 3);
 
-        auto u1 = make_field<int>("u", mesh);
-        auto u2 = make_field<double, 3>("u", mesh);
+        auto u1 = make_scalar_field<int>("u", mesh);
+        auto u2 = make_vector_field<double, 3>("u", mesh);
 
         static_assert(detail::compute_n_comp<decltype(u1), decltype(u2)>() == 4);
 

--- a/tests/test_utils.cpp
+++ b/tests/test_utils.cpp
@@ -16,7 +16,7 @@ namespace samurai
         using Config = UniformConfig<1>;
         auto mesh    = UniformMesh<Config>(box, 3);
 
-        auto u = make_field<double, 1>("u", mesh);
+        auto u = make_field<double>("u", mesh);
 
         static_assert(detail::is_field_function<decltype(5 + u)>::value);
         static_assert(detail::is_field_function<decltype(upwind(1, u))>::value);
@@ -28,7 +28,7 @@ namespace samurai
         using Config = UniformConfig<1>;
         auto mesh    = UniformMesh<Config>(box, 3);
 
-        auto u1 = make_field<int, 1>("u", mesh);
+        auto u1 = make_field<int>("u", mesh);
         auto u2 = make_field<double, 3>("u", mesh);
 
         static_assert(detail::compute_n_comp<decltype(u1), decltype(u2)>() == 4);


### PR DESCRIPTION
## Description
<!-- A clear and concise description of what you have done in this PR. -->
* Changed behavior of `samurai::Field` with only one component to access to values with `field[cell][0]` like a `samurai::Field` with multi-components.
* Renamed `samurai::Field` into `samurai::VectorField`.
* Added a `samurai::ScalarField` to keep previous behavior with one component.
* Added `samurai::make_vector_field` and `samurai::make_scalar_field` function.
* Make deprecated `samurai::make_field`.

## Code of Conduct
By submitting this PR, you agree to follow our [Code of Conduct](https://github.com/hpc-maths/samurai/blob/master/docs/CODE_OF_CONDUCT.md)
- [x] I agree to follow this project's Code of Conduct
