### PR TITLE
fix: Fix `enable_max_level_flux` for prediction 0

### DIFF
--- a/include/samurai/schemes/fv/flux_based/flux_based_scheme__nonlin.hpp
+++ b/include/samurai/schemes/fv/flux_based/flux_based_scheme__nonlin.hpp
@@ -176,9 +176,16 @@ namespace samurai
                                     const input_field_t& field,
                                     std::vector<StencilValues<cfg>>& stencil_values_list)
         {
-            if constexpr (!enable_max_level_flux || mesh_t::config::prediction_order == 0)
+            if constexpr (!enable_max_level_flux)
             {
                 copy_stencil_values(field, cells, stencil_values_list[0]);
+            }
+            else if constexpr (mesh_t::config::prediction_order == 0 && stencil_size <= 4)
+            {
+                for (std::size_t fine_flux_index = 0; fine_flux_index < flux_params.n_fine_fluxes; ++fine_flux_index)
+                {
+                    copy_stencil_values(field, cells, stencil_values_list[fine_flux_index]);
+                }
             }
             else
             {


### PR DESCRIPTION
## Related issue
When `prediction_order = 0`, the computation of fluxes at the finest level failed.

## How has this been tested?
Tested on two-scale-capillarity code.

## Code of Conduct
By submitting this PR, you agree to follow our [Code of Conduct](https://github.com/hpc-maths/samurai/blob/master/docs/CODE_OF_CONDUCT.md)
- [x] I agree to follow this project's Code of Conduct
