### PR TITLE
perf: [WIP] Avoid useless MPI send

### DIFF
--- a/include/samurai/algorithm.hpp
+++ b/include/samurai/algorithm.hpp
@@ -59,7 +59,7 @@ namespace samurai
     }
 
     template <class Mesh, class Func>
-    inline void for_each_level(Mesh& mesh, Func&& f, bool include_empty_levels = false)
+    inline void for_each_level(const Mesh& mesh, Func&& f, bool include_empty_levels = false)
     {
         using mesh_id_t = typename Mesh::mesh_id_t;
         for_each_level(mesh[mesh_id_t::cells], std::forward<Func>(f), include_empty_levels);

--- a/include/samurai/cell_array.hpp
+++ b/include/samurai/cell_array.hpp
@@ -15,6 +15,7 @@
 #include "utils.hpp"
 
 #ifdef SAMURAI_WITH_MPI
+#include <boost/serialization/array.hpp>
 #include <boost/serialization/serialization.hpp>
 #include <boost/serialization/vector.hpp>
 #endif

--- a/include/samurai/field.hpp
+++ b/include/samurai/field.hpp
@@ -729,14 +729,14 @@ namespace samurai
     inline auto Field<mesh_t, value_t, n_comp_, SOA>::begin() -> iterator
     {
         using mesh_id_t = typename mesh_t::mesh_id_t;
-        return iterator(this, this->mesh()[mesh_id_t::cells].begin());
+        return iterator(this, this->mesh()[mesh_id_t::cells].cbegin());
     }
 
     template <class mesh_t, class value_t, std::size_t n_comp_, bool SOA>
     inline auto Field<mesh_t, value_t, n_comp_, SOA>::end() -> iterator
     {
         using mesh_id_t = typename mesh_t::mesh_id_t;
-        return iterator(this, this->mesh()[mesh_id_t::cells].end());
+        return iterator(this, this->mesh()[mesh_id_t::cells].cend());
     }
 
     template <class mesh_t, class value_t, std::size_t n_comp_, bool SOA>

--- a/include/samurai/mesh.hpp
+++ b/include/samurai/mesh.hpp
@@ -929,7 +929,7 @@ namespace samurai
             for_each_meshinterval(m_domain,
                                   [&](auto mi)
                                   {
-                                      for (auto i = mi.i.start; i < mi.i.end; ++i)
+                                      for (auto i = static_cast<std::size_t>(mi.i.start); i < static_cast<std::size_t>(mi.i.end); ++i)
                                       {
                                           if (i >= subdomain_start && i < subdomain_end)
                                           {

--- a/include/samurai/mr/mesh.hpp
+++ b/include/samurai/mr/mesh.hpp
@@ -342,8 +342,8 @@ namespace samurai
                 this->cells()[mesh_id_t::proj_cells][level]    = lcl_proj;
             }
             //            this->update_mesh_neighbour();
-            this->update_mesh_neighbour_all_cells();  //
-            this->update_mesh_neighbour_proj_cells(); //
+            this->update_mesh_neighbour_all_cells(); //
+                                                     //            this->update_mesh_neighbour_proj_cells(); //
         }
         else
         {

--- a/include/samurai/mr/mesh.hpp
+++ b/include/samurai/mr/mesh.hpp
@@ -226,7 +226,9 @@ namespace samurai
             }
             this->cells()[mesh_id_t::all_cells] = {cell_list, false};
 
-            this->update_mesh_neighbour();
+            // this->update_mesh_neighbour();
+            this->update_mesh_neighbour_cells_and_ghosts();
+            this->update_mesh_neighbour_reference();
 
             for (auto& neighbour : this->mpi_neighbourhood())
             {
@@ -339,7 +341,9 @@ namespace samurai
                 this->cells()[mesh_id_t::all_cells][level + 1] = lcl;
                 this->cells()[mesh_id_t::proj_cells][level]    = lcl_proj;
             }
-            this->update_mesh_neighbour();
+            //            this->update_mesh_neighbour();
+            this->update_mesh_neighbour_all_cells();  //
+            this->update_mesh_neighbour_proj_cells(); //
         }
         else
         {

--- a/include/samurai/mr/mesh.hpp
+++ b/include/samurai/mr/mesh.hpp
@@ -342,6 +342,7 @@ namespace samurai
                 this->cells()[mesh_id_t::proj_cells][level]    = lcl_proj;
             }
             //            this->update_mesh_neighbour();
+            this->update_mesh_neighbour_subdomain();
             this->update_mesh_neighbour_all_cells(); //
                                                      //            this->update_mesh_neighbour_proj_cells(); //
         }


### PR DESCRIPTION

## Description

!!! EXPERIMENTAL !!!

In MPI, we send unnecessary `mesh_id_t`s. 
This PR just avoid these sends. 
It enables a gain of around 10% in comparison with the current PR. 


I don't know yet if there is an issue related to this PR.

## Related issue


## How has this been tested?
On advection-2d


