### PR TITLE
build: update googletest and benchmark versions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,6 @@ if(CMAKE_VERSION VERSION_GREATER_EQUAL "3.24.0")
   cmake_policy(SET CMP0135 NEW)
 endif()
 
-
 # Add project_options v0.41.0
 # https://github.com/aminya/project_options
 include(FetchContent)

--- a/cmake/addGoogleBench.cmake
+++ b/cmake/addGoogleBench.cmake
@@ -1,11 +1,8 @@
 include(FetchContent)
 FetchContent_Declare(googlebench
     GIT_REPOSITORY      https://github.com/google/benchmark.git
-    GIT_TAG             v1.8.4)
+    GIT_TAG             v1.9.2)
 FetchContent_GetProperties(googlebench)
 if(NOT googlebench_POPULATED)
-    FetchContent_Populate(googlebench)
-    set(CMAKE_SUPPRESS_DEVELOPER_WARNINGS 1 CACHE BOOL "")
-    add_subdirectory(${googlebench_SOURCE_DIR} ${googlebench_BINARY_DIR} EXCLUDE_FROM_ALL)
-    unset(CMAKE_SUPPRESS_DEVELOPER_WARNINGS)
+    FetchContent_MakeAvailable(googlebench)
 endif()

--- a/cmake/addGoogleTest.cmake
+++ b/cmake/addGoogleTest.cmake
@@ -1,11 +1,8 @@
 include(FetchContent)
 FetchContent_Declare(googletest
     GIT_REPOSITORY      https://github.com/google/googletest.git
-    GIT_TAG             release-1.10.0)
+    GIT_TAG             v1.16.0)
 FetchContent_GetProperties(googletest)
 if(NOT googletest_POPULATED)
-    FetchContent_Populate(googletest)
-    set(CMAKE_SUPPRESS_DEVELOPER_WARNINGS 1 CACHE BOOL "")
-    add_subdirectory(${googletest_SOURCE_DIR} ${googletest_BINARY_DIR} EXCLUDE_FROM_ALL)
-    unset(CMAKE_SUPPRESS_DEVELOPER_WARNINGS)
+    FetchContent_MakeAvailable(googletest)
 endif()

--- a/demos/from_obj/CMakeLists.txt
+++ b/demos/from_obj/CMakeLists.txt
@@ -1,6 +1,7 @@
-find_package(CGAL)
+option(WITH_CGAL "Activate cgal demos" OFF)
 
-if(CGAL_FOUND)
+if(WITH_CGAL)
+    find_package(CGAL)
     find_package(Eigen3 3.1.0 REQUIRED) # (3.1.0 or greater)
     include(CGAL_Eigen3_support)
 


### PR DESCRIPTION
## Description
This PR updates various dependencies used in CMake.

- googletest : v1.16.0
- google benchmark : v1.9.2

## Related issue
CMake build with the version 4.0 is broken without these modifications.

## How has this been tested?
The new CMake version is used in th CI.

## Code of Conduct
By submitting this PR, you agree to follow our [Code of Conduct](https://github.com/hpc-maths/samurai/blob/master/docs/CODE_OF_CONDUCT.md)
- [x] I agree to follow this project's Code of Conduct
