### PR TITLE
perf: Avoid useless MPI send

### DIFF
--- a/include/samurai/algorithm.hpp
+++ b/include/samurai/algorithm.hpp
@@ -59,7 +59,7 @@ namespace samurai
     }
 
     template <class Mesh, class Func>
-    inline void for_each_level(Mesh& mesh, Func&& f, bool include_empty_levels = false)
+    inline void for_each_level(const Mesh& mesh, Func&& f, bool include_empty_levels = false)
     {
         using mesh_id_t = typename Mesh::mesh_id_t;
         for_each_level(mesh[mesh_id_t::cells], std::forward<Func>(f), include_empty_levels);

--- a/include/samurai/field.hpp
+++ b/include/samurai/field.hpp
@@ -1189,14 +1189,14 @@ namespace samurai
     {
         using mesh_id_t = typename mesh_t::mesh_id_t;
         // add comment : the CI is buggy ahahaha
-        return iterator(this, std::as_const(this->mesh()[mesh_id_t::cells]).begin());
+        return iterator(this, this->mesh()[mesh_id_t::cells].cbegin());
     }
 
     template <class mesh_t, class value_t>
     inline auto ScalarField<mesh_t, value_t>::end() -> iterator
     {
         using mesh_id_t = typename mesh_t::mesh_id_t;
-        return iterator(this, std::as_const(this->mesh()[mesh_id_t::cells]).end());
+        return iterator(this, this->mesh()[mesh_id_t::cells]).cend();
     }
 
     template <class mesh_t, class value_t>

--- a/include/samurai/field.hpp
+++ b/include/samurai/field.hpp
@@ -1189,14 +1189,14 @@ namespace samurai
     {
         using mesh_id_t = typename mesh_t::mesh_id_t;
         // add comment : the CI is buggy ahahaha
-        return iterator(this, this->mesh()[mesh_id_t::cells].cbegin());
+        return iterator(this, this->mesh()[mesh_id_t::cells]).cbegin();
     }
 
     template <class mesh_t, class value_t>
     inline auto ScalarField<mesh_t, value_t>::end() -> iterator
     {
         using mesh_id_t = typename mesh_t::mesh_id_t;
-        return iterator(this, this->mesh()[mesh_id_t::cells]).cend();
+        return iterator(this, this->mesh()[mesh_id_t::cells].cend());
     }
 
     template <class mesh_t, class value_t>

--- a/include/samurai/field.hpp
+++ b/include/samurai/field.hpp
@@ -1188,14 +1188,14 @@ namespace samurai
     inline auto ScalarField<mesh_t, value_t>::begin() -> iterator
     {
         using mesh_id_t = typename mesh_t::mesh_id_t;
-        return iterator(this, this->mesh()[mesh_id_t::cells].begin());
+        return iterator(this, std::as_const(this->mesh()[mesh_id_t::cells]).begin());
     }
 
     template <class mesh_t, class value_t>
     inline auto ScalarField<mesh_t, value_t>::end() -> iterator
     {
         using mesh_id_t = typename mesh_t::mesh_id_t;
-        return iterator(this, this->mesh()[mesh_id_t::cells].end());
+        return iterator(this, std::as_const(this->mesh()[mesh_id_t::cells]).end());
     }
 
     template <class mesh_t, class value_t>

--- a/include/samurai/field.hpp
+++ b/include/samurai/field.hpp
@@ -1188,7 +1188,6 @@ namespace samurai
     inline auto ScalarField<mesh_t, value_t>::begin() -> iterator
     {
         using mesh_id_t = typename mesh_t::mesh_id_t;
-        // add comment : the CI is buggy ahahaha
         return iterator(this, this->mesh()[mesh_id_t::cells].cbegin());
     }
 

--- a/include/samurai/field.hpp
+++ b/include/samurai/field.hpp
@@ -1189,7 +1189,7 @@ namespace samurai
     {
         using mesh_id_t = typename mesh_t::mesh_id_t;
         // add comment : the CI is buggy ahahaha
-        return iterator(this, this->mesh()[mesh_id_t::cells]).cbegin();
+        return iterator(this, this->mesh()[mesh_id_t::cells].cbegin());
     }
 
     template <class mesh_t, class value_t>

--- a/include/samurai/field.hpp
+++ b/include/samurai/field.hpp
@@ -1188,6 +1188,7 @@ namespace samurai
     inline auto ScalarField<mesh_t, value_t>::begin() -> iterator
     {
         using mesh_id_t = typename mesh_t::mesh_id_t;
+        // add comment : the CI is buggy ahahaha
         return iterator(this, std::as_const(this->mesh()[mesh_id_t::cells]).begin());
     }
 

--- a/include/samurai/field.hpp
+++ b/include/samurai/field.hpp
@@ -578,14 +578,14 @@ namespace samurai
     inline auto VectorField<mesh_t, value_t, n_comp_, SOA>::begin() -> iterator
     {
         using mesh_id_t = typename mesh_t::mesh_id_t;
-        return iterator(this, this->mesh()[mesh_id_t::cells].begin());
+        return iterator(this, this->mesh()[mesh_id_t::cells].cbegin());
     }
 
     template <class mesh_t, class value_t, std::size_t n_comp_, bool SOA>
     inline auto VectorField<mesh_t, value_t, n_comp_, SOA>::end() -> iterator
     {
         using mesh_id_t = typename mesh_t::mesh_id_t;
-        return iterator(this, this->mesh()[mesh_id_t::cells].end());
+        return iterator(this, this->mesh()[mesh_id_t::cells].cend());
     }
 
     template <class mesh_t, class value_t, std::size_t n_comp_, bool SOA>

--- a/include/samurai/mesh.hpp
+++ b/include/samurai/mesh.hpp
@@ -89,6 +89,7 @@ namespace samurai
         std::size_t nb_cells(std::size_t level, mesh_id_t mesh_id = mesh_id_t::reference) const;
 
         const ca_type& operator[](mesh_id_t mesh_id) const;
+        ca_type& operator[](mesh_id_t mesh_id);
 
         std::size_t max_level() const;
         std::size_t& max_level();
@@ -409,6 +410,12 @@ namespace samurai
 
     template <class D, class Config>
     inline auto Mesh_base<D, Config>::operator[](mesh_id_t mesh_id) const -> const ca_type&
+    {
+        return m_cells[mesh_id];
+    }
+
+    template <class D, class Config>
+    inline auto Mesh_base<D, Config>::operator[](mesh_id_t mesh_id) -> ca_type&
     {
         return m_cells[mesh_id];
     }

--- a/include/samurai/mesh.hpp
+++ b/include/samurai/mesh.hpp
@@ -135,7 +135,7 @@ namespace samurai
 
         void update_mesh_neighbour();
         void update_neighbour_subdomain();
-        void update_meshid_neighbour(typename Mesh_base<D, Config>::mesh_id_t mesh_id);
+        void update_meshid_neighbour(const typename Mesh_base<D, Config>::mesh_id_t& mesh_id);
 
         void to_stream(std::ostream& os) const;
 
@@ -688,7 +688,7 @@ namespace samurai
 
     // Modified function definition
     template <class D, class Config>
-    inline void Mesh_base<D, Config>::update_meshid_neighbour(typename Mesh_base<D, Config>::mesh_id_t mesh_id)
+    inline void Mesh_base<D, Config>::update_meshid_neighbour(const typename Mesh_base<D, Config>::mesh_id_t& mesh_id)
     {
 #ifdef SAMURAI_WITH_MPI
         mpi::communicator world;

--- a/include/samurai/mesh.hpp
+++ b/include/samurai/mesh.hpp
@@ -135,7 +135,7 @@ namespace samurai
 
         void update_mesh_neighbour();
         void update_neighbour_subdomain();
-        void update_meshid_neighbour(const typename Mesh_base<D, Config>::mesh_id_t& mesh_id);
+        void update_meshid_neighbour(const mesh_id_t& mesh_id);
 
         void to_stream(std::ostream& os) const;
 
@@ -688,7 +688,7 @@ namespace samurai
 
     // Modified function definition
     template <class D, class Config>
-    inline void Mesh_base<D, Config>::update_meshid_neighbour(const typename Mesh_base<D, Config>::mesh_id_t& mesh_id)
+    inline void Mesh_base<D, Config>::update_meshid_neighbour(const mesh_id_t& mesh_id)
     {
 #ifdef SAMURAI_WITH_MPI
         mpi::communicator world;

--- a/include/samurai/mr/mesh.hpp
+++ b/include/samurai/mr/mesh.hpp
@@ -227,9 +227,10 @@ namespace samurai
             this->cells()[mesh_id_t::all_cells] = {cell_list, false};
 
             // this->update_mesh_neighbour();
-            update_meshid_neighbour<mesh_id_t::cells_and_ghosts>() update_meshid_neighbour<mesh_id_t::reference>()
+            update_meshid_neighbour<mesh_id_t::cells_and_ghosts>();
+            update_meshid_neighbour<mesh_id_t::reference>();
 
-                for (auto& neighbour : this->mpi_neighbourhood())
+            for (auto& neighbour : this->mpi_neighbourhood())
             {
                 for (std::size_t level = 0; level <= max_level; ++level)
                 {
@@ -342,7 +343,7 @@ namespace samurai
             }
             // this->update_mesh_neighbour();
             this->update_neighbour_subdomain();
-            update_meshid_neighbour<mesh_id_t::all_cells>()
+            update_meshid_neighbour<mesh_id_t::all_cells>();
         }
         else
         {

--- a/include/samurai/mr/mesh.hpp
+++ b/include/samurai/mr/mesh.hpp
@@ -227,8 +227,6 @@ namespace samurai
             this->cells()[mesh_id_t::all_cells] = {cell_list, false};
 
             // this->update_mesh_neighbour();
-            //            this->template update_meshid_neighbour<mesh_id_t::cells_and_ghosts>();
-            //            this->template update_meshid_neighbour<mesh_id_t::reference>();
             this->update_meshid_neighbour(mesh_id_t::cells_and_ghosts);
             this->update_meshid_neighbour(mesh_id_t::reference);
 

--- a/include/samurai/mr/mesh.hpp
+++ b/include/samurai/mr/mesh.hpp
@@ -226,7 +226,6 @@ namespace samurai
             }
             this->cells()[mesh_id_t::all_cells] = {cell_list, false};
 
-            // this->update_mesh_neighbour();
             this->update_meshid_neighbour(mesh_id_t::cells_and_ghosts);
             this->update_meshid_neighbour(mesh_id_t::reference);
 
@@ -341,15 +340,16 @@ namespace samurai
                 this->cells()[mesh_id_t::all_cells][level + 1] = lcl;
                 this->cells()[mesh_id_t::proj_cells][level]    = lcl_proj;
             }
-            // this->update_mesh_neighbour();
             this->update_neighbour_subdomain();
             this->update_meshid_neighbour(mesh_id_t::all_cells);
         }
         else
         {
             this->cells()[mesh_id_t::all_cells] = {cell_list, false};
-            // TODO : what to send here ?
-            this->update_mesh_neighbour();
+            // TODO : I think we do not want to update subdomain in this case, it remains the same iteration after iteration.
+            this > update_neighbour_subdomain();
+            this->update_meshid_neighbour(mesh_id_t::cells_and_ghosts);
+            this->update_meshid_neighbour(mesh_id_t::reference);
         }
     }
 

--- a/include/samurai/mr/mesh.hpp
+++ b/include/samurai/mr/mesh.hpp
@@ -227,8 +227,8 @@ namespace samurai
             this->cells()[mesh_id_t::all_cells] = {cell_list, false};
 
             // this->update_mesh_neighbour();
-            update_meshid_neighbour<mesh_id_t::cells_and_ghosts>();
-            update_meshid_neighbour<mesh_id_t::reference>();
+            this->template update_meshid_neighbour<mesh_id_t::cells_and_ghosts>();
+            this->template update_meshid_neighbour<mesh_id_t::reference>();
 
             for (auto& neighbour : this->mpi_neighbourhood())
             {
@@ -343,7 +343,7 @@ namespace samurai
             }
             // this->update_mesh_neighbour();
             this->update_neighbour_subdomain();
-            update_meshid_neighbour<mesh_id_t::all_cells>();
+            this->template update_meshid_neighbour<mesh_id_t::all_cells>();
         }
         else
         {

--- a/include/samurai/mr/mesh.hpp
+++ b/include/samurai/mr/mesh.hpp
@@ -227,10 +227,9 @@ namespace samurai
             this->cells()[mesh_id_t::all_cells] = {cell_list, false};
 
             // this->update_mesh_neighbour();
-            this->update_neighbour_cells_and_ghosts();
-            this->update_neighbour_reference();
+            update_meshid_neighbour<mesh_id_t::cells_and_ghosts>() update_meshid_neighbour<mesh_id_t::reference>()
 
-            for (auto& neighbour : this->mpi_neighbourhood())
+                for (auto& neighbour : this->mpi_neighbourhood())
             {
                 for (std::size_t level = 0; level <= max_level; ++level)
                 {
@@ -343,7 +342,7 @@ namespace samurai
             }
             // this->update_mesh_neighbour();
             this->update_neighbour_subdomain();
-            this->update_neighbour_all_cells();
+            update_meshid_neighbour<mesh_id_t::all_cells>()
         }
         else
         {

--- a/include/samurai/mr/mesh.hpp
+++ b/include/samurai/mr/mesh.hpp
@@ -347,7 +347,7 @@ namespace samurai
         {
             this->cells()[mesh_id_t::all_cells] = {cell_list, false};
             // TODO : I think we do not want to update subdomain in this case, it remains the same iteration after iteration.
-            this > update_neighbour_subdomain();
+            this->update_neighbour_subdomain();
             this->update_meshid_neighbour(mesh_id_t::cells_and_ghosts);
             this->update_meshid_neighbour(mesh_id_t::reference);
         }

--- a/include/samurai/mr/mesh.hpp
+++ b/include/samurai/mr/mesh.hpp
@@ -227,8 +227,10 @@ namespace samurai
             this->cells()[mesh_id_t::all_cells] = {cell_list, false};
 
             // this->update_mesh_neighbour();
-            this->template update_meshid_neighbour<mesh_id_t::cells_and_ghosts>();
-            this->template update_meshid_neighbour<mesh_id_t::reference>();
+            //            this->template update_meshid_neighbour<mesh_id_t::cells_and_ghosts>();
+            //            this->template update_meshid_neighbour<mesh_id_t::reference>();
+            this->update_meshid_neighbour(mesh_id_t::cells_and_ghosts);
+            this->update_meshid_neighbour(mesh_id_t::reference);
 
             for (auto& neighbour : this->mpi_neighbourhood())
             {
@@ -343,7 +345,7 @@ namespace samurai
             }
             // this->update_mesh_neighbour();
             this->update_neighbour_subdomain();
-            this->template update_meshid_neighbour<mesh_id_t::all_cells>();
+            this->update_meshid_neighbour(mesh_id_t::all_cells);
         }
         else
         {

--- a/include/samurai/mr/mesh.hpp
+++ b/include/samurai/mr/mesh.hpp
@@ -226,7 +226,9 @@ namespace samurai
             }
             this->cells()[mesh_id_t::all_cells] = {cell_list, false};
 
-            this->update_mesh_neighbour();
+            // this->update_mesh_neighbour();
+            this->update_neighbour_cells_and_ghosts();
+            this->update_neighbour_reference();
 
             for (auto& neighbour : this->mpi_neighbourhood())
             {
@@ -339,11 +341,14 @@ namespace samurai
                 this->cells()[mesh_id_t::all_cells][level + 1] = lcl;
                 this->cells()[mesh_id_t::proj_cells][level]    = lcl_proj;
             }
-            this->update_mesh_neighbour();
+            // this->update_mesh_neighbour();
+            this->update_neighbour_subdomain();
+            this->update_neighbour_all_cells();
         }
         else
         {
             this->cells()[mesh_id_t::all_cells] = {cell_list, false};
+            // TODO : what to send here ?
             this->update_mesh_neighbour();
         }
     }


### PR DESCRIPTION
## Description

**This PR should be verified, do not merge without validation**

In MPI, we send unnecessary mesh_id_ts.
This PR just avoid these sends.
It enables in some cases a gain of around 10% in comparison with the current PR.

This PR do not reconstruct the local mesh. This has to be done in another PR. 

## TODO:
- There are some locations that continues to use `update_neighbour_mesh` at the `Mesh_base` constructor , I may have to replace them
- I suggest (Not in this PR) to rename `update_mesh_neighbour` by `update_neighbour_mesh`, or `update_neighbour_meshid` by `update_meshid_neighbour` but it seems to be less clear for me. 
- I may factorize `update_meshid` and `update_subdomain` to send arbitrarily a n `m_cells[id]` or a `m_subdomain`. The code could be unclear 




## Tasks
- [x] I have installed [pre-commit](https://pre-commit.com/) locally and use it to validate my commits.
- [x] The PR title follows the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) convention.
      Available tags: 'build', 'chore', 'ci', 'docs', 'feat', 'fix', 'perf', 'refactor', 'revert', 'style', 'test'
- [x] This new PR is documented.
- [x] This new PR is tested.



## Code of Conduct
By submitting this PR, you agree to follow our [Code of Conduct](https://github.com/hpc-maths/samurai/blob/master/docs/CODE_OF_CONDUCT.md)
- [x] I agree to follow this project's Code of Conduct
