### PR TITLE
fix: enforce xtensor version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -129,11 +129,17 @@ if(SAMURAI_FIELD_CONTAINER MATCHES xtensor)
   message(STATUS "Using xtensor as field container")
   list(APPEND DEPENDENCIES_CONFIGURED xtensor)
   find_package(xtensor CONFIG REQUIRED)
+
+  if (xtensor_VERSION VERSION_GREATER_EQUAL "0.26.0")
+    message(FATAL_ERROR "xtensor version ${xtensor_VERSION} is too new. Maximum allowed version is 0.25.")
+  endif()
+
   target_link_system_libraries(
     samurai
     INTERFACE
     xtensor
   )
+
 endif()
 if(SAMURAI_FIELD_CONTAINER MATCHES eigen3)
   message(STATUS "Using Eigen3 as field container")

--- a/conda/environment.yml
+++ b/conda/environment.yml
@@ -4,7 +4,7 @@ channels:
 dependencies:
   - cmake
   - ninja
-  - xtensor
+  - xtensor<0.26
   - highfive
   - fmt
   - pugixml

--- a/conda/mpi-environment.yml
+++ b/conda/mpi-environment.yml
@@ -4,7 +4,7 @@ channels:
 dependencies:
   - cmake
   - ninja
-  - xtensor
+  - xtensor<0.26
   - highfive
   - fmt
   - pugixml


### PR DESCRIPTION
## Description

	-	Due to factoring, xtensor@0.26 is no longer compatible with samurai

## Related issue
Compilation failed with the newest `xtensor@0.26` version

## Code of Conduct
By submitting this PR, you agree to follow our [Code of Conduct](https://github.com/hpc-maths/samurai/blob/master/docs/CODE_OF_CONDUCT.md)
- [x] I agree to follow this project's Code of Conduct
