### PR TITLE
feat: LevelCellArray with origin point

### DIFF
--- a/include/samurai/level_cell_array.hpp
+++ b/include/samurai/level_cell_array.hpp
@@ -102,6 +102,11 @@ namespace samurai
                        const Box<double, dim>& box,
                        double approx_box_tol = default_approx_box_tol,
                        double scaling_factor = 0);
+        LevelCellArray(std::size_t level,
+                       const Box<double, dim>& box,
+                       const coords_t& origin_point,
+                       double approx_box_tol,
+                       double scaling_factor);
         LevelCellArray(std::size_t level);
         LevelCellArray(std::size_t level, const coords_t& origin_point, double scaling_factor);
 
@@ -180,6 +185,9 @@ namespace samurai
         auto max_indices() const;
         auto minmax_indices() const;
 
+        coords_t min_corner() const;
+        coords_t max_corner() const;
+
         auto& origin_point() const;
         void set_origin_point(const coords_t& origin_point);
 
@@ -219,6 +227,7 @@ namespace samurai
                                        std::integral_constant<std::size_t, 0>);
 
         void init_from_box(const Box<value_t, dim>& box);
+        void init_from_box(const Box<double, dim>& box, const coords_t& origin_point, double approx_box_tol, double scaling_factor);
 
         std::array<std::vector<interval_t>, dim> m_cells;        ///< All intervals in every direction
         std::array<std::vector<std::size_t>, dim - 1> m_offsets; ///< Offsets in interval list for each dim >
@@ -359,24 +368,18 @@ namespace samurai
                                                           double scaling_factor)
         : m_level(level)
     {
-        using box_t   = Box<value_t, dim>;
-        using point_t = typename box_t::point_t;
+        init_from_box(box, box.min_corner(), approx_box_tol, scaling_factor);
+    }
 
-        assert(approx_box_tol > 0 || scaling_factor > 0);
-
-        // The computational domain is an approximation of the desired box.
-        // If `scaling_factor` is given (i.e. > 0), we take it;
-        // otherwise we choose the scaling factor dynamically in order to approximate the desired box
-        // up to the tolerance `approx_box_tol`.
-
-        m_origin_point   = box.min_corner();
-        auto approx_box  = approximate_box(box, approx_box_tol, scaling_factor);
-        m_scaling_factor = scaling_factor;
-
-        point_t start_pt;
-        start_pt.fill(0);
-        point_t end_pt = approx_box.length() / cell_length();
-        init_from_box(box_t{start_pt, end_pt});
+    template <std::size_t Dim, class TInterval>
+    inline LevelCellArray<Dim, TInterval>::LevelCellArray(std::size_t level,
+                                                          const Box<double, dim>& box,
+                                                          const coords_t& origin_point,
+                                                          double approx_box_tol,
+                                                          double scaling_factor)
+        : m_level(level)
+    {
+        init_from_box(box, origin_point, approx_box_tol, scaling_factor);
     }
 
     template <std::size_t Dim, class TInterval>
@@ -833,6 +836,39 @@ namespace samurai
     }
 
     template <std::size_t Dim, class TInterval>
+    inline auto LevelCellArray<Dim, TInterval>::min_corner() const -> coords_t
+    {
+        typename cell_t::indices_t index;
+
+        auto it = this->cbegin();
+
+        index[0] = it->start;
+        for (std::size_t d = 0; d < dim - 1; ++d)
+        {
+            index[d + 1] = it.index()[d];
+        }
+        cell_t min_corner_cell{m_origin_point, m_scaling_factor, m_level, index, it->index};
+        return min_corner_cell.corner();
+    }
+
+    template <std::size_t Dim, class TInterval>
+    inline auto LevelCellArray<Dim, TInterval>::max_corner() const -> coords_t
+    {
+        typename cell_t::indices_t index;
+
+        auto it = this->cend();
+        --it;
+
+        index[0] = it->end - 1;
+        for (std::size_t d = 0; d < dim - 1; ++d)
+        {
+            index[d + 1] = it.index()[d];
+        }
+        cell_t max_corner_cell{m_origin_point, m_scaling_factor, m_level, index, it->index + it->end - 1};
+        return max_corner_cell.corner() + max_corner_cell.length;
+    }
+
+    template <std::size_t Dim, class TInterval>
     inline auto& LevelCellArray<Dim, TInterval>::origin_point() const
     {
         return m_origin_point;
@@ -985,6 +1021,42 @@ namespace samurai
         {
             m_cells[0][i] = {start_pt[0], end_pt[0], static_cast<index_t>(i * dimensions[0]) - start_pt[0]};
         }
+    }
+
+    template <std::size_t Dim, class TInterval>
+    void LevelCellArray<Dim, TInterval>::init_from_box(const Box<double, dim>& box,
+                                                       const coords_t& origin_point,
+                                                       double approx_box_tol,
+                                                       double scaling_factor)
+    {
+        using index_box_t = Box<value_t, dim>;
+        using point_t     = typename index_box_t::point_t;
+
+        assert(approx_box_tol > 0 || scaling_factor > 0);
+
+        m_origin_point = origin_point;
+
+        // The computational domain is an approximation of the desired box.
+        // If `scaling_factor` is given (i.e. > 0), we take it;
+        // otherwise we choose the scaling factor dynamically in order to approximate the desired box
+        // up to the tolerance `approx_box_tol`.
+
+        auto approx_box = approximate_box(box, approx_box_tol, scaling_factor);
+
+        const double warning_tol = 0.5;
+        if (scaling_factor > 0 && xt::any(xt::abs(approx_box.length() - box.length()) >= warning_tol * box.length()))
+        {
+            std::cerr << "Warning: the box " << box << " is poorly approximated by " << approx_box << ". ";
+            std::cerr << "This is due to a too large scaling factor (" << scaling_factor
+                      << "). Choose a smaller value for a better approximation." << std::endl;
+        }
+        m_scaling_factor = scaling_factor;
+
+        auto shift_origin = (approx_box.min_corner() - m_origin_point);
+
+        point_t start_pt = shift_origin / cell_length();
+        point_t end_pt   = (shift_origin + approx_box.length()) / cell_length();
+        init_from_box(index_box_t{start_pt, end_pt});
     }
 
     template <std::size_t Dim, class TInterval>

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -17,6 +17,7 @@ set(SAMURAI_TESTS
     test_cell.cpp
     test_cell_array.cpp
     test_cell_list.cpp
+    test_domain_with_hole.cpp
     test_field.cpp
     test_find.cpp
     test_for_each.cpp

--- a/tests/test_domain_with_hole.cpp
+++ b/tests/test_domain_with_hole.cpp
@@ -20,9 +20,6 @@ namespace samurai
         return Mesh(box, level, level);
     }
 
-    /**
-     * Tests if the scaling factor corresponds to length of the domain.
-     */
     TEST(domain_with_hole, substract_box)
     {
         static constexpr std::size_t dim = 2;

--- a/tests/test_domain_with_hole.cpp
+++ b/tests/test_domain_with_hole.cpp
@@ -1,0 +1,62 @@
+#include <gtest/gtest.h>
+#include <samurai/mr/mesh.hpp>
+#include <samurai/schemes/fv.hpp>
+
+namespace samurai
+{
+    template <std::size_t dim>
+    auto create_mesh(double box_boundary, std::size_t level)
+    {
+        using Config  = samurai::MRConfig<dim>;
+        using Mesh    = samurai::MRMesh<Config>;
+        using Box     = samurai::Box<double, dim>;
+        using point_t = typename Box::point_t;
+
+        point_t box_corner1, box_corner2;
+        box_corner1.fill(0);
+        box_corner2.fill(box_boundary);
+        Box box(box_corner1, box_corner2);
+
+        return Mesh(box, level, level);
+    }
+
+    /**
+     * Tests if the scaling factor corresponds to length of the domain.
+     */
+    TEST(domain_with_hole, substract_box)
+    {
+        static constexpr std::size_t dim = 2;
+
+        using Config    = samurai::MRConfig<dim>;
+        using Mesh      = samurai::MRMesh<Config>;
+        using mesh_id_t = typename Mesh::mesh_id_t;
+        using cl_t      = typename Mesh::cl_type;
+        using lca_t     = typename Mesh::lca_type;
+        using Box       = samurai::Box<double, dim>;
+
+        std::size_t level = 3;
+
+        const Box domain_box({-1., -1.}, {1., 1.});
+        const Box hole_box({0.0, 0.0}, {0.2, 0.2});
+
+        auto origin_point     = domain_box.min_corner();
+        double scaling_factor = 0.2; // this value ensures that the hole is representable at level 0
+
+        auto domain_lca = lca_t(level, domain_box, -1, scaling_factor);
+        auto hole_lca   = lca_t(level, hole_box, origin_point, -1, scaling_factor);
+
+        auto domain_with_hole_set = samurai::difference(domain_lca, hole_lca);
+
+        cl_t domain_with_hole_cl(origin_point, scaling_factor);
+        domain_with_hole_set(
+            [&](const auto& interval, const auto& index_y)
+            {
+                domain_with_hole_cl[level][index_y].add_interval({interval});
+            });
+
+        samurai::MRMesh<Config> mesh{domain_with_hole_cl, level, level};
+
+        EXPECT_EQ(mesh.nb_cells(mesh_id_t::cells), domain_lca.nb_cells() - hole_lca.nb_cells());
+    }
+
+}


### PR DESCRIPTION
## Description
An origin point can be passed to a LevelCellArray so that two LCA can interact even if they are built from different boxes.

## How has this been tested?
`test_domain_with_hole.cpp`

## Code of Conduct
By submitting this PR, you agree to follow our [Code of Conduct](https://github.com/hpc-maths/samurai/blob/master/docs/CODE_OF_CONDUCT.md)
- [x] I agree to follow this project's Code of Conduct
