### PR TITLE
feat: [WIP] Reconstruct neighbour mesh locally 2

### DIFF
--- a/include/samurai/algorithm.hpp
+++ b/include/samurai/algorithm.hpp
@@ -59,7 +59,7 @@ namespace samurai
     }
 
     template <class Mesh, class Func>
-    inline void for_each_level(Mesh& mesh, Func&& f, bool include_empty_levels = false)
+    inline void for_each_level(const Mesh& mesh, Func&& f, bool include_empty_levels = false)
     {
         using mesh_id_t = typename Mesh::mesh_id_t;
         for_each_level(mesh[mesh_id_t::cells], std::forward<Func>(f), include_empty_levels);

--- a/include/samurai/field.hpp
+++ b/include/samurai/field.hpp
@@ -1188,14 +1188,14 @@ namespace samurai
     inline auto ScalarField<mesh_t, value_t>::begin() -> iterator
     {
         using mesh_id_t = typename mesh_t::mesh_id_t;
-        return iterator(this, this->mesh()[mesh_id_t::cells].begin());
+        return iterator(this, std::as_const(this->mesh()[mesh_id_t::cells]).begin());
     }
 
     template <class mesh_t, class value_t>
     inline auto ScalarField<mesh_t, value_t>::end() -> iterator
     {
         using mesh_id_t = typename mesh_t::mesh_id_t;
-        return iterator(this, this->mesh()[mesh_id_t::cells].end());
+        return iterator(this, std::as_const(this->mesh()[mesh_id_t::cells]).end());
     }
 
     template <class mesh_t, class value_t>

--- a/include/samurai/field.hpp
+++ b/include/samurai/field.hpp
@@ -1188,6 +1188,7 @@ namespace samurai
     inline auto ScalarField<mesh_t, value_t>::begin() -> iterator
     {
         using mesh_id_t = typename mesh_t::mesh_id_t;
+        // add comment : the CI is buggy ahahaha
         return iterator(this, std::as_const(this->mesh()[mesh_id_t::cells]).begin());
     }
 

--- a/include/samurai/mesh.hpp
+++ b/include/samurai/mesh.hpp
@@ -89,6 +89,7 @@ namespace samurai
         std::size_t nb_cells(std::size_t level, mesh_id_t mesh_id = mesh_id_t::reference) const;
 
         const ca_type& operator[](mesh_id_t mesh_id) const;
+        ca_type& operator[](mesh_id_t mesh_id);
 
         std::size_t max_level() const;
         std::size_t& max_level();
@@ -409,6 +410,12 @@ namespace samurai
 
     template <class D, class Config>
     inline auto Mesh_base<D, Config>::operator[](mesh_id_t mesh_id) const -> const ca_type&
+    {
+        return m_cells[mesh_id];
+    }
+
+    template <class D, class Config>
+    inline auto Mesh_base<D, Config>::operator[](mesh_id_t mesh_id) -> ca_type&
     {
         return m_cells[mesh_id];
     }

--- a/include/samurai/mr/mesh.hpp
+++ b/include/samurai/mr/mesh.hpp
@@ -228,8 +228,6 @@ namespace samurai
     template <class MeshT>
     void MRMesh<Config>::construct_periodic_cells(MeshT& mesh, cl_type& cell_list)
     {
-        /**
-
 #ifdef SAMURAI_WITH_MPI
         mpi::communicator world;
         // cppcheck-suppress redundantInitialization
@@ -242,7 +240,6 @@ namespace samurai
         // cppcheck-suppress redundantInitialization
         auto min_level = mesh.cells()[mesh_id_t::cells].min_level();
 #endif
-
 
         xt::xtensor_fixed<typename interval_t::value_t, xt::xshape<dim>> stencil;
         xt::xtensor_fixed<typename interval_t::value_t, xt::xshape<dim>> min_corner;
@@ -305,7 +302,6 @@ namespace samurai
                 }
             }
         }
-    **/
     }
 
     template <class Config>

--- a/include/samurai/mr/mesh.hpp
+++ b/include/samurai/mr/mesh.hpp
@@ -221,6 +221,7 @@ namespace samurai
     template <class MeshT>
     void MRMesh<Config>::construct_periodic_cells(MeshT& mesh, cl_type& cell_list)
     {
+        /**
         mpi::communicator world;
         // cppcheck-suppress redundantInitialization
         auto max_level = mpi::all_reduce(world, mesh.cells()[mesh_id_t::cells].max_level(), mpi::maximum<std::size_t>());
@@ -288,6 +289,7 @@ namespace samurai
                 }
             }
         }
+    **/
     }
 
     template <class Config>

--- a/include/samurai/mr/mesh.hpp
+++ b/include/samurai/mr/mesh.hpp
@@ -462,7 +462,7 @@ namespace samurai
             }
 #endif
             // For now, this leads to a segfault.
-            //          construct_periodic_cells(*this, cell_list);
+            construct_periodic_cells(*this, cell_list);
 #ifdef SAMURAI_WITH_MPI
             //          for (std::size_t i = 0; i < this->mpi_neighbourhood().size(); i++)
             //          {

--- a/include/samurai/mr/mesh.hpp
+++ b/include/samurai/mr/mesh.hpp
@@ -356,8 +356,9 @@ namespace samurai
     inline void MRMesh<Config>::update_sub_mesh_impl()
     {
         cl_type cell_list;
+#ifdef SAMURAI_WITH_MPI
         std::vector<cl_type> neighbour_cell_list(this->mpi_neighbourhood().size());
-
+#endif
         // Construction of ghost cells
         // ===========================
         //

--- a/include/samurai/mr/mesh.hpp
+++ b/include/samurai/mr/mesh.hpp
@@ -173,18 +173,10 @@ namespace samurai
     template <class MeshT>
     void MRMesh<Config>::construct_mra_cells(MeshT& mesh, cl_type& cell_list)
     {
-#ifdef SAMURAI_WITH_MPI
-        mpi::communicator world;
-        // cppcheck-suppress redundantInitialization
-        auto max_level = mpi::all_reduce(world, mesh.cells()[mesh_id_t::cells].max_level(), mpi::maximum<std::size_t>());
-        // cppcheck-suppress redundantInitialization
-        auto min_level = mpi::all_reduce(world, mesh.cells()[mesh_id_t::cells].min_level(), mpi::minimum<std::size_t>());
-#else
         // cppcheck-suppress redundantInitialization
         auto max_level = mesh.cells()[mesh_id_t::cells].max_level();
         // cppcheck-suppress redundantInitialization
         auto min_level = mesh.cells()[mesh_id_t::cells].min_level();
-#endif
 
         for (std::size_t level = max_level; level >= ((min_level == 0) ? 1 : min_level); --level)
         {
@@ -228,18 +220,10 @@ namespace samurai
     template <class MeshT>
     void MRMesh<Config>::construct_periodic_cells(MeshT& mesh, cl_type& cell_list)
     {
-#ifdef SAMURAI_WITH_MPI
-        mpi::communicator world;
-        // cppcheck-suppress redundantInitialization
-        auto max_level = mpi::all_reduce(world, mesh.cells()[mesh_id_t::cells].max_level(), mpi::maximum<std::size_t>());
-        // cppcheck-suppress redundantInitialization
-        auto min_level = mpi::all_reduce(world, mesh.cells()[mesh_id_t::cells].min_level(), mpi::minimum<std::size_t>());
-#else
         // cppcheck-suppress redundantInitialization
         auto max_level = mesh.cells()[mesh_id_t::cells].max_level();
         // cppcheck-suppress redundantInitialization
         auto min_level = mesh.cells()[mesh_id_t::cells].min_level();
-#endif
 
         xt::xtensor_fixed<typename interval_t::value_t, xt::xshape<dim>> stencil;
         xt::xtensor_fixed<typename interval_t::value_t, xt::xshape<dim>> min_corner;
@@ -250,8 +234,7 @@ namespace samurai
         auto max_indices = domain.max_indices();
 
         // cppcheck-suppress constStatement
-        for (std::size_t level = mesh.cells()[mesh_id_t::reference].min_level(); level <= mesh.cells()[mesh_id_t::reference].max_level();
-             ++level)
+        for (std::size_t level = min_level; level <= max_level; ++level)
         {
             std::size_t delta_l = domain.level() - level;
             lcl_type& lcl       = cell_list[level];
@@ -309,18 +292,8 @@ namespace samurai
     template <class MeshT>
     void MRMesh<Config>::construct_projection_cells(MeshT& mesh, cl_type& cell_list)
     {
-#ifdef SAMURAI_WITH_MPI
-        mpi::communicator world;
-        // cppcheck-suppress redundantInitialization
-        auto max_level = mpi::all_reduce(world, mesh.cells()[mesh_id_t::cells].max_level(), mpi::maximum<std::size_t>());
-        // cppcheck-suppress redundantInitialization
-        auto min_level = mpi::all_reduce(world, mesh.cells()[mesh_id_t::cells].min_level(), mpi::minimum<std::size_t>());
-#else
         // cppcheck-suppress redundantInitialization
         auto max_level = mesh.cells()[mesh_id_t::cells].max_level();
-        // cppcheck-suppress redundantInitialization
-        auto min_level = mesh.cells()[mesh_id_t::cells].min_level();
-#endif
 
         for (std::size_t level = 0; level < max_level; ++level)
         {
@@ -347,18 +320,8 @@ namespace samurai
     template <class MeshT>
     void MRMesh<Config>::construct_neighbour_cells(MeshT& mesh, cl_type& cell_list)
     {
-#ifdef SAMURAI_WITH_MPI
-        mpi::communicator world;
-        // cppcheck-suppress redundantInitialization
-        auto max_level = mpi::all_reduce(world, mesh.cells()[mesh_id_t::cells].max_level(), mpi::maximum<std::size_t>());
-        // cppcheck-suppress redundantInitialization
-        auto min_level = mpi::all_reduce(world, mesh.cells()[mesh_id_t::cells].min_level(), mpi::minimum<std::size_t>());
-#else
         // cppcheck-suppress redundantInitialization
         auto max_level = mesh.cells()[mesh_id_t::cells].max_level();
-        // cppcheck-suppress redundantInitialization
-        auto min_level = mesh.cells()[mesh_id_t::cells].min_level();
-#endif
 
         for (auto& neighbour : mesh.mpi_neighbourhood())
         {
@@ -392,21 +355,9 @@ namespace samurai
     template <class Config>
     inline void MRMesh<Config>::update_sub_mesh_impl()
     {
-#ifdef SAMURAI_WITH_MPI
-        mpi::communicator world;
-        // cppcheck-suppress redundantInitialization
-        auto max_level = mpi::all_reduce(world, this->cells()[mesh_id_t::cells].max_level(), mpi::maximum<std::size_t>());
-        // cppcheck-suppress redundantInitialization
-        auto min_level = mpi::all_reduce(world, this->cells()[mesh_id_t::cells].min_level(), mpi::minimum<std::size_t>());
         cl_type cell_list;
         std::vector<cl_type> neighbour_cell_list(this->mpi_neighbourhood().size());
-#else
-        // cppcheck-suppress redundantInitialization
-        auto max_level = this->cells()[mesh_id_t::cells].max_level();
-        // cppcheck-suppress redundantInitialization
-        auto min_level = this->cells()[mesh_id_t::cells].min_level();
-        cl_type cell_list;
-#endif
+
         // Construction of ghost cells
         // ===========================
         //

--- a/include/samurai/mr/mesh.hpp
+++ b/include/samurai/mr/mesh.hpp
@@ -249,6 +249,7 @@ namespace samurai
         auto min_indices = domain.min_indices();
         auto max_indices = domain.max_indices();
 
+        // cppcheck-suppress constStatement
         for (std::size_t level = mesh.cells()[mesh_id_t::reference].min_level(); level <= mesh.cells()[mesh_id_t::reference].max_level();
              ++level)
         {

--- a/include/samurai/mr/mesh.hpp
+++ b/include/samurai/mr/mesh.hpp
@@ -429,52 +429,58 @@ namespace samurai
 
         construct_ghost_cells(*this, cell_list);
         // reconstruct ghost cells for neighbourhood
+#ifdef SAMURAI_WITH_MPI
         for (std::size_t i = 0; i < this->mpi_neighbourhood().size(); i++)
         {
             auto& neighbour = this->mpi_neighbourhood()[i];
             construct_ghost_cells((neighbour.mesh), neighbour_cell_list[i]);
         }
-
+#endif
         // Add cells for the MRA
         if (this->max_level() != this->min_level())
         {
             construct_mra_cells(*this, cell_list);
             // this->update_neighbour_reference();
+#ifdef SAMURAI_WITH_MPI
             for (std::size_t i = 0; i < this->mpi_neighbourhood().size(); i++)
             {
                 auto& neighbour = this->mpi_neighbourhood()[i];
                 construct_mra_cells((neighbour.mesh), neighbour_cell_list[i]);
             }
-
+#endif
             construct_neighbour_cells(*this, cell_list);
+#ifdef SAMURAI_WITH_MPI
             for (std::size_t i = 0; i < this->mpi_neighbourhood().size(); i++)
             {
                 auto& neighbour = this->mpi_neighbourhood()[i];
                 construct_neighbour_cells(neighbour.mesh, neighbour_cell_list[i]);
             }
+#endif
             this->cells()[mesh_id_t::all_cells] = {cell_list, false};
-
+#ifdef SAMURAI_WITH_MPI
             for (std::size_t i = 0; i < this->mpi_neighbourhood().size(); i++)
             {
                 auto& neighbour                              = this->mpi_neighbourhood()[i];
                 neighbour.mesh.cells()[mesh_id_t::all_cells] = {neighbour_cell_list[i], false};
             }
-
+#endif
             // For now, this leads to a segfault.
             //          construct_periodic_cells(*this, cell_list);
+#ifdef SAMURAI_WITH_MPI
             //          for (std::size_t i = 0; i < this->mpi_neighbourhood().size(); i++)
             //          {
             //              auto& neighbour = this->mpi_neighbourhood()[i];
             //              construct_periodic_cells(neighbour.mesh, neighbour_cell_list[i]);
             //          }
-
+#endif
             construct_projection_cells(*this, cell_list);
+#ifdef SAMURAI_WITH_MPI
             for (std::size_t i = 0; i < this->mpi_neighbourhood().size(); i++)
             {
                 auto& neighbour = this->mpi_neighbourhood()[i];
                 construct_projection_cells(neighbour.mesh, neighbour_cell_list[i]);
             }
-
+#endif
             //
             // this->update_mesh_neighbour();
             this->update_neighbour_subdomain();

--- a/include/samurai/mr/mesh.hpp
+++ b/include/samurai/mr/mesh.hpp
@@ -173,11 +173,18 @@ namespace samurai
     template <class MeshT>
     void MRMesh<Config>::construct_mra_cells(MeshT& mesh, cl_type& cell_list)
     {
+#ifdef SAMURAI_WITH_MPI
         mpi::communicator world;
         // cppcheck-suppress redundantInitialization
         auto max_level = mpi::all_reduce(world, mesh.cells()[mesh_id_t::cells].max_level(), mpi::maximum<std::size_t>());
         // cppcheck-suppress redundantInitialization
         auto min_level = mpi::all_reduce(world, mesh.cells()[mesh_id_t::cells].min_level(), mpi::minimum<std::size_t>());
+#else
+        // cppcheck-suppress redundantInitialization
+        auto max_level = mesh.cells()[mesh_id_t::cells].max_level();
+        // cppcheck-suppress redundantInitialization
+        auto min_level = mesh.cells()[mesh_id_t::cells].min_level();
+#endif
 
         for (std::size_t level = max_level; level >= ((min_level == 0) ? 1 : min_level); --level)
         {
@@ -222,11 +229,20 @@ namespace samurai
     void MRMesh<Config>::construct_periodic_cells(MeshT& mesh, cl_type& cell_list)
     {
         /**
+
+#ifdef SAMURAI_WITH_MPI
         mpi::communicator world;
         // cppcheck-suppress redundantInitialization
         auto max_level = mpi::all_reduce(world, mesh.cells()[mesh_id_t::cells].max_level(), mpi::maximum<std::size_t>());
         // cppcheck-suppress redundantInitialization
         auto min_level = mpi::all_reduce(world, mesh.cells()[mesh_id_t::cells].min_level(), mpi::minimum<std::size_t>());
+#else
+        // cppcheck-suppress redundantInitialization
+        auto max_level = mesh.cells()[mesh_id_t::cells].max_level();
+        // cppcheck-suppress redundantInitialization
+        auto min_level = mesh.cells()[mesh_id_t::cells].min_level();
+#endif
+
 
         xt::xtensor_fixed<typename interval_t::value_t, xt::xshape<dim>> stencil;
         xt::xtensor_fixed<typename interval_t::value_t, xt::xshape<dim>> min_corner;
@@ -296,11 +312,18 @@ namespace samurai
     template <class MeshT>
     void MRMesh<Config>::construct_projection_cells(MeshT& mesh, cl_type& cell_list)
     {
+#ifdef SAMURAI_WITH_MPI
         mpi::communicator world;
         // cppcheck-suppress redundantInitialization
         auto max_level = mpi::all_reduce(world, mesh.cells()[mesh_id_t::cells].max_level(), mpi::maximum<std::size_t>());
         // cppcheck-suppress redundantInitialization
         auto min_level = mpi::all_reduce(world, mesh.cells()[mesh_id_t::cells].min_level(), mpi::minimum<std::size_t>());
+#else
+        // cppcheck-suppress redundantInitialization
+        auto max_level = mesh.cells()[mesh_id_t::cells].max_level();
+        // cppcheck-suppress redundantInitialization
+        auto min_level = mesh.cells()[mesh_id_t::cells].min_level();
+#endif
 
         for (std::size_t level = 0; level < max_level; ++level)
         {
@@ -327,11 +350,18 @@ namespace samurai
     template <class MeshT>
     void MRMesh<Config>::construct_neighbour_cells(MeshT& mesh, cl_type& cell_list)
     {
+#ifdef SAMURAI_WITH_MPI
         mpi::communicator world;
         // cppcheck-suppress redundantInitialization
         auto max_level = mpi::all_reduce(world, mesh.cells()[mesh_id_t::cells].max_level(), mpi::maximum<std::size_t>());
         // cppcheck-suppress redundantInitialization
         auto min_level = mpi::all_reduce(world, mesh.cells()[mesh_id_t::cells].min_level(), mpi::minimum<std::size_t>());
+#else
+        // cppcheck-suppress redundantInitialization
+        auto max_level = mesh.cells()[mesh_id_t::cells].max_level();
+        // cppcheck-suppress redundantInitialization
+        auto min_level = mesh.cells()[mesh_id_t::cells].min_level();
+#endif
 
         for (auto& neighbour : mesh.mpi_neighbourhood())
         {

--- a/include/samurai/mr/mesh.hpp
+++ b/include/samurai/mr/mesh.hpp
@@ -407,7 +407,7 @@ namespace samurai
         if (this->max_level() != this->min_level())
         {
             construct_mra_cells(*this, cell_list);
-            this->update_neighbour_reference();
+            // this->update_neighbour_reference();
             for (std::size_t i = 0; i < this->mpi_neighbourhood().size(); i++)
             {
                 auto& neighbour = this->mpi_neighbourhood()[i];
@@ -428,12 +428,14 @@ namespace samurai
                 neighbour.mesh.cells()[mesh_id_t::all_cells] = {neighbour_cell_list[i], false};
             }
 
-            construct_periodic_cells(*this, cell_list);
-            for (std::size_t i = 0; i < this->mpi_neighbourhood().size(); i++)
-            {
-                auto& neighbour = this->mpi_neighbourhood()[i];
-                construct_periodic_cells(neighbour.mesh, neighbour_cell_list[i]);
-            }
+            // For now, this leads to a segfault.
+            //          construct_periodic_cells(*this, cell_list);
+            //          for (std::size_t i = 0; i < this->mpi_neighbourhood().size(); i++)
+            //          {
+            //              auto& neighbour = this->mpi_neighbourhood()[i];
+            //              construct_periodic_cells(neighbour.mesh, neighbour_cell_list[i]);
+            //          }
+
             construct_projection_cells(*this, cell_list);
             for (std::size_t i = 0; i < this->mpi_neighbourhood().size(); i++)
             {
@@ -444,7 +446,7 @@ namespace samurai
             //
             // this->update_mesh_neighbour();
             this->update_neighbour_subdomain();
-            this->update_neighbour_all_cells();
+            //            this->update_neighbour_all_cells();
         }
         else
         {

--- a/include/samurai/mr/mesh.hpp
+++ b/include/samurai/mr/mesh.hpp
@@ -226,7 +226,9 @@ namespace samurai
             }
             this->cells()[mesh_id_t::all_cells] = {cell_list, false};
 
-            this->update_mesh_neighbour();
+            // this->update_mesh_neighbour();
+            this->update_neighbour_cells_and_ghosts();
+            this->update_neighbour_reference();
 
             for (auto& neighbour : this->mpi_neighbourhood())
             {
@@ -339,11 +341,14 @@ namespace samurai
                 this->cells()[mesh_id_t::all_cells][level + 1] = lcl;
                 this->cells()[mesh_id_t::proj_cells][level]    = lcl_proj;
             }
-            this->update_mesh_neighbour();
+            // this->update_mesh_neighbour();
+            this->update_neighbour_subdomain();
+            this->update_neighbour_all_cells();
         }
         else
         {
             this->cells()[mesh_id_t::all_cells] = {cell_list, false};
+            // TODO : what to send here ?
             this->update_mesh_neighbour();
         }
     }


### PR DESCRIPTION
## Description

This PR is based on https://github.com/hpc-maths/samurai/pull/307 so please review the PR#307 before

    feat: reconstruct the cells_and_ghost neighbourhood
    
            -       Before: we send/recv the neighbourhood cells_and_ghosts
            -       But we can avoid MPI comms by reconstructing it locally
    
            -       At this point, the advection-2d case works fine

## Related issue


## How has this been tested?
advection-2d

## Code of Conduct
By submitting this PR, you agree to follow our [Code of Conduct](https://github.com/hpc-maths/samurai/blob/master/docs/CODE_OF_CONDUCT.md)
- [x] I agree to follow this project's Code of Conduct
