### PR TITLE
feat: [WIP] Add advection-2d testcase as benchmark

### DIFF
--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -18,13 +18,16 @@ include(addGoogleTest)
 include(addGoogleBench)
 
 find_package(Threads)
+find_package(CLI11)
 
 set(SAMURAI_BENCHMARKS
     benchmark_celllist_construction.cpp
     benchmark_search.cpp
-    benchmark_set.cpp
+    #    benchmark_set.cpp # buggy for now.
     main.cpp
 )
+
+
 
 # foreach(filename IN LISTS SAMURAI_BENCHMARKS)
 #     string(REPLACE ".cpp" "" targetname ${filename})
@@ -35,8 +38,15 @@ set(SAMURAI_BENCHMARKS
 # endforeach()
 
 add_executable(bench_samurai ${SAMURAI_BENCHMARKS})
+
+add_executable(bench_advection_2d benchmark_advection_2d.cpp)
+
+
+
 # target_include_directories(bench_samurai PRIVATE ${SAMURAI_INCLUDE_DIR})
-target_link_libraries(bench_samurai samurai benchmark::benchmark)
+target_link_libraries(bench_samurai samurai CLI11::CLI11 benchmark::benchmark)
+target_link_libraries(bench_advection_2d samurai CLI11::CLI11 benchmark::benchmark)
+
 
 # target_include_directories(bench_samurai_lib PRIVATE ${SAMURAI_INCLUDE_DIR})
 # # if(DOWNLOAD_GTEST OR GTEST_SRC_DIR)

--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -40,13 +40,14 @@ set(SAMURAI_BENCHMARKS
 add_executable(bench_samurai ${SAMURAI_BENCHMARKS})
 
 add_executable(bench_advection_2d benchmark_advection_2d.cpp)
+add_executable(bench_linear_convection benchmark_linear_convection.cpp)
 
 
 
 # target_include_directories(bench_samurai PRIVATE ${SAMURAI_INCLUDE_DIR})
 target_link_libraries(bench_samurai samurai CLI11::CLI11 benchmark::benchmark)
 target_link_libraries(bench_advection_2d samurai CLI11::CLI11 benchmark::benchmark)
-
+target_link_libraries(bench_linear_convection samurai CLI11::CLI11 benchmark::benchmark)
 
 # target_include_directories(bench_samurai_lib PRIVATE ${SAMURAI_INCLUDE_DIR})
 # # if(DOWNLOAD_GTEST OR GTEST_SRC_DIR)

--- a/benchmark/benchmark_advection_2d.cpp
+++ b/benchmark/benchmark_advection_2d.cpp
@@ -1,0 +1,283 @@
+#include <array>
+
+#include <xtensor/xfixed.hpp>
+
+#include <samurai/algorithm.hpp>
+#include <samurai/bc.hpp>
+#include <samurai/field.hpp>
+#include <samurai/io/hdf5.hpp>
+#include <samurai/io/restart.hpp>
+#include <samurai/mr/adapt.hpp>
+#include <samurai/mr/mesh.hpp>
+#include <samurai/samurai.hpp>
+#include <samurai/stencil_field.hpp>
+#include <samurai/subset/node.hpp>
+
+#include <benchmark/benchmark.h>
+
+template <class Field>
+void init(Field& u)
+{
+    auto& mesh = u.mesh();
+    u.resize();
+
+    samurai::for_each_cell(mesh,
+                           [&](auto& cell)
+                           {
+                               auto center           = cell.center();
+                               const double radius   = .2;
+                               const double x_center = 0.3;
+                               const double y_center = 0.3;
+                               if (std::abs(center[0] - x_center) <= radius * radius)
+                               {
+                                   u[cell] = 1;
+                               }
+                               else
+                               {
+                                   u[cell] = 0;
+                               }
+                           });
+}
+
+template <class Field>
+void flux_correction(double dt, const std::array<double, 2>& a, const Field& u, Field& unp1)
+{
+    using mesh_t              = typename Field::mesh_t;
+    using mesh_id_t           = typename mesh_t::mesh_id_t;
+    using interval_t          = typename mesh_t::interval_t;
+    constexpr std::size_t dim = Field::dim;
+
+    auto mesh = u.mesh();
+
+    for (std::size_t level = mesh.min_level(); level < mesh.max_level(); ++level)
+    {
+        xt::xtensor_fixed<int, xt::xshape<dim>> stencil;
+
+        stencil = {
+            {-1, 0}
+        };
+
+        auto subset_right = samurai::intersection(samurai::translate(mesh[mesh_id_t::cells][level + 1], stencil),
+                                                  mesh[mesh_id_t::cells][level])
+                                .on(level);
+
+        subset_right(
+            [&](const auto& i, const auto& index)
+            {
+                auto j          = index[0];
+                const double dx = mesh.cell_length(level);
+
+                unp1(level, i, j) = unp1(level, i, j)
+                                  + dt / dx
+                                        * (samurai::upwind_op<dim, interval_t>(level, i, j).right_flux(a, u)
+                                           - .5 * samurai::upwind_op<dim, interval_t>(level + 1, 2 * i + 1, 2 * j).right_flux(a, u)
+                                           - .5 * samurai::upwind_op<dim, interval_t>(level + 1, 2 * i + 1, 2 * j + 1).right_flux(a, u));
+            });
+
+        stencil = {
+            {1, 0}
+        };
+
+        auto subset_left = samurai::intersection(samurai::translate(mesh[mesh_id_t::cells][level + 1], stencil),
+                                                 mesh[mesh_id_t::cells][level])
+                               .on(level);
+
+        subset_left(
+            [&](const auto& i, const auto& index)
+            {
+                auto j          = index[0];
+                const double dx = mesh.cell_length(level);
+
+                unp1(level, i, j) = unp1(level, i, j)
+                                  - dt / dx
+                                        * (samurai::upwind_op<dim, interval_t>(level, i, j).left_flux(a, u)
+                                           - .5 * samurai::upwind_op<dim, interval_t>(level + 1, 2 * i, 2 * j).left_flux(a, u)
+                                           - .5 * samurai::upwind_op<dim, interval_t>(level + 1, 2 * i, 2 * j + 1).left_flux(a, u));
+            });
+
+        stencil = {
+            {0, -1}
+        };
+
+        auto subset_up = samurai::intersection(samurai::translate(mesh[mesh_id_t::cells][level + 1], stencil), mesh[mesh_id_t::cells][level])
+                             .on(level);
+
+        subset_up(
+            [&](const auto& i, const auto& index)
+            {
+                auto j          = index[0];
+                const double dx = mesh.cell_length(level);
+
+                unp1(level, i, j) = unp1(level, i, j)
+                                  + dt / dx
+                                        * (samurai::upwind_op<dim, interval_t>(level, i, j).up_flux(a, u)
+                                           - .5 * samurai::upwind_op<dim, interval_t>(level + 1, 2 * i, 2 * j + 1).up_flux(a, u)
+                                           - .5 * samurai::upwind_op<dim, interval_t>(level + 1, 2 * i + 1, 2 * j + 1).up_flux(a, u));
+            });
+
+        stencil = {
+            {0, 1}
+        };
+
+        auto subset_down = samurai::intersection(samurai::translate(mesh[mesh_id_t::cells][level + 1], stencil),
+                                                 mesh[mesh_id_t::cells][level])
+                               .on(level);
+
+        subset_down(
+            [&](const auto& i, const auto& index)
+            {
+                auto j          = index[0];
+                const double dx = mesh.cell_length(level);
+
+                unp1(level, i, j) = unp1(level, i, j)
+                                  - dt / dx
+                                        * (samurai::upwind_op<dim, interval_t>(level, i, j).down_flux(a, u)
+                                           - .5 * samurai::upwind_op<dim, interval_t>(level + 1, 2 * i, 2 * j).down_flux(a, u)
+                                           - .5 * samurai::upwind_op<dim, interval_t>(level + 1, 2 * i + 1, 2 * j).down_flux(a, u));
+            });
+    }
+}
+
+template <std::size_t min_level, std::size_t max_level>
+void ADVECTION_2D(benchmark::State& state)
+{
+    for (auto _ : state)
+    {
+        state.PauseTiming();
+
+        double Tf = 0.1;
+
+        constexpr std::size_t dim = 2;
+        using Config              = samurai::MRConfig<dim>;
+
+        // Simulation parameters
+        xt::xtensor_fixed<double, xt::xshape<dim>> min_corner = {0., 0.};
+        xt::xtensor_fixed<double, xt::xshape<dim>> max_corner = {1., 1.};
+        std::array<double, dim> a{
+            {1, 0}
+        };
+        double cfl = 0.5;
+        double t   = 0.;
+        std::string restart_file;
+
+        // Multiresolution parameters
+        double mr_epsilon    = 2.e-4; // Threshold used by multiresolution
+        double mr_regularity = 1.;    // Regularity guess for multiresolution
+        bool correction      = false;
+
+        const samurai::Box<double, dim> box(min_corner, max_corner);
+        samurai::MRMesh<Config> mesh;
+        auto u = samurai::make_scalar_field<double>("u", mesh);
+
+        if (restart_file.empty())
+        {
+            mesh = {box, min_level, max_level};
+            init(u);
+        }
+        else
+        {
+            samurai::load(restart_file, mesh, u);
+        }
+        samurai::make_bc<samurai::Neumann<1>>(u, 0.);
+
+        double dt = cfl * mesh.cell_length(max_level);
+
+        auto unp1 = samurai::make_scalar_field<double>("unp1", mesh);
+
+        auto MRadaptation = samurai::make_MRAdapt(u);
+        MRadaptation(mr_epsilon, mr_regularity);
+
+        std::size_t nt = 0;
+
+        MPI_Barrier(MPI_COMM_WORLD);
+        state.ResumeTiming();
+        for (int i = 0; i < 10; i++)
+        {
+            MRadaptation(mr_epsilon, mr_regularity);
+            t += dt;
+            if (t > Tf)
+            {
+                dt += Tf - t;
+                t = Tf;
+            }
+            samurai::update_ghost_mr(u);
+            unp1.resize();
+            unp1 = u - dt * samurai::upwind(a, u);
+            if (correction)
+            {
+                flux_correction(dt, a, u, unp1);
+            }
+            std::swap(u.array(), unp1.array());
+        }
+        MPI_Barrier(MPI_COMM_WORLD);
+    }
+}
+
+// BENCHMARK(ADVECTION_2D);
+
+// MRA with min_level = 5
+BENCHMARK_TEMPLATE(ADVECTION_2D, 5, 8);
+BENCHMARK_TEMPLATE(ADVECTION_2D, 5, 10);
+BENCHMARK_TEMPLATE(ADVECTION_2D, 5, 12);
+BENCHMARK_TEMPLATE(ADVECTION_2D, 5, 14);
+
+// MRA with max_level - min-level = 2
+BENCHMARK_TEMPLATE(ADVECTION_2D, 6, 8);
+BENCHMARK_TEMPLATE(ADVECTION_2D, 8, 10);
+BENCHMARK_TEMPLATE(ADVECTION_2D, 10, 12);
+BENCHMARK_TEMPLATE(ADVECTION_2D, 12, 14);
+
+// Uniform
+BENCHMARK_TEMPLATE(ADVECTION_2D, 6, 6);
+BENCHMARK_TEMPLATE(ADVECTION_2D, 8, 8);
+BENCHMARK_TEMPLATE(ADVECTION_2D, 10, 10);
+BENCHMARK_TEMPLATE(ADVECTION_2D, 12, 12);
+
+/** SOURCE : https://gist.github.com/mdavezac/eb16de7e8fc08e522ff0d420516094f5
+ **/
+
+// This reporter does nothing.
+// We can use it to disable output from all but the root process
+class NullReporter : public ::benchmark::BenchmarkReporter
+{
+  public:
+
+    NullReporter()
+    {
+    }
+
+    virtual bool ReportContext(const Context&)
+    {
+        return true;
+    }
+
+    virtual void ReportRuns(const std::vector<Run>&)
+    {
+    }
+
+    virtual void Finalize()
+    {
+    }
+};
+
+int main(int argc, char** argv)
+{
+    MPI_Init(&argc, &argv);
+
+    int rank;
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+
+    ::benchmark::Initialize(&argc, argv);
+    if (rank == 0)
+    {
+        ::benchmark::RunSpecifiedBenchmarks();
+    }
+    else
+    {
+        NullReporter null;
+        ::benchmark::RunSpecifiedBenchmarks(&null);
+    }
+
+    MPI_Finalize();
+    return 0;
+}

--- a/benchmark/benchmark_advection_2d.cpp
+++ b/benchmark/benchmark_advection_2d.cpp
@@ -193,7 +193,8 @@ void ADVECTION_2D(benchmark::State& state)
         MPI_Barrier(MPI_COMM_WORLD);
 #endif
         state.ResumeTiming();
-        for (int i = 0; i < 10; i++)
+        int ITER_STEPS = 10;
+        for (int i = 0; i < ITER_STEPS; i++)
         {
             MRadaptation(mr_epsilon, mr_regularity);
             t += dt;
@@ -220,22 +221,36 @@ void ADVECTION_2D(benchmark::State& state)
 // BENCHMARK(ADVECTION_2D);
 
 // MRA with min_level = 5
-BENCHMARK_TEMPLATE(ADVECTION_2D, 5, 8);
-BENCHMARK_TEMPLATE(ADVECTION_2D, 5, 10);
-BENCHMARK_TEMPLATE(ADVECTION_2D, 5, 12);
-BENCHMARK_TEMPLATE(ADVECTION_2D, 5, 14);
+BENCHMARK_TEMPLATE(ADVECTION_2D, 5, 8)->Unit(benchmark::kMillisecond)->Iterations(1);
+;
+BENCHMARK_TEMPLATE(ADVECTION_2D, 5, 10)->Unit(benchmark::kMillisecond)->Iterations(1);
+;
+BENCHMARK_TEMPLATE(ADVECTION_2D, 5, 12)->Unit(benchmark::kMillisecond)->Iterations(1);
+;
+BENCHMARK_TEMPLATE(ADVECTION_2D, 5, 14)->Unit(benchmark::kMillisecond)->Iterations(1);
+;
 
 // MRA with max_level - min-level = 2
-BENCHMARK_TEMPLATE(ADVECTION_2D, 6, 8);
-BENCHMARK_TEMPLATE(ADVECTION_2D, 8, 10);
-BENCHMARK_TEMPLATE(ADVECTION_2D, 10, 12);
-BENCHMARK_TEMPLATE(ADVECTION_2D, 12, 14);
+BENCHMARK_TEMPLATE(ADVECTION_2D, 6, 8)->Unit(benchmark::kMillisecond)->Iterations(1);
+;
+BENCHMARK_TEMPLATE(ADVECTION_2D, 8, 10)->Unit(benchmark::kMillisecond)->Iterations(1);
+;
+BENCHMARK_TEMPLATE(ADVECTION_2D, 10, 12)->Unit(benchmark::kMillisecond)->Iterations(1);
+;
+BENCHMARK_TEMPLATE(ADVECTION_2D, 12, 14)->Unit(benchmark::kMillisecond)->Iterations(1);
+;
 
 // Uniform
-BENCHMARK_TEMPLATE(ADVECTION_2D, 6, 6);
-BENCHMARK_TEMPLATE(ADVECTION_2D, 8, 8);
-BENCHMARK_TEMPLATE(ADVECTION_2D, 10, 10);
-BENCHMARK_TEMPLATE(ADVECTION_2D, 12, 12);
+BENCHMARK_TEMPLATE(ADVECTION_2D, 6, 6)->Unit(benchmark::kMillisecond)->Iterations(1);
+;
+BENCHMARK_TEMPLATE(ADVECTION_2D, 8, 8)->Unit(benchmark::kMillisecond)->Iterations(1);
+;
+BENCHMARK_TEMPLATE(ADVECTION_2D, 10, 10)->Unit(benchmark::kMillisecond)->Iterations(1);
+;
+BENCHMARK_TEMPLATE(ADVECTION_2D, 12, 12)->Unit(benchmark::kMillisecond)->Iterations(1);
+;
+BENCHMARK_TEMPLATE(ADVECTION_2D, 14, 14)->Unit(benchmark::kMillisecond)->Iterations(1);
+;
 
 /** SOURCE : https://gist.github.com/mdavezac/eb16de7e8fc08e522ff0d420516094f5
  **/

--- a/benchmark/benchmark_advection_2d.cpp
+++ b/benchmark/benchmark_advection_2d.cpp
@@ -214,35 +214,22 @@ void ADVECTION_2D(benchmark::State& state)
 
 // MRA with min_level = 5
 BENCHMARK_TEMPLATE(ADVECTION_2D, 5, 8)->Unit(benchmark::kMillisecond)->Iterations(1);
-;
 BENCHMARK_TEMPLATE(ADVECTION_2D, 5, 10)->Unit(benchmark::kMillisecond)->Iterations(1);
-;
 BENCHMARK_TEMPLATE(ADVECTION_2D, 5, 12)->Unit(benchmark::kMillisecond)->Iterations(1);
-;
 BENCHMARK_TEMPLATE(ADVECTION_2D, 5, 14)->Unit(benchmark::kMillisecond)->Iterations(1);
-;
 
 // MRA with max_level - min-level = 2
 BENCHMARK_TEMPLATE(ADVECTION_2D, 6, 8)->Unit(benchmark::kMillisecond)->Iterations(1);
-;
 BENCHMARK_TEMPLATE(ADVECTION_2D, 8, 10)->Unit(benchmark::kMillisecond)->Iterations(1);
-;
 BENCHMARK_TEMPLATE(ADVECTION_2D, 10, 12)->Unit(benchmark::kMillisecond)->Iterations(1);
-;
 BENCHMARK_TEMPLATE(ADVECTION_2D, 12, 14)->Unit(benchmark::kMillisecond)->Iterations(1);
-;
 
 // Uniform
 BENCHMARK_TEMPLATE(ADVECTION_2D, 6, 6)->Unit(benchmark::kMillisecond)->Iterations(1);
-;
 BENCHMARK_TEMPLATE(ADVECTION_2D, 8, 8)->Unit(benchmark::kMillisecond)->Iterations(1);
-;
 BENCHMARK_TEMPLATE(ADVECTION_2D, 10, 10)->Unit(benchmark::kMillisecond)->Iterations(1);
-;
 BENCHMARK_TEMPLATE(ADVECTION_2D, 12, 12)->Unit(benchmark::kMillisecond)->Iterations(1);
-;
 BENCHMARK_TEMPLATE(ADVECTION_2D, 14, 14)->Unit(benchmark::kMillisecond)->Iterations(1);
-;
 
 /** SOURCE : https://gist.github.com/mdavezac/eb16de7e8fc08e522ff0d420516094f5
  **/

--- a/benchmark/benchmark_advection_2d.cpp
+++ b/benchmark/benchmark_advection_2d.cpp
@@ -27,7 +27,7 @@ void init(Field& u)
                                auto center           = cell.center();
                                const double radius   = .2;
                                const double x_center = 0.3;
-                               const double y_center = 0.3;
+                               // const double y_center = 0.3;
                                if (std::abs(center[0] - x_center) <= radius * radius)
                                {
                                    u[cell] = 1;
@@ -163,21 +163,15 @@ void ADVECTION_2D(benchmark::State& state)
         // Multiresolution parameters
         double mr_epsilon    = 2.e-4; // Threshold used by multiresolution
         double mr_regularity = 1.;    // Regularity guess for multiresolution
-        bool correction      = false;
+        // bool correction      = false;
 
         const samurai::Box<double, dim> box(min_corner, max_corner);
         samurai::MRMesh<Config> mesh;
         auto u = samurai::make_scalar_field<double>("u", mesh);
 
-        if (restart_file.empty())
-        {
-            mesh = {box, min_level, max_level};
-            init(u);
-        }
-        else
-        {
-            samurai::load(restart_file, mesh, u);
-        }
+        mesh = {box, min_level, max_level};
+        init(u);
+
         samurai::make_bc<samurai::Neumann<1>>(u, 0.);
 
         double dt = cfl * mesh.cell_length(max_level);
@@ -186,8 +180,6 @@ void ADVECTION_2D(benchmark::State& state)
 
         auto MRadaptation = samurai::make_MRAdapt(u);
         MRadaptation(mr_epsilon, mr_regularity);
-
-        std::size_t nt = 0;
 
 #ifdef SAMURAI_WITH_MPI
         MPI_Barrier(MPI_COMM_WORLD);
@@ -206,10 +198,10 @@ void ADVECTION_2D(benchmark::State& state)
             samurai::update_ghost_mr(u);
             unp1.resize();
             unp1 = u - dt * samurai::upwind(a, u);
-            if (correction)
-            {
-                flux_correction(dt, a, u, unp1);
-            }
+            // if (correction)
+            // {
+            //     flux_correction(dt, a, u, unp1);
+            // }
             std::swap(u.array(), unp1.array());
         }
 #ifdef SAMURAI_WITH_MPI

--- a/benchmark/benchmark_advection_2d.cpp
+++ b/benchmark/benchmark_advection_2d.cpp
@@ -189,7 +189,9 @@ void ADVECTION_2D(benchmark::State& state)
 
         std::size_t nt = 0;
 
+#ifdef SAMURAI_WITH_MPI
         MPI_Barrier(MPI_COMM_WORLD);
+#endif
         state.ResumeTiming();
         for (int i = 0; i < 10; i++)
         {
@@ -209,7 +211,9 @@ void ADVECTION_2D(benchmark::State& state)
             }
             std::swap(u.array(), unp1.array());
         }
+#ifdef SAMURAI_WITH_MPI
         MPI_Barrier(MPI_COMM_WORLD);
+#endif
     }
 }
 
@@ -262,10 +266,13 @@ class NullReporter : public ::benchmark::BenchmarkReporter
 
 int main(int argc, char** argv)
 {
+#ifdef SAMURAI_WITH_MPI
     MPI_Init(&argc, &argv);
-
     int rank;
     MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+#else
+    int rank = 0;
+#endif
 
     ::benchmark::Initialize(&argc, argv);
     if (rank == 0)
@@ -278,6 +285,8 @@ int main(int argc, char** argv)
         ::benchmark::RunSpecifiedBenchmarks(&null);
     }
 
+#ifdef SAMURAI_WITH_MPI
     MPI_Finalize();
+#endif
     return 0;
 }

--- a/benchmark/benchmark_advection_2d.cpp
+++ b/benchmark/benchmark_advection_2d.cpp
@@ -264,20 +264,20 @@ int main(int argc, char** argv)
     MPI_Init(&argc, &argv);
     int rank;
     MPI_Comm_rank(MPI_COMM_WORLD, &rank);
-#else
-    int rank = 0;
-#endif
 
     ::benchmark::Initialize(&argc, argv);
     if (rank == 0)
     {
+#endif
         ::benchmark::RunSpecifiedBenchmarks();
+#ifdef SAMURAI_WITH_MPI
     }
     else
     {
         NullReporter null;
         ::benchmark::RunSpecifiedBenchmarks(&null);
     }
+#endif
 
 #ifdef SAMURAI_WITH_MPI
     MPI_Finalize();

--- a/benchmark/benchmark_linear_convection.cpp
+++ b/benchmark/benchmark_linear_convection.cpp
@@ -160,20 +160,21 @@ void LINEAR_CONVECTION(benchmark::State& state)
 BENCHMARK_TEMPLATE(LINEAR_CONVECTION, 5, 8)->Unit(benchmark::kMillisecond)->Iterations(1);
 BENCHMARK_TEMPLATE(LINEAR_CONVECTION, 5, 10)->Unit(benchmark::kMillisecond)->Iterations(1);
 BENCHMARK_TEMPLATE(LINEAR_CONVECTION, 5, 12)->Unit(benchmark::kMillisecond)->Iterations(1);
-BENCHMARK_TEMPLATE(LINEAR_CONVECTION, 5, 14)->Unit(benchmark::kMillisecond)->Iterations(1);
+// BENCHMARK_TEMPLATE(LINEAR_CONVECTION, 5, 14)->Unit(benchmark::kMillisecond)->Iterations(1);
 
 // MRA with max_level - min-level = 2
 BENCHMARK_TEMPLATE(LINEAR_CONVECTION, 6, 8)->Unit(benchmark::kMillisecond)->Iterations(1);
 BENCHMARK_TEMPLATE(LINEAR_CONVECTION, 8, 10)->Unit(benchmark::kMillisecond)->Iterations(1);
 BENCHMARK_TEMPLATE(LINEAR_CONVECTION, 10, 12)->Unit(benchmark::kMillisecond)->Iterations(1);
-BENCHMARK_TEMPLATE(LINEAR_CONVECTION, 12, 14)->Unit(benchmark::kMillisecond)->Iterations(1);
+// BENCHMARK_TEMPLATE(LINEAR_CONVECTION, 12, 14)->Unit(benchmark::kMillisecond)->Iterations(1);
 
 // Uniform
 BENCHMARK_TEMPLATE(LINEAR_CONVECTION, 6, 6)->Unit(benchmark::kMillisecond)->Iterations(1);
 BENCHMARK_TEMPLATE(LINEAR_CONVECTION, 8, 8)->Unit(benchmark::kMillisecond)->Iterations(1);
 BENCHMARK_TEMPLATE(LINEAR_CONVECTION, 10, 10)->Unit(benchmark::kMillisecond)->Iterations(1);
 BENCHMARK_TEMPLATE(LINEAR_CONVECTION, 12, 12)->Unit(benchmark::kMillisecond)->Iterations(1);
-BENCHMARK_TEMPLATE(LINEAR_CONVECTION, 14, 14)->Unit(benchmark::kMillisecond)->Iterations(1);
+
+// BENCHMARK_TEMPLATE(LINEAR_CONVECTION, 14, 14)->Unit(benchmark::kMillisecond)->Iterations(1);
 
 /** SOURCE : https://gist.github.com/mdavezac/eb16de7e8fc08e522ff0d420516094f5
  **/

--- a/benchmark/benchmark_linear_convection.cpp
+++ b/benchmark/benchmark_linear_convection.cpp
@@ -239,20 +239,19 @@ int main(int argc, char** argv)
     MPI_Init(&argc, &argv);
     int rank;
     MPI_Comm_rank(MPI_COMM_WORLD, &rank);
-#else
-    int rank = 0;
-#endif
-
     ::benchmark::Initialize(&argc, argv);
     if (rank == 0)
     {
+#endif
         ::benchmark::RunSpecifiedBenchmarks();
+#ifdef SAMURAI_WITH_MPI
     }
     else
     {
         NullReporter null;
         ::benchmark::RunSpecifiedBenchmarks(&null);
     }
+#endif
 
 #ifdef SAMURAI_WITH_MPI
     MPI_Finalize();

--- a/benchmark/benchmark_linear_convection.cpp
+++ b/benchmark/benchmark_linear_convection.cpp
@@ -1,0 +1,231 @@
+#include <array>
+
+#include <xtensor/xfixed.hpp>
+
+#include <samurai/algorithm.hpp>
+#include <samurai/bc.hpp>
+#include <samurai/field.hpp>
+#include <samurai/io/hdf5.hpp>
+#include <samurai/io/restart.hpp>
+#include <samurai/mr/adapt.hpp>
+#include <samurai/mr/mesh.hpp>
+#include <samurai/samurai.hpp>
+#include <samurai/stencil_field.hpp>
+#include <samurai/subset/node.hpp>
+
+#include <benchmark/benchmark.h>
+
+template <std::size_t min_level, std::size_t max_level>
+void LINEAR_CONVECTION(benchmark::State& state)
+{
+    for (auto _ : state)
+    {
+        state.PauseTiming();
+
+        static constexpr std::size_t dim = 2;
+        using Config                     = samurai::MRConfig<dim, 3>;
+        using Box                        = samurai::Box<double, dim>;
+        using point_t                    = typename Box::point_t;
+
+        std::cout << "------------------------- Linear convection -------------------------" << std::endl;
+
+        //--------------------//
+        // Program parameters //
+        //--------------------//
+
+        // Simulation parameters
+        double left_box  = -1;
+        double right_box = 1;
+
+        // Time integration
+        double Tf  = 3;
+        double dt  = 0;
+        double cfl = 0.95;
+        double t   = 0.;
+        std::string restart_file;
+
+        // Multiresolution parameters
+        double mr_epsilon    = 1e-4; // Threshold used by multiresolution
+        double mr_regularity = 1.;   // Regularity guess for multiresolution
+
+        //--------------------//
+        // Problem definition //
+        //--------------------//
+
+        point_t box_corner1, box_corner2;
+        box_corner1.fill(left_box);
+        box_corner2.fill(right_box);
+        Box box(box_corner1, box_corner2);
+        std::array<bool, dim> periodic;
+        periodic.fill(true);
+        samurai::MRMesh<Config> mesh;
+        auto u = samurai::make_scalar_field<double>("u", mesh);
+
+        mesh = {box, min_level, max_level, periodic};
+        // Initial solution
+        u = samurai::make_scalar_field<double>("u",
+                                               mesh,
+                                               [](const auto& coords)
+                                               {
+                                                   if constexpr (dim == 1)
+                                                   {
+                                                       const auto& x = coords(0);
+                                                       return (x >= -0.8 && x <= -0.3) ? 1. : 0.;
+                                                   }
+                                                   else
+                                                   {
+                                                       const auto& x = coords(0);
+                                                       const auto& y = coords(1);
+                                                       return (x >= -0.8 && x <= -0.3 && y >= 0.3 && y <= 0.8) ? 1. : 0.;
+                                                   }
+                                               });
+
+        auto unp1 = samurai::make_scalar_field<double>("unp1", mesh);
+        // Intermediary fields for the RK3 scheme
+        auto u1 = samurai::make_scalar_field<double>("u1", mesh);
+        auto u2 = samurai::make_scalar_field<double>("u2", mesh);
+
+        unp1.fill(0);
+        u1.fill(0);
+        u2.fill(0);
+
+        // Convection operator
+        samurai::VelocityVector<dim> velocity;
+        velocity.fill(1);
+        if constexpr (dim == 2)
+        {
+            velocity(1) = -1;
+        }
+        auto conv = samurai::make_convection_weno5<decltype(u)>(velocity);
+
+        //--------------------//
+        //   Time iteration   //
+        //--------------------//
+
+        if (dt == 0)
+        {
+            double dx             = mesh.cell_length(max_level);
+            auto a                = xt::abs(velocity);
+            double sum_velocities = xt::sum(xt::abs(velocity))();
+            dt                    = cfl * dx / sum_velocities;
+        }
+
+        auto MRadaptation = samurai::make_MRAdapt(u);
+        MRadaptation(mr_epsilon, mr_regularity);
+
+#ifdef SAMURAI_WITH_MPI
+        MPI_Barrier(MPI_COMM_WORLD);
+#endif
+        state.RestartTiming();
+        int ITER_STEPS = 10;
+        for (int i = 0; i < ITER_STEPS; i++)
+        {
+            // Move to next timestep
+            t += dt;
+            if (t > Tf)
+            {
+                dt += Tf - t;
+                t = Tf;
+            }
+
+            // Mesh adaptation
+            MRadaptation(mr_epsilon, mr_regularity);
+            samurai::update_ghost_mr(u);
+            unp1.resize();
+            u1.resize();
+            u2.resize();
+            u1.fill(0);
+            u2.fill(0);
+
+            // unp1 = u - dt * conv(u);
+
+            // TVD-RK3 (SSPRK3)
+            u1 = u - dt * conv(u);
+            samurai::update_ghost_mr(u1);
+            u2 = 3. / 4 * u + 1. / 4 * (u1 - dt * conv(u1));
+            samurai::update_ghost_mr(u2);
+            unp1 = 1. / 3 * u + 2. / 3 * (u2 - dt * conv(u2));
+
+            // u <-- unp1
+            std::swap(u.array(), unp1.array());
+        }
+#ifdef SAMURAI_WITH_MPI
+        MPI_Barrier(MPI_COMM_WORLD);
+#endif
+    }
+}
+
+// BENCHMARK(ADVECTION_2D);
+
+// MRA with min_level = 5
+BENCHMARK_TEMPLATE(LINEAR_CONVECTION, 5, 8)->Unit(benchmark::kMillisecond)->Iterations(1);
+BENCHMARK_TEMPLATE(LINEAR_CONVECTION, 5, 10)->Unit(benchmark::kMillisecond)->Iterations(1);
+BENCHMARK_TEMPLATE(LINEAR_CONVECTION, 5, 12)->Unit(benchmark::kMillisecond)->Iterations(1);
+BENCHMARK_TEMPLATE(LINEAR_CONVECTION, 5, 14)->Unit(benchmark::kMillisecond)->Iterations(1);
+
+// MRA with max_level - min-level = 2
+BENCHMARK_TEMPLATE(LINEAR_CONVECTION, 6, 8)->Unit(benchmark::kMillisecond)->Iterations(1);
+BENCHMARK_TEMPLATE(LINEAR_CONVECTION, 8, 10)->Unit(benchmark::kMillisecond)->Iterations(1);
+BENCHMARK_TEMPLATE(LINEAR_CONVECTION, 10, 12)->Unit(benchmark::kMillisecond)->Iterations(1);
+BENCHMARK_TEMPLATE(LINEAR_CONVECTION, 12, 14)->Unit(benchmark::kMillisecond)->Iterations(1);
+
+// Uniform
+BENCHMARK_TEMPLATE(LINEAR_CONVECTION, 6, 6)->Unit(benchmark::kMillisecond)->Iterations(1);
+BENCHMARK_TEMPLATE(LINEAR_CONVECTION, 8, 8)->Unit(benchmark::kMillisecond)->Iterations(1);
+BENCHMARK_TEMPLATE(LINEAR_CONVECTION, 10, 10)->Unit(benchmark::kMillisecond)->Iterations(1);
+BENCHMARK_TEMPLATE(LINEAR_CONVECTION, 12, 12)->Unit(benchmark::kMillisecond)->Iterations(1);
+BENCHMARK_TEMPLATE(LINEAR_CONVECTION, 14, 14)->Unit(benchmark::kMillisecond)->Iterations(1);
+
+/** SOURCE : https://gist.github.com/mdavezac/eb16de7e8fc08e522ff0d420516094f5
+ **/
+
+// This reporter does nothing.
+// We can use it to disable output from all but the root process
+class NullReporter : public ::benchmark::BenchmarkReporter
+{
+  public:
+
+    NullReporter()
+    {
+    }
+
+    virtual bool ReportContext(const Context&)
+    {
+        return true;
+    }
+
+    virtual void ReportRuns(const std::vector<Run>&)
+    {
+    }
+
+    virtual void Finalize()
+    {
+    }
+};
+
+int main(int argc, char** argv)
+{
+#ifdef SAMURAI_WITH_MPI
+    MPI_Init(&argc, &argv);
+    int rank;
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+#else
+    int rank = 0;
+#endif
+
+    ::benchmark::Initialize(&argc, argv);
+    if (rank == 0)
+    {
+        ::benchmark::RunSpecifiedBenchmarks();
+    }
+    else
+    {
+        NullReporter null;
+        ::benchmark::RunSpecifiedBenchmarks(&null);
+    }
+
+#ifdef SAMURAI_WITH_MPI
+    MPI_Finalize();
+#endif
+    return 0;
+}

--- a/benchmark/benchmark_linear_convection.cpp
+++ b/benchmark/benchmark_linear_convection.cpp
@@ -10,6 +10,7 @@
 #include <samurai/mr/adapt.hpp>
 #include <samurai/mr/mesh.hpp>
 #include <samurai/samurai.hpp>
+#include <samurai/schemes/fv.hpp>
 #include <samurai/stencil_field.hpp>
 #include <samurai/subset/node.hpp>
 
@@ -26,8 +27,6 @@ void LINEAR_CONVECTION(benchmark::State& state)
         using Config                     = samurai::MRConfig<dim, 3>;
         using Box                        = samurai::Box<double, dim>;
         using point_t                    = typename Box::point_t;
-
-        std::cout << "------------------------- Linear convection -------------------------" << std::endl;
 
         //--------------------//
         // Program parameters //
@@ -116,7 +115,7 @@ void LINEAR_CONVECTION(benchmark::State& state)
 #ifdef SAMURAI_WITH_MPI
         MPI_Barrier(MPI_COMM_WORLD);
 #endif
-        state.RestartTiming();
+        state.ResumeTiming();
         int ITER_STEPS = 10;
         for (int i = 0; i < ITER_STEPS; i++)
         {

--- a/benchmark/benchmark_linear_convection.cpp
+++ b/benchmark/benchmark_linear_convection.cpp
@@ -56,9 +56,11 @@ void LINEAR_CONVECTION(benchmark::State& state)
         box_corner2.fill(right_box);
         Box box(box_corner1, box_corner2);
         std::array<bool, dim> periodic;
-        periodic.fill(true);
+        periodic.fill(false);
         samurai::MRMesh<Config> mesh;
         auto u = samurai::make_scalar_field<double>("u", mesh);
+
+        samurai::make_bc<samurai::Dirichlet<1>>(u, 0.);
 
         mesh = {box, min_level, max_level, periodic};
         // Initial solution

--- a/benchmark/benchmark_search.cpp
+++ b/benchmark/benchmark_search.cpp
@@ -73,7 +73,8 @@ class MyFixture : public ::benchmark::Fixture
             for (std::size_t s = 0; s < state.range(0); ++s)
             {
                 auto level = std::experimental::randint(min_level, max_level);
-                std::array<int, dim> coord;
+                // std::array<int, dim> coord;
+                xt::xtensor_fixed<int, xt::xshape<dim>> coord;
                 for (auto& c : coord)
                 {
                     c = std::experimental::randint(-bound << level, (bound << level) - 1);

--- a/demos/FiniteVolume/linear_convection.cpp
+++ b/demos/FiniteVolume/linear_convection.cpp
@@ -36,7 +36,7 @@ int main(int argc, char* argv[])
 {
     auto& app = samurai::initialize("Finite volume example for the linear convection equation", argc, argv);
 
-    static constexpr std::size_t dim = 3;
+    static constexpr std::size_t dim = 2;
     using Config                     = samurai::MRConfig<dim, 3>;
     using Box                        = samurai::Box<double, dim>;
     using point_t                    = typename Box::point_t;

--- a/demos/FiniteVolume/linear_convection.cpp
+++ b/demos/FiniteVolume/linear_convection.cpp
@@ -36,7 +36,7 @@ int main(int argc, char* argv[])
 {
     auto& app = samurai::initialize("Finite volume example for the linear convection equation", argc, argv);
 
-    static constexpr std::size_t dim = 2;
+    static constexpr std::size_t dim = 3;
     using Config                     = samurai::MRConfig<dim, 3>;
     using Box                        = samurai::Box<double, dim>;
     using point_t                    = typename Box::point_t;
@@ -110,22 +110,30 @@ int main(int argc, char* argv[])
     {
         mesh = {box, min_level, max_level, periodic};
         // Initial solution
-        u = samurai::make_scalar_field<double>("u",
-                                               mesh,
-                                               [](const auto& coords)
-                                               {
-                                                   if constexpr (dim == 1)
-                                                   {
-                                                       const auto& x = coords(0);
-                                                       return (x >= -0.8 && x <= -0.3) ? 1. : 0.;
-                                                   }
-                                                   else
-                                                   {
-                                                       const auto& x = coords(0);
-                                                       const auto& y = coords(1);
-                                                       return (x >= -0.8 && x <= -0.3 && y >= 0.3 && y <= 0.8) ? 1. : 0.;
-                                                   }
-                                               });
+        u = samurai::make_scalar_field<double>(
+            "u",
+            mesh,
+            [](const auto& coords)
+            {
+                if constexpr (dim == 1)
+                {
+                    const auto& x = coords(0);
+                    return (x >= -0.8 && x <= -0.3) ? 1. : 0.;
+                }
+                else if constexpr (dim == 2)
+                {
+                    const auto& x = coords(0);
+                    const auto& y = coords(1);
+                    return (x >= -0.8 && x <= -0.3 && y >= 0.3 && y <= 0.8) ? 1. : 0.;
+                }
+                else if constexpr (dim == 3)
+                {
+                    const auto& x = coords(0);
+                    const auto& y = coords(1);
+                    const auto& z = coords(2);
+                    return (x >= -0.8 && x <= -0.3 && y >= 0.3 && y <= 0.8 && z >= -0.8 && z <= -0.3) ? 1. : 0.;
+                }
+            });
     }
     else
     {
@@ -147,6 +155,11 @@ int main(int argc, char* argv[])
     if constexpr (dim == 2)
     {
         velocity(1) = -1;
+    }
+    if constexpr (dim == 3)
+    {
+        velocity(1) = -1;
+        velocity(2) = 1;
     }
     auto conv = samurai::make_convection_weno5<decltype(u)>(velocity);
 


### PR DESCRIPTION
## Description
	-	Add advection-2 (the balanced version) as benchmark
	-	Support of MPI through Google benchmark
	-	TODO :
		-	resolve benchmark_set
		-	Add other testcases as benchmark
		-	use different stencil size and type

## Related issue

## How has this been tested?
Tested on my personal machine 
- with `mpirun -np 1` 
- with `mpirun -np 4` which is faster


## Code of Conduct
By submitting this PR, you agree to follow our [Code of Conduct](https://github.com/hpc-maths/samurai/blob/master/docs/CODE_OF_CONDUCT.md)
- [x] I agree to follow this project's Code of Conduct
