### PR TITLE
perf: Naive neighbourhood

### DIFF
--- a/include/samurai/mesh.hpp
+++ b/include/samurai/mesh.hpp
@@ -174,6 +174,9 @@ namespace samurai
         void construct_union();
         void update_sub_mesh();
         void renumbering();
+
+        void find_neighbourhood_naive();
+
         void partition_mesh(std::size_t start_level, const Box<double, dim>& global_box);
         void load_balancing();
         void load_transfer(const std::vector<double>& load_fluxes);
@@ -786,6 +789,29 @@ namespace samurai
     }
 
     template <class D, class Config>
+    void Mesh_base<D, Config>::find_neighbour_naive()
+    {
+#ifdef SAMURAI_WITH_MPI
+        mpi::communicator world;
+        auto rank = world.rank();
+        auto size = world.size();
+        if (rank == 0)
+        {
+            m_mpi_neighbourhood.push_back(1);
+        }
+        else if (rank == size - 1)
+        {
+            m_mpi_neighbourhoof(size - 2);
+        }
+        else
+        {
+            m_mpi_neighbourhood(rank - 1);
+            m_mpi_neighbourhoof(rank + 1);
+        }
+#endif
+    }
+
+    template <class D, class Config>
     void Mesh_base<D, Config>::partition_mesh([[maybe_unused]] std::size_t start_level, [[maybe_unused]] const Box<double, dim>& global_box)
     {
 #ifdef SAMURAI_WITH_MPI
@@ -912,6 +938,8 @@ namespace samurai
                 m_mpi_neighbourhood.push_back(ir);
             }
         }
+
+        find_neighbourhood_naive();
 
         // // Neighbours
         // m_mpi_neighbourhood.reserve(static_cast<std::size_t>(pow(3, dim) - 1));

--- a/include/samurai/mesh.hpp
+++ b/include/samurai/mesh.hpp
@@ -789,24 +789,28 @@ namespace samurai
     }
 
     template <class D, class Config>
-    void Mesh_base<D, Config>::find_neighbour_naive()
+    void Mesh_base<D, Config>::find_neighbourhood_naive()
     {
 #ifdef SAMURAI_WITH_MPI
         mpi::communicator world;
         auto rank = world.rank();
         auto size = world.size();
-        if (rank == 0)
+        m_mpi_neighbourhood.reserve(0);
+        if (size > 1)
         {
-            m_mpi_neighbourhood.push_back(1);
-        }
-        else if (rank == size - 1)
-        {
-            m_mpi_neighbourhoof(size - 2);
-        }
-        else
-        {
-            m_mpi_neighbourhood(rank - 1);
-            m_mpi_neighbourhoof(rank + 1);
+            if (rank == 0)
+            {
+                m_mpi_neighbourhood.push_back(1);
+            }
+            else if (rank == size - 1)
+            {
+                m_mpi_neighbourhood.push_back(size - 2);
+            }
+            else
+            {
+                m_mpi_neighbourhood.push_back(rank - 1);
+                m_mpi_neighbourhood.push_back(rank + 1);
+            }
         }
 #endif
     }
@@ -930,14 +934,14 @@ namespace samurai
 
         this->m_cells[mesh_id_t::cells][start_level] = subdomain_cells;
 
-        m_mpi_neighbourhood.reserve(static_cast<std::size_t>(size) - 1);
-        for (int ir = 0; ir < size; ++ir)
-        {
-            if (ir != rank)
-            {
-                m_mpi_neighbourhood.push_back(ir);
-            }
-        }
+        //        m_mpi_neighbourhood.reserve(static_cast<std::size_t>(size) - 1);
+        //        for (int ir = 0; ir < size; ++ir)
+        //        {
+        //            if (ir != rank)
+        //            {
+        //                m_mpi_neighbourhood.push_back(ir);
+        //            }
+        //        }
 
         find_neighbourhood_naive();
 


### PR DESCRIPTION


## Description
Here is a naive solution to construct in a naive way the neighbourhood. 
It is optimal as long as you are using a naive partition as for now. 
Each rank have one or two neighbours. 
This do not works properly with periodic.
We need to improve this implementation by adding new `find_neighbourhood_<strategy>` in the future. 

## Related issue
Perforance issue

## How has this been tested?
on advection-2d

## Code of Conduct
By submitting this PR, you agree to follow our [Code of Conduct](https://github.com/hpc-maths/samurai/blob/master/docs/CODE_OF_CONDUCT.md)
- [x] I agree to follow this project's Code of Conduct
