### PR TITLE
fix: remove warning

### DIFF
--- a/include/samurai/mesh.hpp
+++ b/include/samurai/mesh.hpp
@@ -874,7 +874,7 @@ namespace samurai
                                   {
                                       for (auto i = mi.i.start; i < mi.i.end; ++i)
                                       {
-                                          if (i >= subdomain_start && i < subdomain_end)
+                                          if (static_cast<std::size_t>(i) >= subdomain_start && static_cast<std::size_t>(i) < subdomain_end)
                                           {
                                               subdomain_cells[mi.index].add_point(i);
                                           }


### PR DESCRIPTION
## Description
Previously, due to a `int` versus `std::size_t` comparison, there was a warning. 
This PR cast the int and remove the warning. 

## Related issue
```warning: comparison of integer expressions of different signedness: ‘int’ and ‘std::size_t’ {aka ‘long unsigned int’} [-Wsign-compare]```

## How has this been tested?
advection-2d

## Code of Conduct
By submitting this PR, you agree to follow our [Code of Conduct](https://github.com/hpc-maths/samurai/blob/master/docs/CODE_OF_CONDUCT.md)
- [x] I agree to follow this project's Code of Conduct
