### PR TITLE
fix: forward declare LevelCellArray in static_algorithm.hpp

### DIFF
--- a/include/samurai/static_algorithm.hpp
+++ b/include/samurai/static_algorithm.hpp
@@ -9,7 +9,7 @@
 
 namespace samurai
 {
-    template <std::size_t Dim, class TInterval = default_config::interval_t>
+    template <std::size_t Dim, class TInterval>
     class LevelCellArray;
 
     // Static loop with boundaries known at compile time

--- a/include/samurai/static_algorithm.hpp
+++ b/include/samurai/static_algorithm.hpp
@@ -9,6 +9,9 @@
 
 namespace samurai
 {
+    template <std::size_t Dim, class TInterval = default_config::interval_t>
+    class LevelCellArray;
+
     // Static loop with boundaries known at compile time
     namespace detail
     {


### PR DESCRIPTION
## Description
Some functions declared in `static_algorithm.hpp` use `LevelCellArray`.
Therefore, including `static_alogrithm.hpp` in the "wrong order" (i.e. before `LevelCellArray` is declared) will produce an error.
This issue can be resolved by forward declaring `LevelCellArray`. 

## Code of Conduct
By submitting this PR, you agree to follow our [Code of Conduct](https://github.com/hpc-maths/samurai/blob/master/docs/CODE_OF_CONDUCT.md)
- [X] I agree to follow this project's Code of Conduct
