### PR TITLE
feat: parallel restart

### DIFF
--- a/include/samurai/io/util.hpp
+++ b/include/samurai/io/util.hpp
@@ -34,4 +34,34 @@ namespace samurai
         }
         return data;
     }
+
+    template <class Field, class SubMesh>
+    auto extract_data_as_vector(const Field& field, const SubMesh& submesh)
+    {
+        using size_type        = typename Field::inner_types::size_type;
+        std::size_t data_shape = submesh.nb_cells() * field.n_comp;
+        std::vector<typename Field::value_type> data(data_shape);
+
+        if (submesh.nb_cells() != 0)
+        {
+            std::size_t index = 0;
+            for_each_cell(submesh,
+                          [&](auto cell)
+                          {
+                              if constexpr (Field::is_scalar)
+                              {
+                                  data[index++] = field[cell];
+                              }
+                              else
+                              {
+                                  for (size_type i = 0; i < field.n_comp; ++i)
+                                  {
+                                      data[index + i] = field[cell][i];
+                                  }
+                                  index += field.n_comp;
+                              }
+                          });
+        }
+        return data;
+    }
 }

--- a/include/samurai/mesh.hpp
+++ b/include/samurai/mesh.hpp
@@ -329,6 +329,7 @@ namespace samurai
         update_sub_mesh();
         renumbering();
 
+#ifdef SAMURAI_WITH_MPI
         mpi::communicator world;
         m_mpi_neighbourhood.clear();
         for (int i = 0; i < world.size(); ++i)
@@ -338,6 +339,7 @@ namespace samurai
                 m_mpi_neighbourhood.emplace_back(i);
             }
         }
+#endif
         update_mesh_neighbour();
 
         set_origin_point(ca.origin_point());
@@ -749,7 +751,7 @@ namespace samurai
 
         m_domain = {lcl};
 #else
-        m_domain = m_subdomain
+        m_domain = m_subdomain;
 #endif
     }
 

--- a/include/samurai/mesh.hpp
+++ b/include/samurai/mesh.hpp
@@ -808,17 +808,6 @@ namespace samurai
                     lcl[index_yz].add_interval(interval);
                 });
 
-            // for (auto& neighbour : m_mpi_neighbourhood)
-            // {
-            //     auto neigh_expr = intersection(m_subdomain, union_(neighbour.mesh.m_cells[mesh_id_t::cells][level], m_union[level]))
-            //                           .on(level - 1);
-
-            //     neigh_expr(
-            //         [&](const auto& interval, const auto& index_yz)
-            //         {
-            //             lcl[index_yz].add_interval(interval);
-            //         });
-            // }
             m_union[level - 1] = {lcl};
         }
     }

--- a/include/samurai/mr/mesh.hpp
+++ b/include/samurai/mr/mesh.hpp
@@ -354,9 +354,8 @@ namespace samurai
                         //~ for (const auto& mpi_neighbor : this->mpi_neighbourhood())
                         for (size_t neighbor_id = 0; neighbor_id != this->mpi_neighbourhood().size(); ++neighbor_id)
                         {
-                            const auto& mpi_neighbor                = this->mpi_neighbourhood()[neighbor_id];
-                            const auto& neighbor_extended_subdomain = neighbourhood_extended_subdomain[neighbor_id][level];
-                            const auto& neighbor_mesh_ref           = mpi_neighbor.mesh[mesh_id_t::reference];
+                            const auto& mpi_neighbor      = this->mpi_neighbourhood()[neighbor_id];
+                            const auto& neighbor_mesh_ref = mpi_neighbor.mesh[mesh_id_t::reference];
 
                             auto set1_mpi = intersection(translate(intersection(neighbor_mesh_ref[level], lca_min), shift),
                                                          intersection(lca_extended_subdomain, lca_max));


### PR DESCRIPTION
## Description
This PR allows a parallel simulation to be restarted. Since load balancing has not yet been completed, the restart process checks that the number of processes is the same in the simulation that is being restarted and in the restart file. If not, an error message is displayed.

This constraint will be removed once load balancing is working as expected.

## Code of Conduct
By submitting this PR, you agree to follow our [Code of Conduct](https://github.com/hpc-maths/samurai/blob/master/docs/CODE_OF_CONDUCT.md)
- [x] I agree to follow this project's Code of Conduct
