### PR TITLE
feat: check if a set is empty

### DIFF
--- a/include/samurai/subset/node.hpp
+++ b/include/samurai/subset/node.hpp
@@ -161,6 +161,11 @@ namespace samurai
                 m_s);
         }
 
+        bool empty()
+        {
+            return empty_check(*this);
+        }
+
         bool exist() const
         {
             return std::apply(
@@ -429,6 +434,11 @@ namespace samurai
         }
 
         bool exist() const
+        {
+            return !m_lca.empty();
+        }
+
+        bool empty() const
         {
             return !m_lca.empty();
         }

--- a/tests/test_subset.cpp
+++ b/tests/test_subset.cpp
@@ -1302,4 +1302,21 @@ namespace samurai
               });
         EXPECT_TRUE(never_call);
     }
+
+    TEST(subset, empty)
+    {
+        LevelCellArray<1> lca(1);
+        LevelCellArray<1> lca_empty(1);
+        lca.add_interval_back({0, 16}, {});
+        xt::xtensor_fixed<int, xt::xshape<1>> translation{16};
+
+        EXPECT_FALSE(lca.empty());
+        EXPECT_TRUE(lca_empty.empty());
+
+        EXPECT_TRUE(intersection(lca, lca_empty).empty());
+        EXPECT_FALSE(intersection(lca, lca).empty());
+        EXPECT_FALSE(difference(lca, lca_empty).empty());
+        EXPECT_TRUE(intersection(lca, translate(lca, translation)).empty());
+    }
+
 }


### PR DESCRIPTION
## Description
For now, there is a method in set algebra called 'exist' that checks whether a subset can exist. For example, the intersection of a set and an empty set is also empty, so there is no need to go further. The same applies to the difference between an empty set and a set.

However, it may also be interesting to know whether the set can exist and whether it is empty. This PR implements this method. If we find an interval, we return true immediately. Otherwise, we search through the set until the end.

## How has this been tested?
A test is added in `test_subset.cpp` file.

## Code of Conduct
By submitting this PR, you agree to follow our [Code of Conduct](https://github.com/hpc-maths/samurai/blob/master/docs/CODE_OF_CONDUCT.md)
- [x] I agree to follow this project's Code of Conduct
