### PR TITLE
fix: subset

### DIFF
--- a/include/samurai/subset/node.hpp
+++ b/include/samurai/subset/node.hpp
@@ -423,6 +423,7 @@ namespace samurai
 
         auto& on(auto level)
         {
+            m_ref_level = std::max(m_ref_level, static_cast<std::size_t>(level));
             m_min_level = std::min(m_min_level, static_cast<std::size_t>(level));
             m_level     = static_cast<std::size_t>(level);
             return *this;

--- a/include/samurai/subset/start_end_fct.hpp
+++ b/include/samurai/subset/start_end_fct.hpp
@@ -38,11 +38,11 @@ namespace samurai
         template <std::size_t, bool from_diff_op = false, class Func>
         inline auto start(const Func& f) const
         {
-            auto new_f = [&, f](auto, auto i, auto dec)
+            auto new_f = [&, f](auto level, auto i, auto dec)
             {
                 if constexpr (from_diff_op)
                 {
-                    dec = 1;
+                    dec = (static_cast<std::size_t>(level) > m_level) ? 1 : 0;
                 }
                 int value = (((i - dec) >> m_shift) << m_shift) + dec;
                 return f(m_level, value, dec);
@@ -53,11 +53,11 @@ namespace samurai
         template <std::size_t, bool from_diff_op = false, class Func>
         inline auto end(const Func& f) const
         {
-            auto new_f = [&, f](auto, auto i, auto dec)
+            auto new_f = [&, f](auto level, auto i, auto dec)
             {
                 if constexpr (from_diff_op)
                 {
-                    dec = 0;
+                    dec = (static_cast<std::size_t>(level) > m_level) ? 0 : 1;
                 }
                 int value = (((i - dec) >> m_shift) + dec) << m_shift;
                 return f(m_level, value, dec);
@@ -126,7 +126,7 @@ namespace samurai
 
                 if constexpr (from_diff_op)
                 {
-                    dec = 1;
+                    dec = (static_cast<std::size_t>(level) > m_level) ? 1 : 0;
                 }
                 int value = (((((i - dec) >> max2curr) + m_t[d - 1]) >> curr2min) + dec) << min2max;
 
@@ -146,7 +146,7 @@ namespace samurai
 
                 if constexpr (from_diff_op)
                 {
-                    dec = 0;
+                    dec = (static_cast<std::size_t>(level) > m_level) ? 0 : 1;
                 }
                 int value = (((((i - dec) >> max2curr) + m_t[d - 1]) >> curr2min) + dec) << min2max;
 
@@ -215,9 +215,10 @@ namespace samurai
 
                 if constexpr (from_diff_op)
                 {
+                    dec = (static_cast<std::size_t>(level) > m_level) ? 1 : 0;
                     dec = 1;
                 }
-                int value = (((((i - dec) >> max2curr) - m_c) >> curr2min) + dec) << min2max;
+                int value = (((((i - dec) >> max2curr) + m_c) >> curr2min) + dec) << min2max;
                 return f(m_level, value, dec);
             };
             return new_f;
@@ -234,7 +235,7 @@ namespace samurai
 
                 if constexpr (from_diff_op)
                 {
-                    dec = 0;
+                    dec = (static_cast<std::size_t>(level) > m_level) ? 0 : 1;
                 }
                 int value = (((((i - dec) >> max2curr) - m_c) >> curr2min) + dec) << min2max;
                 return f(m_level, value, dec);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -17,6 +17,7 @@ set(SAMURAI_TESTS
     test_cell.cpp
     test_cell_array.cpp
     test_cell_list.cpp
+    test_corner_projection.cpp
     test_domain_with_hole.cpp
     test_field.cpp
     test_find.cpp

--- a/tests/test_corner_projection.cpp
+++ b/tests/test_corner_projection.cpp
@@ -1,0 +1,88 @@
+#include <gtest/gtest.h>
+#include <samurai/field.hpp>
+#include <samurai/mr/mesh.hpp>
+#include <samurai/samurai.hpp>
+#include <samurai/subset/node.hpp>
+
+namespace samurai
+{
+    TEST(subset, corner_projection)
+    {
+        static constexpr std::size_t dim = 2;
+        using Config                     = MRConfig<dim>;
+        using Box                        = Box<double, dim>;
+        using Mesh                       = MRMesh<Config>;
+        using interval_t                 = typename Mesh::interval_t;
+        using mesh_id_t                  = typename Mesh::mesh_id_t;
+        using direction_t                = DirectionVector<dim>;
+
+        Box box({-1., -1.}, {1., 1.});
+
+        std::size_t min_level = 2;
+        std::size_t max_level = 6;
+
+        Mesh mesh{box, min_level, max_level};
+
+        direction_t direction = {-1, -1}; // corner direction
+        std::size_t level     = 6;
+
+        auto domain            = self(mesh.domain()).on(level);
+        auto fine_inner_corner = difference(
+            domain,
+            union_(translate(domain, direction_t{-direction[0], 0}), translate(domain, direction_t{0, -direction[1]})));
+
+        bool found     = false;
+        std::size_t nb = 0;
+        fine_inner_corner(
+            [&](const auto& i, const auto& index)
+            {
+                EXPECT_EQ(i, interval_t(0, 1));
+                EXPECT_EQ(index[0], 0);
+                ++nb;
+                found = true;
+            });
+        EXPECT_EQ(nb, 1);
+        EXPECT_TRUE(found);
+
+        auto fine_outer_corner = intersection(translate(fine_inner_corner, direction), mesh[mesh_id_t::reference][level]);
+        found                  = false;
+        nb                     = 0;
+        fine_outer_corner(
+            [&](const auto& i, const auto& index)
+            {
+                EXPECT_EQ(i, interval_t(-1, 0));
+                EXPECT_EQ(index[0], -1);
+                ++nb;
+                found = true;
+            });
+        EXPECT_EQ(nb, 1);
+        EXPECT_TRUE(found);
+
+        found = false;
+        nb    = 0;
+        fine_outer_corner.on(level - 1)(
+            [&](const auto& i, const auto& index)
+            {
+                EXPECT_EQ(i, interval_t(-1, 0));
+                EXPECT_EQ(index[0], -1);
+                ++nb;
+                found = true;
+            });
+        EXPECT_EQ(nb, 1);
+        EXPECT_TRUE(found);
+
+        auto parent_ghost = intersection(fine_outer_corner.on(level - 1), mesh[mesh_id_t::reference][level - 1]);
+        found             = false;
+        nb                = 0;
+        parent_ghost(
+            [&](const auto& i, const auto& index)
+            {
+                EXPECT_EQ(i, interval_t(-1, 0));
+                EXPECT_EQ(index[0], -1);
+                ++nb;
+                found = true;
+            });
+        EXPECT_EQ(nb, 1);
+        EXPECT_TRUE(found);
+    }
+}


### PR DESCRIPTION
## Description
The difference operator does not work as expected when the levels of the set elements and the set level are the same.

## Related issue

This example didn't work

```cpp
int main(int argc, char* argv[])
{
 static constexpr std::size_t dim = 2;
 using Config = samurai::MRConfig<dim>;
 using Box = samurai::Box<double, dim>;
 using Mesh = samurai::MRMesh<Config>;
 using mesh_id_t = typename Mesh::mesh_id_t;
 using direction_t = samurai::DirectionVector<dim>;

 Box box({-1., -1.}, {1., 1.});

 std::size_t min_level = 2;
 std::size_t max_level = 6;

 Mesh mesh{box, min_level, max_level};

 auto u = samurai::make_scalar_field<double>("u", mesh);

 direction_t direction = {-1, -1}; // corner direction
 std::size_t level = 6;

 std::cout << "--- Projecting outer corner at level " << level << " to level " << (level - 1) << " in direction " << direction << ": "
 << std::endl;

 // Cette partie-là fonctionne
 auto domain = self(mesh.domain()).on(level);
 auto fine_inner_corner = difference(
 domain,
 union_(translate(domain, direction_t{-direction[0], 0}), translate(domain, direction_t{0, -direction[1]})));
 fine_inner_corner(
 [&](const auto& i, const auto& index)
 {
 std::cout << "Fine inner corner at level " << level << ": i = " << i << ", index = " << index << std::endl;
 });
 auto fine_outer_corner = intersection(translate(fine_inner_corner, direction), mesh[mesh_id_t::reference][level]);
 fine_outer_corner(
 [&](const auto& i, const auto& index)
 {
 std::cout << "Fine outer corner at level " << level << ": i = " << i << ", index = " << index << std::endl;
 });
 // Ici ça ne marche plus...
 auto parent_ghost = intersection(fine_outer_corner.on(level - 1), mesh[mesh_id_t::reference][level - 1]);
 int nb = 0;
 parent_ghost(
 [&](const auto& i, const auto& index)
 {
 nb++;
 std::cout << "Parent ghost at level " << (level - 1) << ": i = " << i << ", index = " << index << " "
 << (nb == 1 ? "OK" : "NOT OK...") << std::endl;
 });
}
```

Thanks @pmatalon  !

## How has this been tested?

This example has been added in `test_corner_prjection.cpp`.

## Code of Conduct
By submitting this PR, you agree to follow our [Code of Conduct](https://github.com/hpc-maths/samurai/blob/master/docs/CODE_OF_CONDUCT.md)
- [x] I agree to follow this project's Code of Conduct
