### PR TITLE
fix: correct timer

### DIFF
--- a/include/samurai/timers.hpp
+++ b/include/samurai/timers.hpp
@@ -127,7 +127,7 @@ namespace samurai
                         maxrank = static_cast<int>(iproc);
                     }
 
-                    ave += timer.second.elapsed;
+                    ave += all[iproc];
                 }
 
                 ave /= static_cast<double>(world.size());


### PR DESCRIPTION
## Description
Previously, the average timer was buggy and displayed the rank-0 time. This commit corrected that and computed the actual average value.

## Related issue
Average timer was incorrect.

## How has this been tested?
In `advection-2d` with 3 ranks.

## Code of Conduct
By submitting this PR, you agree to follow our [Code of Conduct](https://github.com/hpc-maths/samurai/blob/master/docs/CODE_OF_CONDUCT.md)
- [x] I agree to follow this project's Code of Conduct
