### PR TITLE
perf: Reducing MPI communications in update_ghost_mr 

### DIFF
--- a/demos/FiniteVolume/advection_2d.cpp
+++ b/demos/FiniteVolume/advection_2d.cpp
@@ -247,7 +247,6 @@ int main(int argc, char* argv[])
     auto MRadaptation = samurai::make_MRAdapt(u);
     MRadaptation(mr_epsilon, mr_regularity);
     save(path, filename, u, "_init");
-
     std::size_t nsave = 1;
     std::size_t nt    = 0;
 

--- a/include/samurai/mr/adapt.hpp
+++ b/include/samurai/mr/adapt.hpp
@@ -245,10 +245,11 @@ namespace samurai
         {
             update_tag_subdomains(level, m_tag, true);
         }
-
+        //~ save(std::filesystem::current_path(), "ite_" + std::to_string(ite) + "_before_update_ghosts", {true, true}, mesh, m_fields);
         times::timers.stop("mesh adaptation");
         update_ghost_mr(m_fields);
         times::timers.start("mesh adaptation");
+        //~ save(std::filesystem::current_path(), "ite_" + std::to_string(ite) + "_after_update_ghosts", {true, true}, mesh, m_fields);
 
         for (std::size_t level = ((min_level > 0) ? min_level - 1 : 0); level < max_level - ite; ++level)
         {

--- a/include/samurai/mr/mesh.hpp
+++ b/include/samurai/mr/mesh.hpp
@@ -412,6 +412,7 @@ namespace samurai
             this->update_neighbour_subdomain();
             this->update_meshid_neighbour(mesh_id_t::cells_and_ghosts);
             this->update_meshid_neighbour(mesh_id_t::reference);
+            this->update_meshid_neighbour(mesh_id_t::proj_cells);
         }
     }
 


### PR DESCRIPTION
 <!-- Thank you for your contribution to samurai! -->

<!-- Please check the following before submitting your PR -->
- [X] I have installed [pre-commit](https://pre-commit.com/) locally and use it to validate my commits.
- [X] The PR title follows the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) convention.
      Available tags: 'build', 'chore', 'ci', 'docs', 'feat', 'fix', 'perf', 'refactor', 'revert', 'style', 'test'
- [X] This new PR is documented.
- [] This new PR is tested.

## Description
`update_ghost_mr` used to do level-by-level communications. The present PR fixes this by sending the ghosts from all levels all-together, therefore reducing the total level of communication from O(n_levels) to O(1). 

## Related issue

## How has this been tested?

## Code of Conduct
By submitting this PR, you agree to follow our [Code of Conduct](https://github.com/hpc-maths/samurai/blob/master/docs/CODE_OF_CONDUCT.md)
- [X] I agree to follow this project's Code of Conduct
