### PR TITLE
fix: fix template deduction for mat_vec function

### DIFF
--- a/include/samurai/storage/collapsable_linear_algebra.hpp
+++ b/include/samurai/storage/collapsable_linear_algebra.hpp
@@ -100,7 +100,7 @@ namespace samurai
         // return e;
     }
 
-    template <bool SOA, class value_type, std::enable_if_t<std::is_floating_point_v<value_type>, bool> = true>
+    template <bool SOA, bool can_collapse, class value_type, std::enable_if_t<std::is_floating_point_v<value_type>, bool> = true>
     auto mat_vec(value_type A, value_type x)
     {
         return A * x;


### PR DESCRIPTION
 <!-- Thank you for your contribution to samurai! -->

<!-- Please check the following before submitting your PR -->
- [x] I have installed [pre-commit](https://pre-commit.com/) locally and use it to validate my commits.
- [x] The PR title follows the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) convention.
      Available tags: 'build', 'chore', 'ci', 'docs', 'feat', 'fix', 'perf', 'refactor', 'revert', 'style', 'test'
- [ ] This new PR is documented.
- [ ] This new PR is tested.

## Description
<!-- A clear and concise description of what you have done in this PR. -->
* Add the boolean template parameter `can_collapse` to all `mat_vec` functions.

## Related issue
<!-- List the issues solved by this PR, if any. -->
* Correct function deduction of `mat_vec` when use implicit scheme

## How has this been tested?
<!-- Give the list of files used to test this new implementation. -->

## Code of Conduct
By submitting this PR, you agree to follow our [Code of Conduct](https://github.com/hpc-maths/samurai/blob/master/docs/CODE_OF_CONDUCT.md)
- [x] I agree to follow this project's Code of Conduct
