### PR TITLE
fix: add direction and cell to implicit BC

### DIFF
--- a/include/samurai/petsc/fv/FV_scheme_assembly.hpp
+++ b/include/samurai/petsc/fv/FV_scheme_assembly.hpp
@@ -571,12 +571,12 @@ namespace samurai
                         double bc_value;
                         if constexpr (field_t::is_scalar)
                         {
-                            bc_value = bc->value({}, {}, boundary_point);
+                            bc_value = bc->value(towards_out, cell, boundary_point);
                         }
                         else
                         {
-                            bc_value = bc->value({}, {}, boundary_point)(field_i); // TODO: call get_value() only once instead of
-                                                                                   // once per field_i
+                            bc_value = bc->value(towards_out, cell, boundary_point)(field_i); // TODO: call get_value() only once instead of
+                                                                                              // once per field_i
                         }
 
                         if constexpr (dirichlet_enfcmt == DirichletEnforcement::Elimination)


### PR DESCRIPTION
## Description
The arguments `direction` and `cell` have been added to the function that computes the BC value to enforce. This concerns only the implicit setting, where those arguments were not filled.

## Code of Conduct
By submitting this PR, you agree to follow our [Code of Conduct](https://github.com/hpc-maths/samurai/blob/master/docs/CODE_OF_CONDUCT.md)
- [x] I agree to follow this project's Code of Conduct
