### PR TITLE
feat: Add row_index() and col_index() to operator sum

### DIFF
--- a/include/samurai/petsc/fv/cell_based_scheme_assembly.hpp
+++ b/include/samurai/petsc/fv/cell_based_scheme_assembly.hpp
@@ -13,15 +13,15 @@ namespace samurai
           protected:
 
             using base_class = FVSchemeAssembly<Scheme>;
-            using base_class::col_index;
             using base_class::dim;
             using base_class::n_comp;
-            using base_class::row_index;
             using base_class::set_is_row_not_empty;
 
           public:
 
+            using base_class::col_index;
             using base_class::mesh;
+            using base_class::row_index;
             using base_class::scheme;
             using base_class::set_current_insert_mode;
             using base_class::unknown;

--- a/include/samurai/petsc/fv/flux_based_scheme_assembly.hpp
+++ b/include/samurai/petsc/fv/flux_based_scheme_assembly.hpp
@@ -16,16 +16,16 @@ namespace samurai
           protected:
 
             using base_class = FVSchemeAssembly<Scheme>;
-            using base_class::col_index;
             using base_class::dim;
             using base_class::n_comp;
-            using base_class::row_index;
             using base_class::set_is_row_not_empty;
 
           public:
 
+            using base_class::col_index;
             using base_class::ghost_elimination_enabled;
             using base_class::mesh;
+            using base_class::row_index;
             using base_class::scheme;
             using base_class::set_current_insert_mode;
             using base_class::unknown;

--- a/include/samurai/petsc/fv/operator_sum_assembly.hpp
+++ b/include/samurai/petsc/fv/operator_sum_assembly.hpp
@@ -13,6 +13,7 @@ namespace samurai
 
             using scheme_t = OperatorSum<Operators...>;
             using field_t  = typename scheme_t::field_t;
+            using cell_t   = typename field_t::mesh_t::cell_t;
 
           private:
 
@@ -265,6 +266,26 @@ namespace samurai
             void enforce_projection_prediction(Vec& b) const
             {
                 largest_stencil_assembly().enforce_projection_prediction(b);
+            }
+
+            inline PetscInt col_index(PetscInt cell_index, unsigned int field_j) const
+            {
+                return largest_stencil_assembly().col_index(cell_index, field_j);
+            }
+
+            inline PetscInt row_index(PetscInt cell_index, [[maybe_unused]] unsigned int field_i) const
+            {
+                return largest_stencil_assembly().row_index(cell_index, field_i);
+            }
+
+            inline PetscInt col_index(const cell_t& cell, unsigned int field_j) const
+            {
+                return largest_stencil_assembly().col_index(cell, field_j);
+            }
+
+            inline PetscInt row_index(const cell_t& cell, unsigned int field_i) const
+            {
+                return largest_stencil_assembly().row_index(cell, field_i);
             }
 
             bool matrix_is_symmetric() const override


### PR DESCRIPTION
## Description
Functions `row_index()` and `col_index()` are now available in an operator sum.

## Code of Conduct
By submitting this PR, you agree to follow our [Code of Conduct](https://github.com/hpc-maths/samurai/blob/master/docs/CODE_OF_CONDUCT.md)
- [x] I agree to follow this project's Code of Conduct
