### PR TITLE
feat: add finer-level-flux option

### DIFF
--- a/demos/FiniteVolume/burgers_mra.cpp
+++ b/demos/FiniteVolume/burgers_mra.cpp
@@ -310,11 +310,10 @@ int main(int argc, char* argv[])
 
     std::size_t nsave;
 
-    scheme.enable_finer_level_flux(false);
+    scheme.enable_max_level_flux(false);
     run_simulation(u, unp1, u_max, unp1_max, scheme, cfl, mr_epsilon, mr_regularity, init_sol, nfiles, path, filename, nsave);
 
-    scheme.enable_finer_level_flux(true);
-    samurai::args::finer_level_flux = -1;
+    scheme.enable_max_level_flux(true);
     run_simulation(u, unp1, u_max, unp1_max, scheme, cfl, mr_epsilon, mr_regularity, init_sol, nfiles, path, filename, nsave);
 
     std::cout << std::endl;

--- a/demos/FiniteVolume/burgers_mra.cpp
+++ b/demos/FiniteVolume/burgers_mra.cpp
@@ -83,11 +83,18 @@ void run_simulation(Field& u,
 {
     auto& mesh = u.mesh();
 
-    std::cout << std::endl << "max-level-flux enabled: " << scheme.enable_max_level_flux() << std::endl;
+    std::cout << std::endl << "finer-level-flux enabled: " << scheme.enable_finer_level_flux() << std::endl;
 
-    if (scheme.enable_max_level_flux())
+    if (scheme.enable_finer_level_flux())
     {
-        filename += "_mlf";
+        if (samurai::args::finer_level_flux == -1)
+        {
+            filename += "_mlf";
+        }
+        else
+        {
+            filename += fmt::format("_lf_{}", samurai::args::finer_level_flux);
+        }
     }
 
     // Initial solution

--- a/demos/FiniteVolume/burgers_mra.cpp
+++ b/demos/FiniteVolume/burgers_mra.cpp
@@ -310,10 +310,11 @@ int main(int argc, char* argv[])
 
     std::size_t nsave;
 
-    scheme.enable_max_level_flux(false);
+    scheme.enable_finer_level_flux(false);
     run_simulation(u, unp1, u_max, unp1_max, scheme, cfl, mr_epsilon, mr_regularity, init_sol, nfiles, path, filename, nsave);
 
-    scheme.enable_max_level_flux(true);
+    scheme.enable_finer_level_flux(true);
+    samurai::args::finer_level_flux = -1;
     run_simulation(u, unp1, u_max, unp1_max, scheme, cfl, mr_epsilon, mr_regularity, init_sol, nfiles, path, filename, nsave);
 
     std::cout << std::endl;

--- a/demos/FiniteVolume/burgers_mra.cpp
+++ b/demos/FiniteVolume/burgers_mra.cpp
@@ -83,18 +83,11 @@ void run_simulation(Field& u,
 {
     auto& mesh = u.mesh();
 
-    std::cout << std::endl << "finer-level-flux enabled: " << scheme.enable_finer_level_flux() << std::endl;
+    std::cout << std::endl << "max-level-flux enabled: " << scheme.enable_max_level_flux() << std::endl;
 
-    if (scheme.enable_finer_level_flux())
+    if (scheme.enable_max_level_flux())
     {
-        if (samurai::args::finer_level_flux == -1)
-        {
-            filename += "_mlf";
-        }
-        else
-        {
-            filename += fmt::format("_lf_{}", samurai::args::finer_level_flux);
-        }
+        filename += "_mlf";
     }
 
     // Initial solution

--- a/include/samurai/arguments.hpp
+++ b/include/samurai/arguments.hpp
@@ -12,9 +12,9 @@ namespace samurai
 #ifdef SAMURAI_WITH_MPI
         static bool dont_redirect_output = false;
 #endif
-        static bool enable_max_level_flux = false;
-        static bool refine_boundary       = false;
-        static bool save_debug_fields     = false;
+        static int finer_level_flux   = 0;
+        static bool refine_boundary   = false;
+        static bool save_debug_fields = false;
     }
 
     inline void read_samurai_arguments(CLI::App& app, int& argc, char**& argv)
@@ -25,7 +25,10 @@ namespace samurai
             ->group("IO");
 #endif
         app.add_flag("--timers", args::timers, "Print timers at the end of the program")->capture_default_str()->group("Tools");
-        app.add_flag("--enable-max-level-flux", args::enable_max_level_flux, "Enable the computation of fluxes at the finest level")
+        app.add_option(
+               "--finer-level-flux",
+               args::finer_level_flux,
+               "Computation of fluxes at finer levels (default: 0, i.e. no finer level flux, -1 for max_level flux, > 0 for current level + finer_level_flux)")
             ->capture_default_str()
             ->group("SAMURAI");
         app.add_flag("--refine-boundary", args::refine_boundary, "Keep the boundary refined at max_level")->capture_default_str()->group("SAMURAI");

--- a/include/samurai/reconstruction.hpp
+++ b/include/samurai/reconstruction.hpp
@@ -870,11 +870,12 @@ namespace samurai
                             {
                                 auto dst   = field_dst(level_dst, interval_t{i.start + ii, i.start + ii + 1});
                                 auto i_src = (i.start + static_cast<value_t>(ii)) >> shift;
-                                dst        = portion(field_src,
-                                              level_src,
-                                              interval_t{i_src, i_src + 1},
-                                              shift,
-                                              i.start + ii - (i_src << static_cast<value_t>(shift)));
+                                portion(dst,
+                                        field_src,
+                                        level_src,
+                                        shift,
+                                        std::make_tuple(interval_t{i_src, i_src + 1}),
+                                        std::make_tuple(i.start + ii - (i_src << static_cast<value_t>(shift))));
                             }
                         }
                         else if constexpr (dim == 2)
@@ -885,13 +886,12 @@ namespace samurai
                                 auto dst   = field_dst(level_dst, interval_t{i.start + ii, i.start + ii + 1}, j);
                                 auto i_src = (i.start + static_cast<value_t>(ii)) >> shift;
                                 auto j_src = j >> shift;
-                                dst        = portion(field_src,
-                                              level_src,
-                                              interval_t{i_src, i_src + 1},
-                                              j_src,
-                                              shift,
-                                              i.start + ii - (i_src << static_cast<value_t>(shift)),
-                                              j - (j_src << shift));
+                                portion(dst,
+                                        field_src,
+                                        level_src,
+                                        shift,
+                                        std::make_tuple(interval_t{i_src, i_src + 1}, j_src),
+                                        std::make_tuple(i.start + ii - (i_src << static_cast<value_t>(shift)), j - (j_src << shift)));
                             }
                         }
                         else if constexpr (dim == 3)
@@ -904,15 +904,14 @@ namespace samurai
                                 auto i_src = (i.start + static_cast<value_t>(ii)) >> shift;
                                 auto j_src = j >> shift;
                                 auto k_src = k >> shift;
-                                dst        = portion(field_src,
-                                              level_src,
-                                              interval_t{i_src, i_src + 1},
-                                              j_src,
-                                              k_src,
-                                              shift,
-                                              i.start + ii - (i_src << static_cast<value_t>(shift)),
-                                              j - (j_src << shift),
-                                              k - (k_src << shift));
+                                portion(dst,
+                                        field_src,
+                                        level_src,
+                                        shift,
+                                        std::make_tuple(interval_t{i_src, i_src + 1}, j_src, k_src),
+                                        std::make_tuple(i.start + ii - (i_src << static_cast<value_t>(shift)),
+                                                        j - (j_src << shift),
+                                                        k - (k_src << shift)));
                             }
                         }
                     });

--- a/include/samurai/schemes/fv/flux_based/explicit_flux_based_scheme__nonlin.hpp
+++ b/include/samurai/schemes/fv/flux_based/explicit_flux_based_scheme__nonlin.hpp
@@ -32,11 +32,11 @@ namespace samurai
 
       private:
 
-        template <bool enable_max_level_flux>
+        template <bool enable_finer_level_flux>
         void _apply(std::size_t d, output_field_t& output_field, input_field_t& input_field)
         {
             // Interior interfaces
-            scheme().template for_each_interior_interface<Run::Parallel, enable_max_level_flux>( // We need the 'template' keyword...
+            scheme().template for_each_interior_interface<Run::Parallel, enable_finer_level_flux>( // We need the 'template' keyword...
                 d,
                 input_field,
                 [&](const auto& cell, auto& contrib)
@@ -53,7 +53,7 @@ namespace samurai
             // Boundary interfaces
             if (scheme().include_boundary_fluxes())
             {
-                scheme().template for_each_boundary_interface<Run::Parallel, enable_max_level_flux>( // We need the 'template' keyword...
+                scheme().template for_each_boundary_interface<Run::Parallel, enable_finer_level_flux>( // We need the 'template' keyword...
                     d,
                     input_field,
                     [&](const auto& cell, auto& contrib)
@@ -70,7 +70,7 @@ namespace samurai
 
         void apply(std::size_t d, output_field_t& output_field, input_field_t& input_field) override
         {
-            if (args::enable_max_level_flux || scheme().enable_max_level_flux()) // cppcheck-suppress knownConditionTrueFalse
+            if (args::finer_level_flux != 0 || scheme().enable_finer_level_flux()) // cppcheck-suppress knownConditionTrueFalse
             {
                 _apply<true>(d, output_field, input_field);
             }

--- a/include/samurai/schemes/fv/flux_based/flux_based_scheme.hpp
+++ b/include/samurai/schemes/fv/flux_based/flux_based_scheme.hpp
@@ -22,7 +22,7 @@ namespace samurai
         using bdry_cfg = BoundaryConfigFV<cfg::stencil_size / 2>;
 
         // cppcheck-suppress knownConditionTrueFalse
-        if (args::enable_max_level_flux && cfg::dim > 1 && cfg::stencil_size > 4 && !args::refine_boundary)
+        if (args::finer_level_flux != 0 && cfg::dim > 1 && cfg::stencil_size > 4 && !args::refine_boundary)
         {
             std::cout << "Warning: for stencils larger than 4, computing fluxes at max_level may cause issues close to the boundary."
                       << std::endl;

--- a/include/samurai/schemes/fv/flux_based/flux_based_scheme__nonlin.hpp
+++ b/include/samurai/schemes/fv/flux_based/flux_based_scheme__nonlin.hpp
@@ -181,11 +181,11 @@ namespace samurai
         {
             if constexpr (input_field_t::is_scalar)
             {
-                predicted_value = portion(field, level, coarse_cell_indices, delta_l, fine_cell_indices)[0];
+                portion(predicted_value, field, level, coarse_cell_indices, delta_l, fine_cell_indices);
             }
             else
             {
-                predicted_value = portion(field, level, coarse_cell_indices, delta_l, fine_cell_indices);
+                portion(predicted_value, field, level, coarse_cell_indices, delta_l, fine_cell_indices);
             }
         }
 

--- a/include/samurai/schemes/fv/flux_based/flux_based_scheme__nonlin.hpp
+++ b/include/samurai/schemes/fv/flux_based/flux_based_scheme__nonlin.hpp
@@ -472,7 +472,7 @@ namespace samurai
                 auto h_l   = mesh.cell_length(level);
                 auto h_lp1 = mesh.cell_length(level + 1);
 
-                auto h_face = mesh.cell_length(detail::get_dest_level<enable_finer_level_flux>(level + 1, max_level));
+                auto h_face = mesh.cell_length(detail::get_dest_level<enable_finer_level_flux>(level + 1, m_finer_level_flux, max_level));
 
                 flux_params.set_level(level + 1);
                 flux_params.cell_length = h_face;

--- a/include/samurai/schemes/fv/flux_based/flux_based_scheme__nonlin.hpp
+++ b/include/samurai/schemes/fv/flux_based/flux_based_scheme__nonlin.hpp
@@ -181,11 +181,11 @@ namespace samurai
         {
             if constexpr (input_field_t::is_scalar)
             {
-                portion(predicted_value, field, level, coarse_cell_indices, delta_l, fine_cell_indices);
+                portion(predicted_value, field, level, delta_l, coarse_cell_indices, fine_cell_indices);
             }
             else
             {
-                portion(predicted_value, field, level, coarse_cell_indices, delta_l, fine_cell_indices);
+                portion(predicted_value, field, level, delta_l, coarse_cell_indices, fine_cell_indices);
             }
         }
 

--- a/tests/test_portion.cpp
+++ b/tests/test_portion.cpp
@@ -28,7 +28,7 @@ namespace samurai
         auto mesh                 = UniformMesh<config>(Box<double, dim>({0}, {1}), 5);
         auto u                    = init(mesh);
 
-        auto p = portion<1>(u, 5, interval_t{2, 3}, 4, 0);
+        auto p = portion<1>(u, 5, 4, std::make_tuple(interval_t{2, 3}), std::make_tuple(0));
         EXPECT_EQ(p[0], ((2 << 4) + .5) / (1 << 9));
     }
 
@@ -40,7 +40,7 @@ namespace samurai
         auto mesh                 = UniformMesh<config>(Box<double, dim>({0, 0}, {1, 1}), 5);
         auto u                    = init(mesh);
 
-        auto p = portion<1>(u, 5, interval_t{2, 3}, 2, 4, 0, 0);
+        auto p = portion<1>(u, 5, 4, std::make_tuple(interval_t{2, 3}, 2), std::make_tuple(0, 0));
         EXPECT_EQ(p[0], 2 * ((2 << 4) + .5) / (1 << 9));
     }
 
@@ -52,7 +52,7 @@ namespace samurai
         auto mesh                 = UniformMesh<config>(Box<double, dim>({0, 0, 0}, {1, 1, 1}), 5);
         auto u                    = init(mesh);
 
-        auto p = portion<1>(u, 5, interval_t{2, 3}, 2, 2, 4, 0, 0, 0);
+        auto p = portion<1>(u, 5, 4, std::make_tuple(interval_t{2, 3}, 2, 2), std::make_tuple(0, 0, 0));
         EXPECT_EQ(p[0], 3 * ((2 << 4) + .5) / (1 << 9));
     }
 }


### PR DESCRIPTION
## Description
This PR removes the option `--enable--max-level-flux` and replaces it with the more flexible option `--finer-level-flux`. Setting this option to `-1` results in the same behaviour as before with  the option `--enable--max-level-flux`. If a positive integer `i` is provided, the flux is computed at `level + i`.

## Code of Conduct
By submitting this PR, you agree to follow our [Code of Conduct](https://github.com/hpc-maths/samurai/blob/master/docs/CODE_OF_CONDUCT.md)
- [x] I agree to follow this project's Code of Conduct
