### PR TITLE
chore: cancel run if a commit is added to the PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -323,7 +323,7 @@ jobs:
             - name: Installl cxx compiler
               shell: bash -l {0}
               run: |
-                  micromamba install -y cxx-compiler<1.11
+                  micromamba install -y cxx-compiler\<1.11.0
 
             - name: micromamba informations
               shell: bash -l {0}


### PR DESCRIPTION
## Description
The CI is modified to cancel previous jobs when a commit is appended to the current PR.

## Code of Conduct
By submitting this PR, you agree to follow our [Code of Conduct](https://github.com/hpc-maths/samurai/blob/master/docs/CODE_OF_CONDUCT.md)
- [x] I agree to follow this project's Code of Conduct
