### PR TITLE
feat: PETSc dependency managed by samurai

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,11 +3,271 @@
 *.vscode
 *.h5
 *.xdmf
-.VSCodeCounter
 vcpkg*
 __pycache__
-.DS_Store
 .pixi
 .cache
-CMakeCache.txt
 *.old
+
+# Created by https://www.toptal.com/developers/gitignore/api/cmake,linux,macos,visualstudiocode,python
+# Edit at https://www.toptal.com/developers/gitignore?templates=cmake,linux,macos,visualstudiocode,python
+
+### CMake ###
+CMakeLists.txt.user
+CMakeCache.txt
+CMakeFiles
+CMakeScripts
+Testing
+Makefile
+cmake_install.cmake
+install_manifest.txt
+compile_commands.json
+CTestTestfile.cmake
+_deps
+
+### CMake Patch ###
+CMakeUserPresets.json
+
+# External projects
+*-prefix/
+
+### Linux ###
+*~
+
+# temporary files which can be created if a process still has a handle open of a deleted file
+.fuse_hidden*
+
+# KDE directory preferences
+.directory
+
+# Linux trash folder which might appear on any partition or disk
+.Trash-*
+
+# .nfs files are created when an open file is removed but is still being accessed
+.nfs*
+
+### macOS ###
+# General
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+### macOS Patch ###
+# iCloud generated files
+*.icloud
+
+### Python ###
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#pdm.lock
+#   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
+#   in version control.
+#   https://pdm.fming.dev/#use-with-ide
+.pdm.toml
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+#.idea/
+
+### Python Patch ###
+# Poetry local configuration file - https://python-poetry.org/docs/configuration/#local-configuration
+poetry.toml
+
+# ruff
+.ruff_cache/
+
+# LSP config files
+pyrightconfig.json
+
+### VisualStudioCode ###
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
+!.vscode/*.code-snippets
+
+# Local History for Visual Studio Code
+.history/
+
+# Built Visual Studio Code Extensions
+*.vsix
+
+### VisualStudioCode Patch ###
+# Ignore all local history of files
+.history
+.ionide
+
+# End of https://www.toptal.com/developers/gitignore/api/cmake,linux,macos,visualstudiocode,python

--- a/cmake/samuraiConfig.cmake.in
+++ b/cmake/samuraiConfig.cmake.in
@@ -1,6 +1,7 @@
 
 option(SAMURAI_WITH_OPENMP "Enable OpenMP" OFF)
 if(${SAMURAI_WITH_OPENMP})
+    message(STATUS "SAMURAI_WITH_OPENMP = ON")
     find_dependency(OpenMP)
     if(OpenMP_CXX_FOUND)
         target_link_libraries(samurai::samurai INTERFACE OpenMP::OpenMP_CXX)
@@ -13,6 +14,7 @@ endif()
 
 option(SAMURAI_WITH_MPI "Enable MPI" OFF)
 if(SAMURAI_WITH_MPI)
+  message(STATUS "SAMURAI_WITH_MPI = ON")
   if (NOT HDF5_IS_PARALLEL)
     message(FATAL_ERROR "HDF5 is not parallel. Please install a parallel version.")
   endif()
@@ -21,9 +23,25 @@ if(SAMURAI_WITH_MPI)
   target_compile_definitions(samurai::samurai INTERFACE SAMURAI_WITH_MPI)
 endif()
 
+option(SAMURAI_WITH_PETSC "Enable PETSc" OFF)
+if(${SAMURAI_WITH_PETSC})
+  message(STATUS "SAMURAI_WITH_PETSC = ON")
+
+  include(CMakeFindDependencyMacro)
+  find_dependency(PkgConfig)
+
+  pkg_check_modules(PETSC REQUIRED PETSc)
+  include_directories(${PETSC_INCLUDE_DIRS})
+  find_package(MPI)
+
+  target_compile_definitions(samurai::samurai INTERFACE SAMURAI_WITH_PETSC)
+  target_link_libraries(samurai::samurai INTERFACE ${PETSC_LINK_LIBRARIES} ${MPI_LIBRARIES})
+endif()
+
 
 option(SAMURAI_CHECK_NAN "Check NaN in computations" OFF)
 if(SAMURAI_CHECK_NAN)
+  message(STATUS "SAMURAI_CHECK_NAN = ON")
   target_compile_definitions(samurai::samurai INTERFACE SAMURAI_CHECK_NAN)
 endif()
 

--- a/demos/FiniteVolume/CMakeLists.txt
+++ b/demos/FiniteVolume/CMakeLists.txt
@@ -25,12 +25,14 @@ burgers_mra.cpp:finite-volume-burgers-mra
 burgers_os.cpp:finite-volume-burgers-os
 )
 
-include(FindPkgConfig)
+include(CMakeFindDependencyMacro)
+find_dependency(PkgConfig)
 pkg_check_modules(PETSC PETSc)
 # Create executables with PETSc
 if(PETSC_FOUND)
     include_directories(${PETSC_INCLUDE_DIRS})
     find_package(MPI)
+    target_compile_definitions(samurai INTERFACE SAMURAI_WITH_PETSC)
 
     foreach(demo_entry ${PETSC_DEMOS})
         string(REPLACE ":" ";" demo_parts ${demo_entry})

--- a/demos/FiniteVolume/heat.cpp
+++ b/demos/FiniteVolume/heat.cpp
@@ -107,23 +107,11 @@ int main(int argc, char* argv[])
     app.add_option("--path", path, "Output path")->capture_default_str()->group("Output");
     app.add_option("--filename", filename, "File name prefix")->capture_default_str()->group("Output");
     app.add_flag("--save-final-state-only", save_final_state_only, "Save final state only")->group("Output");
-
-    app.allow_extras();
     SAMURAI_PARSE(argc, argv);
-
-    //------------------//
-    // Petsc initialize //
-    //------------------//
-
-    samurai::times::timers.start("petsc init");
-    PetscInitialize(&argc, &argv, 0, nullptr);
 
     PetscMPIInt size;
     PetscCallMPI(MPI_Comm_size(PETSC_COMM_WORLD, &size));
     PetscCheck(size == 1, PETSC_COMM_WORLD, PETSC_ERR_WRONG_MPI_SIZE, "This is a uniprocessor example only!");
-    PetscOptionsSetValue(NULL, "-options_left", "off"); // If on, Petsc will issue warnings saying that
-                                                        // the options managed by CLI are unused
-    samurai::times::timers.stop("petsc init");
 
     //--------------------//
     // Problem definition //
@@ -263,10 +251,6 @@ int main(int argc, char* argv[])
     {
         save(path, filename, u);
     }
-
-    samurai::times::timers.start("petsc finalize");
-    PetscFinalize();
-    samurai::times::timers.stop("petsc finalize");
 
     samurai::finalize();
     return 0;

--- a/demos/FiniteVolume/heat_heterogeneous.cpp
+++ b/demos/FiniteVolume/heat_heterogeneous.cpp
@@ -79,21 +79,11 @@ int main(int argc, char* argv[])
     app.add_option("--path", path, "Output path")->capture_default_str()->group("Output");
     app.add_option("--filename", filename, "File name prefix")->capture_default_str()->group("Output");
     app.add_flag("--save-final-state-only", save_final_state_only, "Save final state only")->group("Output");
-
-    app.allow_extras();
     SAMURAI_PARSE(argc, argv);
-
-    //------------------//
-    // Petsc initialize //
-    //------------------//
-
-    PetscInitialize(&argc, &argv, 0, nullptr);
 
     PetscMPIInt size;
     PetscCallMPI(MPI_Comm_size(PETSC_COMM_WORLD, &size));
     PetscCheck(size == 1, PETSC_COMM_WORLD, PETSC_ERR_WRONG_MPI_SIZE, "This is a uniprocessor example only!");
-    PetscOptionsSetValue(NULL, "-options_left", "off"); // If on, Petsc will issue warnings saying that
-                                                        // the options managed by CLI are unused
 
     //--------------------//
     // Problem definition //
@@ -222,7 +212,6 @@ int main(int argc, char* argv[])
         save(path, filename, u);
     }
 
-    PetscFinalize();
     samurai::finalize();
     return 0;
 }

--- a/demos/FiniteVolume/heat_nonlinear.cpp
+++ b/demos/FiniteVolume/heat_nonlinear.cpp
@@ -155,20 +155,11 @@ int main(int argc, char* argv[])
     app.add_option("--path", path, "Output path")->capture_default_str()->group("Output");
     app.add_option("--filename", filename, "File name prefix")->capture_default_str()->group("Output");
     app.add_flag("--save-final-state-only", save_final_state_only, "Save final state only")->group("Output");
-
-    app.allow_extras();
     SAMURAI_PARSE(argc, argv);
-
-    //------------------//
-    // Petsc initialize //
-    //------------------//
-
-    PetscInitialize(&argc, &argv, 0, nullptr);
 
     PetscMPIInt size;
     PetscCallMPI(MPI_Comm_size(PETSC_COMM_WORLD, &size));
     PetscCheck(size == 1, PETSC_COMM_WORLD, PETSC_ERR_WRONG_MPI_SIZE, "This is a uniprocessor example only!");
-    PetscOptionsSetValue(NULL, "-options_left", "off");
 
     //--------------------//
     // Problem definition //
@@ -298,7 +289,6 @@ int main(int argc, char* argv[])
         save(path, filename, u);
     }
 
-    PetscFinalize();
     samurai::finalize();
     return 0;
 }

--- a/demos/FiniteVolume/lid_driven_cavity.cpp
+++ b/demos/FiniteVolume/lid_driven_cavity.cpp
@@ -135,8 +135,6 @@ int main(int argc, char* argv[])
     app.add_option("--nfiles", nfiles, "Number of output files")->capture_default_str()->group("Output");
     app.add_flag("--export-velocity", export_velocity, "Export velocity field")->capture_default_str()->group("Output");
     app.add_flag("--export-reconstruct", export_reconstruct, "Export reconstructed fields")->capture_default_str()->group("Output");
-
-    app.allow_extras();
     SAMURAI_PARSE(argc, argv);
 
     if (!fs::exists(path))
@@ -144,14 +142,9 @@ int main(int argc, char* argv[])
         fs::create_directory(path);
     }
 
-    samurai::times::timers.start("petsc init");
-    PetscInitialize(&argc, &argv, 0, nullptr);
-
     PetscMPIInt size;
     PetscCallMPI(MPI_Comm_size(PETSC_COMM_WORLD, &size));
     PetscCheck(size == 1, PETSC_COMM_WORLD, PETSC_ERR_WRONG_MPI_SIZE, "This is a uniprocessor example only!");
-    PetscOptionsSetValue(NULL, "-options_left", "off"); // disable warning for unused options
-    samurai::times::timers.stop("petsc init");
 
     auto box = samurai::Box<double, dim>({0, 0}, {1, 1});
 
@@ -475,9 +468,6 @@ int main(int argc, char* argv[])
     }
 
     stokes_solver.destroy_petsc_objects();
-    samurai::times::timers.start("petsc finalize");
-    PetscFinalize();
-    samurai::times::timers.stop("petsc finalize");
     samurai::finalize();
     return 0;
 }

--- a/demos/FiniteVolume/manual_block_matrix_assembly.cpp
+++ b/demos/FiniteVolume/manual_block_matrix_assembly.cpp
@@ -193,8 +193,6 @@ int main(int argc, char* argv[])
 
     std::cout << "------------------------- Begin -------------------------" << std::endl;
 
-    PetscInitialize(&argc, &argv, 0, nullptr);
-
     std::size_t min_level = 3;
     std::size_t max_level = 3;
 
@@ -289,8 +287,6 @@ int main(int argc, char* argv[])
     Vec v = assembly.create_vector(u_e, aux_Ce, u_s);
     VecView(v, PETSC_VIEWER_STDOUT_(PETSC_COMM_SELF));
     std::cout << std::endl;
-
-    PetscFinalize();
 
     samurai::finalize();
     return 0;

--- a/demos/FiniteVolume/nagumo.cpp
+++ b/demos/FiniteVolume/nagumo.cpp
@@ -95,23 +95,11 @@ int main(int argc, char* argv[])
     app.add_option("--path", path, "Output path")->capture_default_str()->group("Output");
     app.add_option("--filename", filename, "File name prefix")->capture_default_str()->group("Output");
     app.add_flag("--save-final-state-only", save_final_state_only, "Save final state only")->group("Output");
-
-    app.allow_extras();
     SAMURAI_PARSE(argc, argv);
-
-    //------------------//
-    // Petsc initialize //
-    //------------------//
-
-    samurai::times::timers.start("petsc init");
-    PetscInitialize(&argc, &argv, 0, nullptr);
 
     PetscMPIInt size;
     PetscCallMPI(MPI_Comm_size(PETSC_COMM_WORLD, &size));
     PetscCheck(size == 1, PETSC_COMM_WORLD, PETSC_ERR_WRONG_MPI_SIZE, "This is a uniprocessor example only!");
-    PetscOptionsSetValue(NULL, "-options_left", "off"); // If on, Petsc will issue warnings saying that
-                                                        // the options managed by CLI are unused
-    samurai::times::timers.stop("petsc init");
 
     //--------------------//
     // Problem definition //
@@ -289,10 +277,6 @@ int main(int argc, char* argv[])
     {
         save(path, filename, u);
     }
-
-    samurai::times::timers.start("petsc finalize");
-    PetscFinalize();
-    samurai::times::timers.stop("petsc finalize");
 
     samurai::finalize();
     return 0;

--- a/demos/FiniteVolume/stokes_2d.cpp
+++ b/demos/FiniteVolume/stokes_2d.cpp
@@ -185,8 +185,6 @@ int main(int argc, char* argv[])
     app.add_option("--path", path, "Output path")->capture_default_str()->group("Output");
     app.add_option("--filename", filename, "File name prefix")->capture_default_str()->group("Output");
     app.add_option("--nfiles", nfiles, "Number of output files")->capture_default_str()->group("Output");
-
-    app.allow_extras();
     SAMURAI_PARSE(argc, argv);
 
     if (!fs::exists(path))
@@ -194,12 +192,9 @@ int main(int argc, char* argv[])
         fs::create_directory(path);
     }
 
-    PetscInitialize(&argc, &argv, 0, nullptr);
-
     PetscMPIInt size;
     PetscCallMPI(MPI_Comm_size(PETSC_COMM_WORLD, &size));
     PetscCheck(size == 1, PETSC_COMM_WORLD, PETSC_ERR_WRONG_MPI_SIZE, "This is a uniprocessor example only!");
-    PetscOptionsSetValue(NULL, "-options_left", "off"); // disable warning for unused options
 
     auto box  = samurai::Box<double, dim>({0, 0}, {1, 1});
     auto mesh = Mesh(box, min_level, max_level);
@@ -589,7 +584,6 @@ int main(int argc, char* argv[])
         std::cerr << "Unknown test case. Allowed options are 's' = stationary, 'ns' = non-stationary." << std::endl;
     }
 
-    PetscFinalize();
     samurai::finalize();
     return 0;
 }

--- a/demos/highorder/main.cpp
+++ b/demos/highorder/main.cpp
@@ -145,8 +145,6 @@ int main(int argc, char* argv[])
     app.add_option("--path", path, "Output path")->capture_default_str()->group("Output");
     app.add_option("--filename", filename, "File name prefix")->capture_default_str()->group("Output");
     app.add_option("--nfiles", nfiles, "Number of output files")->capture_default_str()->group("Output");
-
-    app.allow_extras();
     SAMURAI_PARSE(argc, argv);
 
     samurai::Box<double, dim> box(min_corner, max_corner);
@@ -154,9 +152,6 @@ int main(int argc, char* argv[])
     using mesh_id_t = typename mesh_t::mesh_id_t;
     using cl_type   = typename mesh_t::cl_type;
     mesh_t init_mesh{box, min_level, max_level};
-
-    PetscInitialize(&argc, &argv, 0, nullptr);
-    PetscOptionsSetValue(NULL, "-options_left", "off");
 
     auto adapt_field = samurai::make_scalar_field<double>("adapt_field",
                                                           init_mesh,
@@ -323,7 +318,6 @@ int main(int argc, char* argv[])
         error_coarse        = error;
         error_recons_coarse = error_recons;
     }
-    PetscFinalize();
 
     samurai::finalize();
     return 0;

--- a/demos/multigrid/main.cpp
+++ b/demos/multigrid/main.cpp
@@ -129,12 +129,6 @@ int main(int argc, char* argv[])
     constexpr bool is_soa         = true;
     using Field                   = samurai::VectorField<Mesh, double, n_comp, is_soa>;
 
-    //------------------//
-    // Petsc initialize //
-    //------------------//
-
-    PetscInitialize(&argc, &argv, 0, help);
-
     PetscMPIInt size;
     PetscCallMPI(MPI_Comm_size(PETSC_COMM_WORLD, &size));
     PetscCheck(size == 1, PETSC_COMM_WORLD, PETSC_ERR_WRONG_MPI_SIZE, "This is a uniprocessor example only!");
@@ -322,7 +316,6 @@ int main(int argc, char* argv[])
     }
 
     delete test_case;
-    PetscFinalize();
 
     samurai::finalize();
     return 0;

--- a/include/samurai/arguments.hpp
+++ b/include/samurai/arguments.hpp
@@ -44,7 +44,9 @@ namespace samurai
         app.add_option("--mr-reg", args::regularity, "The regularity criteria used by the multiresolution to adapt the mesh")
             ->group("Multiresolution");
         app.add_flag("--mr-rel-detail", args::rel_detail, "Use relative detail instead of absolute detail")->group("Multiresolution");
+#ifdef SAMURAI_WITH_PETSC
         app.allow_extras();
+#endif
         app.set_help_flag("", ""); // deactivate --help option
         try
         {


### PR DESCRIPTION
## Description

- `PetscInitialize(argc, argv)` is called in `samurai::initialize(argc, argv)` and `PetscFinalize()` is called in `samurai::finalize()`.

- samurai projects do not have to include PETSc as a dependency, it is now managed by samurai. In the `CMakeLists.txt` file, the line
```
set(SAMURAI_WITH_PETSC On)
```
must be included before
```
find_package(samurai CONFIG REQUIRED)
```
to trigger the link with PETSc.

## Code of Conduct
By submitting this PR, you agree to follow our [Code of Conduct](https://github.com/hpc-maths/samurai/blob/master/docs/CODE_OF_CONDUCT.md)
- [x] I agree to follow this project's Code of Conduct
