### PR TITLE
fix: user prediction function

### DIFF
--- a/include/samurai/algorithm/update.hpp
+++ b/include/samurai/algorithm/update.hpp
@@ -1349,7 +1349,14 @@ namespace samurai
         }
     }
 
+    template <class PredictionFn, class Mesh>
+        requires IsMesh<Mesh>
+    void update_fields(PredictionFn&&, Mesh&)
+    {
+    }
+
     template <class Mesh>
+        requires IsMesh<Mesh>
     void update_fields(Mesh&)
     {
     }
@@ -1395,7 +1402,7 @@ namespace samurai
     void update_fields(PredictionFn&& prediction_fn, Mesh& new_mesh, Field& field, Fields&... fields)
     {
         detail::update_field(std::forward<PredictionFn>(prediction_fn), new_mesh, field);
-        update_fields(new_mesh, fields...);
+        update_fields(std::forward<PredictionFn>(prediction_fn), new_mesh, fields...);
     }
 
     template <class Tag, class... Fields>


### PR DESCRIPTION
## Description
When a user adds its own prediction function that updates the values in the refine cells, this function is not used by the extra fields in the MRA adaptation. This PR fixes this issue.

## Code of Conduct
By submitting this PR, you agree to follow our [Code of Conduct](https://github.com/hpc-maths/samurai/blob/master/docs/CODE_OF_CONDUCT.md)
- [x] I agree to follow this project's Code of Conduct
