### PR TITLE
feat: automatic update_ghost_mr()

### DIFF
--- a/demos/FiniteVolume/burgers.cpp
+++ b/demos/FiniteVolume/burgers.cpp
@@ -265,15 +265,12 @@ int main_dim(int argc, char* argv[])
         }
 
         // RK3 time scheme
-        samurai::update_ghost_mr(u);
-        u1 = u - dt * conv(u);
-        samurai::update_ghost_mr(u1);
-        u2 = 3. / 4 * u + 1. / 4 * (u1 - dt * conv(u1));
-        samurai::update_ghost_mr(u2);
+        u1   = u - dt * conv(u);
+        u2   = 3. / 4 * u + 1. / 4 * (u1 - dt * conv(u1));
         unp1 = 1. / 3 * u + 2. / 3 * (u2 - dt * conv(u2));
 
         // u <-- unp1
-        std::swap(u.array(), unp1.array());
+        samurai::swap(u, unp1);
 
         // Save the result
         if (t >= static_cast<double>(nsave + 1) * dt_save || t == Tf)
@@ -295,7 +292,6 @@ int main_dim(int argc, char* argv[])
             if (mesh.min_level() != mesh.max_level())
             {
                 // Reconstruction on the finest level
-                samurai::update_ghost_mr(u);
                 auto u_recons = samurai::reconstruction(u);
                 error         = samurai::L2_error(u_recons,
                                           [&](const auto& coord)

--- a/demos/FiniteVolume/burgers_mra.cpp
+++ b/demos/FiniteVolume/burgers_mra.cpp
@@ -166,18 +166,16 @@ void run_simulation(Field& u,
 
         // Mesh adaptation
         MRadaptation(mra_config);
-        samurai::update_ghost_mr(u);
         unp1.resize();
 
         unp1     = u - dt * scheme(u);
         unp1_max = u_max - dt * scheme(u_max);
 
         // u <-- unp1
-        std::swap(u.array(), unp1.array());
-        std::swap(u_max.array(), unp1_max.array());
+        samurai::swap(u, unp1);
+        samurai::swap(u_max, unp1_max);
 
         // Reconstruction
-        samurai::update_ghost_mr(u);
         auto u_recons = samurai::reconstruction(u);
 
         // Error

--- a/demos/FiniteVolume/burgers_os.cpp
+++ b/demos/FiniteVolume/burgers_os.cpp
@@ -215,8 +215,6 @@ int main(int argc, char* argv[])
             return 1;
         }
 
-        samurai::update_ghost_mr(u);
-
         unp1.resize();
 
         unp1 = u - dt * conv(u);

--- a/demos/FiniteVolume/heat.cpp
+++ b/demos/FiniteVolume/heat.cpp
@@ -203,7 +203,6 @@ int main(int argc, char* argv[])
 
         // Mesh adaptation
         MRadaptation(mra_config);
-        samurai::update_ghost_mr(u);
         unp1.resize();
 
         if (explicit_scheme)
@@ -217,7 +216,7 @@ int main(int argc, char* argv[])
         }
 
         // u <-- unp1
-        std::swap(u.array(), unp1.array());
+        samurai::swap(u, unp1);
 
         // Save the result
         if (!save_final_state_only)

--- a/demos/FiniteVolume/heat_heterogeneous.cpp
+++ b/demos/FiniteVolume/heat_heterogeneous.cpp
@@ -180,7 +180,6 @@ int main(int argc, char* argv[])
 
         // Mesh adaptation
         MRadaptation(mra_config);
-        samurai::update_ghost_mr(u);
         unp1.resize();
         K.resize();
         set_K_values();
@@ -196,7 +195,7 @@ int main(int argc, char* argv[])
         }
 
         // u <-- unp1
-        std::swap(u.array(), unp1.array());
+        samurai::swap(u, unp1);
 
         // Save the result
         if (!save_final_state_only)

--- a/demos/FiniteVolume/heat_nonlinear.cpp
+++ b/demos/FiniteVolume/heat_nonlinear.cpp
@@ -253,7 +253,6 @@ int main(int argc, char* argv[])
 
         // Mesh adaptation
         MRadaptation(mra_config);
-        samurai::update_ghost_mr(u);
         unp1.resize();
 
         if (explicit_scheme)
@@ -266,7 +265,7 @@ int main(int argc, char* argv[])
         }
 
         // u <-- unp1
-        std::swap(u.array(), unp1.array());
+        samurai::swap(u, unp1);
 
         double error = samurai::L2_error(u,
                                          [&](const auto& coords)

--- a/demos/FiniteVolume/lid_driven_cavity.cpp
+++ b/demos/FiniteVolume/lid_driven_cavity.cpp
@@ -355,7 +355,6 @@ int main(int argc, char* argv[])
         }
 
         // Solve Stokes system
-        samurai::update_ghost_mr(velocity);
         rhs = velocity - dt * conv(velocity);
         zero.fill(0);
         stokes_solver.solve(rhs, zero);
@@ -365,17 +364,14 @@ int main(int argc, char* argv[])
         ink_np1.resize();
 
         // Transfer velocity_np1 to the 2nd mesh (--> velocity2)
-        samurai::update_ghost_mr(velocity_np1);
         samurai::transfer(velocity_np1, velocity2);
 
         // Ink convection
-        samurai::update_ghost_mr(ink);
-        samurai::update_ghost_mr(velocity2);
         ink_np1 = ink - dt * conv2(ink);
 
         // Prepare next step
-        std::swap(velocity.array(), velocity_np1.array());
-        std::swap(ink.array(), ink_np1.array());
+        samurai::swap(velocity, velocity_np1);
+        samurai::swap(ink, ink_np1);
         min_level_n = min_level_np1;
         max_level_n = max_level_np1;
 
@@ -393,7 +389,6 @@ int main(int argc, char* argv[])
 
             if (export_reconstruct)
             {
-                samurai::update_ghost_mr(ink);
                 auto ink_recons = samurai::reconstruction(ink);
                 samurai::save(path, fmt::format("ldc_ink_recons_ite_{}", nsave), ink_recons.mesh(), ink_recons);
             }
@@ -405,7 +400,6 @@ int main(int argc, char* argv[])
 
                 if (export_reconstruct)
                 {
-                    samurai::update_ghost_mr(velocity);
                     auto velocity_recons = samurai::reconstruction(velocity);
                     samurai::save(path, fmt::format("ldc_velocity_recons_ite_{}", nsave), velocity_recons.mesh(), velocity_recons);
                 }

--- a/demos/FiniteVolume/linear_convection.cpp
+++ b/demos/FiniteVolume/linear_convection.cpp
@@ -127,10 +127,6 @@ int main(int argc, char* argv[])
     auto u1 = samurai::make_scalar_field<double>("u1", mesh);
     auto u2 = samurai::make_scalar_field<double>("u2", mesh);
 
-    unp1.fill(0);
-    u1.fill(0);
-    u2.fill(0);
-
     // Convection operator
     samurai::VelocityVector<dim> velocity;
     velocity.fill(1);
@@ -176,24 +172,19 @@ int main(int argc, char* argv[])
 
         // Mesh adaptation
         MRadaptation(mra_config);
-        samurai::update_ghost_mr(u);
         unp1.resize();
         u1.resize();
         u2.resize();
-        u1.fill(0);
-        u2.fill(0);
 
         // unp1 = u - dt * conv(u);
 
         // TVD-RK3 (SSPRK3)
-        u1 = u - dt * conv(u);
-        samurai::update_ghost_mr(u1);
-        u2 = 3. / 4 * u + 1. / 4 * (u1 - dt * conv(u1));
-        samurai::update_ghost_mr(u2);
+        u1   = u - dt * conv(u);
+        u2   = 3. / 4 * u + 1. / 4 * (u1 - dt * conv(u1));
         unp1 = 1. / 3 * u + 2. / 3 * (u2 - dt * conv(u2));
 
         // u <-- unp1
-        std::swap(u.array(), unp1.array());
+        samurai::swap(u, unp1);
 
         // Save the result
         if (nfiles == 0 || t >= static_cast<double>(nsave + 1) * dt_save || t == Tf)

--- a/demos/FiniteVolume/linear_convection_obstacle.cpp
+++ b/demos/FiniteVolume/linear_convection_obstacle.cpp
@@ -151,7 +151,6 @@ int main(int argc, char* argv[])
 
         MRadaptation(mra_config, velocity);
         // samurai::save(path, fmt::format("{}_mesh", filename), {true, true}, mesh, u);
-        samurai::update_ghost_mr(u);
         samurai::for_each_cell(mesh,
                                [&](const auto& cell)
                                {
@@ -165,14 +164,12 @@ int main(int argc, char* argv[])
         // unp1 = u - dt * conv(u);
 
         // TVD-RK3 (SSPRK3)
-        u1 = u - dt * conv(u);
-        samurai::update_ghost_mr(u1);
-        u2 = 3. / 4 * u + 1. / 4 * (u1 - dt * conv(u1));
-        samurai::update_ghost_mr(u2);
+        u1   = u - dt * conv(u);
+        u2   = 3. / 4 * u + 1. / 4 * (u1 - dt * conv(u1));
         unp1 = 1. / 3 * u + 2. / 3 * (u2 - dt * conv(u2));
 
         // u <-- unp1
-        std::swap(u.array(), unp1.array());
+        samurai::swap(u, unp1);
 
         // Save the result
         if (nfiles == 0 || t >= static_cast<double>(nsave + 1) * dt_save || t == Tf)

--- a/demos/FiniteVolume/nagumo.cpp
+++ b/demos/FiniteVolume/nagumo.cpp
@@ -207,7 +207,6 @@ int main(int argc, char* argv[])
 
         // Mesh adaptation
         MRadaptation(mra_config);
-        samurai::update_ghost_mr(u);
         unp1.resize();
         rhs.resize();
 
@@ -245,7 +244,7 @@ int main(int argc, char* argv[])
         }
 
         // u <-- unp1
-        std::swap(u.array(), unp1.array());
+        samurai::swap(u, unp1);
 
         // Compute error
         double error = samurai::L2_error(u,

--- a/demos/FiniteVolume/stokes_2d.cpp
+++ b/demos/FiniteVolume/stokes_2d.cpp
@@ -525,7 +525,7 @@ int main(int argc, char* argv[])
             stokes_solver.solve(rhs, zero);
 
             // Prepare next step
-            samurai::swap(velocity, velocity_unp1);
+            samurai::swap(velocity, velocity_np1);
             t_n         = t_np1;
             min_level_n = min_level_np1;
             max_level_n = max_level_np1;

--- a/demos/FiniteVolume/stokes_2d.cpp
+++ b/demos/FiniteVolume/stokes_2d.cpp
@@ -525,7 +525,7 @@ int main(int argc, char* argv[])
             stokes_solver.solve(rhs, zero);
 
             // Prepare next step
-            std::swap(velocity.array(), velocity_np1.array());
+            samurai::swap(velocity, velocity_unp1);
             t_n         = t_np1;
             min_level_n = min_level_np1;
             max_level_n = max_level_np1;
@@ -551,7 +551,6 @@ int main(int argc, char* argv[])
             if (min_level != max_level)
             {
                 // Reconstruction on the finest level
-                samurai::update_ghost_mr(velocity);
                 auto velocity_recons = samurai::reconstruction(velocity);
                 // Error
                 double error_recons = samurai::L2_error(velocity_recons,

--- a/demos/highorder/main.cpp
+++ b/demos/highorder/main.cpp
@@ -284,7 +284,6 @@ int main(int argc, char* argv[])
         }
         std::cout << std::endl;
 
-        samurai::update_ghost_mr(u);
         auto u_recons = samurai::reconstruction(u);
 
         double error_recons = L2_error(u_recons, exact_func);

--- a/demos/tutorial/reconstruction_2d.cpp
+++ b/demos/tutorial/reconstruction_2d.cpp
@@ -145,8 +145,6 @@ int main(int argc, char* argv[])
                            });
     samurai::save(path, filename, mrmesh, u, level_);
 
-    samurai::update_ghost_mr(u);
-
     auto t1            = std::chrono::high_resolution_clock::now();
     auto u_reconstruct = reconstruction(u);
     auto t2            = std::chrono::high_resolution_clock::now();

--- a/docs/source/reference/local_schemes.rst
+++ b/docs/source/reference/local_schemes.rst
@@ -7,7 +7,6 @@ The local schemes are part of the Finite Volume module, enabled by
 .. code-block:: c++
 
     #include <samurai/schemes/fv.hpp>
-    #include <samurai/petsc.hpp> // optional, necessary for implicit schemes
 
 They are characterized by a function that applies to a field, whose computation only involves information located in the current mesh cell.
 The C++ interface is built similarly to the :doc:`flux-based Finite Volume schemes <finite_volume_schemes>`.
@@ -25,7 +24,7 @@ First of all, the structural information about the scheme must be declared.
 It contains:
 
 - the :code:`input_field_type`: the C++ type of the field :math:`u`.
-- the :code:`output_n_comp`: the number of components of field of the resulting field :math:`v`.
+- the :code:`output_field_type`: the C++ type of the resulting field :math:`v`.
 - the :code:`scheme_type`, to be selected amongst the values of
 
 .. code-block:: c++
@@ -42,12 +41,12 @@ Here is an example:
 
 .. code-block:: c++
 
-    auto u = samurai::make_field<...>("u", mesh);
+    auto u = samurai::make_scalar_field<double>("u", mesh);
 
     using cfg  = samurai::LocalCellSchemeConfig<
-                        SchemeType::NonLinear,      // scheme_type
-                        decltype(u)::n_comp, // output_n_comp (here identical to the number of components of input field)
-                        decltype(u)>;               // input_field_type
+                        SchemeType::NonLinear, // scheme_type
+                        decltype(u),           // output_field_type (here identical to the input field)
+                        decltype(u)>;          // input_field_type
 
 Secondly, we create the operator from the configuration :code:`cfg`:
 
@@ -70,7 +69,7 @@ or in an implicit context
 
 .. code-block:: c++
 
-    auto b = samurai::make_field<...>("b", mesh);
+    auto b = samurai::make_scalar_field<double>("b", mesh);
     samurai::petsc::solve(A, u, b); // solves the equation A(u) = b
 
 Note that the :code:`solve` function involves a linear or a non-linear solver according to the :code:`SchemeType` declared in :code:`cfg`.
@@ -99,12 +98,12 @@ The parameters of the function are
 - :code:`cell`: the current local cell;
 - :code:`field`: the input field, to which the operator applies. Its actual type is declared in :code:`cfg`.
 
-The return type :code:`SchemeValue<cfg>` is a array-like structure of size :code:`output_n_comp` (declared in :code:`cfg`).
+The return type :code:`SchemeValue<cfg>` is a array-like structure of size :code:`output_fied_type::n_comp` (declared in :code:`cfg`).
 It is based on the :code:`xtensor` library, so all :code:`xtensor` functions and accessors can be used.
 The :math:`i`-th component can be accessed with :code:`result(i)`.
 
 .. note::
-    If :code:`output_n_comp` is set to 1, :code:`SchemeValue<cfg>` reduces to a scalar type (typically :code:`double`).
+    If :code:`output_field_type` is a scalar field, :code:`SchemeValue<cfg>` reduces to a scalar type (typically :code:`double`).
 
 If the operator is to be implicited, its jacobian function must also be defined.
 If only explicit applications of the operator shall be used, then this step is optional.
@@ -122,4 +121,4 @@ If only explicit applications of the operator shall be used, then this step is o
 
 .. warning::
     The type :code:`JacobianMatrix<cfg>` is a matrix of size :code:`output_n_comp x input_field_type`.
-    However, if :code:`output_n_comp = input_n_comp = 1`, it reduces to a scalar type (typically :code:`double`).
+    However, if both :code:`output_field_type` and :code:`input_field_type` are scalar fields, it reduces to a scalar type (typically :code:`double`).

--- a/include/samurai/algorithm/update.hpp
+++ b/include/samurai/algorithm/update.hpp
@@ -505,6 +505,22 @@ namespace samurai
         update_outer_ghosts(level, fields...);
     }
 
+    template <class Field>
+    void update_ghost_mr_if_needed(Field& field)
+    {
+        if (!field.ghosts_updated())
+        {
+            update_ghost_mr(field);
+        }
+    }
+
+    template <class Field, class... Fields>
+    void update_ghost_mr_if_needed(Field& field, Fields&... other_fields)
+    {
+        update_ghost_mr_if_needed(field);
+        update_ghost_mr_if_needed(other_fields...);
+    }
+
     template <class Field, class... Fields>
     void update_ghost_mr(Field& field, Fields&... other_fields)
     {
@@ -550,6 +566,9 @@ namespace samurai
             update_ghost_subdomains(level, field, other_fields...);
         }
         // save(fs::current_path(), "update_ghosts", {true, true}, mesh, field);
+
+        field.ghosts_updated() = true;
+        ((other_fields.ghosts_updated() = true), ...);
 
         times::timers.stop("ghost update");
     }
@@ -1345,7 +1364,7 @@ namespace samurai
                 set_refine.apply_op(std::forward<PredictionOp>(prediction_op)(new_field, field));
             }
 
-            std::swap(field.array(), new_field.array());
+            swap(field, new_field);
         }
     }
 

--- a/include/samurai/field.hpp
+++ b/include/samurai/field.hpp
@@ -21,6 +21,7 @@ namespace fs = std::filesystem;
 #include "bc/bc.hpp"
 #include "cell.hpp"
 #include "cell_array.hpp"
+#include "concepts.hpp"
 #include "field_expression.hpp"
 #include "mesh_holder.hpp"
 #include "numeric/gauss_legendre.hpp"

--- a/include/samurai/field.hpp
+++ b/include/samurai/field.hpp
@@ -394,15 +394,8 @@ namespace samurai
 
         void to_stream(std::ostream& os) const;
 
-        bool& ghosts_updated()
-        {
-            return m_ghosts_updated;
-        }
-
-        bool ghosts_updated() const
-        {
-            return m_ghosts_updated;
-        }
+        bool& ghosts_updated();
+        bool ghosts_updated() const;
 
         template <class Bc_derived>
         auto attach_bc(const Bc_derived& bc);
@@ -586,6 +579,18 @@ namespace samurai
     inline std::string& VectorField<mesh_t, value_t, n_comp_, SOA>::name()
     {
         return m_name;
+    }
+
+    template <class mesh_t, class value_t, std::size_t n_comp_, bool SOA>
+    inline bool& VectorField<mesh_t, value_t, n_comp_, SOA>::ghosts_updated()
+    {
+        return m_ghosts_updated;
+    }
+
+    template <class mesh_t, class value_t, std::size_t n_comp_, bool SOA>
+    inline bool VectorField<mesh_t, value_t, n_comp_, SOA>::ghosts_updated() const
+    {
+        return m_ghosts_updated;
     }
 
     // --- iterators ----------------------------------------------------------
@@ -1019,15 +1024,8 @@ namespace samurai
 
         void to_stream(std::ostream& os) const;
 
-        bool& ghosts_updated()
-        {
-            return m_ghosts_updated;
-        }
-
-        bool ghosts_updated() const
-        {
-            return m_ghosts_updated;
-        }
+        bool& ghosts_updated();
+        bool ghosts_updated() const;
 
         template <class Bc_derived>
         auto attach_bc(const Bc_derived& bc);
@@ -1211,6 +1209,18 @@ namespace samurai
     inline std::string& ScalarField<mesh_t, value_t>::name()
     {
         return m_name;
+    }
+
+    template <class mesh_t, class value_t>
+    inline bool& ScalarField<mesh_t, value_t>::ghosts_updated()
+    {
+        return m_ghosts_updated;
+    }
+
+    template <class mesh_t, class value_t>
+    inline bool ScalarField<mesh_t, value_t>::ghosts_updated() const
+    {
+        return m_ghosts_updated;
     }
 
     // --- iterators ----------------------------------------------------------

--- a/include/samurai/reconstruction.hpp
+++ b/include/samurai/reconstruction.hpp
@@ -508,11 +508,13 @@ namespace samurai
     }
 
     template <class Field>
-    auto reconstruction(const Field& field)
+    auto reconstruction(Field& field)
     {
         using mesh_t    = typename Field::mesh_t;
         using mesh_id_t = typename mesh_t::mesh_id_t;
         using ca_type   = typename mesh_t::ca_type;
+
+        update_ghost_mr_if_needed(field);
 
         auto make_field_like = [](std::string const& name, auto& mesh)
         {
@@ -805,6 +807,8 @@ namespace samurai
         using value_t                    = typename interval_t::value_t;
         auto& mesh_src                   = field_src.mesh();
         auto& mesh_dst                   = field_dst.mesh();
+
+        update_ghost_mr_if_needed(field_src);
 
         field_dst.fill(0.);
 

--- a/include/samurai/schemes/fv/FV_scheme.hpp
+++ b/include/samurai/schemes/fv/FV_scheme.hpp
@@ -187,11 +187,25 @@ namespace samurai
             }
         }
 
+        void update_ghosts_if_needed(input_field_t& input_field)
+        {
+            if constexpr (cfg::stencil_size > 1)
+            {
+                update_ghost_mr_if_needed(input_field);
+            }
+            if constexpr (cfg::has_parameter_field)
+            {
+                update_ghost_mr_if_needed(parameter_field());
+            }
+        }
+
         /**
          * Explicit application of the scheme
          */
         auto operator()(input_field_t& input_field)
         {
+            this->update_ghosts_if_needed(input_field);
+
             times::timers.start(name() + " operator");
             auto explicit_scheme = make_explicit(derived_cast());
             auto output_field    = explicit_scheme.apply_to(input_field);
@@ -201,6 +215,8 @@ namespace samurai
 
         void apply(output_field_t& output_field, input_field_t& input_field)
         {
+            this->update_ghosts_if_needed(input_field);
+
             times::timers.start(name() + " operator");
             auto explicit_scheme = make_explicit(derived_cast());
             explicit_scheme.apply(output_field, input_field);
@@ -209,6 +225,8 @@ namespace samurai
 
         auto operator()(std::size_t d, input_field_t& input_field)
         {
+            this->update_ghosts_if_needed(input_field);
+
             times::timers.start(name() + " operator");
             auto explicit_scheme = make_explicit(derived_cast());
             auto output_field    = explicit_scheme.apply_to(d, input_field);
@@ -218,6 +236,8 @@ namespace samurai
 
         void apply(std::size_t d, output_field_t& output_field, input_field_t& input_field)
         {
+            this->update_ghosts_if_needed(input_field);
+
             times::timers.start(name() + " operator");
             auto explicit_scheme = make_explicit(derived_cast());
             explicit_scheme.apply(d, output_field, input_field);

--- a/include/samurai/schemes/fv/cell_based/cell_based_scheme_definition.hpp
+++ b/include/samurai/schemes/fv/cell_based/cell_based_scheme_definition.hpp
@@ -24,6 +24,7 @@ namespace samurai
         using output_field_t                                  = std::decay_t<output_field_t_>;
         using input_field_t                                   = std::decay_t<input_field_t_>;
         using parameter_field_t                               = void*; // unused in cell-based schemes but must exist
+        static constexpr bool has_parameter_field = !std::is_same_v<parameter_field_t, void*>; // cppcheck-suppress unusedStructMember
     };
 
     template <SchemeType scheme_type, std::size_t neighbourhood_width, class output_field_t, class input_field_t>


### PR DESCRIPTION
## Description
`update_ghost_mr(u);` is called internally when needed:
- in flux-based and cell-based schemes (e.g. `conv(u)`)
- in `reconstruction(u)`
- in `transfer(u, v)`

In order not to perform the ghost update multiple times, the field stores boolean `ghost_updated` flag, which is set to true when `update_ghost_mr(u)` is called, and set to false when `u` is modified by samurai (but not when `u` is directly modified by the user, e.g. in a `for_each_cell` call). Consequently, existing codes will work without loss of performance.

## Code of Conduct
By submitting this PR, you agree to follow our [Code of Conduct](https://github.com/hpc-maths/samurai/blob/master/docs/CODE_OF_CONDUCT.md)
- [x] I agree to follow this project's Code of Conduct
