### PR TITLE
fix: h_face

### DIFF
--- a/include/samurai/schemes/fv/flux_based/flux_based_scheme__nonlin.hpp
+++ b/include/samurai/schemes/fv/flux_based/flux_based_scheme__nonlin.hpp
@@ -428,8 +428,8 @@ namespace samurai
             // Same level
             for (std::size_t level = min_level; level <= max_level; ++level)
             {
-                auto h      = mesh.cell_length(level);
-                auto h_face = mesh.cell_length(detail::get_dest_level<enable_finer_level_flux>(level, m_finer_level_flux, max_level));
+                auto h = mesh.cell_length(level);
+                auto h_face = mesh.cell_length(detail::get_dest_level<enable_finer_level_flux>(level, m_finer_level_flux, mesh.max_level()));
                 auto factor = h_factor(h_face, h);
 
                 flux_params.set_level(level);
@@ -465,7 +465,8 @@ namespace samurai
                 auto h_l   = mesh.cell_length(level);
                 auto h_lp1 = mesh.cell_length(level + 1);
 
-                auto h_face = mesh.cell_length(detail::get_dest_level<enable_finer_level_flux>(level + 1, m_finer_level_flux, max_level));
+                auto h_face = mesh.cell_length(
+                    detail::get_dest_level<enable_finer_level_flux>(level + 1, m_finer_level_flux, mesh.max_level()));
 
                 flux_params.set_level(level + 1);
                 flux_params.cell_length = h_face;


### PR DESCRIPTION
## Description
The computation of the face length when the portion was used was incorrect. It takes the max_level of the cells, rather than the global max_level of the simulation. Therefore, the scaling factor was incorrect, producing a solution that moved too fast.

## Code of Conduct
By submitting this PR, you agree to follow our [Code of Conduct](https://github.com/hpc-maths/samurai/blob/master/docs/CODE_OF_CONDUCT.md)
- [x] I agree to follow this project's Code of Conduct
