### PR TITLE
ci: Add installation test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -552,6 +552,6 @@ jobs:
 
                   cp ../demos/FiniteVolume/advection_2d.cpp main.cpp
 
-                  cmake . -Bbuild
+                  cmake . -Bbuild -DSAMURAI_WITH_MPI=ON
                   cmake --build build
                   ./build/test_app

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -497,3 +497,61 @@ jobs:
                   mpiexec -n 2 ./demos/FiniteVolume/finite-volume-burgers --Tf 0.1 --nfiles 1 --max-level 8
                   # This test is failing with 3 processes due to a bug in the exchange of subdomain corners
                   # mpiexec -n 3 ./demos/FiniteVolume/finite-volume-burgers --Tf 0.1 --nfiles 1 --max-level 8
+
+    #
+    # test samurai installation
+    #
+    #########################################################
+    samurai-installation:
+        needs: [pre-commit, cppcheck]
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v4
+
+            - name: Mamba and samurai env installation
+              uses: mamba-org/setup-micromamba@v2
+              with:
+                  environment-file: conda/mpi-environment.yml
+                  environment-name: samurai-env
+                  cache-environment: true
+
+            - name: Compiler installation
+              shell: bash -l {0}
+              run: |
+                  micromamba install -y cxx-compiler
+
+            - name: Configure
+              shell: bash -l {0}
+              run: |
+                  cmake \
+                      . \
+                      -Bbuild \
+                      -DWITH_MPI=ON \
+                      -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX
+
+            - name: Install samurai
+              shell: bash -l {0}
+              run: |
+                  cmake --build build --target install
+
+            - name: Check samurai installation
+              shell: bash -l {0}
+              run: |
+                  mkdir -p test_installation
+                  cd test_installation
+
+                  cat > CMakeLists.txt << 'EOF'
+                  cmake_minimum_required(VERSION 3.18)
+                  project(test_samurai_installation)
+
+                  find_package(samurai REQUIRED)
+
+                  add_executable(test_app main.cpp)
+                  target_link_libraries(test_app samurai::samurai)
+                  EOF
+
+                  cp ../demos/FiniteVolume/advection_2d.cpp main.cpp
+
+                  cmake . -Bbuild
+                  cmake --build build
+                  ./build/test_app

--- a/cmake/samuraiConfig.cmake.in
+++ b/cmake/samuraiConfig.cmake.in
@@ -13,7 +13,7 @@ endif()
 
 
 option(SAMURAI_WITH_MPI "Enable MPI" OFF)
-if(SAMURAI_WITH_MPI)
+if(${SAMURAI_WITH_MPI})
   message(STATUS "SAMURAI_WITH_MPI = ON")
   if (NOT HDF5_IS_PARALLEL)
     message(FATAL_ERROR "HDF5 is not parallel. Please install a parallel version.")


### PR DESCRIPTION
## Description
This PR adds an installation test of samurai by installing it with conda. It then tries to compile the `advection_2.cpp` example in a separate folder with a CMakeLists.txt file using the installed samurai version.

## How has this been tested?
By trying to compile `advection_2d.cpp` with an installed version of samurai.

## Code of Conduct
By submitting this PR, you agree to follow our [Code of Conduct](https://github.com/hpc-maths/samurai/blob/master/docs/CODE_OF_CONDUCT.md)
- [x] I agree to follow this project's Code of Conduct
