### PR TITLE
fix: Remove warnings when using GCC

### DIFF
--- a/include/samurai/algorithm.hpp
+++ b/include/samurai/algorithm.hpp
@@ -174,12 +174,16 @@ namespace samurai
     template <class MeshIntervalType, class SetType, class Func>
     inline void parallel_for_each_meshinterval(SetType& set, Func&& f)
     {
+#if defined(SAMURAI_WITH_OPENMP)
 #pragma omp parallel
 #pragma omp single nowait
+#endif
         set(
             [&](const auto& i, const auto& index)
             {
+#if defined(SAMURAI_WITH_OPENMP)
 #pragma omp task
+#endif
                 {
                     MeshIntervalType mesh_interval(set.level());
                     mesh_interval.i     = i;
@@ -235,12 +239,16 @@ namespace samurai
         using cell_t        = Cell<dim, TInterval>;
         using index_value_t = typename cell_t::value_t;
 
+#if defined(SAMURAI_WITH_OPENMP)
 #pragma omp parallel
 #pragma omp single nowait
+#endif
         {
             for (auto it = lca.cbegin(); it != lca.cend(); ++it)
             {
+#if defined(SAMURAI_WITH_OPENMP)
 #pragma omp task
+#endif
                 for (index_value_t i = it->start; i < it->end; ++i)
                 {
                     typename cell_t::indices_t index;

--- a/include/samurai/field.hpp
+++ b/include/samurai/field.hpp
@@ -3,7 +3,6 @@
 
 #pragma once
 
-
 #include <algorithm>
 #include <array>
 #include <memory>

--- a/include/samurai/field.hpp
+++ b/include/samurai/field.hpp
@@ -3,6 +3,7 @@
 
 #pragma once
 
+
 #include <algorithm>
 #include <array>
 #include <memory>

--- a/include/samurai/level_cell_array.hpp
+++ b/include/samurai/level_cell_array.hpp
@@ -9,7 +9,6 @@
 #include <type_traits>
 #include <vector>
 
-
 #ifdef SAMURAI_WITH_MPI
 #include <boost/serialization/serialization.hpp>
 #include <boost/serialization/vector.hpp>
@@ -46,7 +45,7 @@ namespace samurai
         explicit LevelCellArray_reverse_iterator(iterator&& it)
             : base_type(std::move(it))
         {
-}
+        }
 
 #if defined(__GNUC__) && !defined(__clang__)
 #pragma GCC diagnostic pop

--- a/include/samurai/level_cell_array.hpp
+++ b/include/samurai/level_cell_array.hpp
@@ -497,7 +497,6 @@ namespace samurai
         typename iterator::offset_type_iterator offset_index;
         typename iterator::iterator_container current_index;
         typename iterator::coord_type index;
-        index.fill(0);
 
         for (std::size_t d = 0; d < dim; ++d)
         {
@@ -518,7 +517,6 @@ namespace samurai
         typename iterator::offset_type_iterator offset_index;
         typename iterator::iterator_container current_index;
         typename iterator::coord_type index;
-        index.fill(0);
 
         for (std::size_t d = 0; d < dim; ++d)
         {
@@ -541,7 +539,6 @@ namespace samurai
         typename const_iterator::offset_type_iterator offset_index;
         typename const_iterator::iterator_container current_index;
         typename const_iterator::coord_type index;
-        index.fill(0);
 
         for (std::size_t d = 0; d < dim; ++d)
         {
@@ -564,7 +561,6 @@ namespace samurai
         typename const_iterator::offset_type_iterator offset_index;
         typename const_iterator::iterator_container current_index;
         typename const_iterator::coord_type index;
-        index.fill(0);
 
         for (std::size_t d = 0; d < dim; ++d)
         {

--- a/include/samurai/level_cell_array.hpp
+++ b/include/samurai/level_cell_array.hpp
@@ -496,7 +496,7 @@ namespace samurai
     {
         typename iterator::offset_type_iterator offset_index;
         typename iterator::iterator_container current_index;
-        typename iterator::coord_type index;
+        typename iterator::coord_type index{};
 
         for (std::size_t d = 0; d < dim; ++d)
         {
@@ -516,7 +516,7 @@ namespace samurai
     {
         typename iterator::offset_type_iterator offset_index;
         typename iterator::iterator_container current_index;
-        typename iterator::coord_type index;
+        typename iterator::coord_type index{};
 
         for (std::size_t d = 0; d < dim; ++d)
         {
@@ -538,7 +538,7 @@ namespace samurai
     {
         typename const_iterator::offset_type_iterator offset_index;
         typename const_iterator::iterator_container current_index;
-        typename const_iterator::coord_type index;
+        typename const_iterator::coord_type index{};
 
         for (std::size_t d = 0; d < dim; ++d)
         {
@@ -560,7 +560,7 @@ namespace samurai
     {
         typename const_iterator::offset_type_iterator offset_index;
         typename const_iterator::iterator_container current_index;
-        typename const_iterator::coord_type index;
+        typename const_iterator::coord_type index{};
 
         for (std::size_t d = 0; d < dim; ++d)
         {

--- a/include/samurai/level_cell_array.hpp
+++ b/include/samurai/level_cell_array.hpp
@@ -47,10 +47,6 @@ namespace samurai
         {
         }
 
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC diagnostic pop
-#endif
-
         const coord_type index() const
         {
             iterator it = this->base();

--- a/include/samurai/level_cell_array.hpp
+++ b/include/samurai/level_cell_array.hpp
@@ -9,6 +9,7 @@
 #include <type_traits>
 #include <vector>
 
+
 #ifdef SAMURAI_WITH_MPI
 #include <boost/serialization/serialization.hpp>
 #include <boost/serialization/vector.hpp>
@@ -45,7 +46,11 @@ namespace samurai
         explicit LevelCellArray_reverse_iterator(iterator&& it)
             : base_type(std::move(it))
         {
-        }
+}
+
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
 
         const coord_type index() const
         {
@@ -497,6 +502,7 @@ namespace samurai
         typename iterator::offset_type_iterator offset_index;
         typename iterator::iterator_container current_index;
         typename iterator::coord_type index;
+        index.fill(0);
 
         for (std::size_t d = 0; d < dim; ++d)
         {
@@ -517,6 +523,7 @@ namespace samurai
         typename iterator::offset_type_iterator offset_index;
         typename iterator::iterator_container current_index;
         typename iterator::coord_type index;
+        index.fill(0);
 
         for (std::size_t d = 0; d < dim; ++d)
         {
@@ -539,6 +546,7 @@ namespace samurai
         typename const_iterator::offset_type_iterator offset_index;
         typename const_iterator::iterator_container current_index;
         typename const_iterator::coord_type index;
+        index.fill(0);
 
         for (std::size_t d = 0; d < dim; ++d)
         {
@@ -561,6 +569,7 @@ namespace samurai
         typename const_iterator::offset_type_iterator offset_index;
         typename const_iterator::iterator_container current_index;
         typename const_iterator::coord_type index;
+        index.fill(0);
 
         for (std::size_t d = 0; d < dim; ++d)
         {

--- a/include/samurai/mr/rel_detail.hpp
+++ b/include/samurai/mr/rel_detail.hpp
@@ -40,10 +40,10 @@ namespace samurai
         template <class... TFields>
         void set_inv_max_field(auto& inv_max_fields, const Field_tuple<TFields...>& field)
         {
-            auto f = [](auto& inv_max_fields, const auto& field, auto& dec)
+            auto f = [](auto& inv_max_fields_var, const auto& fld, auto& offset)
             {
-                set_inv_max_field(inv_max_fields, field, dec);
-                dec += field.n_comp;
+                set_inv_max_field(inv_max_fields_var, fld, offset);
+                offset += fld.n_comp;
             };
 
             std::size_t dec = 0;

--- a/include/samurai/petsc/nonlinear_local_solvers.hpp
+++ b/include/samurai/petsc/nonlinear_local_solvers.hpp
@@ -134,7 +134,9 @@ namespace samurai
                 std::vector<Mat> J_list(n_threads);
                 std::vector<Vec> r_list(n_threads);
 
+#if defined(SAMURAI_WITH_OPENMP)
 #pragma omp parallel for
+#endif
                 for (std::size_t thread_num = 0; thread_num < n_threads; ++thread_num)
                 {
                     SNESCreate(PETSC_COMM_SELF, &snes_list[thread_num]);
@@ -186,7 +188,9 @@ namespace samurai
                                             VecDestroy(&b);
                                         });
 
+#if defined(SAMURAI_WITH_OPENMP)
 #pragma omp parallel for
+#endif
                 for (std::size_t thread_num = 0; thread_num < n_threads; ++thread_num)
                 {
                     MatDestroy(&J_list[thread_num]);

--- a/include/samurai/reconstruction.hpp
+++ b/include/samurai/reconstruction.hpp
@@ -280,9 +280,9 @@ namespace samurai
             }(std::make_index_sequence<std::tuple_size_v<std::decay_t<decltype(coeff_arrays)>>>{});
 
             auto end = std::apply(
-                [](auto&... coeff_arrays)
+                [](auto&... arrays)
                 {
-                    return std::make_tuple(coeff_arrays.size()...);
+                    return std::make_tuple(arrays.size()...);
                 },
                 coeff_arrays);
 
@@ -666,9 +666,9 @@ namespace samurai
                  const std::tuple<typename Field::interval_t, index_t...>& i,
                  const std::tuple<cell_index_t...>& ii)
     {
-        auto get_f = [&](std::size_t level, const auto&... indices)
+        auto get_f = [&](std::size_t lvl, const auto&... indices)
         {
-            return f(element, level, indices...);
+            return f(element, lvl, indices...);
         };
         detail::portion_impl<Field::mesh_t::config::prediction_stencil_radius, Field>(result, f, get_f, level, delta_l, i, ii);
     }
@@ -699,9 +699,9 @@ namespace samurai
                  const std::tuple<typename Field::interval_t, index_t...>& i,
                  const std::tuple<cell_index_t...>& ii)
     {
-        auto get_f = [&](std::size_t level, const auto&... indices)
+        auto get_f = [&](std::size_t lvl, const auto&... indices)
         {
-            return f(level, indices...);
+            return f(lvl, indices...);
         };
 
         detail::portion_impl<prediction_stencil_radius, Field>(result, get_f, level, delta_l, i, ii);
@@ -781,21 +781,21 @@ namespace samurai
         using interval_t                 = typename Field::interval_t;
         static_assert(dim <= 3, "Not implemented for dim > 3");
 
-        auto get_f = [&](std::size_t level, const auto&... indices)
+        auto get_f = [&](std::size_t lvl, const auto&... indices)
         {
             if constexpr (Field::is_scalar)
             {
-                return f(level, indices...);
+                return f(lvl, indices...);
             }
             else
             {
                 if constexpr (Field::is_soa)
                 {
-                    return xt::view(f(level, indices...), xt::all(), 0);
+                    return xt::view(f(lvl, indices...), xt::all(), 0);
                 }
                 else
                 {
-                    return xt::view(f(level, indices...), 0);
+                    return xt::view(f(lvl, indices...), 0);
                 }
             }
         };

--- a/include/samurai/schemes/fv/flux_based/explicit_flux_based_scheme__lin_hom.hpp
+++ b/include/samurai/schemes/fv/flux_based/explicit_flux_based_scheme__lin_hom.hpp
@@ -67,12 +67,16 @@ namespace samurai
                         // clang-format off
                         if (left_cell.level == right_cell.level || i.size() == 1) // if same level, or a jump in the x-direction (<=> i.size()=1)
                         {
+                            #if defined(SAMURAI_WITH_OPENMP)
                             #pragma omp simd
+                            #endif
                             for (index_t ii = 0; ii < static_cast<index_t>(i.size()); ++ii)
                             {
                                 field_value(output_field, left_cell_index_init + ii, field_i) += left_cell_coeff * field_value(input_field, comput_index_init + ii, field_j);
                             }
+                            #if defined(SAMURAI_WITH_OPENMP)
                             #pragma omp simd
+                            #endif
                             for (index_t ii = 0; ii < static_cast<index_t>(i.size()); ++ii)
                             {
                                 field_value(output_field, right_cell_index_init + ii, field_i) += right_cell_coeff * field_value(input_field, comput_index_init + ii, field_j);
@@ -84,13 +88,17 @@ namespace samurai
                             // The fine interval is even (exept in the x-direction, handled by the preceding if).
                             // We always have i.size() fine cells for i.size()/2 coarse cells.
                             assert(i.size() % 2 == 0);
+                            #if defined(SAMURAI_WITH_OPENMP)
                             #pragma omp simd
+                            #endif
                             for (index_t ii = 0; ii < static_cast<index_t>(i.size() / 2); ++ii) // iteration on the coarse cells
                             {
                                 field_value(output_field, left_cell_index_init + ii, field_i) += left_cell_coeff * field_value(input_field, comput_index_init + 2*ii  , field_j)
                                                                                                + left_cell_coeff * field_value(input_field, comput_index_init + 2*ii+1, field_j);
                             }
+                            #if defined(SAMURAI_WITH_OPENMP)
                             #pragma omp simd
+                            #endif
                             for (index_t ii = 0; ii < static_cast<index_t>(i.size()); ++ii) // iteration on the fine cells
                             {
                                 field_value(output_field, right_cell_index_init + ii, field_i) += right_cell_coeff * field_value(input_field, comput_index_init + ii, field_j);
@@ -100,12 +108,16 @@ namespace samurai
                         {
                             // Same as above, the other way around.
                             assert(i.size() % 2 == 0);
+                            #if defined(SAMURAI_WITH_OPENMP)
                             #pragma omp simd
+                            #endif
                             for (index_t ii = 0; ii < static_cast<index_t>(i.size()); ++ii)
                             {
                                 field_value(output_field, left_cell_index_init + ii, field_i) += left_cell_coeff * field_value(input_field, comput_index_init + ii, field_j);
                             }
+                            #if defined(SAMURAI_WITH_OPENMP)
                             #pragma omp simd
+                            #endif
                             for (index_t ii = 0; ii < static_cast<index_t>(i.size() / 2); ++ii)
                             {
                                 field_value(output_field, right_cell_index_init + ii, field_i) += right_cell_coeff * field_value(input_field, comput_index_init + 2*ii  , field_j)
@@ -161,12 +173,16 @@ namespace samurai
                         // clang-format off
                         if (left_cell.level == right_cell.level || i.size() == 1) // if same level, or a jump in the x-direction (<=> i.size()=1)
                         {
+                            #if defined(SAMURAI_WITH_OPENMP)
                             #pragma omp simd
+                            #endif
                             for (index_t ii = 0; ii < static_cast<index_t>(i.size()); ++ii)
                             {
                                 left_contributions[static_cast<std::size_t>(ii)] += left_cell_coeff * field_value(input_field, comput_index_init + ii, field_j);
                             }
+                            #if defined(SAMURAI_WITH_OPENMP)
                             #pragma omp simd
+                            #endif
                             for (index_t ii = 0; ii < static_cast<index_t>(i.size()); ++ii)
                             {
                                 right_contributions[static_cast<std::size_t>(ii)] += right_cell_coeff * field_value(input_field, comput_index_init + ii, field_j);
@@ -178,13 +194,17 @@ namespace samurai
                             // The fine interval is even (exept in the x-direction, handled by the preceding if).
                             // We always have i.size() fine cells for i.size()/2 coarse cells.
                             assert(i.size() % 2 == 0);
+                            #if defined(SAMURAI_WITH_OPENMP)
                             #pragma omp simd
+                            #endif
                             for (index_t ii = 0; ii < static_cast<index_t>(i.size() / 2); ++ii) // iteration on the coarse cells
                             {
                                 left_contributions[static_cast<std::size_t>(ii)] += left_cell_coeff * field_value(input_field, comput_index_init + 2*ii  , field_j)
                                                                                   + left_cell_coeff * field_value(input_field, comput_index_init + 2*ii+1, field_j);
                             }
+                            #if defined(SAMURAI_WITH_OPENMP)
                             #pragma omp simd
+                            #endif
                             for (index_t ii = 0; ii < static_cast<index_t>(i.size()); ++ii) // iteration on the fine cells
                             {
                                 right_contributions[static_cast<std::size_t>(ii)] += right_cell_coeff * field_value(input_field, comput_index_init + ii, field_j);
@@ -194,12 +214,16 @@ namespace samurai
                         {
                             // Same as above, the other way around.
                             assert(i.size() % 2 == 0);
+                            #if defined(SAMURAI_WITH_OPENMP)
                             #pragma omp simd
+                            #endif
                             for (index_t ii = 0; ii < static_cast<index_t>(i.size()); ++ii)
                             {
                                 left_contributions[static_cast<std::size_t>(ii)] += left_cell_coeff * field_value(input_field, comput_index_init + ii, field_j);
                             }
+                            #if defined(SAMURAI_WITH_OPENMP)
                             #pragma omp simd
+                            #endif
                             for (index_t ii = 0; ii < static_cast<index_t>(i.size() / 2); ++ii)
                             {
                                 right_contributions[static_cast<std::size_t>(ii)] += right_cell_coeff * field_value(input_field, comput_index_init + 2*ii  , field_j)
@@ -216,12 +240,16 @@ namespace samurai
                 // clang-format off
                 for (index_t ii = 0; ii < static_cast<index_t>(left_contributions.size()); ++ii)
                 {
+                    #if defined(SAMURAI_WITH_OPENMP)
                     #pragma omp atomic update
+                    #endif
                     field_value(output_field, left_cell_index_init + ii, field_i) += left_contributions[static_cast<std::size_t>(ii)];
                 }
                 for (index_t ii = 0; ii < static_cast<index_t>(right_contributions.size()); ++ii)
                 {
+                    #if defined(SAMURAI_WITH_OPENMP)
                     #pragma omp atomic update
+                    #endif
                     field_value(output_field, right_cell_index_init + ii, field_i) += right_contributions[static_cast<std::size_t>(ii)];
                 }
                 // clang-format on
@@ -303,7 +331,9 @@ namespace samurai
 
                                 // clang-format off
 
+                                #if defined(SAMURAI_WITH_OPENMP)
                                 #pragma omp simd
+                                #endif
                                 for (index_t ii = 0; ii < static_cast<index_t>(stencil.interval().size()); ++ii)
                                 {
                                     field_value(output_field, cell_index_init + ii, field_i) += coeff * field_value(input_field, comput_index_init + ii, field_j);

--- a/include/samurai/schemes/fv/flux_based/explicit_flux_based_scheme__nonlin.hpp
+++ b/include/samurai/schemes/fv/flux_based/explicit_flux_based_scheme__nonlin.hpp
@@ -44,7 +44,9 @@ namespace samurai
                     for (size_type field_i = 0; field_i < output_n_comp; ++field_i)
                     {
                     // clang-format off
+                        #if defined(SAMURAI_WITH_OPENMP)
                         #pragma omp atomic update
+                        #endif
                         field_value(output_field, cell, field_i) += this->scheme().flux_value_cmpnent(contrib, field_i);
                         // clang-format on
                     }


### PR DESCRIPTION
## Description
  - Fix -Wmaybe-uninitialized by value-initializing iterator coord buffers in LevelCellArray.
  - Wrap OpenMP pragmas with SAMURAI_WITH_OPENMP guards to silence warnings when OpenMP is off.
  - Minor lambda parameter renames to avoid -Wshadow/-Wunused-parameter.



## Related issue
Warnings when compiling with GCC

## How has this been tested?
Compiled demos --> no more warnings when compiling `advection-2d` and `burgers`

## Code of Conduct
By submitting this PR, you agree to follow our [Code of Conduct](https://github.com/hpc-maths/samurai/blob/master/docs/CODE_OF_CONDUCT.md)
- [x] I agree to follow this project's Code of Conduct
