### PR TITLE
feat: ND projection and prediction operator

### DIFF
--- a/include/samurai/mesh.hpp
+++ b/include/samurai/mesh.hpp
@@ -5,6 +5,8 @@
 
 #include <array>
 #include <set>
+#include <tuple>
+#include <utility>
 
 #include <fmt/format.h>
 
@@ -946,27 +948,38 @@ namespace samurai
     {
         using direction_t = DirectionVector<dim>;
 
-        static_assert(dim <= 3, "Only 2D and 3D are supported.");
-
+        // Generic implementation for any dim >= 2.
+        // For a diagonal direction d (each component ±1), the "corner" subset is:
+        //   domain \ union_{i=0}^{dim-1}( translate(domain, e_i * -d[i]) )
+        // where e_i is the canonical unit vector along axis i.
+        // We build the union_ call generically using an index sequence.
         m_corners.clear();
         for_each_diagonal_direction<dim>(
             [&](const auto& direction)
             {
-                if constexpr (dim == 2)
+                // Build a tuple of dim translates, one per axis
+                auto translates = [&]<std::size_t... Is>(std::index_sequence<Is...>)
                 {
-                    m_corners.push_back(difference(m_domain,
-                                                   union_(translate(m_domain, direction_t{-direction[0], 0}),
-                                                          translate(m_domain, direction_t{0, -direction[1]})))
-                                            .to_lca());
-                }
-                else if constexpr (dim == 3)
-                {
-                    m_corners.push_back(difference(m_domain,
-                                                   union_(translate(m_domain, direction_t{-direction[0], 0, 0}),
-                                                          translate(m_domain, direction_t{0, -direction[1], 0}),
-                                                          translate(m_domain, direction_t{0, 0, -direction[2]})))
-                                            .to_lca());
-                }
+                    // For axis I: shift is -direction[I] along axis I, 0 elsewhere
+                    auto make_translate = [&]<std::size_t I>(std::integral_constant<std::size_t, I>)
+                    {
+                        direction_t shift{};
+                        shift.fill(0);
+                        shift[I] = -direction[I];
+                        return translate(m_domain, shift);
+                    };
+                    return std::make_tuple(make_translate(std::integral_constant<std::size_t, Is>{})...);
+                }(std::make_index_sequence<dim>{});
+
+                // Apply union_ to the tuple of translates
+                auto u = std::apply(
+                    [](const auto&... ts)
+                    {
+                        return union_(ts...);
+                    },
+                    translates);
+
+                m_corners.push_back(difference(m_domain, u).to_lca());
             });
     }
 

--- a/include/samurai/mr/rel_detail.hpp
+++ b/include/samurai/mr/rel_detail.hpp
@@ -6,6 +6,8 @@
 #include <array>
 #include <limits>
 
+#include <xtensor/containers/xadapt.hpp>
+
 namespace samurai
 {
     namespace detail

--- a/include/samurai/numeric/prediction.hpp
+++ b/include/samurai/numeric/prediction.hpp
@@ -90,518 +90,279 @@ namespace samurai
         INIT_OPERATOR(prediction_op)
 
         template <class T1, class T2>
-        void operator()(Dim<1>, T1& dest, const T2& src, std::integral_constant<std::size_t, 0>, std::integral_constant<bool, true>) const;
+        void operator()(Dim<dim>, T1& dest, const T2& src, std::integral_constant<std::size_t, 0>, std::integral_constant<bool, true>) const;
 
         template <class T1, class T2>
-        void operator()(Dim<1>, T1& dest, const T2& src, std::integral_constant<std::size_t, 0>, std::integral_constant<bool, false>) const;
+        void operator()(Dim<dim>, T1& dest, const T2& src, std::integral_constant<std::size_t, 0>, std::integral_constant<bool, false>) const;
 
         template <class T1, class T2, std::size_t order>
         void
-        operator()(Dim<1>, T1& dest, const T2& src, std::integral_constant<std::size_t, order>, std::integral_constant<bool, true>) const;
+        operator()(Dim<dim>, T1& dest, const T2& src, std::integral_constant<std::size_t, order>, std::integral_constant<bool, true>) const;
 
         template <class T1, class T2, std::size_t order>
         void
-        operator()(Dim<1>, T1& dest, const T2& src, std::integral_constant<std::size_t, order>, std::integral_constant<bool, false>) const;
-
-        template <class T1, class T2>
-        void operator()(Dim<2>, T1& dest, const T2& src, std::integral_constant<std::size_t, 0>, std::integral_constant<bool, true>) const;
-
-        template <class T1, class T2>
-        void operator()(Dim<2>, T1& dest, const T2& src, std::integral_constant<std::size_t, 0>, std::integral_constant<bool, false>) const;
-
-        template <class T1, class T2, std::size_t order>
-        void
-        operator()(Dim<2>, T1& dest, const T2& src, std::integral_constant<std::size_t, order>, std::integral_constant<bool, true>) const;
-
-        template <class T1, class T2, std::size_t order>
-        void
-        operator()(Dim<2>, T1& dest, const T2& src, std::integral_constant<std::size_t, order>, std::integral_constant<bool, false>) const;
-
-        template <class T1, class T2>
-        void operator()(Dim<3>, T1& dest, const T2& src, std::integral_constant<std::size_t, 0>, std::integral_constant<bool, true>) const;
-
-        template <class T1, class T2>
-        void operator()(Dim<3>, T1& dest, const T2& src, std::integral_constant<std::size_t, 0>, std::integral_constant<bool, false>) const;
-
-        template <class T1, class T2, std::size_t order>
-        void
-        operator()(Dim<3>, T1& dest, const T2& src, std::integral_constant<std::size_t, order>, std::integral_constant<bool, true>) const;
-
-        template <class T1, class T2, std::size_t order>
-        void
-        operator()(Dim<3>, T1& dest, const T2& src, std::integral_constant<std::size_t, order>, std::integral_constant<bool, false>) const;
+        operator()(Dim<dim>, T1& dest, const T2& src, std::integral_constant<std::size_t, order>, std::integral_constant<bool, false>) const;
     };
 
     template <std::size_t dim, class TInterval>
     template <class T1, class T2>
-    SAMURAI_INLINE void prediction_op<dim, TInterval>::operator()(Dim<1>,
+    SAMURAI_INLINE void prediction_op<dim, TInterval>::operator()(Dim<dim>,
                                                                   T1& dest,
                                                                   const T2& src,
                                                                   std::integral_constant<std::size_t, 0>,
                                                                   std::integral_constant<bool, true>) const
     {
-        auto ii = i << 1;
-        ii.step = 2;
+        auto src_offset = memory_offset(src.mesh(), {level, i.start, index});
 
-        dest(level + 1, ii)     = src(level, i);
-        dest(level + 1, ii + 1) = src(level, i);
-    }
+        std::vector<std::size_t> dest_offsets;
+        dest_offsets.reserve(1ULL << (dim - 1));
 
-    template <std::size_t dim, class TInterval>
-    template <class T1, class T2>
-    SAMURAI_INLINE void prediction_op<dim, TInterval>::operator()(Dim<1>,
-                                                                  T1& dest,
-                                                                  const T2& src,
-                                                                  std::integral_constant<std::size_t, 0>,
-                                                                  std::integral_constant<bool, false>) const
-    {
-        auto even_i = i.even_elements();
-        if (even_i.is_valid())
-        {
-            auto coarse_even_i  = even_i >> 1;
-            dest(level, even_i) = src(level - 1, coarse_even_i);
-        }
-
-        auto odd_i = i.odd_elements();
-        if (odd_i.is_valid())
-        {
-            auto coarse_odd_i  = odd_i >> 1;
-            dest(level, odd_i) = src(level - 1, coarse_odd_i);
-        }
-    }
-
-    template <std::size_t dim, class TInterval>
-    template <class T1, class T2, std::size_t order>
-    SAMURAI_INLINE void prediction_op<dim, TInterval>::operator()(Dim<1>,
-                                                                  T1& dest,
-                                                                  const T2& src,
-                                                                  std::integral_constant<std::size_t, order>,
-                                                                  std::integral_constant<bool, true>) const
-    {
-        auto ii = i << 1;
-        ii.step = 2;
-
-        using value_t    = typename TInterval::value_t;
-        auto sorder      = static_cast<value_t>(order);
-        auto interp_even = interp_coeffs<2 * order + 1>(1.);
-        auto interp_odd  = interp_coeffs<2 * order + 1>(-1.);
-
-        dest(level + 1, ii)     = 0;
-        dest(level + 1, ii + 1) = 0;
-
-        for (value_t ki = 0; ki < 2 * sorder + 1; ++ki)
-        {
-            std::size_t uki = static_cast<std::size_t>(ki);
-            auto field_ik   = src(level, i + ki - sorder);
-            dest(level + 1, ii) += interp_even[uki] * field_ik;
-            dest(level + 1, ii + 1) += interp_odd[uki] * field_ik;
-        }
-    }
-
-    template <std::size_t dim, class TInterval>
-    template <class T1, class T2, std::size_t order>
-    SAMURAI_INLINE void prediction_op<dim, TInterval>::operator()(Dim<1>,
-                                                                  T1& dest,
-                                                                  const T2& src,
-                                                                  std::integral_constant<std::size_t, order>,
-                                                                  std::integral_constant<bool, false>) const
-    {
-        using value_t    = typename TInterval::value_t;
-        auto sorder      = static_cast<value_t>(order);
-        auto interp_even = interp_coeffs<2 * order + 1>(1.);
-        auto interp_odd  = interp_coeffs<2 * order + 1>(-1.);
-
-        auto apply_pred = [&](const auto& i_f, const auto& i_c, const auto& interpi)
-        {
-            dest(level, i_f) = 0;
-
-            for (value_t ki = 0; ki < 2 * sorder + 1; ++ki)
+        static_nested_loop<dim - 1, 0, 2>(
+            [&](const auto& stencil)
             {
-                std::size_t uki = static_cast<std::size_t>(ki);
-                auto field_ij   = src(level - 1, i_c + ki - sorder);
-                dest(level, i_f) += interpi[uki] * field_ij;
-            };
+                auto new_index = 2 * index + stencil;
+                dest_offsets.push_back(memory_offset(dest.mesh(), {level + 1, 2 * i.start, new_index}));
+            });
+
+        const auto* src_data = src.data();
+        auto* dest_data      = dest.data();
+
+        for (std::size_t i_c = 0, i_f = 0; i_c < i.size(); ++i_c, i_f += 2)
+        {
+            for (std::size_t s = 0; s < dest_offsets.size(); ++s)
+            {
+                dest_data[dest_offsets[s] + i_f]     = src_data[src_offset + i_c];
+                dest_data[dest_offsets[s] + i_f + 1] = src_data[src_offset + i_c];
+            }
+        }
+    }
+
+    template <std::size_t dim, std::size_t b, std::size_t e>
+    consteval auto make_index_ranges()
+    {
+        constexpr std::size_t base = e - b;
+        static_assert(base > 0, "make_index_ranges requires e > b");
+
+        constexpr std::size_t count = ce_pow(base, dim);
+        std::array<std::array<std::size_t, dim>, count> result{};
+
+        for (std::size_t n = 0; n < count; ++n)
+        {
+            std::size_t value = n;
+            for (std::size_t d = 0; d < dim; ++d)
+            {
+                result[n][d] = b + (value % base);
+                value /= base;
+            }
+        }
+        return result;
+    }
+
+    template <std::size_t dim, class TInterval>
+    template <class T1, class T2, std::size_t pred_stencil_size>
+    SAMURAI_INLINE void prediction_op<dim, TInterval>::operator()(Dim<dim>,
+                                                                  T1& dest,
+                                                                  const T2& src,
+                                                                  std::integral_constant<std::size_t, pred_stencil_size>,
+                                                                  std::integral_constant<bool, true>) const
+    {
+        constexpr std::size_t order = 2 * pred_stencil_size + 1;
+        using value_t               = typename TInterval::value_t;
+        auto spred_stencil_size     = static_cast<value_t>(pred_stencil_size);
+
+        // (even index coefficients, odd index coefficients)
+        std::array<std::array<double, order>, 2> interp_coeff_pair = {
+            {interp_coeffs<order>(1.), interp_coeffs<order>(-1.)}
         };
 
-        auto even_i = i.even_elements();
-        if (even_i.is_valid())
-        {
-            apply_pred(even_i, even_i >> 1, interp_even);
-        }
+        // Compute the memory accessors for the source data
+        // For example, in 2D, for a prediction stencil of size 1, we need to access the following cells in the source field
+        //
+        // (level, i-1, j+1) (level, i, j+1) (level, i+1, j+1)
+        // (level, i-1, j  ) (level, i, j  ) (level, i+1, j  )
+        // (level, i-1, j-1) (level, i, j-1) (level, i+1, j-1)
+        //
+        // Since the data are contiguous in the i direction, we just have to compute the memory adresses of the first column.
 
-        auto odd_i = i.odd_elements();
-        if (odd_i.is_valid())
-        {
-            apply_pred(odd_i, odd_i >> 1, interp_odd);
-        }
-    }
-
-    template <std::size_t dim, class TInterval>
-    template <class T1, class T2>
-    SAMURAI_INLINE void prediction_op<dim, TInterval>::operator()(Dim<2>,
-                                                                  T1& dest,
-                                                                  const T2& src,
-                                                                  std::integral_constant<std::size_t, 0>,
-                                                                  std::integral_constant<bool, true>) const
-    {
-        auto ii = i << 1;
-        ii.step = 2;
-
-        auto jj = j << 1;
-
-        dest(level + 1, ii, jj)         = src(level, i, j);
-        dest(level + 1, ii + 1, jj)     = src(level, i, j);
-        dest(level + 1, ii, jj + 1)     = src(level, i, j);
-        dest(level + 1, ii + 1, jj + 1) = src(level, i, j);
-    }
-
-    template <std::size_t dim, class TInterval>
-    template <class T1, class T2>
-    SAMURAI_INLINE void prediction_op<dim, TInterval>::operator()(Dim<2>,
-                                                                  T1& dest,
-                                                                  const T2& src,
-                                                                  std::integral_constant<std::size_t, 0>,
-                                                                  std::integral_constant<bool, false>) const
-    {
-        if (j & 1)
-        {
-            auto even_i = i.even_elements();
-            if (even_i.is_valid())
+        std::array<std::size_t, ce_pow(order, dim - 1)> src_offsets;
+        std::size_t ind = 0;
+        static_nested_loop<dim - 1, -static_cast<int>(pred_stencil_size), static_cast<int>(pred_stencil_size) + 1>(
+            [&](const auto& stencil)
             {
-                auto coarse_even_i     = even_i >> 1;
-                dest(level, even_i, j) = src(level - 1, coarse_even_i, j >> 1);
-            }
+                auto new_index     = index + stencil;
+                src_offsets[ind++] = memory_offset(src.mesh(), {level, i.start - spred_stencil_size, new_index});
+            });
 
-            auto odd_i = i.odd_elements();
-            if (odd_i.is_valid())
+        // Compute the memory accessors for the destination data
+        // For example, in 2D, we need to access the following cells in the destination field
+        //
+        // (level + 1, 2i  , 2j  ) (level + 1, 2i+1, 2j  )
+        // (level + 1, 2i+1, 2j+1) (level + 1, 2i+1, 2j+1)
+        //
+        // Since the data are contiguous in the i direction, once again, we just have to compute the memory adresses of the first column.
+
+        std::array<std::size_t, 1ULL << dim> dest_offsets;
+        ind = 0;
+        static_nested_loop<dim - 1, 0, 2>(
+            [&](const auto& stencil)
             {
-                auto coarse_odd_i     = odd_i >> 1;
-                dest(level, odd_i, j) = src(level - 1, coarse_odd_i, j >> 1);
-            }
-        }
-        else
+                auto new_index        = 2 * index + stencil;
+                dest_offsets[ind]     = memory_offset(dest.mesh(), {level + 1, 2 * i.start, new_index});
+                dest_offsets[ind + 1] = dest_offsets[ind] + 1;
+                ind += 2;
+            });
+
+        const auto* src_data = src.data();
+        auto* dest_data      = dest.data();
+
+        std::array<double, 1ULL << dim> dest_values{};
+
+        for (std::size_t i_c = 0, i_f = 0; i_c < i.size(); ++i_c, i_f += 2)
         {
-            auto even_i = i.even_elements();
-            if (even_i.is_valid())
-            {
-                auto coarse_even_i     = even_i >> 1;
-                dest(level, even_i, j) = src(level - 1, coarse_even_i, j >> 1);
-            }
-
-            auto odd_i = i.odd_elements();
-            if (odd_i.is_valid())
-            {
-                auto coarse_odd_i     = odd_i >> 1;
-                dest(level, odd_i, j) = src(level - 1, coarse_odd_i, j >> 1);
-            }
-        }
-    }
-
-    template <std::size_t dim, class TInterval>
-    template <class T1, class T2, std::size_t order>
-    SAMURAI_INLINE void prediction_op<dim, TInterval>::operator()(Dim<2>,
-                                                                  T1& dest,
-                                                                  const T2& src,
-                                                                  std::integral_constant<std::size_t, order>,
-                                                                  std::integral_constant<bool, true>) const
-    {
-        auto ii = i << 1;
-        ii.step = 2;
-
-        auto jj = j << 1;
-
-        using value_t    = typename TInterval::value_t;
-        auto sorder      = static_cast<value_t>(order);
-        auto interp_even = interp_coeffs<2 * order + 1>(1.);
-        auto interp_odd  = interp_coeffs<2 * order + 1>(-1.);
-
-        dest(level + 1, ii, jj)         = 0;
-        dest(level + 1, ii + 1, jj)     = 0;
-        dest(level + 1, ii, jj + 1)     = 0;
-        dest(level + 1, ii + 1, jj + 1) = 0;
-
-        for (value_t kj = 0; kj < 2 * sorder + 1; ++kj)
-        {
-            std::size_t ukj = static_cast<std::size_t>(kj);
-            for (value_t ki = 0; ki < 2 * sorder + 1; ++ki)
-            {
-                std::size_t uki = static_cast<std::size_t>(ki);
-                auto field_ij   = src(level, i + ki - sorder, j + kj - sorder);
-                dest(level + 1, ii, jj) += interp_even[uki] * interp_even[ukj] * field_ij;
-                dest(level + 1, ii + 1, jj) += interp_odd[uki] * interp_even[ukj] * field_ij;
-                dest(level + 1, ii, jj + 1) += interp_even[uki] * interp_odd[ukj] * field_ij;
-                dest(level + 1, ii + 1, jj + 1) += interp_odd[uki] * interp_odd[ukj] * field_ij;
-            }
-        }
-    }
-
-    template <std::size_t dim, class TInterval>
-    template <class T1, class T2, std::size_t order>
-    SAMURAI_INLINE void prediction_op<dim, TInterval>::operator()(Dim<2>,
-                                                                  T1& dest,
-                                                                  const T2& src,
-                                                                  std::integral_constant<std::size_t, order>,
-                                                                  std::integral_constant<bool, false>) const
-    {
-        using value_t    = typename TInterval::value_t;
-        auto sorder      = static_cast<value_t>(order);
-        auto interp_even = interp_coeffs<2 * order + 1>(1.);
-        auto interp_odd  = interp_coeffs<2 * order + 1>(-1.);
-
-        auto apply_pred = [&](const auto& i_f, const auto& i_c, const auto& interpi, const auto& interpj)
-        {
-            dest(level, i_f, j) = 0;
-
-            for (value_t kj = 0; kj < 2 * sorder + 1; ++kj)
-            {
-                std::size_t ukj = static_cast<std::size_t>(kj);
-                for (value_t ki = 0; ki < 2 * sorder + 1; ++ki)
+            dest_values.fill(0);
+            static_nested_loop<dim, 0, order>(
+                [&](const auto& stencil)
                 {
-                    std::size_t uki = static_cast<std::size_t>(ki);
-                    auto field_ij   = src(level - 1, i_c + ki - sorder, (j >> 1) + kj - sorder);
-#ifdef SAMURAI_CHECK_NAN
-                    if (xt::any(xt::isnan(field_ij)))
-                    {
-                        std::cerr << "NaN detected in prediction_op at level " << level - 1 << ", i " << i_c + ki - sorder << ", j "
-                                  << (j >> 1) + kj - sorder << std::endl;
-                        exit(1);
-                    }
-#endif
-                    dest(level, i_f, j) += interpi[uki] * interpj[ukj] * field_ij;
-                };
-            }
-        };
+                    std::size_t io = std::accumulate(stencil.rbegin(),
+                                                     stencil.rend() - 1,
+                                                     0U,
+                                                     [order](auto acc, auto x)
+                                                     {
+                                                         return order * acc + static_cast<std::size_t>(x);
+                                                     });
+                    auto field_ijk = src_data[src_offsets[io] + i_c + static_cast<std::size_t>(stencil[0])];
 
-        if (j & 1)
-        {
-            auto even_i = i.even_elements();
-            if (even_i.is_valid())
-            {
-                apply_pred(even_i, even_i >> 1, interp_even, interp_odd);
-            }
-
-            auto odd_i = i.odd_elements();
-            if (odd_i.is_valid())
-            {
-                apply_pred(odd_i, odd_i >> 1, interp_odd, interp_odd);
-            }
-        }
-        else
-        {
-            auto even_i = i.even_elements();
-            if (even_i.is_valid())
-            {
-                apply_pred(even_i, even_i >> 1, interp_even, interp_even);
-            }
-
-            auto odd_i = i.odd_elements();
-            if (odd_i.is_valid())
-            {
-                apply_pred(odd_i, odd_i >> 1, interp_odd, interp_even);
-            }
-        }
-    }
-
-    template <std::size_t dim, class TInterval>
-    template <class T1, class T2>
-    SAMURAI_INLINE void prediction_op<dim, TInterval>::operator()(Dim<3>,
-                                                                  T1& dest,
-                                                                  const T2& src,
-                                                                  std::integral_constant<std::size_t, 0>,
-                                                                  std::integral_constant<bool, true>) const
-    {
-        auto ii = i << 1;
-        ii.step = 2;
-
-        auto jj = j << 1;
-        auto kk = k << 1;
-
-        dest(level + 1, ii, jj, kk)             = src(level, i, j, k);
-        dest(level + 1, ii + 1, jj, kk)         = src(level, i, j, k);
-        dest(level + 1, ii, jj + 1, kk)         = src(level, i, j, k);
-        dest(level + 1, ii + 1, jj + 1, kk)     = src(level, i, j, k);
-        dest(level + 1, ii, jj, kk + 1)         = src(level, i, j, k);
-        dest(level + 1, ii + 1, jj, kk + 1)     = src(level, i, j, k);
-        dest(level + 1, ii, jj + 1, kk + 1)     = src(level, i, j, k);
-        dest(level + 1, ii + 1, jj + 1, kk + 1) = src(level, i, j, k);
-    }
-
-    template <std::size_t dim, class TInterval>
-    template <class T1, class T2>
-    SAMURAI_INLINE void prediction_op<dim, TInterval>::operator()(Dim<3>,
-                                                                  T1& dest,
-                                                                  const T2& src,
-                                                                  std::integral_constant<std::size_t, 0>,
-                                                                  std::integral_constant<bool, false>) const
-    {
-        auto even_i = i.even_elements();
-        if (even_i.is_valid())
-        {
-            auto coarse_even_i        = even_i >> 1;
-            dest(level, even_i, j, k) = src(level - 1, coarse_even_i, j >> 1, k >> 1);
-        }
-
-        auto odd_i = i.odd_elements();
-        if (odd_i.is_valid())
-        {
-            auto coarse_odd_i        = odd_i >> 1;
-            dest(level, odd_i, j, k) = src(level - 1, coarse_odd_i, j >> 1, k >> 1);
-        }
-    }
-
-    template <std::size_t dim, class TInterval>
-    template <class T1, class T2, std::size_t order>
-    SAMURAI_INLINE void prediction_op<dim, TInterval>::operator()(Dim<3>,
-                                                                  T1& dest,
-                                                                  const T2& src,
-                                                                  std::integral_constant<std::size_t, order>,
-                                                                  std::integral_constant<bool, true>) const
-    {
-        auto i_f = i << 1;
-        i_f.step = 2;
-
-        auto j_f = j << 1;
-        auto k_f = k << 1;
-
-        using value_t    = typename TInterval::value_t;
-        auto sorder      = static_cast<value_t>(order);
-        auto interp_even = interp_coeffs<2 * order + 1>(1.);
-        auto interp_odd  = interp_coeffs<2 * order + 1>(-1.);
-
-        dest(level + 1, i_f, j_f, k_f)             = 0;
-        dest(level + 1, i_f + 1, j_f, k_f)         = 0;
-        dest(level + 1, i_f, j_f + 1, k_f)         = 0;
-        dest(level + 1, i_f + 1, j_f + 1, k_f)     = 0;
-        dest(level + 1, i_f, j_f, k_f + 1)         = 0;
-        dest(level + 1, i_f + 1, j_f, k_f + 1)     = 0;
-        dest(level + 1, i_f, j_f + 1, k_f + 1)     = 0;
-        dest(level + 1, i_f + 1, j_f + 1, k_f + 1) = 0;
-
-        for (value_t kk = 0; kk < 2 * sorder + 1; ++kk)
-        {
-            std::size_t ukk = static_cast<std::size_t>(kk);
-            for (value_t kj = 0; kj < 2 * sorder + 1; ++kj)
-            {
-                std::size_t ukj = static_cast<std::size_t>(kj);
-                for (value_t ki = 0; ki < 2 * sorder + 1; ++ki)
-                {
-                    std::size_t uki = static_cast<std::size_t>(ki);
-                    auto field_ijk  = src(level, i + ki - sorder, j + kj - sorder, k + kk - sorder);
-                    dest(level + 1, i_f, j_f, k_f) += interp_even[uki] * interp_even[ukj] * interp_even[ukk] * field_ijk;
-                    dest(level + 1, i_f + 1, j_f, k_f) += interp_odd[uki] * interp_even[ukj] * interp_even[ukk] * field_ijk;
-                    dest(level + 1, i_f, j_f + 1, k_f) += interp_even[uki] * interp_odd[ukj] * interp_even[ukk] * field_ijk;
-                    dest(level + 1, i_f + 1, j_f + 1, k_f) += interp_odd[uki] * interp_odd[ukj] * interp_even[ukk] * field_ijk;
-                    dest(level + 1, i_f, j_f, k_f + 1) += interp_even[uki] * interp_even[ukj] * interp_odd[ukk] * field_ijk;
-                    dest(level + 1, i_f + 1, j_f, k_f + 1) += interp_odd[uki] * interp_even[ukj] * interp_odd[ukk] * field_ijk;
-                    dest(level + 1, i_f, j_f + 1, k_f + 1) += interp_even[uki] * interp_odd[ukj] * interp_odd[ukk] * field_ijk;
-                    dest(level + 1, i_f + 1, j_f + 1, k_f + 1) += interp_odd[uki] * interp_odd[ukj] * interp_odd[ukk] * field_ijk;
-                }
-            }
-        }
-    }
-
-    template <std::size_t dim, class TInterval>
-    template <class T1, class T2, std::size_t order>
-    SAMURAI_INLINE void prediction_op<dim, TInterval>::operator()(Dim<3>,
-                                                                  T1& dest,
-                                                                  const T2& src,
-                                                                  std::integral_constant<std::size_t, order>,
-                                                                  std::integral_constant<bool, false>) const
-    {
-        using value_t    = typename TInterval::value_t;
-        auto sorder      = static_cast<value_t>(order);
-        auto interp_even = interp_coeffs<2 * order + 1>(1.);
-        auto interp_odd  = interp_coeffs<2 * order + 1>(-1.);
-
-        auto apply_pred = [&](const auto& i_f, const auto& i_c, const auto& interpi, const auto interpj, const auto interpk)
-        {
-            dest(level, i_f, j, k) = 0;
-
-            for (value_t kk = 0; kk < 2 * sorder + 1; ++kk)
-            {
-                std::size_t ukk = static_cast<std::size_t>(kk);
-                for (value_t kj = 0; kj < 2 * sorder + 1; ++kj)
-                {
-                    std::size_t ukj = static_cast<std::size_t>(kj);
-                    for (value_t ki = 0; ki < 2 * sorder + 1; ++ki)
-                    {
-                        std::size_t uki = static_cast<std::size_t>(ki);
-                        auto field_ijk  = src(level - 1, i_c + ki - sorder, (j >> 1) + kj - sorder, (k >> 1) + kk - sorder);
-#ifdef SAMURAI_CHECK_NAN
-                        if (xt::any(xt::isnan(field_ijk)))
+                    std::size_t ind = 0;
+                    std::apply(
+                        [&](const auto&... s)
                         {
-                            std::cerr << "NaN detected in prediction_op at level " << level - 1 << ", i " << i_c + ki - sorder << ", j "
-                                      << (j >> 1) + kj - sorder << ", k " << (k >> 1) + kk - sorder << std::endl;
-                            exit(1);
-                        }
-#endif
-                        dest(level, i_f, j, k) += interpi[uki] * interpj[ukj] * interpk[ukk] * field_ijk;
-                    };
-                }
-            }
-        };
+                            (void)std::initializer_list<int>{(
+                                (dest_values[ind++] += field_ijk
+                                                     * std::apply(
+                                                           [&](const auto&... ki)
+                                                           {
+                                                               std::size_t is = 0;
+                                                               double coeff   = 1.;
+                                                               ((coeff *= interp_coeff_pair[ki][static_cast<std::size_t>(stencil[is])], ++is),
+                                                                ...);
+                                                               return coeff;
+                                                           },
+                                                           s)),
+                                0)...};
+                        },
+                        make_index_ranges<dim, 0, dim>());
+                });
 
-        if (k & 1)
+            std::size_t id = 0;
+            std::apply(
+                [&](const auto&... s)
+                {
+                    ((dest_data[s + i_f] = dest_values[id++]), ...);
+                },
+                dest_offsets);
+        }
+    }
+
+    template <std::size_t dim, class TInterval>
+    template <class T1, class T2>
+    SAMURAI_INLINE void prediction_op<dim, TInterval>::operator()(Dim<dim>,
+                                                                  T1& dest,
+                                                                  const T2& src,
+                                                                  std::integral_constant<std::size_t, 0>,
+                                                                  std::integral_constant<bool, false>) const
+    {
+        const auto* src_data = src.data();
+        auto* dest_data      = dest.data();
+
+        auto even_i = i.even_elements();
+        if (even_i.is_valid())
         {
-            if (j & 1)
+            auto src_offset  = memory_offset(src.mesh(), {level - 1, even_i.start >> 1, index >> 1});
+            auto dest_offset = memory_offset(dest.mesh(), {level, even_i.start, index});
+            for (std::size_t i_f = 0, i_c = 0; i_f < even_i.size(); i_f += 2, ++i_c)
             {
-                auto even_i = i.even_elements();
-                if (even_i.is_valid())
-                {
-                    apply_pred(even_i, even_i >> 1, interp_even, interp_odd, interp_odd);
-                }
-
-                auto odd_i = i.odd_elements();
-                if (odd_i.is_valid())
-                {
-                    apply_pred(odd_i, odd_i >> 1, interp_odd, interp_odd, interp_odd);
-                }
-            }
-            else
-            {
-                auto even_i = i.even_elements();
-                if (even_i.is_valid())
-                {
-                    apply_pred(even_i, even_i >> 1, interp_even, interp_even, interp_odd);
-                }
-
-                auto odd_i = i.odd_elements();
-                if (odd_i.is_valid())
-                {
-                    apply_pred(odd_i, odd_i >> 1, interp_odd, interp_even, interp_odd);
-                }
+                dest_data[dest_offset + i_f] = src_data[src_offset + i_c];
             }
         }
-        else
+
+        auto odd_i = i.odd_elements();
+        if (odd_i.is_valid())
         {
-            if (j & 1)
+            auto src_offset  = memory_offset(src.mesh(), {level - 1, odd_i.start >> 1, index >> 1});
+            auto dest_offset = memory_offset(dest.mesh(), {level, odd_i.start, index});
+            for (std::size_t i_f = 0, i_c = 0; i_f < odd_i.size(); i_f += 2, ++i_c)
             {
-                auto even_i = i.even_elements();
-                if (even_i.is_valid())
-                {
-                    apply_pred(even_i, even_i >> 1, interp_even, interp_odd, interp_even);
-                }
-
-                auto odd_i = i.odd_elements();
-                if (odd_i.is_valid())
-                {
-                    apply_pred(odd_i, odd_i >> 1, interp_odd, interp_odd, interp_even);
-                }
+                dest_data[dest_offset + i_f] = src_data[src_offset + i_c];
             }
-            else
+        }
+    }
+
+    template <std::size_t dim, class TInterval>
+    template <class T1, class T2, std::size_t pred_stencil_size>
+    SAMURAI_INLINE void prediction_op<dim, TInterval>::operator()(Dim<dim>,
+                                                                  T1& dest,
+                                                                  const T2& src,
+                                                                  std::integral_constant<std::size_t, pred_stencil_size>,
+                                                                  std::integral_constant<bool, false>) const
+    {
+        constexpr std::size_t order = 2 * pred_stencil_size + 1;
+        using value_t               = typename TInterval::value_t;
+
+        // (even index coefficients, odd index coefficients)
+        std::array<std::array<double, order>, 2> interp_coeff_pair = {
+            {interp_coeffs<order>(1.), interp_coeffs<order>(-1.)}
+        };
+
+        const auto* src_data = src.data();
+        auto* dest_data      = dest.data();
+
+        auto dest_offset = memory_offset(dest.mesh(), {level, i.start, index});
+
+        std::array<std::size_t, dim> parity;
+        for (std::size_t d = 1; d < dim; ++d)
+        {
+            parity[d] = (index[d - 1] & 1) ? 1 : 0;
+        }
+
+        std::array<std::size_t, ce_pow(order, dim)> src_offsets;
+        std::size_t ind = 0;
+        static_nested_loop<dim, -static_cast<int>(pred_stencil_size), static_cast<int>(pred_stencil_size) + 1>(
+            [&](const auto& stencil)
             {
-                auto even_i = i.even_elements();
-                if (even_i.is_valid())
-                {
-                    apply_pred(even_i, even_i >> 1, interp_even, interp_even, interp_even);
-                }
+                auto new_index     = (index >> 1) + xt::view(stencil, xt::range(1, dim));
+                src_offsets[ind++] = memory_offset(src.mesh(), {level - 1, (i.start >> 1) + stencil[0], new_index});
+            });
 
-                auto odd_i = i.odd_elements();
-                if (odd_i.is_valid())
+        auto apply_pred = [&](const auto& i_f, const auto& i_c)
+        {
+            dest_data[dest_offset + i_f] = 0;
+
+            double dest_value = 0;
+            std::size_t io    = 0;
+            static_nested_loop<dim, 0, order>(
+                [&](const auto& stencil)
                 {
-                    apply_pred(odd_i, odd_i >> 1, interp_odd, interp_even, interp_even);
-                }
-            }
+                    auto field_ijk = src_data[src_offsets[io++] + i_c];
+
+                    parity[0] = ((i.start + static_cast<value_t>(i_f)) & 1) ? 1 : 0;
+
+                    dest_value += field_ijk
+                                * std::apply(
+                                      [&](const auto&... ki)
+                                      {
+                                          std::size_t is = 0;
+                                          double coeff   = 1.;
+                                          ((coeff *= interp_coeff_pair[ki][static_cast<std::size_t>(stencil[is])], ++is), ...);
+                                          return coeff;
+                                      },
+                                      parity);
+                });
+            dest_data[dest_offset + i_f] = dest_value;
+        };
+
+        for (std::size_t i_f = 0; i_f < i.size(); ++i_f)
+        {
+            apply_pred(i_f, i_f >> 1);
         }
     }
 
@@ -618,36 +379,14 @@ namespace samurai
         }
 
         template <std::size_t order, bool dest_on_level, class Head, class... Tail>
-        SAMURAI_INLINE void operator()(Dim<1>,
+        SAMURAI_INLINE void operator()(Dim<dim>,
                                        std::integral_constant<std::size_t, order> o,
                                        std::integral_constant<bool, dest_on_level> dest,
                                        Head& source,
                                        Tail&... sources) const
         {
-            prediction_op<dim, interval_t>(level, i)(Dim<1>{}, source, source, o, dest);
-            this->operator()(Dim<1>{}, o, dest, sources...);
-        }
-
-        template <std::size_t order, bool dest_on_level, class Head, class... Tail>
-        SAMURAI_INLINE void operator()(Dim<2>,
-                                       std::integral_constant<std::size_t, order> o,
-                                       std::integral_constant<bool, dest_on_level> dest,
-                                       Head& source,
-                                       Tail&... sources) const
-        {
-            prediction_op<dim, interval_t>(level, i, j)(Dim<2>{}, source, source, o, dest);
-            this->operator()(Dim<2>{}, o, dest, sources...);
-        }
-
-        template <std::size_t order, bool dest_on_level, class Head, class... Tail>
-        SAMURAI_INLINE void operator()(Dim<3>,
-                                       std::integral_constant<std::size_t, order> o,
-                                       std::integral_constant<bool, dest_on_level> dest,
-                                       Head& source,
-                                       Tail&... sources) const
-        {
-            prediction_op<dim, interval_t>(level, i, j, k)(Dim<3>{}, source, source, o, dest);
-            this->operator()(Dim<3>{}, o, dest, sources...);
+            prediction_op<dim, interval_t>(level, i, index)(Dim<dim>{}, source, source, o, dest);
+            this->operator()(Dim<dim>{}, o, dest, sources...);
         }
     };
 

--- a/include/samurai/numeric/prediction.hpp
+++ b/include/samurai/numeric/prediction.hpp
@@ -95,17 +95,19 @@ namespace samurai
         template <class T1, class T2>
         void operator()(Dim<dim>, T1& dest, const T2& src, std::integral_constant<std::size_t, 0>, std::integral_constant<bool, false>) const;
 
-        // template <class T1, class T2, std::size_t order>
-        // void
-        // operator()(Dim<dim>, T1& dest, const T2& src, std::integral_constant<std::size_t, order>, std::integral_constant<bool, true>)
-        // const;
         template <class T1, class T2, std::size_t order>
         void
-        operator()(Dim<2>, T1& dest, const T2& src, std::integral_constant<std::size_t, order>, std::integral_constant<bool, true>) const;
+        operator()(Dim<dim>, T1& dest, const T2& src, std::integral_constant<std::size_t, order>, std::integral_constant<bool, true>) const;
+
+        // template <class T1, class T2, std::size_t order>
+        // void
+        // operator()(Dim<2>, T1& dest, const T2& src, std::integral_constant<std::size_t, order>, std::integral_constant<bool, true>)
+        // const;
 
         template <class T1, class T2, std::size_t order>
         void
         operator()(Dim<dim>, T1& dest, const T2& src, std::integral_constant<std::size_t, order>, std::integral_constant<bool, false>) const;
+
         // template <class T1, class T2, std::size_t order>
         // void
         // operator()(Dim<2>, T1& dest, const T2& src, std::integral_constant<std::size_t, order>, std::integral_constant<bool, false>)
@@ -169,141 +171,115 @@ namespace samurai
         return result;
     }
 
-    // template <std::size_t dim, class TInterval>
-    // template <class DEST, class SRC, std::size_t pred_stencil_size>
-    // SAMURAI_INLINE void prediction_op<dim, TInterval>::operator()(Dim<dim>,
-    //                                                               DEST& dest,
-    //                                                               const SRC& src,
-    //                                                               std::integral_constant<std::size_t, pred_stencil_size>,
-    //                                                               std::integral_constant<bool, true>) const
-    // {
-    //     static_assert(DEST::n_comp == SRC::n_comp, "Source and destination fields must have the same number of components");
+    template <std::size_t dim, class TInterval>
+    template <class DEST, class SRC, std::size_t pred_stencil_size>
+    SAMURAI_INLINE void prediction_op<dim, TInterval>::operator()(Dim<dim>,
+                                                                  DEST& dest,
+                                                                  const SRC& src,
+                                                                  std::integral_constant<std::size_t, pred_stencil_size>,
+                                                                  std::integral_constant<bool, true>) const
+    {
+        static_assert(DEST::n_comp == SRC::n_comp, "Source and destination fields must have the same number of components");
 
-    //     constexpr std::size_t order = 2 * pred_stencil_size + 1;
-    //     using value_t               = typename TInterval::value_t;
-    //     auto spred_stencil_size     = static_cast<value_t>(pred_stencil_size);
+        constexpr std::size_t order = 2 * pred_stencil_size + 1;
 
-    //     // (even index coefficients, odd index coefficients)
-    //     std::array<std::array<double, order>, 2> interp_coeff_pair = {
-    //         {interp_coeffs<order>(1.), interp_coeffs<order>(-1.)}
-    //     };
+        // (even index coefficients, odd index coefficients)
+        std::array<std::array<double, order>, 2> interp_coeff_pair = {
+            {interp_coeffs<order>(1.), interp_coeffs<order>(-1.)}
+        };
 
-    //     // Compute the memory accessors for the source data
-    //     // For example, in 2D, for a prediction stencil of size 1, we need to access the following cells in the source field
-    //     //
-    //     // (level, i-1, j+1) (level, i, j+1) (level, i+1, j+1)
-    //     // (level, i-1, j  ) (level, i, j  ) (level, i+1, j  )
-    //     // (level, i-1, j-1) (level, i, j-1) (level, i+1, j-1)
-    //     //
-    //     // Since the data are contiguous in the i direction, we just have to compute the memory adresses of the first column.
+        // Compute the memory accessors for the source data
+        // For example, in 2D, for a prediction stencil of size 1, we need to access the following cells in the source field
+        //
+        // (level, i-1, j+1) (level, i, j+1) (level, i+1, j+1)
+        // (level, i-1, j  ) (level, i, j  ) (level, i+1, j  )
+        // (level, i-1, j-1) (level, i, j-1) (level, i+1, j-1)
+        //
+        // Since the data are contiguous in the i direction, we just have to compute the memory adresses of the first column.
 
-    //     std::array<std::size_t, ce_pow(order, dim - 1)> src_offsets;
-    //     std::size_t ind = 0;
-    //     static_nested_loop<dim - 1, -static_cast<int>(pred_stencil_size), static_cast<int>(pred_stencil_size) + 1>(
-    //         [&](const auto& stencil)
-    //         {
-    //             auto new_index     = index + stencil;
-    //             src_offsets[ind++] = memory_offset(src.mesh(), {level, i.start - spred_stencil_size, new_index});
-    //         });
+        std::array<std::size_t, ce_pow(order, dim)> src_offsets;
+        std::size_t ind = 0;
+        static_nested_loop<dim, -static_cast<int>(pred_stencil_size), static_cast<int>(pred_stencil_size) + 1>(
+            [&](const auto& stencil)
+            {
+                auto new_index     = index + xt::view(stencil, xt::range(1, dim));
+                src_offsets[ind++] = memory_offset(src.mesh(), {level, i.start + stencil[0], new_index});
+            });
 
-    //     // Compute the memory accessors for the destination data
-    //     // For example, in 2D, we need to access the following cells in the destination field
-    //     //
-    //     // (level + 1, 2i  , 2j  ) (level + 1, 2i+1, 2j  )
-    //     // (level + 1, 2i+1, 2j+1) (level + 1, 2i+1, 2j+1)
-    //     //
-    //     // Since the data are contiguous in the i direction, once again, we just have to compute the memory adresses of the first column.
+        // Compute the memory accessors for the destination data
+        // For example, in 2D, we need to access the following cells in the destination field
+        //
+        // (level + 1, 2i  , 2j  ) (level + 1, 2i+1, 2j  )
+        // (level + 1, 2i+1, 2j+1) (level + 1, 2i+1, 2j+1)
+        //
+        // Since the data are contiguous in the i direction, once again, we just have to compute the memory adresses of the first column.
 
-    //     std::array<std::size_t, 1ULL << dim> dest_offsets;
-    //     ind = 0;
-    //     static_nested_loop<dim - 1, 0, 2>(
-    //         [&](const auto& stencil)
-    //         {
-    //             auto new_index        = 2 * index + stencil;
-    //             dest_offsets[ind]     = memory_offset(dest.mesh(), {level + 1, 2 * i.start, new_index});
-    //             dest_offsets[ind + 1] = dest_offsets[ind] + SRC::n_comp; // next cell in the i direction
-    //             ind += 2;
-    //         });
+        std::array<std::size_t, 1ULL << dim> dest_offsets;
+        ind = 0;
+        static_nested_loop<dim - 1, 0, 2>(
+            [&](const auto& stencil)
+            {
+                auto new_index        = 2 * index + stencil;
+                dest_offsets[ind]     = memory_offset(dest.mesh(), {level + 1, 2 * i.start, new_index});
+                dest_offsets[ind + 1] = dest_offsets[ind] + 1;
+                ind += 2;
+            });
 
-    //     const auto* src_data = src.data();
-    //     auto* dest_data      = dest.data();
+        const auto* src_data = src.data();
+        auto* dest_data      = dest.data();
 
-    //     std::array<double, (1ULL << dim) * SRC::n_comp> dest_values{};
+        std::array<double, (1ULL << dim) * SRC::n_comp> dest_values{};
+        for (std::size_t i_c = 0, i_f = 0; i_c < i.size(); ++i_c, i_f += 2)
+        {
+            dest_values.fill(0);
+            std::size_t io = 0;
+            static_nested_loop<dim, 0, order>(
+                [&](const auto& stencil)
+                {
+                    std::array<double, SRC::n_comp> field_ijk{};
+                    for (std::size_t n = 0; n < SRC::n_comp; ++n)
+                    {
+                        field_ijk[n] = src_data[(src_offsets[io] + i_c) * SRC::n_comp + n];
+                    }
+                    ++io;
 
-    //     for (std::size_t i_c = 0, i_f = 0; i_c < i.size(); ++i_c, i_f += 2)
-    //     {
-    //         dest_values.fill(0);
-    //         static_nested_loop<dim, 0, order>(
-    //             [&](const auto& stencil)
-    //             {
-    //                 std::size_t io = std::accumulate(stencil.rbegin(),
-    //                                                  stencil.rend() - 1,
-    //                                                  0U,
-    //                                                  [order](auto acc, auto x)
-    //                                                  {
-    //                                                      return order * acc + static_cast<std::size_t>(x);
-    //                                                  });
+                    std::size_t ind = 0;
+                    std::apply(
+                        [&](const auto&... s)
+                        {
+                            for (std::size_t n = 0; n < SRC::n_comp; ++n)
+                            {
+                                (void)std::initializer_list<int>{
+                                    ((dest_values[ind++] += field_ijk[n]
+                                                          * std::apply(
+                                                                [&](const auto&... ki)
+                                                                {
+                                                                    std::size_t is = 0;
+                                                                    double coeff   = 1.;
+                                                                    ((coeff *= interp_coeff_pair[ki][static_cast<std::size_t>(stencil[is])],
+                                                                      ++is),
+                                                                     ...);
+                                                                    return coeff;
+                                                                },
+                                                                s)),
+                                     0)...};
+                            }
+                        },
+                        make_index_ranges<dim, 0, 2>());
+                });
 
-    //                 std::array<double, SRC::n_comp> field_ijk{};
-    //                 for (std::size_t n = 0; n < SRC::n_comp; ++n)
-    //                 {
-    //                     field_ijk[n] = src_data[src_offsets[io] + (i_c + static_cast<std::size_t>(stencil[0])) * SRC::n_comp + n];
-    //                 }
-
-    //                 std::size_t ind = 0;
-    //                 std::apply(
-    //                     [&](const auto&... s)
-    //                     {
-    //                         for (std::size_t n = 0; n < SRC::n_comp; ++n)
-    //                         {
-    //                             (void)std::initializer_list<int>{
-    //                                 ((dest_values[ind * SRC::n_comp
-    //                                               + n] += field_ijk[n]
-    //                                                     * std::apply(
-    //                                                           [&](const auto&... ki)
-    //                                                           {
-    //                                                               std::size_t is = 0;
-    //                                                               double coeff   = 1.;
-    //                                                               ((coeff *=
-    //                                                               interp_coeff_pair[ki][static_cast<std::size_t>(stencil[is])],
-    //                                                                 ++is),
-    //                                                                ...);
-    //                                                               return coeff;
-    //                                                           },
-    //                                                           s)),
-    //                                  0)...};
-    //                         }
-    //                         // (void)std::initializer_list<int>{(
-    //                         //     (dest_values[ind++] += field_ijk
-    //                         //                          * std::apply(
-    //                         //                                [&](const auto&... ki)
-    //                         //                                {
-    //                         //                                    std::size_t is = 0;
-    //                         //                                    double coeff   = 1.;
-    //                         //                                    ((coeff *=
-    //                         interp_coeff_pair[ki][static_cast<std::size_t>(stencil[is])],
-    //                         //                                    ++is),
-    //                         //                                     ...);
-    //                         //                                    return coeff;
-    //                         //                                },
-    //                         //                                s)),
-    //                         //     0)...};
-    //                     },
-    //                     make_index_ranges<dim, 0, dim>());
-    //             });
-
-    //         std::size_t id = 0;
-    //         std::apply(
-    //             [&](const auto&... s)
-    //             {
-    //                 for (std::size_t n = 0; n < SRC::n_comp; ++n)
-    //                 {
-    //                     ((dest_data[s + i_f * SRC::n_comp + n] = dest_values[id++]), ...);
-    //                 }
-    //             },
-    //             dest_offsets);
-    //     }
-    // }
+            std::size_t id = 0;
+            std::apply(
+                [&](const auto&... s)
+                {
+                    for (std::size_t n = 0; n < SRC::n_comp; ++n)
+                    {
+                        ((dest_data[(s + i_f) * SRC::n_comp + n] = dest_values[id++]), ...);
+                    }
+                },
+                dest_offsets);
+        }
+    }
 
     template <std::size_t dim, class TInterval>
     template <class T1, class T2>
@@ -335,44 +311,6 @@ namespace samurai
             for (std::size_t i_f = 0, i_c = 0; i_f < odd_i.size(); i_f += 2, ++i_c)
             {
                 dest_data[dest_offset + i_f] = src_data[src_offset + i_c];
-            }
-        }
-    }
-
-    template <std::size_t dim, class TInterval>
-    template <class T1, class T2, std::size_t order>
-    SAMURAI_INLINE void prediction_op<dim, TInterval>::operator()(Dim<2>,
-                                                                  T1& dest,
-                                                                  const T2& src,
-                                                                  std::integral_constant<std::size_t, order>,
-                                                                  std::integral_constant<bool, true>) const
-    {
-        auto ii = i << 1;
-        ii.step = 2;
-
-        auto jj = j << 1;
-
-        using value_t    = typename TInterval::value_t;
-        auto sorder      = static_cast<value_t>(order);
-        auto interp_even = interp_coeffs<2 * order + 1>(1.);
-        auto interp_odd  = interp_coeffs<2 * order + 1>(-1.);
-
-        dest(level + 1, ii, jj)         = 0;
-        dest(level + 1, ii + 1, jj)     = 0;
-        dest(level + 1, ii, jj + 1)     = 0;
-        dest(level + 1, ii + 1, jj + 1) = 0;
-
-        for (value_t kj = 0; kj < 2 * sorder + 1; ++kj)
-        {
-            std::size_t ukj = static_cast<std::size_t>(kj);
-            for (value_t ki = 0; ki < 2 * sorder + 1; ++ki)
-            {
-                std::size_t uki = static_cast<std::size_t>(ki);
-                auto field_ij   = src(level, i + ki - sorder, j + kj - sorder);
-                dest(level + 1, ii, jj) += interp_even[uki] * interp_even[ukj] * field_ij;
-                dest(level + 1, ii + 1, jj) += interp_odd[uki] * interp_even[ukj] * field_ij;
-                dest(level + 1, ii, jj + 1) += interp_even[uki] * interp_odd[ukj] * field_ij;
-                dest(level + 1, ii + 1, jj + 1) += interp_odd[uki] * interp_odd[ukj] * field_ij;
             }
         }
     }
@@ -423,7 +361,7 @@ namespace samurai
                 {
                     for (std::size_t n = 0; n < SRC::n_comp; ++n)
                     {
-                        auto field_ijk = src_data[src_offsets[io++] + i_c * SRC::n_comp + n];
+                        auto field_ijk = src_data[(src_offsets[io] + i_c) * SRC::n_comp + n];
 
                         dest_value[n] += field_ijk
                                        * std::apply(
@@ -436,11 +374,12 @@ namespace samurai
                                              },
                                              parity);
                     }
+                    io++;
                 });
 
             for (std::size_t n = 0; n < SRC::n_comp; ++n)
             {
-                dest_data[dest_offset + i_f * SRC::n_comp + n] = dest_value[n];
+                dest_data[(dest_offset + i_f) * SRC::n_comp + n] = dest_value[n];
             }
             parity[0] = (parity[0] & 1) ? 0 : 1;
         };
@@ -450,6 +389,111 @@ namespace samurai
             apply_pred(i_f, static_cast<std::size_t>(((i.start + static_cast<value_t>(i_f)) >> 1) - (i.start >> 1)));
         }
     }
+
+    // template <std::size_t dim, class TInterval>
+    // template <class T1, class T2, std::size_t order>
+    // SAMURAI_INLINE void prediction_op<dim, TInterval>::operator()(Dim<2>,
+    //                                                               T1& dest,
+    //                                                               const T2& src,
+    //                                                               std::integral_constant<std::size_t, order>,
+    //                                                               std::integral_constant<bool, true>) const
+    // {
+    //     auto ii = i << 1;
+    //     ii.step = 2;
+
+    //     auto jj = j << 1;
+
+    //     using value_t    = typename TInterval::value_t;
+    //     auto sorder      = static_cast<value_t>(order);
+    //     auto interp_even = interp_coeffs<2 * order + 1>(1.);
+    //     auto interp_odd  = interp_coeffs<2 * order + 1>(-1.);
+
+    //     dest(level + 1, ii, jj)         = 0;
+    //     dest(level + 1, ii + 1, jj)     = 0;
+    //     dest(level + 1, ii, jj + 1)     = 0;
+    //     dest(level + 1, ii + 1, jj + 1) = 0;
+
+    //     for (value_t kj = 0; kj < 2 * sorder + 1; ++kj)
+    //     {
+    //         std::size_t ukj = static_cast<std::size_t>(kj);
+    //         for (value_t ki = 0; ki < 2 * sorder + 1; ++ki)
+    //         {
+    //             std::size_t uki = static_cast<std::size_t>(ki);
+    //             auto field_ij   = src(level, i + ki - sorder, j + kj - sorder);
+    //             dest(level + 1, ii, jj) += interp_even[uki] * interp_even[ukj] * field_ij;
+    //             dest(level + 1, ii + 1, jj) += interp_odd[uki] * interp_even[ukj] * field_ij;
+    //             dest(level + 1, ii, jj + 1) += interp_even[uki] * interp_odd[ukj] * field_ij;
+    //             dest(level + 1, ii + 1, jj + 1) += interp_odd[uki] * interp_odd[ukj] * field_ij;
+    //         }
+    //     }
+    // }
+
+    //     template <std::size_t dim, class TInterval>
+    //     template <class T1, class T2, std::size_t order>
+    //     SAMURAI_INLINE void prediction_op<dim, TInterval>::operator()(Dim<2>,
+    //                                                                   T1& dest,
+    //                                                                   const T2& src,
+    //                                                                   std::integral_constant<std::size_t, order>,
+    //                                                                   std::integral_constant<bool, false>) const
+    //     {
+    //         using value_t    = typename TInterval::value_t;
+    //         auto sorder      = static_cast<value_t>(order);
+    //         auto interp_even = interp_coeffs<2 * order + 1>(1.);
+    //         auto interp_odd  = interp_coeffs<2 * order + 1>(-1.);
+
+    //         auto apply_pred = [&](const auto& i_f, const auto& i_c, const auto& interpi, const auto& interpj)
+    //         {
+    //             dest(level, i_f, j) = 0;
+
+    //             for (value_t kj = 0; kj < 2 * sorder + 1; ++kj)
+    //             {
+    //                 std::size_t ukj = static_cast<std::size_t>(kj);
+    //                 for (value_t ki = 0; ki < 2 * sorder + 1; ++ki)
+    //                 {
+    //                     std::size_t uki = static_cast<std::size_t>(ki);
+    //                     auto field_ij   = src(level - 1, i_c + ki - sorder, (j >> 1) + kj - sorder);
+    // #ifdef SAMURAI_CHECK_NAN
+    //                     if (xt::any(xt::isnan(field_ij)))
+    //                     {
+    //                         std::cerr << "NaN detected in prediction_op at level " << level - 1 << ", i " << i_c + ki - sorder << ", j "
+    //                                   << (j >> 1) + kj - sorder << std::endl;
+    //                         exit(1);
+    //                     }
+    // #endif
+    //                     dest(level, i_f, j) += interpi[uki] * interpj[ukj] * field_ij;
+    //                 };
+    //             }
+    //         };
+
+    //         if (j & 1)
+    //         {
+    //             auto even_i = i.even_elements();
+    //             if (even_i.is_valid())
+    //             {
+    //                 apply_pred(even_i, even_i >> 1, interp_even, interp_odd);
+    //             }
+
+    //             auto odd_i = i.odd_elements();
+    //             if (odd_i.is_valid())
+    //             {
+    //                 apply_pred(odd_i, odd_i >> 1, interp_odd, interp_odd);
+    //             }
+    //         }
+    //         else
+    //         {
+    //             auto even_i = i.even_elements();
+    //             if (even_i.is_valid())
+    //             {
+    //                 apply_pred(even_i, even_i >> 1, interp_even, interp_even);
+    //             }
+
+    //             auto odd_i = i.odd_elements();
+    //             if (odd_i.is_valid())
+    //             {
+    //                 apply_pred(odd_i, odd_i >> 1, interp_odd, interp_even);
+    //             }
+    //         }
+    //     }
 
     template <std::size_t dim, class TInterval>
     class variadic_prediction_op : public field_operator_base<dim, TInterval>

--- a/include/samurai/numeric/prediction.hpp
+++ b/include/samurai/numeric/prediction.hpp
@@ -264,6 +264,7 @@ namespace samurai
                                                                   std::integral_constant<bool, false>) const
     {
         static_assert(DEST::n_comp == SRC::n_comp, "Source and destination fields must have the same number of components");
+        using value_t = typename TInterval::value_t;
 
         const auto* src_data = src.data();
         auto* dest_data      = dest.data();

--- a/include/samurai/numeric/prediction.hpp
+++ b/include/samurai/numeric/prediction.hpp
@@ -4,20 +4,17 @@
 #pragma once
 
 #include <array>
+#include <initializer_list>
+#include <tuple>
 #include <type_traits>
+#include <utility>
+#include <vector>
 
-#include <xtensor/containers/xadapt.hpp>
 #include <xtensor/views/xview.hpp>
 
 #include "../operators_base.hpp"
-#include "../storage/utils.hpp"
-#ifdef SAMURAI_CHECK_NAN
-#include "../io/hdf5.hpp"
-#endif
-
-#ifdef SAMURAI_CHECK_NAN
-#include <mpi.h>
-#endif
+#include "../static_algorithm.hpp"
+#include "../utils.hpp"
 
 namespace samurai
 {
@@ -138,27 +135,6 @@ namespace samurai
                 }
             }
         }
-    }
-
-    template <std::size_t dim, std::size_t b, std::size_t e>
-    consteval auto make_index_ranges()
-    {
-        constexpr std::size_t base = e - b;
-        static_assert(base > 0, "make_index_ranges requires e > b");
-
-        constexpr std::size_t count = ce_pow(base, dim);
-        std::array<std::array<std::size_t, dim>, count> result{};
-
-        for (std::size_t n = 0; n < count; ++n)
-        {
-            std::size_t value = n;
-            for (std::size_t d = 0; d < dim; ++d)
-            {
-                result[n][d] = b + (value % base);
-                value /= base;
-            }
-        }
-        return result;
     }
 
     template <std::size_t dim, class TInterval>

--- a/include/samurai/numeric/prediction.hpp
+++ b/include/samurai/numeric/prediction.hpp
@@ -109,6 +109,8 @@ namespace samurai
                                                                   std::integral_constant<std::size_t, 0>,
                                                                   std::integral_constant<bool, true>) const
     {
+        static_assert(DEST::n_comp == SRC::n_comp, "Source and destination fields must have the same number of components");
+
         auto src_offset = memory_offset(src.mesh(), {level, i.start, index});
 
         std::vector<std::size_t> dest_offsets;
@@ -128,10 +130,14 @@ namespace samurai
         {
             for (std::size_t s = 0; s < dest_offsets.size(); ++s)
             {
+                const std::size_t src_index   = (src_offset + i_c) * SRC::n_comp;
+                const std::size_t dest_index0 = (dest_offsets[s] + i_f) * SRC::n_comp;
+                const std::size_t dest_index1 = (dest_offsets[s] + i_f + 1) * SRC::n_comp;
+
                 for (std::size_t n = 0; n < SRC::n_comp; ++n)
                 {
-                    dest_data[dest_offsets[s] + i_f * SRC::n_comp + n]       = src_data[src_offset + i_c * SRC::n_comp + n];
-                    dest_data[dest_offsets[s] + (i_f + 1) * SRC::n_comp + n] = src_data[src_offset + i_c * SRC::n_comp + n];
+                    dest_data[dest_index0 + n] = src_data[src_index + n];
+                    dest_data[dest_index1 + n] = src_data[src_index + n];
                 }
             }
         }
@@ -161,7 +167,7 @@ namespace samurai
         // (level, i-1, j  ) (level, i, j  ) (level, i+1, j  )
         // (level, i-1, j-1) (level, i, j-1) (level, i+1, j-1)
         //
-        // Since the data are contiguous in the i direction, we just have to compute the memory adresses of the first column.
+        // Since the data are contiguous in the i direction, we just have to compute the memory addresses of the first column.
 
         std::array<std::size_t, ce_pow(order, dim)> src_offsets;
         std::size_t ind = 0;
@@ -176,9 +182,9 @@ namespace samurai
         // For example, in 2D, we need to access the following cells in the destination field
         //
         // (level + 1, 2i  , 2j  ) (level + 1, 2i+1, 2j  )
-        // (level + 1, 2i+1, 2j+1) (level + 1, 2i+1, 2j+1)
+        // (level + 1, 2i  , 2j+1) (level + 1, 2i+1, 2j+1)
         //
-        // Since the data are contiguous in the i direction, once again, we just have to compute the memory adresses of the first column.
+        // Since the data are contiguous in the i direction, once again, we just have to compute the memory addresses of the first column.
 
         std::array<std::size_t, 1ULL << dim> dest_offsets;
         ind = 0;
@@ -260,31 +266,15 @@ namespace samurai
         const auto* src_data = src.data();
         auto* dest_data      = dest.data();
 
-        auto even_i = i.even_elements();
-        if (even_i.is_valid())
-        {
-            auto src_offset  = memory_offset(src.mesh(), {level - 1, even_i.start >> 1, index >> 1});
-            auto dest_offset = memory_offset(dest.mesh(), {level, even_i.start, index});
-            for (std::size_t i_f = 0, i_c = 0; i_f < even_i.size(); i_f += 2, ++i_c)
-            {
-                for (std::size_t n = 0; n < T2::n_comp; ++n)
-                {
-                    dest_data[(dest_offset + i_f) * T2::n_comp + n] = src_data[(src_offset + i_c) * T2::n_comp + n];
-                }
-            }
-        }
+        auto src_offset  = memory_offset(src.mesh(), {level - 1, i.start >> 1, index >> 1});
+        auto dest_offset = memory_offset(dest.mesh(), {level, i.start, index});
 
-        auto odd_i = i.odd_elements();
-        if (odd_i.is_valid())
+        for (std::size_t i_f = 0; i_f < i.size(); ++i_f)
         {
-            auto src_offset  = memory_offset(src.mesh(), {level - 1, odd_i.start >> 1, index >> 1});
-            auto dest_offset = memory_offset(dest.mesh(), {level, odd_i.start, index});
-            for (std::size_t i_f = 0, i_c = 0; i_f < odd_i.size(); i_f += 2, ++i_c)
+            std::size_t ic = static_cast<std::size_t>(((i.start + static_cast<value_t>(i_f)) >> 1) - (i.start >> 1));
+            for (std::size_t n = 0; n < T2::n_comp; ++n)
             {
-                for (std::size_t n = 0; n < T2::n_comp; ++n)
-                {
-                    dest_data[(dest_offset + i_f) * T2::n_comp + n] = src_data[(src_offset + i_c) * T2::n_comp + n];
-                }
+                dest_data[(dest_offset + i_f) * T2::n_comp + n] = src_data[(src_offset + i_c) * T2::n_comp + n];
             }
         }
     }
@@ -297,6 +287,8 @@ namespace samurai
                                                                   std::integral_constant<std::size_t, pred_stencil_size>,
                                                                   std::integral_constant<bool, false>) const
     {
+        static_assert(DEST::n_comp == SRC::n_comp, "Source and destination fields must have the same number of components");
+
         constexpr std::size_t order = 2 * pred_stencil_size + 1;
         using value_t               = typename TInterval::value_t;
 

--- a/include/samurai/numeric/prediction.hpp
+++ b/include/samurai/numeric/prediction.hpp
@@ -99,19 +99,9 @@ namespace samurai
         void
         operator()(Dim<dim>, T1& dest, const T2& src, std::integral_constant<std::size_t, order>, std::integral_constant<bool, true>) const;
 
-        // template <class T1, class T2, std::size_t order>
-        // void
-        // operator()(Dim<2>, T1& dest, const T2& src, std::integral_constant<std::size_t, order>, std::integral_constant<bool, true>)
-        // const;
-
         template <class T1, class T2, std::size_t order>
         void
         operator()(Dim<dim>, T1& dest, const T2& src, std::integral_constant<std::size_t, order>, std::integral_constant<bool, false>) const;
-
-        // template <class T1, class T2, std::size_t order>
-        // void
-        // operator()(Dim<2>, T1& dest, const T2& src, std::integral_constant<std::size_t, order>, std::integral_constant<bool, false>)
-        // const;
     };
 
     template <std::size_t dim, class TInterval>
@@ -389,111 +379,6 @@ namespace samurai
             apply_pred(i_f, static_cast<std::size_t>(((i.start + static_cast<value_t>(i_f)) >> 1) - (i.start >> 1)));
         }
     }
-
-    // template <std::size_t dim, class TInterval>
-    // template <class T1, class T2, std::size_t order>
-    // SAMURAI_INLINE void prediction_op<dim, TInterval>::operator()(Dim<2>,
-    //                                                               T1& dest,
-    //                                                               const T2& src,
-    //                                                               std::integral_constant<std::size_t, order>,
-    //                                                               std::integral_constant<bool, true>) const
-    // {
-    //     auto ii = i << 1;
-    //     ii.step = 2;
-
-    //     auto jj = j << 1;
-
-    //     using value_t    = typename TInterval::value_t;
-    //     auto sorder      = static_cast<value_t>(order);
-    //     auto interp_even = interp_coeffs<2 * order + 1>(1.);
-    //     auto interp_odd  = interp_coeffs<2 * order + 1>(-1.);
-
-    //     dest(level + 1, ii, jj)         = 0;
-    //     dest(level + 1, ii + 1, jj)     = 0;
-    //     dest(level + 1, ii, jj + 1)     = 0;
-    //     dest(level + 1, ii + 1, jj + 1) = 0;
-
-    //     for (value_t kj = 0; kj < 2 * sorder + 1; ++kj)
-    //     {
-    //         std::size_t ukj = static_cast<std::size_t>(kj);
-    //         for (value_t ki = 0; ki < 2 * sorder + 1; ++ki)
-    //         {
-    //             std::size_t uki = static_cast<std::size_t>(ki);
-    //             auto field_ij   = src(level, i + ki - sorder, j + kj - sorder);
-    //             dest(level + 1, ii, jj) += interp_even[uki] * interp_even[ukj] * field_ij;
-    //             dest(level + 1, ii + 1, jj) += interp_odd[uki] * interp_even[ukj] * field_ij;
-    //             dest(level + 1, ii, jj + 1) += interp_even[uki] * interp_odd[ukj] * field_ij;
-    //             dest(level + 1, ii + 1, jj + 1) += interp_odd[uki] * interp_odd[ukj] * field_ij;
-    //         }
-    //     }
-    // }
-
-    //     template <std::size_t dim, class TInterval>
-    //     template <class T1, class T2, std::size_t order>
-    //     SAMURAI_INLINE void prediction_op<dim, TInterval>::operator()(Dim<2>,
-    //                                                                   T1& dest,
-    //                                                                   const T2& src,
-    //                                                                   std::integral_constant<std::size_t, order>,
-    //                                                                   std::integral_constant<bool, false>) const
-    //     {
-    //         using value_t    = typename TInterval::value_t;
-    //         auto sorder      = static_cast<value_t>(order);
-    //         auto interp_even = interp_coeffs<2 * order + 1>(1.);
-    //         auto interp_odd  = interp_coeffs<2 * order + 1>(-1.);
-
-    //         auto apply_pred = [&](const auto& i_f, const auto& i_c, const auto& interpi, const auto& interpj)
-    //         {
-    //             dest(level, i_f, j) = 0;
-
-    //             for (value_t kj = 0; kj < 2 * sorder + 1; ++kj)
-    //             {
-    //                 std::size_t ukj = static_cast<std::size_t>(kj);
-    //                 for (value_t ki = 0; ki < 2 * sorder + 1; ++ki)
-    //                 {
-    //                     std::size_t uki = static_cast<std::size_t>(ki);
-    //                     auto field_ij   = src(level - 1, i_c + ki - sorder, (j >> 1) + kj - sorder);
-    // #ifdef SAMURAI_CHECK_NAN
-    //                     if (xt::any(xt::isnan(field_ij)))
-    //                     {
-    //                         std::cerr << "NaN detected in prediction_op at level " << level - 1 << ", i " << i_c + ki - sorder << ", j "
-    //                                   << (j >> 1) + kj - sorder << std::endl;
-    //                         exit(1);
-    //                     }
-    // #endif
-    //                     dest(level, i_f, j) += interpi[uki] * interpj[ukj] * field_ij;
-    //                 };
-    //             }
-    //         };
-
-    //         if (j & 1)
-    //         {
-    //             auto even_i = i.even_elements();
-    //             if (even_i.is_valid())
-    //             {
-    //                 apply_pred(even_i, even_i >> 1, interp_even, interp_odd);
-    //             }
-
-    //             auto odd_i = i.odd_elements();
-    //             if (odd_i.is_valid())
-    //             {
-    //                 apply_pred(odd_i, odd_i >> 1, interp_odd, interp_odd);
-    //             }
-    //         }
-    //         else
-    //         {
-    //             auto even_i = i.even_elements();
-    //             if (even_i.is_valid())
-    //             {
-    //                 apply_pred(even_i, even_i >> 1, interp_even, interp_even);
-    //             }
-
-    //             auto odd_i = i.odd_elements();
-    //             if (odd_i.is_valid())
-    //             {
-    //                 apply_pred(odd_i, odd_i >> 1, interp_odd, interp_even);
-    //             }
-    //         }
-    //     }
 
     template <std::size_t dim, class TInterval>
     class variadic_prediction_op : public field_operator_base<dim, TInterval>

--- a/include/samurai/numeric/prediction.hpp
+++ b/include/samurai/numeric/prediction.hpp
@@ -95,20 +95,28 @@ namespace samurai
         template <class T1, class T2>
         void operator()(Dim<dim>, T1& dest, const T2& src, std::integral_constant<std::size_t, 0>, std::integral_constant<bool, false>) const;
 
+        // template <class T1, class T2, std::size_t order>
+        // void
+        // operator()(Dim<dim>, T1& dest, const T2& src, std::integral_constant<std::size_t, order>, std::integral_constant<bool, true>)
+        // const;
         template <class T1, class T2, std::size_t order>
         void
-        operator()(Dim<dim>, T1& dest, const T2& src, std::integral_constant<std::size_t, order>, std::integral_constant<bool, true>) const;
+        operator()(Dim<2>, T1& dest, const T2& src, std::integral_constant<std::size_t, order>, std::integral_constant<bool, true>) const;
 
         template <class T1, class T2, std::size_t order>
         void
         operator()(Dim<dim>, T1& dest, const T2& src, std::integral_constant<std::size_t, order>, std::integral_constant<bool, false>) const;
+        // template <class T1, class T2, std::size_t order>
+        // void
+        // operator()(Dim<2>, T1& dest, const T2& src, std::integral_constant<std::size_t, order>, std::integral_constant<bool, false>)
+        // const;
     };
 
     template <std::size_t dim, class TInterval>
-    template <class T1, class T2>
+    template <class DEST, class SRC>
     SAMURAI_INLINE void prediction_op<dim, TInterval>::operator()(Dim<dim>,
-                                                                  T1& dest,
-                                                                  const T2& src,
+                                                                  DEST& dest,
+                                                                  const SRC& src,
                                                                   std::integral_constant<std::size_t, 0>,
                                                                   std::integral_constant<bool, true>) const
     {
@@ -131,8 +139,11 @@ namespace samurai
         {
             for (std::size_t s = 0; s < dest_offsets.size(); ++s)
             {
-                dest_data[dest_offsets[s] + i_f]     = src_data[src_offset + i_c];
-                dest_data[dest_offsets[s] + i_f + 1] = src_data[src_offset + i_c];
+                for (std::size_t n = 0; n < SRC::n_comp; ++n)
+                {
+                    dest_data[dest_offsets[s] + i_f * SRC::n_comp + n]       = src_data[src_offset + i_c * SRC::n_comp + n];
+                    dest_data[dest_offsets[s] + (i_f + 1) * SRC::n_comp + n] = src_data[src_offset + i_c * SRC::n_comp + n];
+                }
             }
         }
     }
@@ -158,110 +169,141 @@ namespace samurai
         return result;
     }
 
-    template <std::size_t dim, class TInterval>
-    template <class T1, class T2, std::size_t pred_stencil_size>
-    SAMURAI_INLINE void prediction_op<dim, TInterval>::operator()(Dim<dim>,
-                                                                  T1& dest,
-                                                                  const T2& src,
-                                                                  std::integral_constant<std::size_t, pred_stencil_size>,
-                                                                  std::integral_constant<bool, true>) const
-    {
-        constexpr std::size_t order = 2 * pred_stencil_size + 1;
-        using value_t               = typename TInterval::value_t;
-        auto spred_stencil_size     = static_cast<value_t>(pred_stencil_size);
+    // template <std::size_t dim, class TInterval>
+    // template <class DEST, class SRC, std::size_t pred_stencil_size>
+    // SAMURAI_INLINE void prediction_op<dim, TInterval>::operator()(Dim<dim>,
+    //                                                               DEST& dest,
+    //                                                               const SRC& src,
+    //                                                               std::integral_constant<std::size_t, pred_stencil_size>,
+    //                                                               std::integral_constant<bool, true>) const
+    // {
+    //     static_assert(DEST::n_comp == SRC::n_comp, "Source and destination fields must have the same number of components");
 
-        // (even index coefficients, odd index coefficients)
-        std::array<std::array<double, order>, 2> interp_coeff_pair = {
-            {interp_coeffs<order>(1.), interp_coeffs<order>(-1.)}
-        };
+    //     constexpr std::size_t order = 2 * pred_stencil_size + 1;
+    //     using value_t               = typename TInterval::value_t;
+    //     auto spred_stencil_size     = static_cast<value_t>(pred_stencil_size);
 
-        // Compute the memory accessors for the source data
-        // For example, in 2D, for a prediction stencil of size 1, we need to access the following cells in the source field
-        //
-        // (level, i-1, j+1) (level, i, j+1) (level, i+1, j+1)
-        // (level, i-1, j  ) (level, i, j  ) (level, i+1, j  )
-        // (level, i-1, j-1) (level, i, j-1) (level, i+1, j-1)
-        //
-        // Since the data are contiguous in the i direction, we just have to compute the memory adresses of the first column.
+    //     // (even index coefficients, odd index coefficients)
+    //     std::array<std::array<double, order>, 2> interp_coeff_pair = {
+    //         {interp_coeffs<order>(1.), interp_coeffs<order>(-1.)}
+    //     };
 
-        std::array<std::size_t, ce_pow(order, dim - 1)> src_offsets;
-        std::size_t ind = 0;
-        static_nested_loop<dim - 1, -static_cast<int>(pred_stencil_size), static_cast<int>(pred_stencil_size) + 1>(
-            [&](const auto& stencil)
-            {
-                auto new_index     = index + stencil;
-                src_offsets[ind++] = memory_offset(src.mesh(), {level, i.start - spred_stencil_size, new_index});
-            });
+    //     // Compute the memory accessors for the source data
+    //     // For example, in 2D, for a prediction stencil of size 1, we need to access the following cells in the source field
+    //     //
+    //     // (level, i-1, j+1) (level, i, j+1) (level, i+1, j+1)
+    //     // (level, i-1, j  ) (level, i, j  ) (level, i+1, j  )
+    //     // (level, i-1, j-1) (level, i, j-1) (level, i+1, j-1)
+    //     //
+    //     // Since the data are contiguous in the i direction, we just have to compute the memory adresses of the first column.
 
-        // Compute the memory accessors for the destination data
-        // For example, in 2D, we need to access the following cells in the destination field
-        //
-        // (level + 1, 2i  , 2j  ) (level + 1, 2i+1, 2j  )
-        // (level + 1, 2i+1, 2j+1) (level + 1, 2i+1, 2j+1)
-        //
-        // Since the data are contiguous in the i direction, once again, we just have to compute the memory adresses of the first column.
+    //     std::array<std::size_t, ce_pow(order, dim - 1)> src_offsets;
+    //     std::size_t ind = 0;
+    //     static_nested_loop<dim - 1, -static_cast<int>(pred_stencil_size), static_cast<int>(pred_stencil_size) + 1>(
+    //         [&](const auto& stencil)
+    //         {
+    //             auto new_index     = index + stencil;
+    //             src_offsets[ind++] = memory_offset(src.mesh(), {level, i.start - spred_stencil_size, new_index});
+    //         });
 
-        std::array<std::size_t, 1ULL << dim> dest_offsets;
-        ind = 0;
-        static_nested_loop<dim - 1, 0, 2>(
-            [&](const auto& stencil)
-            {
-                auto new_index        = 2 * index + stencil;
-                dest_offsets[ind]     = memory_offset(dest.mesh(), {level + 1, 2 * i.start, new_index});
-                dest_offsets[ind + 1] = dest_offsets[ind] + 1;
-                ind += 2;
-            });
+    //     // Compute the memory accessors for the destination data
+    //     // For example, in 2D, we need to access the following cells in the destination field
+    //     //
+    //     // (level + 1, 2i  , 2j  ) (level + 1, 2i+1, 2j  )
+    //     // (level + 1, 2i+1, 2j+1) (level + 1, 2i+1, 2j+1)
+    //     //
+    //     // Since the data are contiguous in the i direction, once again, we just have to compute the memory adresses of the first column.
 
-        const auto* src_data = src.data();
-        auto* dest_data      = dest.data();
+    //     std::array<std::size_t, 1ULL << dim> dest_offsets;
+    //     ind = 0;
+    //     static_nested_loop<dim - 1, 0, 2>(
+    //         [&](const auto& stencil)
+    //         {
+    //             auto new_index        = 2 * index + stencil;
+    //             dest_offsets[ind]     = memory_offset(dest.mesh(), {level + 1, 2 * i.start, new_index});
+    //             dest_offsets[ind + 1] = dest_offsets[ind] + SRC::n_comp; // next cell in the i direction
+    //             ind += 2;
+    //         });
 
-        std::array<double, 1ULL << dim> dest_values{};
+    //     const auto* src_data = src.data();
+    //     auto* dest_data      = dest.data();
 
-        for (std::size_t i_c = 0, i_f = 0; i_c < i.size(); ++i_c, i_f += 2)
-        {
-            dest_values.fill(0);
-            static_nested_loop<dim, 0, order>(
-                [&](const auto& stencil)
-                {
-                    std::size_t io = std::accumulate(stencil.rbegin(),
-                                                     stencil.rend() - 1,
-                                                     0U,
-                                                     [order](auto acc, auto x)
-                                                     {
-                                                         return order * acc + static_cast<std::size_t>(x);
-                                                     });
-                    auto field_ijk = src_data[src_offsets[io] + i_c + static_cast<std::size_t>(stencil[0])];
+    //     std::array<double, (1ULL << dim) * SRC::n_comp> dest_values{};
 
-                    std::size_t ind = 0;
-                    std::apply(
-                        [&](const auto&... s)
-                        {
-                            (void)std::initializer_list<int>{(
-                                (dest_values[ind++] += field_ijk
-                                                     * std::apply(
-                                                           [&](const auto&... ki)
-                                                           {
-                                                               std::size_t is = 0;
-                                                               double coeff   = 1.;
-                                                               ((coeff *= interp_coeff_pair[ki][static_cast<std::size_t>(stencil[is])], ++is),
-                                                                ...);
-                                                               return coeff;
-                                                           },
-                                                           s)),
-                                0)...};
-                        },
-                        make_index_ranges<dim, 0, dim>());
-                });
+    //     for (std::size_t i_c = 0, i_f = 0; i_c < i.size(); ++i_c, i_f += 2)
+    //     {
+    //         dest_values.fill(0);
+    //         static_nested_loop<dim, 0, order>(
+    //             [&](const auto& stencil)
+    //             {
+    //                 std::size_t io = std::accumulate(stencil.rbegin(),
+    //                                                  stencil.rend() - 1,
+    //                                                  0U,
+    //                                                  [order](auto acc, auto x)
+    //                                                  {
+    //                                                      return order * acc + static_cast<std::size_t>(x);
+    //                                                  });
 
-            std::size_t id = 0;
-            std::apply(
-                [&](const auto&... s)
-                {
-                    ((dest_data[s + i_f] = dest_values[id++]), ...);
-                },
-                dest_offsets);
-        }
-    }
+    //                 std::array<double, SRC::n_comp> field_ijk{};
+    //                 for (std::size_t n = 0; n < SRC::n_comp; ++n)
+    //                 {
+    //                     field_ijk[n] = src_data[src_offsets[io] + (i_c + static_cast<std::size_t>(stencil[0])) * SRC::n_comp + n];
+    //                 }
+
+    //                 std::size_t ind = 0;
+    //                 std::apply(
+    //                     [&](const auto&... s)
+    //                     {
+    //                         for (std::size_t n = 0; n < SRC::n_comp; ++n)
+    //                         {
+    //                             (void)std::initializer_list<int>{
+    //                                 ((dest_values[ind * SRC::n_comp
+    //                                               + n] += field_ijk[n]
+    //                                                     * std::apply(
+    //                                                           [&](const auto&... ki)
+    //                                                           {
+    //                                                               std::size_t is = 0;
+    //                                                               double coeff   = 1.;
+    //                                                               ((coeff *=
+    //                                                               interp_coeff_pair[ki][static_cast<std::size_t>(stencil[is])],
+    //                                                                 ++is),
+    //                                                                ...);
+    //                                                               return coeff;
+    //                                                           },
+    //                                                           s)),
+    //                                  0)...};
+    //                         }
+    //                         // (void)std::initializer_list<int>{(
+    //                         //     (dest_values[ind++] += field_ijk
+    //                         //                          * std::apply(
+    //                         //                                [&](const auto&... ki)
+    //                         //                                {
+    //                         //                                    std::size_t is = 0;
+    //                         //                                    double coeff   = 1.;
+    //                         //                                    ((coeff *=
+    //                         interp_coeff_pair[ki][static_cast<std::size_t>(stencil[is])],
+    //                         //                                    ++is),
+    //                         //                                     ...);
+    //                         //                                    return coeff;
+    //                         //                                },
+    //                         //                                s)),
+    //                         //     0)...};
+    //                     },
+    //                     make_index_ranges<dim, 0, dim>());
+    //             });
+
+    //         std::size_t id = 0;
+    //         std::apply(
+    //             [&](const auto&... s)
+    //             {
+    //                 for (std::size_t n = 0; n < SRC::n_comp; ++n)
+    //                 {
+    //                     ((dest_data[s + i_f * SRC::n_comp + n] = dest_values[id++]), ...);
+    //                 }
+    //             },
+    //             dest_offsets);
+    //     }
+    // }
 
     template <std::size_t dim, class TInterval>
     template <class T1, class T2>
@@ -298,6 +340,44 @@ namespace samurai
     }
 
     template <std::size_t dim, class TInterval>
+    template <class T1, class T2, std::size_t order>
+    SAMURAI_INLINE void prediction_op<dim, TInterval>::operator()(Dim<2>,
+                                                                  T1& dest,
+                                                                  const T2& src,
+                                                                  std::integral_constant<std::size_t, order>,
+                                                                  std::integral_constant<bool, true>) const
+    {
+        auto ii = i << 1;
+        ii.step = 2;
+
+        auto jj = j << 1;
+
+        using value_t    = typename TInterval::value_t;
+        auto sorder      = static_cast<value_t>(order);
+        auto interp_even = interp_coeffs<2 * order + 1>(1.);
+        auto interp_odd  = interp_coeffs<2 * order + 1>(-1.);
+
+        dest(level + 1, ii, jj)         = 0;
+        dest(level + 1, ii + 1, jj)     = 0;
+        dest(level + 1, ii, jj + 1)     = 0;
+        dest(level + 1, ii + 1, jj + 1) = 0;
+
+        for (value_t kj = 0; kj < 2 * sorder + 1; ++kj)
+        {
+            std::size_t ukj = static_cast<std::size_t>(kj);
+            for (value_t ki = 0; ki < 2 * sorder + 1; ++ki)
+            {
+                std::size_t uki = static_cast<std::size_t>(ki);
+                auto field_ij   = src(level, i + ki - sorder, j + kj - sorder);
+                dest(level + 1, ii, jj) += interp_even[uki] * interp_even[ukj] * field_ij;
+                dest(level + 1, ii + 1, jj) += interp_odd[uki] * interp_even[ukj] * field_ij;
+                dest(level + 1, ii, jj + 1) += interp_even[uki] * interp_odd[ukj] * field_ij;
+                dest(level + 1, ii + 1, jj + 1) += interp_odd[uki] * interp_odd[ukj] * field_ij;
+            }
+        }
+    }
+
+    template <std::size_t dim, class TInterval>
     template <class T1, class T2, std::size_t pred_stencil_size>
     SAMURAI_INLINE void prediction_op<dim, TInterval>::operator()(Dim<dim>,
                                                                   T1& dest,
@@ -319,6 +399,7 @@ namespace samurai
         auto dest_offset = memory_offset(dest.mesh(), {level, i.start, index});
 
         std::array<std::size_t, dim> parity;
+        parity[0] = (i.start & 1) ? 1 : 0;
         for (std::size_t d = 1; d < dim; ++d)
         {
             parity[d] = (index[d - 1] & 1) ? 1 : 0;
@@ -335,16 +416,12 @@ namespace samurai
 
         auto apply_pred = [&](const auto& i_f, const auto& i_c)
         {
-            dest_data[dest_offset + i_f] = 0;
-
             double dest_value = 0;
             std::size_t io    = 0;
             static_nested_loop<dim, 0, order>(
                 [&](const auto& stencil)
                 {
                     auto field_ijk = src_data[src_offsets[io++] + i_c];
-
-                    parity[0] = ((i.start + static_cast<value_t>(i_f)) & 1) ? 1 : 0;
 
                     dest_value += field_ijk
                                 * std::apply(
@@ -358,11 +435,12 @@ namespace samurai
                                       parity);
                 });
             dest_data[dest_offset + i_f] = dest_value;
+            parity[0]                    = (parity[0] & 1) ? 0 : 1;
         };
 
         for (std::size_t i_f = 0; i_f < i.size(); ++i_f)
         {
-            apply_pred(i_f, i_f >> 1);
+            apply_pred(i_f, static_cast<std::size_t>(((i.start + static_cast<value_t>(i_f)) >> 1) - (i.start >> 1)));
         }
     }
 

--- a/include/samurai/numeric/prediction.hpp
+++ b/include/samurai/numeric/prediction.hpp
@@ -86,19 +86,21 @@ namespace samurai
 
         INIT_OPERATOR(prediction_op)
 
-        template <class T1, class T2>
-        void operator()(Dim<dim>, T1& dest, const T2& src, std::integral_constant<std::size_t, 0>, std::integral_constant<bool, true>) const;
-
-        template <class T1, class T2>
-        void operator()(Dim<dim>, T1& dest, const T2& src, std::integral_constant<std::size_t, 0>, std::integral_constant<bool, false>) const;
-
-        template <class T1, class T2, std::size_t order>
+        template <class DEST, class SRC>
         void
-        operator()(Dim<dim>, T1& dest, const T2& src, std::integral_constant<std::size_t, order>, std::integral_constant<bool, true>) const;
+        operator()(Dim<dim>, DEST& dest, const SRC& src, std::integral_constant<std::size_t, 0>, std::integral_constant<bool, true>) const;
 
-        template <class T1, class T2, std::size_t order>
+        template <class DEST, class SRC>
         void
-        operator()(Dim<dim>, T1& dest, const T2& src, std::integral_constant<std::size_t, order>, std::integral_constant<bool, false>) const;
+        operator()(Dim<dim>, DEST& dest, const SRC& src, std::integral_constant<std::size_t, 0>, std::integral_constant<bool, false>) const;
+
+        template <class DEST, class SRC, std::size_t order>
+        void
+        operator()(Dim<dim>, DEST& dest, const SRC& src, std::integral_constant<std::size_t, order>, std::integral_constant<bool, true>) const;
+
+        template <class DEST, class SRC, std::size_t order>
+        void
+        operator()(Dim<dim>, DEST& dest, const SRC& src, std::integral_constant<std::size_t, order>, std::integral_constant<bool, false>) const;
     };
 
     template <std::size_t dim, class TInterval>
@@ -254,14 +256,14 @@ namespace samurai
     }
 
     template <std::size_t dim, class TInterval>
-    template <class T1, class T2>
+    template <class DEST, class SRC>
     SAMURAI_INLINE void prediction_op<dim, TInterval>::operator()(Dim<dim>,
-                                                                  T1& dest,
-                                                                  const T2& src,
+                                                                  DEST& dest,
+                                                                  const SRC& src,
                                                                   std::integral_constant<std::size_t, 0>,
                                                                   std::integral_constant<bool, false>) const
     {
-        static_assert(T1::n_comp == T2::n_comp, "Source and destination fields must have the same number of components");
+        static_assert(DEST::n_comp == SRC::n_comp, "Source and destination fields must have the same number of components");
 
         const auto* src_data = src.data();
         auto* dest_data      = dest.data();
@@ -271,10 +273,10 @@ namespace samurai
 
         for (std::size_t i_f = 0; i_f < i.size(); ++i_f)
         {
-            std::size_t ic = static_cast<std::size_t>(((i.start + static_cast<value_t>(i_f)) >> 1) - (i.start >> 1));
-            for (std::size_t n = 0; n < T2::n_comp; ++n)
+            const std::size_t i_c = static_cast<std::size_t>(((i.start + static_cast<value_t>(i_f)) >> 1) - (i.start >> 1));
+            for (std::size_t n = 0; n < SRC::n_comp; ++n)
             {
-                dest_data[(dest_offset + i_f) * T2::n_comp + n] = src_data[(src_offset + i_c) * T2::n_comp + n];
+                dest_data[(dest_offset + i_f) * SRC::n_comp + n] = src_data[(src_offset + i_c) * SRC::n_comp + n];
             }
         }
     }
@@ -397,8 +399,8 @@ namespace samurai
                                                            std::integral_constant<bool, dest_on_level>{});
     }
 
-    template <std::size_t order, bool dest_on_level, class T1, class T2>
-    SAMURAI_INLINE auto prediction(T1& field_dest, const T2& field_src)
+    template <std::size_t order, bool dest_on_level, class DEST, class SRC>
+    SAMURAI_INLINE auto prediction(DEST& field_dest, const SRC& field_src)
     {
         return make_field_operator_function<prediction_op>(field_dest,
                                                            field_src,

--- a/include/samurai/numeric/prediction.hpp
+++ b/include/samurai/numeric/prediction.hpp
@@ -378,10 +378,10 @@ namespace samurai
     }
 
     template <std::size_t dim, class TInterval>
-    template <class T1, class T2, std::size_t pred_stencil_size>
+    template <class DEST, class SRC, std::size_t pred_stencil_size>
     SAMURAI_INLINE void prediction_op<dim, TInterval>::operator()(Dim<dim>,
-                                                                  T1& dest,
-                                                                  const T2& src,
+                                                                  DEST& dest,
+                                                                  const SRC& src,
                                                                   std::integral_constant<std::size_t, pred_stencil_size>,
                                                                   std::integral_constant<bool, false>) const
     {
@@ -416,26 +416,33 @@ namespace samurai
 
         auto apply_pred = [&](const auto& i_f, const auto& i_c)
         {
-            double dest_value = 0;
-            std::size_t io    = 0;
+            std::array<double, SRC::n_comp> dest_value{};
+            std::size_t io = 0;
             static_nested_loop<dim, 0, order>(
                 [&](const auto& stencil)
                 {
-                    auto field_ijk = src_data[src_offsets[io++] + i_c];
+                    for (std::size_t n = 0; n < SRC::n_comp; ++n)
+                    {
+                        auto field_ijk = src_data[src_offsets[io++] + i_c * SRC::n_comp + n];
 
-                    dest_value += field_ijk
-                                * std::apply(
-                                      [&](const auto&... ki)
-                                      {
-                                          std::size_t is = 0;
-                                          double coeff   = 1.;
-                                          ((coeff *= interp_coeff_pair[ki][static_cast<std::size_t>(stencil[is])], ++is), ...);
-                                          return coeff;
-                                      },
-                                      parity);
+                        dest_value[n] += field_ijk
+                                       * std::apply(
+                                             [&](const auto&... ki)
+                                             {
+                                                 std::size_t is = 0;
+                                                 double coeff   = 1.;
+                                                 ((coeff *= interp_coeff_pair[ki][static_cast<std::size_t>(stencil[is])], ++is), ...);
+                                                 return coeff;
+                                             },
+                                             parity);
+                    }
                 });
-            dest_data[dest_offset + i_f] = dest_value;
-            parity[0]                    = (parity[0] & 1) ? 0 : 1;
+
+            for (std::size_t n = 0; n < SRC::n_comp; ++n)
+            {
+                dest_data[dest_offset + i_f * SRC::n_comp + n] = dest_value[n];
+            }
+            parity[0] = (parity[0] & 1) ? 0 : 1;
         };
 
         for (std::size_t i_f = 0; i_f < i.size(); ++i_f)

--- a/include/samurai/numeric/prediction.hpp
+++ b/include/samurai/numeric/prediction.hpp
@@ -255,6 +255,8 @@ namespace samurai
                                                                   std::integral_constant<std::size_t, 0>,
                                                                   std::integral_constant<bool, false>) const
     {
+        static_assert(T1::n_comp == T2::n_comp, "Source and destination fields must have the same number of components");
+
         const auto* src_data = src.data();
         auto* dest_data      = dest.data();
 
@@ -265,7 +267,10 @@ namespace samurai
             auto dest_offset = memory_offset(dest.mesh(), {level, even_i.start, index});
             for (std::size_t i_f = 0, i_c = 0; i_f < even_i.size(); i_f += 2, ++i_c)
             {
-                dest_data[dest_offset + i_f] = src_data[src_offset + i_c];
+                for (std::size_t n = 0; n < T2::n_comp; ++n)
+                {
+                    dest_data[(dest_offset + i_f) * T2::n_comp + n] = src_data[(src_offset + i_c) * T2::n_comp + n];
+                }
             }
         }
 
@@ -276,7 +281,10 @@ namespace samurai
             auto dest_offset = memory_offset(dest.mesh(), {level, odd_i.start, index});
             for (std::size_t i_f = 0, i_c = 0; i_f < odd_i.size(); i_f += 2, ++i_c)
             {
-                dest_data[dest_offset + i_f] = src_data[src_offset + i_c];
+                for (std::size_t n = 0; n < T2::n_comp; ++n)
+                {
+                    dest_data[(dest_offset + i_f) * T2::n_comp + n] = src_data[(src_offset + i_c) * T2::n_comp + n];
+                }
             }
         }
     }

--- a/include/samurai/numeric/projection.hpp
+++ b/include/samurai/numeric/projection.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "../operators_base.hpp"
+#include "../static_algorithm.hpp"
 
 namespace samurai
 {

--- a/include/samurai/numeric/projection.hpp
+++ b/include/samurai/numeric/projection.hpp
@@ -46,17 +46,18 @@ namespace samurai
 
             for (std::size_t ii = 0, i_f = 0; ii < i.size(); ++ii, i_f += 2)
             {
-                std::array<double, SRC::n_comp> sum{};
+                std::array<double, SRC::n_comp> sum;
+                sum.fill(0);
                 for (std::size_t s = 0; s < src_offsets.size(); ++s)
                 {
                     for (std::size_t n = 0; n < SRC::n_comp; ++n)
                     {
-                        sum[n] += src_data[src_offsets[s] + i_f * SRC::n_comp + n] + src_data[src_offsets[s] + (i_f + 1) * SRC::n_comp + n];
+                        sum[n] += src_data[(src_offsets[s] + i_f) * SRC::n_comp + n] + src_data[(src_offsets[s] + i_f + 1) * SRC::n_comp + n];
                     }
                 }
                 for (std::size_t n = 0; n < SRC::n_comp; ++n)
                 {
-                    dest_data[dst_offsets + ii * SRC::n_comp + n] = sum[n] * inv;
+                    dest_data[(dst_offsets + ii) * SRC::n_comp + n] = sum[n] * inv;
                 }
             }
         }

--- a/include/samurai/numeric/projection.hpp
+++ b/include/samurai/numeric/projection.hpp
@@ -19,27 +19,39 @@ namespace samurai
         INIT_OPERATOR(projection_op_)
 
         template <class T1, class T2>
-        SAMURAI_INLINE void operator()(Dim<1>, T1& dest, const T2& src) const
+        SAMURAI_INLINE void operator()(Dim<dim>, T1& dest, const T2& src) const
         {
-            dest(level, i) = .5 * (src(level + 1, 2 * i) + src(level + 1, 2 * i + 1));
-        }
+            auto dst_offsets = give_me_offset(dest.mesh(), {level, i.start, index});
 
-        template <class T1, class T2>
-        SAMURAI_INLINE void operator()(Dim<2>, T1& dest, const T2& src) const
-        {
-            dest(level, i, j) = .25
-                              * (src(level + 1, 2 * i, 2 * j) + src(level + 1, 2 * i, 2 * j + 1) + src(level + 1, 2 * i + 1, 2 * j)
-                                 + src(level + 1, 2 * i + 1, 2 * j + 1));
-        }
+            std::vector<std::size_t> src_offsets;
+            src_offsets.reserve(1ULL << (dim - 1));
 
-        template <class T1, class T2>
-        SAMURAI_INLINE void operator()(Dim<3>, T1& dest, const T2& src) const
-        {
-            dest(level, i, j, k) = .125
-                                 * (src(level + 1, 2 * i, 2 * j, 2 * k) + src(level + 1, 2 * i + 1, 2 * j, 2 * k)
-                                    + src(level + 1, 2 * i, 2 * j + 1, 2 * k) + src(level + 1, 2 * i + 1, 2 * j + 1, 2 * k)
-                                    + src(level + 1, 2 * i, 2 * j, 2 * k + 1) + src(level + 1, 2 * i + 1, 2 * j, 2 * k + 1)
-                                    + src(level + 1, 2 * i, 2 * j + 1, 2 * k + 1) + src(level + 1, 2 * i + 1, 2 * j + 1, 2 * k + 1));
+            if constexpr (dim == 1)
+            {
+                src_offsets.push_back(give_me_offset(src.mesh(), {level + 1, 2 * i.start}));
+            }
+            else
+            {
+                static_nested_loop<dim - 1, 0, 2>(
+                    [&](const auto& stencil)
+                    {
+                        auto new_index = 2 * index + stencil;
+                        src_offsets.push_back(give_me_offset(src.mesh(), {level + 1, 2 * i.start, new_index}));
+                    });
+            }
+
+            const auto* src_data = src.data();
+            auto dest_data       = dest.data();
+
+            for (std::size_t ii = 0, i_f = 0; ii < i.size(); ++ii, i_f += 2)
+            {
+                double sum = 0;
+                for (std::size_t s = 0; s < src_offsets.size(); ++s)
+                {
+                    sum += src_data[src_offsets[s] + i_f] + src_data[src_offsets[s] + i_f + 1];
+                }
+                dest_data[dst_offsets + ii] = sum / static_cast<double>(1ULL << dim);
+            }
         }
     };
 

--- a/include/samurai/numeric/projection.hpp
+++ b/include/samurai/numeric/projection.hpp
@@ -18,9 +18,10 @@ namespace samurai
 
         INIT_OPERATOR(projection_op_)
 
-        template <class T1, class T2>
-        SAMURAI_INLINE void operator()(Dim<dim>, T1& dest, const T2& src) const
+        template <class DEST, class SRC>
+        SAMURAI_INLINE void operator()(Dim<dim>, DEST& dest, const SRC& src) const
         {
+            static_assert(DEST::n_comp == SRC::n_comp, "Source and destination fields must have the same number of components");
             auto dst_offsets = memory_offset(dest.mesh(), {level, i.start, index});
 
             std::array<std::size_t, 1ULL << (dim - 1)> src_offsets;
@@ -45,12 +46,18 @@ namespace samurai
 
             for (std::size_t ii = 0, i_f = 0; ii < i.size(); ++ii, i_f += 2)
             {
-                double sum = 0;
+                std::array<double, SRC::n_comp> sum{};
                 for (std::size_t s = 0; s < src_offsets.size(); ++s)
                 {
-                    sum += src_data[src_offsets[s] + i_f] + src_data[src_offsets[s] + i_f + 1];
+                    for (std::size_t n = 0; n < SRC::n_comp; ++n)
+                    {
+                        sum[n] += src_data[src_offsets[s] + i_f * SRC::n_comp + n] + src_data[src_offsets[s] + (i_f + 1) * SRC::n_comp + n];
+                    }
                 }
-                dest_data[dst_offsets + ii] = sum * inv;
+                for (std::size_t n = 0; n < SRC::n_comp; ++n)
+                {
+                    dest_data[dst_offsets + ii * SRC::n_comp + n] = sum[n] * inv;
+                }
             }
         }
     };

--- a/include/samurai/numeric/projection.hpp
+++ b/include/samurai/numeric/projection.hpp
@@ -21,27 +21,27 @@ namespace samurai
         template <class T1, class T2>
         SAMURAI_INLINE void operator()(Dim<dim>, T1& dest, const T2& src) const
         {
-            auto dst_offsets = give_me_offset(dest.mesh(), {level, i.start, index});
+            auto dst_offsets = memory_offset(dest.mesh(), {level, i.start, index});
 
-            std::vector<std::size_t> src_offsets;
-            src_offsets.reserve(1ULL << (dim - 1));
-
+            std::array<std::size_t, 1ULL << (dim - 1)> src_offsets;
             if constexpr (dim == 1)
             {
-                src_offsets.push_back(give_me_offset(src.mesh(), {level + 1, 2 * i.start}));
+                src_offsets[0] = memory_offset(src.mesh(), {level + 1, 2 * i.start});
             }
             else
             {
+                std::size_t ind = 0;
                 static_nested_loop<dim - 1, 0, 2>(
                     [&](const auto& stencil)
                     {
-                        auto new_index = 2 * index + stencil;
-                        src_offsets.push_back(give_me_offset(src.mesh(), {level + 1, 2 * i.start, new_index}));
+                        auto new_index     = 2 * index + stencil;
+                        src_offsets[ind++] = memory_offset(src.mesh(), {level + 1, 2 * i.start, new_index});
                     });
             }
 
             const auto* src_data = src.data();
-            auto dest_data       = dest.data();
+            auto* dest_data      = dest.data();
+            constexpr double inv = 1.0 / static_cast<double>(1ULL << dim);
 
             for (std::size_t ii = 0, i_f = 0; ii < i.size(); ++ii, i_f += 2)
             {
@@ -50,7 +50,7 @@ namespace samurai
                 {
                     sum += src_data[src_offsets[s] + i_f] + src_data[src_offsets[s] + i_f + 1];
                 }
-                dest_data[dst_offsets + ii] = sum / static_cast<double>(1ULL << dim);
+                dest_data[dst_offsets + ii] = sum * inv;
             }
         }
     };

--- a/include/samurai/static_algorithm.hpp
+++ b/include/samurai/static_algorithm.hpp
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <array>
 #include <type_traits>
 
 #include <xtensor/containers/xfixed.hpp>

--- a/include/samurai/static_algorithm.hpp
+++ b/include/samurai/static_algorithm.hpp
@@ -7,8 +7,6 @@
 
 #include <xtensor/containers/xfixed.hpp>
 
-#include "level_cell_array.hpp"
-
 namespace samurai
 {
     template <std::size_t Dim, class TInterval>
@@ -309,4 +307,25 @@ namespace samurai
             }
         }
     };
+
+    template <std::size_t dim, std::size_t b, std::size_t e>
+    consteval auto make_index_ranges()
+    {
+        constexpr std::size_t base = e - b;
+        static_assert(base > 0, "make_index_ranges requires e > b");
+
+        constexpr std::size_t count = ce_pow(base, dim);
+        std::array<std::array<std::size_t, dim>, count> result{};
+
+        for (std::size_t n = 0; n < count; ++n)
+        {
+            std::size_t value = n;
+            for (std::size_t d = 0; d < dim; ++d)
+            {
+                result[n][d] = b + (value % base);
+                value /= base;
+            }
+        }
+        return result;
+    }
 } // namespace samurai

--- a/include/samurai/utils.hpp
+++ b/include/samurai/utils.hpp
@@ -4,12 +4,14 @@
 #pragma once
 
 #include <algorithm>
+#include <array>
 #include <cmath>
 #include <functional>
 #include <limits>
 #include <numeric>
 #include <tuple>
 #include <type_traits>
+#include <vector>
 
 #include <xtensor/containers/xfixed.hpp>
 
@@ -372,7 +374,107 @@ namespace samurai
         template <class T>
         constexpr bool is_field_type_v = is_field_type<std::decay_t<T>>::value;
 
+        /**
+         * @brief Aggregate holding a refinement level and `Dim` integer coordinates.
+         *
+         * Designed for ergonomic brace-initialization at call sites without naming the type:
+         * @code
+         * memory_offsets(mesh, {level, x, y}, {level + 1, 2 * x, 2 * y});
+         * @endcode
+         *
+         * @tparam Dim    Number of spatial dimensions (== mesh_t::dim).
+         * @tparam ValueT Coordinate integer type     (== mesh_t::interval_t::value_t).
+         */
+        template <std::size_t Dim, class ValueT>
+        struct CellCoord
+        {
+            std::size_t level;
+            std::array<ValueT, Dim> coords;
+
+            /// Flat construction: @c CellCoord{lvl, x, y, z} without nested braces.
+            template <class... Coords>
+                requires(sizeof...(Coords) == Dim) && (std::convertible_to<Coords, ValueT> && ...)
+            constexpr CellCoord(std::size_t lvl, Coords... c)
+                : level{lvl}
+                , coords{static_cast<ValueT>(c)...}
+            {
+            }
+
+            /// Construct from first coordinate and remaining coordinates packed in an array.
+            template <class FirstT, class RestT>
+                requires std::convertible_to<FirstT, ValueT> && std::convertible_to<RestT, ValueT>
+            constexpr CellCoord(std::size_t lvl, FirstT i, const std::array<RestT, Dim - 1>& rest)
+                : level{lvl}
+                , coords{}
+            {
+                coords[0] = static_cast<ValueT>(i);
+                for (std::size_t d = 1; d < Dim; ++d)
+                {
+                    coords[d] = static_cast<ValueT>(rest[d - 1]);
+                }
+            }
+
+            /// Construct from first coordinate and an indexable container/expression for remaining coordinates.
+            template <class FirstT, class RestContainer>
+                requires std::convertible_to<FirstT, ValueT>
+                          && (!std::same_as<std::remove_cvref_t<RestContainer>, std::array<ValueT, Dim - 1>>)
+                          && requires(const RestContainer& rest) {
+                                 { rest[std::size_t{0}] } -> std::convertible_to<ValueT>;
+                             }
+            constexpr CellCoord(std::size_t lvl, FirstT i, const RestContainer& rest)
+                : level{lvl}
+                , coords{}
+            {
+                coords[0] = static_cast<ValueT>(i);
+                for (std::size_t d = 1; d < Dim; ++d)
+                {
+                    coords[d] = static_cast<ValueT>(rest[d - 1]);
+                }
+            }
+        };
+
     } // namespace detail
+
+    /**
+     * @brief Compute flat cell indices from a list of (level, coordinates) descriptors.
+     *
+     * Each brace-enclosed argument is implicitly constructed as a
+     * @c detail::CellCoord<Mesh::dim, Mesh::interval_t::value_t>, so no explicit type is
+     * required at the call site:
+     * @code
+     * auto offsets = memory_offsets(mesh, {level, i.start, j},
+     *                                      {level + 1, 2 * i.start, 2 * j});
+     * @endcode
+     *
+     * @param mesh The mesh on which indices are computed.
+     * @param args Braced list of (level, coord…) descriptors; one per desired index.
+     * @return @c std::vector<std::size_t> of flat cell indices, one per descriptor.
+     */
+    template <class Mesh>
+    SAMURAI_INLINE auto
+    memory_offsets(const Mesh& mesh, std::initializer_list<detail::CellCoord<Mesh::dim, typename Mesh::interval_t::value_t>> args)
+    {
+        std::vector<std::size_t> indices;
+        indices.reserve(args.size());
+        for (const auto& c : args)
+        {
+            indices.push_back(
+                [&]<std::size_t... Is>(std::index_sequence<Is...>)
+                {
+                    return static_cast<std::size_t>(mesh.get_index(c.level, c.coords[Is]...));
+                }(std::make_index_sequence<Mesh::dim>{}));
+        }
+        return indices;
+    }
+
+    template <class Mesh>
+    SAMURAI_INLINE auto memory_offset(const Mesh& mesh, const detail::CellCoord<Mesh::dim, typename Mesh::interval_t::value_t>& arg)
+    {
+        return [&]<std::size_t... Is>(std::index_sequence<Is...>)
+        {
+            return static_cast<std::size_t>(mesh.get_index(arg.level, arg.coords[Is]...));
+        }(std::make_index_sequence<Mesh::dim>{});
+    }
 
     template <class R, class T1, class T2>
     R safe_subs(T1 a, T2 b)

--- a/include/samurai/utils.hpp
+++ b/include/samurai/utils.hpp
@@ -456,14 +456,16 @@ namespace samurai
     {
         std::vector<std::size_t> indices;
         indices.reserve(args.size());
-        for (const auto& c : args)
-        {
-            indices.push_back(
-                [&]<std::size_t... Is>(std::index_sequence<Is...>)
-                {
-                    return static_cast<std::size_t>(mesh.get_index(c.level, c.coords[Is]...));
-                }(std::make_index_sequence<Mesh::dim>{}));
-        }
+        std::transform(args.begin(),
+                       args.end(),
+                       std::back_inserter(indices),
+                       [&](const auto& c)
+                       {
+                           return [&]<std::size_t... Is>(std::index_sequence<Is...>)
+                           {
+                               return static_cast<std::size_t>(mesh.get_index(c.level, c.coords[Is]...));
+                           }(std::make_index_sequence<Mesh::dim>{});
+                       });
         return indices;
     }
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -30,6 +30,7 @@ set(SAMURAI_TESTS
     test_mra.cpp
     test_periodic.cpp
     test_portion.cpp
+    test_projection_prediction_roundtrip.cpp
     test_restart.cpp
     test_scaling.cpp
     test_stencil.cpp

--- a/tests/test_projection_prediction_roundtrip.cpp
+++ b/tests/test_projection_prediction_roundtrip.cpp
@@ -7,6 +7,7 @@
 #include <cmath>
 #include <cstddef>
 #include <functional>
+#include <limits>
 #include <string>
 
 #include <samurai/box.hpp>
@@ -99,6 +100,31 @@ namespace samurai
             return max_err;
         }
 
+        // Poison the fine-level cells with NaN so that any un-predicted cell
+        // produces a detectable error — a prediction no-op cannot pass.
+        template <class Field>
+        void fill_by_nan(std::size_t L, Field& u)
+        {
+            auto& mesh      = u.mesh();
+            using mesh_id_t = typename Field::mesh_t::mesh_id_t;
+
+            for_each_cell(mesh[mesh_id_t::cells][L],
+                          [&](const auto& cell)
+                          {
+                              if constexpr (Field::is_scalar)
+                              {
+                                  u[cell] = std::numeric_limits<double>::quiet_NaN();
+                              }
+                              else
+                              {
+                                  for (std::size_t c = 0; c < Field::n_comp; ++c)
+                                  {
+                                      u[cell][c] = std::numeric_limits<double>::quiet_NaN();
+                                  }
+                              }
+                          });
+        }
+
         //=========================================================================
         // Helper: projection + prediction roundtrip.
         //
@@ -156,10 +182,18 @@ namespace samurai
             auto proj_set = intersection(mesh[mesh_id_t::cells][L], mesh[mesh_id_t::reference][L - 1]).on(L - 1);
             proj_set.apply_op(projection(u));
 
+            // from fine level
+            fill_by_nan(L, u);
             auto pred_set = intersection(mesh[mesh_id_t::cells][L], mesh[mesh_id_t::reference][L - 1]).on(L);
             pred_set.apply_op(prediction<s, false>(u));
+            auto from_fine_error = max_abs_error(u, L, cell_avg_fn);
 
-            return max_abs_error(u, L, cell_avg_fn);
+            // from coarse level
+            fill_by_nan(L, u);
+            proj_set.apply_op(prediction<s, true>(u));
+            auto from_coarse_error = max_abs_error(u, L, cell_avg_fn);
+
+            return std::max(from_fine_error, from_coarse_error);
         }
 
         //=========================================================================

--- a/tests/test_projection_prediction_roundtrip.cpp
+++ b/tests/test_projection_prediction_roundtrip.cpp
@@ -3,9 +3,11 @@
 
 #include <gtest/gtest.h>
 
-#include <algorithm>
+#include <array>
 #include <cmath>
 #include <cstddef>
+#include <functional>
+#include <string>
 
 #include <samurai/box.hpp>
 #include <samurai/field.hpp>
@@ -18,6 +20,12 @@ namespace samurai
 {
     namespace
     {
+        enum class FieldType : std::uint8_t
+        {
+            Scalar,
+            Vector
+        };
+
         //=========================================================================
         // Helper: mesh creation
         //
@@ -29,9 +37,9 @@ namespace samurai
         auto make_two_level_mesh(std::size_t L)
         {
             auto mesh_cfg = mesh_config<dim, s>().min_level(L - 1).max_level(L).max_stencil_radius(std::max(2, s)).disable_args_parse();
-            // Build unit-hypercube box generically: [0,1]^dim
             using point_t = xt::xtensor_fixed<double, xt::xshape<dim>>;
-            point_t lo, hi;
+            point_t lo;
+            point_t hi;
             lo.fill(0.0);
             hi.fill(1.0);
             auto box = Box<double, dim>(lo, hi);
@@ -39,42 +47,10 @@ namespace samurai
         }
 
         //=========================================================================
-        // Helper: 1D cell average
+        // Helper: N-dimensional cell average for a separable polynomial.
         //
-        // Computes (1/h) * integral_{xc-h/2}^{xc+h/2} p(x) dx using the
-        // antiderivative of p.  Exact in floating-point for polynomial antiderivs.
-        //=========================================================================
-        template <class Cell, class AntiderivFn>
-        double cell_avg_1d(const Cell& cell, const AntiderivFn& antideriv)
-        {
-            const double xc   = cell.center()[0];
-            const double half = cell.length / 2.0;
-            return (antideriv(xc + half) - antideriv(xc - half)) / cell.length;
-        }
-
-        //=========================================================================
-        // Helper: 2D cell average for separable polynomial f(x)*g(y)
-        //
-        // avg = avg_x(f) * avg_y(g), computed via antiderivatives.
-        //=========================================================================
-        template <class Cell, class AntiderivX, class AntiderivY>
-        double cell_avg_2d(const Cell& cell, const AntiderivX& antideriv_x, const AntiderivY& antideriv_y)
-        {
-            const double xc   = cell.center()[0];
-            const double yc   = cell.center()[1];
-            const double half = cell.length / 2.0;
-            const double h    = cell.length;
-            const double ax   = (antideriv_x(xc + half) - antideriv_x(xc - half)) / h;
-            const double ay   = (antideriv_y(yc + half) - antideriv_y(yc - half)) / h;
-            return ax * ay;
-        }
-
-        //=========================================================================
-        // Helper: N-dimensional cell average for separable polynomial
-        //
-        // Given a cell and a callable antiderivs(i) -> antideriv function for
-        // axis i, computes product_{i=0}^{dim-1} avg_i(antiderivs(i)).
-        // Separability means cell_avg(f) = prod_i cell_avg_1d(f_i).
+        // antiderivs(i) returns the antiderivative function for axis i.
+        // cell_avg(f) = prod_i [ (A_i(c_i + h/2) - A_i(c_i - h/2)) / h ]
         //=========================================================================
         template <std::size_t dim, class Cell, class AntiderivArray>
         double cell_avg_nd(const Cell& cell, const AntiderivArray& antiderivs)
@@ -91,10 +67,10 @@ namespace samurai
         }
 
         //=========================================================================
-        // Helper: error calculation — scalar field
+        // Helper: max absolute error over all cells and field components.
         //
-        // Returns the maximum absolute difference between field values at level L
-        // and the reference cell-average function applied to each cell.
+        // Expected value at component c: (c+1) * cell_avg_fn(cell).
+        // Works for both ScalarField (n_comp=1, is_scalar=true) and VectorField.
         //=========================================================================
         template <class Field, class CellAvgFn>
         double max_abs_error(const Field& u, std::size_t L, const CellAvgFn& cell_avg_fn)
@@ -104,83 +80,82 @@ namespace samurai
             for_each_cell(u.mesh()[mesh_id_t::cells][L],
                           [&](const auto& cell)
                           {
-                              const double expected = cell_avg_fn(cell);
-                              const double actual   = u[cell];
-                              const double err      = std::abs(actual - expected);
-                              max_err               = std::max(max_err, err);
-                          });
-            return max_err;
-        }
-
-        //=========================================================================
-        // Helper: error calculation — vector field
-        //
-        // Checks every component c: expected value is (c+1) * cell_avg_fn(cell).
-        // Returns the maximum absolute difference over all cells and components.
-        //=========================================================================
-        template <std::size_t n_comp, class Field, class CellAvgFn>
-        double max_abs_error_vector(const Field& u, std::size_t L, const CellAvgFn& cell_avg_fn)
-        {
-            using mesh_id_t = typename Field::mesh_t::mesh_id_t;
-            double max_err  = 0.0;
-            for_each_cell(u.mesh()[mesh_id_t::cells][L],
-                          [&](const auto& cell)
-                          {
                               const double base = cell_avg_fn(cell);
-                              for (std::size_t c = 0; c < n_comp; ++c)
+                              for (std::size_t c = 0; c < Field::n_comp; ++c)
                               {
                                   const double expected = static_cast<double>(c + 1) * base;
-                                  const double actual   = u[cell][static_cast<int>(c)];
-                                  const double err      = std::abs(actual - expected);
-                                  max_err               = std::max(max_err, err);
+                                  double actual;
+                                  if constexpr (Field::is_scalar)
+                                  {
+                                      actual = u[cell];
+                                  }
+                                  else
+                                  {
+                                      actual = u[cell][c];
+                                  }
+                                  max_err = std::max(max_err, std::abs(actual - expected));
                               }
                           });
             return max_err;
         }
 
         //=========================================================================
-        // Helper: roundtrip test body
+        // Helper: projection + prediction roundtrip.
         //
-        // 1. Build uniform mesh (levels L-1 and L).
+        // 1. Build two-level mesh (L-1, L).
         // 2. Fill ALL cells and ghosts at every level with exact cell averages.
-        //    Ghost cells at L-1 need exact values so that the prediction stencil
-        //    (which reads s coarse neighbors on each side) operates correctly.
-        // 3. Project level L -> L-1 (overwrites interior L-1 cells with cell averages
-        //    computed from fine children — exact for any polynomial).
-        // 4. Predict level L-1 -> L  (exact for polynomials of degree < 2s+1).
-        // 5. Return max absolute error vs. exact cell averages at level L.
+        //    Ghost cells at L-1 must hold exact values so the prediction stencil
+        //    has valid coarse neighbors.
+        // 3. Project L -> L-1  (exact for any polynomial).
+        // 4. Predict L-1 -> L  (exact for polynomials of per-axis degree <= 2s).
+        // 5. Return max absolute error vs exact cell averages at level L.
         //
-        // Subset algebra pattern (Design Decision 4):
-        //   projection:  intersection(mesh[cells][L], mesh[reference][L-1]).on(L-1)
-        //   prediction:  intersection(mesh[cells][L], mesh[reference][L-1]).on(L)
+        // For VectorField, component c is initialised with (c+1)*cell_avg so each
+        // component carries a distinct non-trivial polynomial.
         //=========================================================================
-        template <std::size_t s, std::size_t dim, class CellAvgFn>
+        template <FieldType ft, std::size_t n_comp, std::size_t s, std::size_t dim, class CellAvgFn>
         double roundtrip_error(std::size_t L, const CellAvgFn& cell_avg_fn)
         {
             using mesh_id_t = typename decltype(make_two_level_mesh<dim, static_cast<int>(s)>(L))::mesh_id_t;
 
             auto mesh = make_two_level_mesh<dim, static_cast<int>(s)>(L);
 
-            auto u = make_scalar_field<double>("u", mesh);
+            auto u = [&]()
+            {
+                if constexpr (ft == FieldType::Scalar)
+                {
+                    return make_scalar_field<double>("u", mesh);
+                }
+                else
+                {
+                    return make_vector_field<double, n_comp>("u", mesh);
+                }
+            }();
             u.resize();
 
-            // Initialize ALL cells and ghosts at every level with exact cell averages.
-            // Ghost cells at L-1 must hold correct values so that the prediction stencil
-            // has valid coarse-level neighbors at the domain boundary.
             for (std::size_t lvl = mesh.min_level(); lvl <= mesh.max_level(); ++lvl)
             {
                 for_each_cell(mesh[mesh_id_t::reference][lvl],
                               [&](const auto& cell)
                               {
-                                  u[cell] = cell_avg_fn(cell);
+                                  const double base = cell_avg_fn(cell);
+                                  if constexpr (ft == FieldType::Scalar)
+                                  {
+                                      u[cell] = base;
+                                  }
+                                  else
+                                  {
+                                      for (std::size_t c = 0; c < n_comp; ++c)
+                                      {
+                                          u[cell][c] = static_cast<double>(c + 1) * base;
+                                      }
+                                  }
                               });
             }
 
-            // Project: level L -> L-1 (average fine children to get coarse cell average)
             auto proj_set = intersection(mesh[mesh_id_t::cells][L], mesh[mesh_id_t::reference][L - 1]).on(L - 1);
             proj_set.apply_op(projection(u));
 
-            // Predict: level L-1 -> L  (dest_on_level=false: reads from level-1, writes to level)
             auto pred_set = intersection(mesh[mesh_id_t::cells][L], mesh[mesh_id_t::reference][L - 1]).on(L);
             pred_set.apply_op(prediction<s, false>(u));
 
@@ -188,1007 +163,277 @@ namespace samurai
         }
 
         //=========================================================================
-        // Helper: VectorField roundtrip
+        // Dispatch helper: call roundtrip_error<ft, n_comp, s, dim> from runtime
+        // (s, dim) values.  Covers s in {0,1,2,3} and dim in {1,...,6}.
         //
-        // Same logic as roundtrip_error, but uses a VectorField with n_comp
-        // components. Component c is initialised with (c+1) * cell_avg_fn(cell),
-        // so each component carries a distinct non-trivial polynomial and we verify
-        // all components are recovered after projection + prediction.
+        // Antiderivatives of the maximal-degree separable polynomial for each s.
+        //
+        // The prediction operator with stencil radius s is exact for polynomials
+        // whose per-axis degree is at most 2s.  For each s we test the boundary
+        // case: the highest-degree polynomial the operator must reproduce exactly.
+        //
+        //   s=0  constant 3.14                      (no antideriv needed)
+        //   s=1  u = 1 + 2t + 3t^2  (degree 2),    A(t) = t + t^2   + t^3
+        //   s=2  u = 1 + t + ... + t^4 (degree 4),  A(t) = t + t^2/2 + ... + t^5/5
+        //   s=3  u = 1 + t + ... + t^6 (degree 6),  A(t) = t + t^2/2 + ... + t^7/7
         //=========================================================================
-        template <std::size_t n_comp, std::size_t s, std::size_t dim, class CellAvgFn>
-        double roundtrip_error_vector(std::size_t L, const CellAvgFn& cell_avg_fn)
+        template <FieldType ft, std::size_t n_comp, std::size_t s, std::size_t dim>
+        double run_case(std::size_t L)
         {
-            using mesh_id_t = typename decltype(make_two_level_mesh<dim, static_cast<int>(s)>(L))::mesh_id_t;
-
-            auto mesh = make_two_level_mesh<dim, static_cast<int>(s)>(L);
-
-            auto u = make_vector_field<double, n_comp>("u", mesh);
-            u.resize();
-
-            // Initialize ALL cells and ghosts: component c gets (c+1) * cell_avg_fn(cell)
-            for (std::size_t lvl = mesh.min_level(); lvl <= mesh.max_level(); ++lvl)
+            if constexpr (s == 0)
             {
-                for_each_cell(mesh[mesh_id_t::reference][lvl],
-                              [&](const auto& cell)
-                              {
-                                  const double base = cell_avg_fn(cell);
-                                  for (std::size_t c = 0; c < n_comp; ++c)
-                                  {
-                                      u[cell][static_cast<int>(c)] = static_cast<double>(c + 1) * base;
-                                  }
-                              });
+                // s=0: constant polynomial — cell average equals the constant.
+                return roundtrip_error<ft, n_comp, s, dim>(L,
+                                                           [](const auto& /*cell*/)
+                                                           {
+                                                               return 3.14;
+                                                           });
             }
+            else if constexpr (s == 1)
+            {
+                // s=1: per-axis degree 2 — A(t) = t + t^2 + t^3  (antideriv of 1+2t+3t^2)
+                return roundtrip_error<ft, n_comp, s, dim>(L,
+                                                           [](const auto& cell)
+                                                           {
+                                                               return cell_avg_nd<dim>(cell,
+                                                                                       [](std::size_t /*i*/)
+                                                                                       {
+                                                                                           return [](double t)
+                                                                                           {
+                                                                                               const double t2 = t * t;
+                                                                                               const double t3 = t2 * t;
+                                                                                               return t + t2 + t3;
+                                                                                           };
+                                                                                       });
+                                                           });
+            }
+            else if constexpr (s == 2)
+            {
+                // s=2: per-axis degree 4 — A(t) = t + t^2/2 + t^3/3 + t^4/4 + t^5/5
+                return roundtrip_error<ft, n_comp, s, dim>(L,
+                                                           [](const auto& cell)
+                                                           {
+                                                               return cell_avg_nd<dim>(cell,
+                                                                                       [](std::size_t /*i*/)
+                                                                                       {
+                                                                                           return [](double t)
+                                                                                           {
+                                                                                               const double t2 = t * t;
+                                                                                               const double t3 = t2 * t;
+                                                                                               const double t4 = t3 * t;
+                                                                                               const double t5 = t4 * t;
+                                                                                               return t + (t2 / 2.0) + (t3 / 3.0)
+                                                                                                    + (t4 / 4.0) + (t5 / 5.0);
+                                                                                           };
+                                                                                       });
+                                                           });
+            }
+            else
+            {
+                // s=3: per-axis degree 6 — A(t) = t + t^2/2 + ... + t^7/7
+                return roundtrip_error<ft, n_comp, s, dim>(L,
+                                                           [](const auto& cell)
+                                                           {
+                                                               return cell_avg_nd<dim>(cell,
+                                                                                       [](std::size_t /*i*/)
+                                                                                       {
+                                                                                           return [](double t)
+                                                                                           {
+                                                                                               const double t2 = t * t;
+                                                                                               const double t3 = t2 * t;
+                                                                                               const double t4 = t3 * t;
+                                                                                               const double t5 = t4 * t;
+                                                                                               const double t6 = t5 * t;
+                                                                                               const double t7 = t6 * t;
+                                                                                               return t + (t2 / 2.0) + (t3 / 3.0) + (t4 / 4.0)
+                                                                                                    + (t5 / 5.0) + (t6 / 6.0) + (t7 / 7.0);
+                                                                                           };
+                                                                                       });
+                                                           });
+            }
+        }
 
-            // Project: level L -> L-1
-            auto proj_set = intersection(mesh[mesh_id_t::cells][L], mesh[mesh_id_t::reference][L - 1]).on(L - 1);
-            proj_set.apply_op(projection(u));
+        // Dispatch on dim (1..6) for a fixed (ft, n_comp, s).
+        template <FieldType ft, std::size_t n_comp, std::size_t s>
+        double dispatch_dim(std::size_t dim, std::size_t L)
+        {
+            switch (dim)
+            {
+                case 1:
+                    return run_case<ft, n_comp, s, 1>(L);
+                case 2:
+                    return run_case<ft, n_comp, s, 2>(L);
+                case 3:
+                    return run_case<ft, n_comp, s, 3>(L);
+                case 4:
+                    return run_case<ft, n_comp, s, 4>(L);
+                case 5:
+                    return run_case<ft, n_comp, s, 5>(L);
+                case 6:
+                    return run_case<ft, n_comp, s, 6>(L);
+                default:
+                    return -1.0;
+            }
+        }
 
-            // Predict: level L-1 -> L
-            auto pred_set = intersection(mesh[mesh_id_t::cells][L], mesh[mesh_id_t::reference][L - 1]).on(L);
-            pred_set.apply_op(prediction<s, false>(u));
+        // Dispatch on s (0..3), then dim, for a fixed (ft, n_comp).
+        template <FieldType ft, std::size_t n_comp>
+        double dispatch_s_dim(std::size_t s, std::size_t dim, std::size_t L)
+        {
+            switch (s)
+            {
+                case 0:
+                    return dispatch_dim<ft, n_comp, 0>(dim, L);
+                case 1:
+                    return dispatch_dim<ft, n_comp, 1>(dim, L);
+                case 2:
+                    return dispatch_dim<ft, n_comp, 2>(dim, L);
+                case 3:
+                    return dispatch_dim<ft, n_comp, 3>(dim, L);
+                default:
+                    return -1.0;
+            }
+        }
 
-            return max_abs_error_vector<n_comp>(u, L, cell_avg_fn);
+        // Top-level dispatch: also on FieldType.
+        double dispatch_all(FieldType ft, std::size_t s, std::size_t dim, std::size_t L)
+        {
+            if (ft == FieldType::Scalar)
+            {
+                return dispatch_s_dim<FieldType::Scalar, 1>(s, dim, L);
+            }
+            return dispatch_s_dim<FieldType::Vector, 2>(s, dim, L);
+        }
+
+        //=========================================================================
+        // Test parameters
+        //=========================================================================
+        struct RoundtripParams
+        {
+            FieldType ft;
+            std::size_t s;
+            std::size_t dim;
+            std::size_t L;
+            double tol;
+
+            // Human-readable name for INSTANTIATE_TEST_SUITE_P.
+            std::string name() const
+            {
+                const std::string ft_str = (ft == FieldType::Scalar) ? "scalar" : "vec2";
+                return ft_str + "_s" + std::to_string(s) + "_" + std::to_string(dim) + "D";
+            }
+        };
+
+        // Level and tolerance table.
+        //
+        // Level choice:
+        //   - 1D–4D s=0..3: L=4 gives 16 fine cells per axis — enough for all orders.
+        //   - 5D–6D s=0: L=3 (32 cells total is fine for constants).
+        //   - 5D–6D s>=1: L=2 (runtime would explode at L=3: 8^5=32k, 8^6=262k cells).
+        //   - 3D s=3, 4D s>=2: L=3 is sufficient and avoids excessive runtime.
+        //
+        // Tolerance choice (empirical, set at ~5x observed error):
+        //   - Floating-point error accumulates as (2s+1)^dim interpolation terms.
+        //   - Higher dim and s -> looser tolerance.
+        //   - s=0 (piecewise-constant copy): machine-precision exact -> 1e-14.
+        //   - s>=1 low dim: 1e-13.
+        //   - s>=2 higher dim: progressively looser.
+        std::vector<RoundtripParams> make_params()
+        {
+            // clang-format off
+            // {.ft,                  .s, .dim, .L, .tol}
+            std::vector<RoundtripParams> p = {
+                // ---- s=0: constant -----------------------------------------------
+                {.ft=FieldType::Scalar, .s=0, .dim=1, .L=4, .tol=1e-14},
+                {.ft=FieldType::Scalar, .s=0, .dim=2, .L=4, .tol=1e-14},
+                {.ft=FieldType::Scalar, .s=0, .dim=3, .L=4, .tol=1e-14},
+                {.ft=FieldType::Scalar, .s=0, .dim=4, .L=3, .tol=1e-14},
+                {.ft=FieldType::Scalar, .s=0, .dim=5, .L=3, .tol=1e-14},
+                {.ft=FieldType::Scalar, .s=0, .dim=6, .L=3, .tol=1e-14},
+
+                // ---- s=1: per-axis degree 2 ---------------------------------------
+                {.ft=FieldType::Scalar, .s=1, .dim=1, .L=4, .tol=1e-13},
+                {.ft=FieldType::Scalar, .s=1, .dim=2, .L=4, .tol=1e-13},
+                {.ft=FieldType::Scalar, .s=1, .dim=3, .L=4, .tol=1e-13},
+                {.ft=FieldType::Scalar, .s=1, .dim=4, .L=3, .tol=1e-13},
+                {.ft=FieldType::Scalar, .s=1, .dim=5, .L=3, .tol=1e-13},
+                {.ft=FieldType::Scalar, .s=1, .dim=6, .L=3, .tol=5e-10},
+
+                // ---- s=2: per-axis degree 4 ---------------------------------------
+                {.ft=FieldType::Scalar, .s=2, .dim=1, .L=4, .tol=1e-13},
+                {.ft=FieldType::Scalar, .s=2, .dim=2, .L=4, .tol=1e-13},
+                {.ft=FieldType::Scalar, .s=2, .dim=3, .L=4, .tol=1e-13},
+                {.ft=FieldType::Scalar, .s=2, .dim=4, .L=3, .tol=3e-12},
+                {.ft=FieldType::Scalar, .s=2, .dim=5, .L=2, .tol=3e-11},
+                {.ft=FieldType::Scalar, .s=2, .dim=6, .L=2, .tol=5e-10},
+
+                // ---- s=3: per-axis degree 6 ---------------------------------------
+                {.ft=FieldType::Scalar, .s=3, .dim=1, .L=5, .tol=1e-13},
+                {.ft=FieldType::Scalar, .s=3, .dim=2, .L=5, .tol=5e-13},
+                {.ft=FieldType::Scalar, .s=3, .dim=3, .L=3, .tol=5e-13},
+                {.ft=FieldType::Scalar, .s=3, .dim=4, .L=3, .tol=1e-11},
+                {.ft=FieldType::Scalar, .s=3, .dim=5, .L=2, .tol=1e-10},
+                {.ft=FieldType::Scalar, .s=3, .dim=6, .L=2, .tol=5e-09},
+
+                // ---- vec2 s=0 ----------------------------------------------------
+                {.ft=FieldType::Vector, .s=0, .dim=1, .L=4, .tol=1e-14},
+                {.ft=FieldType::Vector, .s=0, .dim=2, .L=4, .tol=1e-14},
+                {.ft=FieldType::Vector, .s=0, .dim=3, .L=4, .tol=1e-14},
+                {.ft=FieldType::Vector, .s=0, .dim=4, .L=3, .tol=1e-14},
+                {.ft=FieldType::Vector, .s=0, .dim=5, .L=3, .tol=1e-14},
+                {.ft=FieldType::Vector, .s=0, .dim=6, .L=3, .tol=1e-14},
+
+                // ---- vec2 s=1 ----------------------------------------------------
+                {.ft=FieldType::Vector, .s=1, .dim=1, .L=4, .tol=1e-13},
+                {.ft=FieldType::Vector, .s=1, .dim=2, .L=4, .tol=1e-13},
+                {.ft=FieldType::Vector, .s=1, .dim=3, .L=4, .tol=1e-13},
+                {.ft=FieldType::Vector, .s=1, .dim=4, .L=3, .tol=1e-13},
+                {.ft=FieldType::Vector, .s=1, .dim=5, .L=3, .tol=1e-13},
+                {.ft=FieldType::Vector, .s=1, .dim=6, .L=3, .tol=5e-10},
+
+                // ---- vec2 s=2 ----------------------------------------------------
+                {.ft=FieldType::Vector, .s=2, .dim=1, .L=4, .tol=1e-13},
+                {.ft=FieldType::Vector, .s=2, .dim=2, .L=4, .tol=1e-13},
+                {.ft=FieldType::Vector, .s=2, .dim=3, .L=4, .tol=5e-13},
+                {.ft=FieldType::Vector, .s=2, .dim=4, .L=3, .tol=1e-11},
+                {.ft=FieldType::Vector, .s=2, .dim=5, .L=2, .tol=1e-10},
+                {.ft=FieldType::Vector, .s=2, .dim=6, .L=2, .tol=1e-09},
+
+                // ---- vec2 s=3 ----------------------------------------------------
+                {.ft=FieldType::Vector, .s=3, .dim=1, .L=5, .tol=1e-13},
+                {.ft=FieldType::Vector, .s=3, .dim=2, .L=5, .tol=1e-12},
+                {.ft=FieldType::Vector, .s=3, .dim=3, .L=3, .tol=3e-12},
+                {.ft=FieldType::Vector, .s=3, .dim=4, .L=3, .tol=2e-11},
+                {.ft=FieldType::Vector, .s=3, .dim=5, .L=2, .tol=2e-10},
+                {.ft=FieldType::Vector, .s=3, .dim=6, .L=2, .tol=1e-08},
+            };
+            // clang-format on
+            return p;
         }
 
     } // anonymous namespace
 
     //=========================================================================
-    // Stencil radius 0 — constant polynomials
-    // Prediction order 1: roundtrip is exact for degree 0 (constants).
-    // Cell average of a constant equals the constant itself.
+    // Parameterized test suite
     //=========================================================================
 
-    TEST(ProjectionPredictionRoundtrip, s0_1D_constant)
+    class RoundtripTest : public ::testing::TestWithParam<RoundtripParams>
     {
-        // u(x) = 3.14  — cell average equals 3.14 at all cells
-        const double err = roundtrip_error<0, 1>(4,
-                                                 [](const auto& /*cell*/)
-                                                 {
-                                                     return 3.14;
-                                                 });
-        EXPECT_LE(err, 1e-14) << "1D constant polynomial roundtrip error too large: " << err;
+    };
+
+    TEST_P(RoundtripTest, ProjectionPrediction)
+    {
+        const auto& p    = GetParam();
+        const double err = dispatch_all(p.ft, p.s, p.dim, p.L);
+        EXPECT_LE(err, p.tol) << p.name() << " roundtrip error too large: " << err;
     }
 
-    TEST(ProjectionPredictionRoundtrip, s0_2D_constant)
-    {
-        const double err = roundtrip_error<0, 2>(4,
-                                                 [](const auto& /*cell*/)
-                                                 {
-                                                     return 3.14;
-                                                 });
-        EXPECT_LE(err, 1e-14) << "2D constant polynomial roundtrip error too large: " << err;
-    }
-
-    TEST(ProjectionPredictionRoundtrip, s0_3D_constant)
-    {
-        const double err = roundtrip_error<0, 3>(4,
-                                                 [](const auto& /*cell*/)
-                                                 {
-                                                     return 3.14;
-                                                 });
-        EXPECT_LE(err, 1e-14) << "3D constant polynomial roundtrip error too large: " << err;
-    }
-
-    //=========================================================================
-    // Stencil radius 1 — polynomials up to degree 2
-    // Prediction order 3: roundtrip is exact for cell averages of degree < 3.
-    //
-    // Fields store cell averages; we initialize using exact antiderivative
-    // integration so that the data is consistent with the FV interpretation.
-    //=========================================================================
-
-    TEST(ProjectionPredictionRoundtrip, s1_1D_linear)
-    {
-        // u(x) = 1 + 2x,  antideriv P(x) = x + x^2
-        // Cell average over [xc-h/2, xc+h/2] = 1 + 2*xc  (no O(h^2) correction for linears)
-        const double err = roundtrip_error<1, 1>(4,
-                                                 [](const auto& cell)
-                                                 {
-                                                     return cell_avg_1d(cell,
-                                                                        [](double x)
-                                                                        {
-                                                                            const double x2 = x * x;
-                                                                            return x + x2; // P(x) = x + x^2  (antideriv of 1+2x)
-                                                                        });
-                                                 });
-        EXPECT_LE(err, 1e-13) << "1D linear polynomial roundtrip error too large: " << err;
-    }
-
-    TEST(ProjectionPredictionRoundtrip, s1_1D_quadratic)
-    {
-        // u(x) = 1 + 2x + 3x^2,  antideriv P(x) = x + x^2 + x^3
-        // Cell avg = 1 + 2*xc + 3*(xc^2 + h^2/12)  — differs from point value at center
-        const double err = roundtrip_error<1, 1>(4,
-                                                 [](const auto& cell)
-                                                 {
-                                                     return cell_avg_1d(cell,
-                                                                        [](double x)
-                                                                        {
-                                                                            const double x2 = x * x;
-                                                                            const double x3 = x2 * x;
-                                                                            return x + x2 + x3; // antideriv of (1 + 2x + 3x^2)
-                                                                        });
-                                                 });
-        EXPECT_LE(err, 1e-13) << "1D quadratic polynomial roundtrip error too large: " << err;
-    }
-
-    TEST(ProjectionPredictionRoundtrip, s1_2D_degree2)
-    {
-        // u(x,y) = (1+x)*(1+y)  — separable, degree 2
-        // Antiderivs: Ax(x) = x + x^2/2,  Ay(y) = y + y^2/2
-        const double err = roundtrip_error<1, 2>(4,
-                                                 [](const auto& cell)
-                                                 {
-                                                     return cell_avg_2d(
-                                                         cell,
-                                                         [](double x)
-                                                         {
-                                                             const double x2 = x * x;
-                                                             return x + (x2 / 2.0); // antideriv of (1+x)
-                                                         },
-                                                         [](double y)
-                                                         {
-                                                             const double y2 = y * y;
-                                                             return y + (y2 / 2.0); // antideriv of (1+y)
-                                                         });
-                                                 });
-        EXPECT_LE(err, 1e-13) << "2D degree-2 polynomial roundtrip error too large: " << err;
-    }
-
-    TEST(ProjectionPredictionRoundtrip, s1_3D_degree2)
-    {
-        // u(x,y,z) = (1+x)*(1+y)*(1+z)  — fully separable, degree 3 (each factor linear)
-        // Antideriv for each: A(t) = t + t^2/2
-        const double err = roundtrip_error<1, 3>(4,
-                                                 [](const auto& cell)
-                                                 {
-                                                     const double xc   = cell.center()[0];
-                                                     const double yc   = cell.center()[1];
-                                                     const double zc   = cell.center()[2];
-                                                     const double half = cell.length / 2.0;
-                                                     const double h    = cell.length;
-                                                     auto antideriv    = [](double t)
-                                                     {
-                                                         const double t2 = t * t;
-                                                         return t + (t2 / 2.0);
-                                                     };
-                                                     const double ax = (antideriv(xc + half) - antideriv(xc - half)) / h;
-                                                     const double ay = (antideriv(yc + half) - antideriv(yc - half)) / h;
-                                                     const double az = (antideriv(zc + half) - antideriv(zc - half)) / h;
-                                                     return ax * ay * az;
-                                                 });
-        EXPECT_LE(err, 1e-13) << "3D degree-2 polynomial roundtrip error too large: " << err;
-    }
-
-    //=========================================================================
-    // Stencil radius 2 — polynomials up to degree 4
-    // Prediction order 5: roundtrip is exact for cell averages of degree < 5.
-    //
-    // Separable polynomials: cell avg factors as avg_x(f) * avg_y(g) * ...
-    //=========================================================================
-
-    TEST(ProjectionPredictionRoundtrip, s2_1D_degree4)
-    {
-        // u(x) = 1 + x + x^2 + x^3 + x^4
-        // Antideriv P(x) = x + x^2/2 + x^3/3 + x^4/4 + x^5/5
-        const double err = roundtrip_error<2, 1>(4,
-                                                 [](const auto& cell)
-                                                 {
-                                                     return cell_avg_1d(cell,
-                                                                        [](double x)
-                                                                        {
-                                                                            const double x2 = x * x;
-                                                                            const double x3 = x2 * x;
-                                                                            const double x4 = x3 * x;
-                                                                            const double x5 = x4 * x;
-                                                                            return x + (x2 / 2.0) + (x3 / 3.0) + (x4 / 4.0) + (x5 / 5.0);
-                                                                        });
-                                                 });
-        EXPECT_LE(err, 1e-13) << "1D degree-4 polynomial roundtrip error too large: " << err;
-    }
-
-    TEST(ProjectionPredictionRoundtrip, s2_2D_degree4)
-    {
-        // u(x,y) = (1 + x + x^2) * (1 + y + y^2) — separable, max degree per variable = 2, total = 4
-        // Antideriv_x: Ax(x) = x + x^2/2 + x^3/3;  Antideriv_y: Ay(y) = y + y^2/2 + y^3/3
-        const double err = roundtrip_error<2, 2>(4,
-                                                 [](const auto& cell)
-                                                 {
-                                                     return cell_avg_2d(
-                                                         cell,
-                                                         [](double x)
-                                                         {
-                                                             const double x2 = x * x;
-                                                             const double x3 = x2 * x;
-                                                             return x + (x2 / 2.0) + (x3 / 3.0); // antideriv of (1+x+x^2)
-                                                         },
-                                                         [](double y)
-                                                         {
-                                                             const double y2 = y * y;
-                                                             const double y3 = y2 * y;
-                                                             return y + (y2 / 2.0) + (y3 / 3.0); // antideriv of (1+y+y^2)
-                                                         });
-                                                 });
-        EXPECT_LE(err, 1e-13) << "2D degree-4 polynomial roundtrip error too large: " << err;
-    }
-
-    TEST(ProjectionPredictionRoundtrip, s2_3D_degree4)
-    {
-        // u(x,y,z) = (1+x+x^2)*(1+y)*(1+z) — separable, degree 4
-        const double err = roundtrip_error<2, 3>(4,
-                                                 [](const auto& cell)
-                                                 {
-                                                     const double xc   = cell.center()[0];
-                                                     const double yc   = cell.center()[1];
-                                                     const double zc   = cell.center()[2];
-                                                     const double half = cell.length / 2.0;
-                                                     const double h    = cell.length;
-                                                     auto antideriv_x  = [](double x)
-                                                     {
-                                                         const double x2 = x * x;
-                                                         const double x3 = x2 * x;
-                                                         return x + (x2 / 2.0) + (x3 / 3.0);
-                                                     };
-                                                     auto antideriv_yz = [](double t)
-                                                     {
-                                                         const double t2 = t * t;
-                                                         return t + (t2 / 2.0);
-                                                     };
-                                                     const double ax = (antideriv_x(xc + half) - antideriv_x(xc - half)) / h;
-                                                     const double ay = (antideriv_yz(yc + half) - antideriv_yz(yc - half)) / h;
-                                                     const double az = (antideriv_yz(zc + half) - antideriv_yz(zc - half)) / h;
-                                                     return ax * ay * az;
-                                                 });
-        EXPECT_LE(err, 1e-13) << "3D degree-4 polynomial roundtrip error too large: " << err;
-    }
-
-    //=========================================================================
-    // Stencil radius 3 — polynomials up to degree 6
-    // Prediction order 7: roundtrip is exact for cell averages of degree < 7.
-    //=========================================================================
-
-    TEST(ProjectionPredictionRoundtrip, s3_1D_degree6)
-    {
-        // u(x) = 1 + x + x^2 + x^3 + x^4 + x^5 + x^6
-        // Antideriv P(x) = x + x^2/2 + x^3/3 + x^4/4 + x^5/5 + x^6/6 + x^7/7
-        const double err = roundtrip_error<3, 1>(5,
-                                                 [](const auto& cell)
-                                                 {
-                                                     return cell_avg_1d(cell,
-                                                                        [](double x)
-                                                                        {
-                                                                            const double x2 = x * x;
-                                                                            const double x3 = x2 * x;
-                                                                            const double x4 = x3 * x;
-                                                                            const double x5 = x4 * x;
-                                                                            const double x6 = x5 * x;
-                                                                            const double x7 = x6 * x;
-                                                                            return x + (x2 / 2.0) + (x3 / 3.0) + (x4 / 4.0) + (x5 / 5.0)
-                                                                                 + (x6 / 6.0) + (x7 / 7.0);
-                                                                        });
-                                                 });
-        EXPECT_LE(err, 1e-13) << "1D degree-6 polynomial roundtrip error too large: " << err;
-    }
-
-    TEST(ProjectionPredictionRoundtrip, s3_2D_degree6)
-    {
-        // u(x,y) = (1 + x + x^2 + x^3) * (1 + y + y^2 + y^3) — separable, degree 6
-        // Antiderivs: A(t) = t + t^2/2 + t^3/3 + t^4/4
-        const double err = roundtrip_error<3, 2>(5,
-                                                 [](const auto& cell)
-                                                 {
-                                                     return cell_avg_2d(
-                                                         cell,
-                                                         [](double x)
-                                                         {
-                                                             const double x2 = x * x;
-                                                             const double x3 = x2 * x;
-                                                             const double x4 = x3 * x;
-                                                             return x + (x2 / 2.0) + (x3 / 3.0) + (x4 / 4.0);
-                                                         },
-                                                         [](double y)
-                                                         {
-                                                             const double y2 = y * y;
-                                                             const double y3 = y2 * y;
-                                                             const double y4 = y3 * y;
-                                                             return y + (y2 / 2.0) + (y3 / 3.0) + (y4 / 4.0);
-                                                         });
-                                                 });
-        EXPECT_LE(err, 1e-13) << "2D degree-6 polynomial roundtrip error too large: " << err;
-    }
-
-    TEST(ProjectionPredictionRoundtrip, s3_3D_degree6)
-    {
-        // u(x,y,z) = (1+x+x^2+x^3)*(1+y+y^2)*(1+z+z^2) — separable, degree 7 per-variable max 3,2,2
-        // Each variable's max degree is within prediction exactness range for s=3.
-        const double err = roundtrip_error<3, 3>(5,
-                                                 [](const auto& cell)
-                                                 {
-                                                     const double xc   = cell.center()[0];
-                                                     const double yc   = cell.center()[1];
-                                                     const double zc   = cell.center()[2];
-                                                     const double half = cell.length / 2.0;
-                                                     const double h    = cell.length;
-                                                     auto antideriv_x  = [](double x)
-                                                     {
-                                                         const double x2 = x * x;
-                                                         const double x3 = x2 * x;
-                                                         const double x4 = x3 * x;
-                                                         return x + (x2 / 2.0) + (x3 / 3.0) + (x4 / 4.0);
-                                                     };
-                                                     auto antideriv_yz = [](double t)
-                                                     {
-                                                         const double t2 = t * t;
-                                                         const double t3 = t2 * t;
-                                                         return t + (t2 / 2.0) + (t3 / 3.0);
-                                                     };
-                                                     const double ax = (antideriv_x(xc + half) - antideriv_x(xc - half)) / h;
-                                                     const double ay = (antideriv_yz(yc + half) - antideriv_yz(yc - half)) / h;
-                                                     const double az = (antideriv_yz(zc + half) - antideriv_yz(zc - half)) / h;
-                                                     return ax * ay * az;
-                                                 });
-        // 3D high-order case: allow slightly larger tolerance due to floating-point accumulation
-        EXPECT_LE(err, 5e-13) << "3D degree-6 polynomial roundtrip error too large: " << err;
-    }
-
-    //=========================================================================
-    // 4D, 5D, 6D tests
-    //
-    // For high-dimensional cases we use L=3 (8 fine cells per axis) to keep
-    // compilation and runtime manageable.  All polynomials are separable so
-    // that the exact cell-average factors per axis.
-    //=========================================================================
-
-    // --- s=0: constants ---
-
-    TEST(ProjectionPredictionRoundtrip, s0_4D_constant)
-    {
-        const double err = roundtrip_error<0, 4>(3,
-                                                 [](const auto& /*cell*/)
-                                                 {
-                                                     return 3.14;
-                                                 });
-        EXPECT_LE(err, 1e-14) << "4D constant polynomial roundtrip error too large: " << err;
-    }
-
-    TEST(ProjectionPredictionRoundtrip, s0_5D_constant)
-    {
-        const double err = roundtrip_error<0, 5>(3,
-                                                 [](const auto& /*cell*/)
-                                                 {
-                                                     return 3.14;
-                                                 });
-        EXPECT_LE(err, 1e-14) << "5D constant polynomial roundtrip error too large: " << err;
-    }
-
-    TEST(ProjectionPredictionRoundtrip, s0_6D_constant)
-    {
-        const double err = roundtrip_error<0, 6>(3,
-                                                 [](const auto& /*cell*/)
-                                                 {
-                                                     return 3.14;
-                                                 });
-        EXPECT_LE(err, 1e-14) << "6D constant polynomial roundtrip error too large: " << err;
-    }
-
-    // --- s=1: degree-2 separable polynomial (each axis factor: 1+t, antideriv: t+t^2/2) ---
-
-    TEST(ProjectionPredictionRoundtrip, s1_4D_degree2)
-    {
-        // u = prod_{i=0}^{3} (1 + x_i),  antideriv per axis: A(t) = t + t^2/2
-        auto antideriv = [](double t)
-        {
-            return t + (t * t / 2.0);
-        };
-        const double err = roundtrip_error<1, 4>(3,
-                                                 [&antideriv](const auto& cell)
-                                                 {
-                                                     return cell_avg_nd<4>(cell,
-                                                                           [&antideriv](std::size_t /*i*/)
-                                                                           {
-                                                                               return antideriv;
-                                                                           });
-                                                 });
-        EXPECT_LE(err, 1e-13) << "4D degree-2 polynomial roundtrip error too large: " << err;
-    }
-
-    TEST(ProjectionPredictionRoundtrip, s1_5D_degree2)
-    {
-        auto antideriv = [](double t)
-        {
-            return t + (t * t / 2.0);
-        };
-        const double err = roundtrip_error<1, 5>(3,
-                                                 [&antideriv](const auto& cell)
-                                                 {
-                                                     return cell_avg_nd<5>(cell,
-                                                                           [&antideriv](std::size_t /*i*/)
-                                                                           {
-                                                                               return antideriv;
-                                                                           });
-                                                 });
-        EXPECT_LE(err, 1e-13) << "5D degree-2 polynomial roundtrip error too large: " << err;
-    }
-
-    TEST(ProjectionPredictionRoundtrip, s1_6D_degree2)
-    {
-        auto antideriv = [](double t)
-        {
-            return t + (t * t / 2.0);
-        };
-        const double err = roundtrip_error<1, 6>(3,
-                                                 [&antideriv](const auto& cell)
-                                                 {
-                                                     return cell_avg_nd<6>(cell,
-                                                                           [&antideriv](std::size_t /*i*/)
-                                                                           {
-                                                                               return antideriv;
-                                                                           });
-                                                 });
-        EXPECT_LE(err, 1e-13) << "6D degree-2 polynomial roundtrip error too large: " << err;
-    }
-
-    // --- s=2: degree-4 separable polynomial (each axis: 1+t+t^2, antideriv: t+t^2/2+t^3/3) ---
-
-    TEST(ProjectionPredictionRoundtrip, s2_4D_degree4)
-    {
-        auto antideriv = [](double t)
-        {
-            const double t2 = t * t;
-            const double t3 = t2 * t;
-            return t + (t2 / 2.0) + (t3 / 3.0);
-        };
-        const double err = roundtrip_error<2, 4>(3,
-                                                 [&antideriv](const auto& cell)
-                                                 {
-                                                     return cell_avg_nd<4>(cell,
-                                                                           [&antideriv](std::size_t /*i*/)
-                                                                           {
-                                                                               return antideriv;
-                                                                           });
-                                                 });
-        EXPECT_LE(err, 5e-13) << "4D degree-4 polynomial roundtrip error too large: " << err;
-    }
-
-    TEST(ProjectionPredictionRoundtrip, s2_5D_degree4)
-    {
-        auto antideriv = [](double t)
-        {
-            const double t2 = t * t;
-            const double t3 = t2 * t;
-            return t + (t2 / 2.0) + (t3 / 3.0);
-        };
-        const double err = roundtrip_error<2, 5>(2,
-                                                 [&antideriv](const auto& cell)
-                                                 {
-                                                     return cell_avg_nd<5>(cell,
-                                                                           [&antideriv](std::size_t /*i*/)
-                                                                           {
-                                                                               return antideriv;
-                                                                           });
-                                                 });
-        EXPECT_LE(err, 5e-12) << "5D degree-4 polynomial roundtrip error too large: " << err;
-    }
-
-    TEST(ProjectionPredictionRoundtrip, s2_6D_degree4)
-    {
-        auto antideriv = [](double t)
-        {
-            const double t2 = t * t;
-            const double t3 = t2 * t;
-            return t + (t2 / 2.0) + (t3 / 3.0);
-        };
-        const double err = roundtrip_error<2, 6>(2,
-                                                 [&antideriv](const auto& cell)
-                                                 {
-                                                     return cell_avg_nd<6>(cell,
-                                                                           [&antideriv](std::size_t /*i*/)
-                                                                           {
-                                                                               return antideriv;
-                                                                           });
-                                                 });
-        EXPECT_LE(err, 5e-11) << "6D degree-4 polynomial roundtrip error too large: " << err;
-    }
-
-    // --- s=3: degree-6 separable polynomial (each axis: 1+t+t^2+t^3, antideriv: t+t^2/2+t^3/3+t^4/4) ---
-
-    TEST(ProjectionPredictionRoundtrip, s3_4D_degree6)
-    {
-        auto antideriv = [](double t)
-        {
-            const double t2 = t * t;
-            const double t3 = t2 * t;
-            const double t4 = t3 * t;
-            return t + (t2 / 2.0) + (t3 / 3.0) + (t4 / 4.0);
-        };
-        const double err = roundtrip_error<3, 4>(3,
-                                                 [&antideriv](const auto& cell)
-                                                 {
-                                                     return cell_avg_nd<4>(cell,
-                                                                           [&antideriv](std::size_t /*i*/)
-                                                                           {
-                                                                               return antideriv;
-                                                                           });
-                                                 });
-        EXPECT_LE(err, 2e-12) << "4D degree-6 polynomial roundtrip error too large: " << err;
-    }
-
-    TEST(ProjectionPredictionRoundtrip, s3_5D_degree6)
-    {
-        auto antideriv = [](double t)
-        {
-            const double t2 = t * t;
-            const double t3 = t2 * t;
-            const double t4 = t3 * t;
-            return t + (t2 / 2.0) + (t3 / 3.0) + (t4 / 4.0);
-        };
-        const double err = roundtrip_error<3, 5>(2,
-                                                 [&antideriv](const auto& cell)
-                                                 {
-                                                     return cell_avg_nd<5>(cell,
-                                                                           [&antideriv](std::size_t /*i*/)
-                                                                           {
-                                                                               return antideriv;
-                                                                           });
-                                                 });
-        EXPECT_LE(err, 1e-11) << "5D degree-6 polynomial roundtrip error too large: " << err;
-    }
-
-    TEST(ProjectionPredictionRoundtrip, s3_6D_degree6)
-    {
-        auto antideriv = [](double t)
-        {
-            const double t2 = t * t;
-            const double t3 = t2 * t;
-            const double t4 = t3 * t;
-            return t + (t2 / 2.0) + (t3 / 3.0) + (t4 / 4.0);
-        };
-        const double err = roundtrip_error<3, 6>(2,
-                                                 [&antideriv](const auto& cell)
-                                                 {
-                                                     return cell_avg_nd<6>(cell,
-                                                                           [&antideriv](std::size_t /*i*/)
-                                                                           {
-                                                                               return antideriv;
-                                                                           });
-                                                 });
-        EXPECT_LE(err, 5e-10) << "6D degree-6 polynomial roundtrip error too large: " << err;
-    }
-
-    //=========================================================================
-    // VectorField roundtrip tests
-    //
-    // Mirror of the scalar tests above using a 2-component VectorField.
-    // Component 0 carries 1*cell_avg, component 1 carries 2*cell_avg,
-    // so both components carry distinct non-trivial data and we verify
-    // all are recovered after projection + prediction.
-    //
-    // Tolerances and levels are identical to the corresponding scalar tests.
-    //=========================================================================
-
-    // --- s=0: constants ---
-
-    TEST(ProjectionPredictionRoundtrip, vec2_s0_1D_constant)
-    {
-        const double err = roundtrip_error_vector<2, 0, 1>(4,
-                                                           [](const auto& /*cell*/)
-                                                           {
-                                                               return 3.14;
-                                                           });
-        EXPECT_LE(err, 1e-14) << "vec2 1D constant roundtrip error too large: " << err;
-    }
-
-    TEST(ProjectionPredictionRoundtrip, vec2_s0_2D_constant)
-    {
-        const double err = roundtrip_error_vector<2, 0, 2>(4,
-                                                           [](const auto& /*cell*/)
-                                                           {
-                                                               return 3.14;
-                                                           });
-        EXPECT_LE(err, 1e-14) << "vec2 2D constant roundtrip error too large: " << err;
-    }
-
-    TEST(ProjectionPredictionRoundtrip, vec2_s0_3D_constant)
-    {
-        const double err = roundtrip_error_vector<2, 0, 3>(4,
-                                                           [](const auto& /*cell*/)
-                                                           {
-                                                               return 3.14;
-                                                           });
-        EXPECT_LE(err, 1e-14) << "vec2 3D constant roundtrip error too large: " << err;
-    }
-
-    TEST(ProjectionPredictionRoundtrip, vec2_s0_4D_constant)
-    {
-        const double err = roundtrip_error_vector<2, 0, 4>(3,
-                                                           [](const auto& /*cell*/)
-                                                           {
-                                                               return 3.14;
-                                                           });
-        EXPECT_LE(err, 1e-14) << "vec2 4D constant roundtrip error too large: " << err;
-    }
-
-    TEST(ProjectionPredictionRoundtrip, vec2_s0_5D_constant)
-    {
-        const double err = roundtrip_error_vector<2, 0, 5>(3,
-                                                           [](const auto& /*cell*/)
-                                                           {
-                                                               return 3.14;
-                                                           });
-        EXPECT_LE(err, 1e-14) << "vec2 5D constant roundtrip error too large: " << err;
-    }
-
-    TEST(ProjectionPredictionRoundtrip, vec2_s0_6D_constant)
-    {
-        const double err = roundtrip_error_vector<2, 0, 6>(3,
-                                                           [](const auto& /*cell*/)
-                                                           {
-                                                               return 3.14;
-                                                           });
-        EXPECT_LE(err, 1e-14) << "vec2 6D constant roundtrip error too large: " << err;
-    }
-
-    // --- s=1: degree-2 separable ---
-
-    TEST(ProjectionPredictionRoundtrip, vec2_s1_1D_degree2)
-    {
-        const double err = roundtrip_error_vector<2, 1, 1>(4,
-                                                           [](const auto& cell)
-                                                           {
-                                                               return cell_avg_1d(cell,
-                                                                                  [](double x)
-                                                                                  {
-                                                                                      return x + (x * x);
-                                                                                  });
-                                                           });
-        EXPECT_LE(err, 1e-13) << "vec2 1D degree-2 roundtrip error too large: " << err;
-    }
-
-    TEST(ProjectionPredictionRoundtrip, vec2_s1_2D_degree2)
-    {
-        const double err = roundtrip_error_vector<2, 1, 2>(4,
-                                                           [](const auto& cell)
-                                                           {
-                                                               return cell_avg_2d(
-                                                                   cell,
-                                                                   [](double x)
-                                                                   {
-                                                                       return x + (x * x / 2.0);
-                                                                   },
-                                                                   [](double y)
-                                                                   {
-                                                                       return y + (y * y / 2.0);
-                                                                   });
-                                                           });
-        EXPECT_LE(err, 1e-13) << "vec2 2D degree-2 roundtrip error too large: " << err;
-    }
-
-    TEST(ProjectionPredictionRoundtrip, vec2_s1_3D_degree2)
-    {
-        auto antideriv = [](double t)
-        {
-            return t + (t * t / 2.0);
-        };
-        const double err = roundtrip_error_vector<2, 1, 3>(4,
-                                                           [&antideriv](const auto& cell)
-                                                           {
-                                                               return cell_avg_nd<3>(cell,
-                                                                                     [&antideriv](std::size_t /*i*/)
-                                                                                     {
-                                                                                         return antideriv;
-                                                                                     });
-                                                           });
-        EXPECT_LE(err, 1e-13) << "vec2 3D degree-2 roundtrip error too large: " << err;
-    }
-
-    TEST(ProjectionPredictionRoundtrip, vec2_s1_4D_degree2)
-    {
-        auto antideriv = [](double t)
-        {
-            return t + (t * t / 2.0);
-        };
-        const double err = roundtrip_error_vector<2, 1, 4>(3,
-                                                           [&antideriv](const auto& cell)
-                                                           {
-                                                               return cell_avg_nd<4>(cell,
-                                                                                     [&antideriv](std::size_t /*i*/)
-                                                                                     {
-                                                                                         return antideriv;
-                                                                                     });
-                                                           });
-        EXPECT_LE(err, 1e-13) << "vec2 4D degree-2 roundtrip error too large: " << err;
-    }
-
-    TEST(ProjectionPredictionRoundtrip, vec2_s1_5D_degree2)
-    {
-        auto antideriv = [](double t)
-        {
-            return t + (t * t / 2.0);
-        };
-        const double err = roundtrip_error_vector<2, 1, 5>(3,
-                                                           [&antideriv](const auto& cell)
-                                                           {
-                                                               return cell_avg_nd<5>(cell,
-                                                                                     [&antideriv](std::size_t /*i*/)
-                                                                                     {
-                                                                                         return antideriv;
-                                                                                     });
-                                                           });
-        EXPECT_LE(err, 1e-13) << "vec2 5D degree-2 roundtrip error too large: " << err;
-    }
-
-    TEST(ProjectionPredictionRoundtrip, vec2_s1_6D_degree2)
-    {
-        auto antideriv = [](double t)
-        {
-            return t + (t * t / 2.0);
-        };
-        const double err = roundtrip_error_vector<2, 1, 6>(3,
-                                                           [&antideriv](const auto& cell)
-                                                           {
-                                                               return cell_avg_nd<6>(cell,
-                                                                                     [&antideriv](std::size_t /*i*/)
-                                                                                     {
-                                                                                         return antideriv;
-                                                                                     });
-                                                           });
-        EXPECT_LE(err, 1e-13) << "vec2 6D degree-2 roundtrip error too large: " << err;
-    }
-
-    // --- s=2: degree-4 separable ---
-
-    TEST(ProjectionPredictionRoundtrip, vec2_s2_1D_degree4)
-    {
-        const double err = roundtrip_error_vector<2, 2, 1>(4,
-                                                           [](const auto& cell)
-                                                           {
-                                                               return cell_avg_1d(cell,
-                                                                                  [](double x)
-                                                                                  {
-                                                                                      const double x2 = x * x;
-                                                                                      const double x3 = x2 * x;
-                                                                                      const double x4 = x3 * x;
-                                                                                      const double x5 = x4 * x;
-                                                                                      return x + (x2 / 2.0) + (x3 / 3.0) + (x4 / 4.0)
-                                                                                           + (x5 / 5.0);
-                                                                                  });
-                                                           });
-        EXPECT_LE(err, 1e-13) << "vec2 1D degree-4 roundtrip error too large: " << err;
-    }
-
-    TEST(ProjectionPredictionRoundtrip, vec2_s2_2D_degree4)
-    {
-        const double err = roundtrip_error_vector<2, 2, 2>(4,
-                                                           [](const auto& cell)
-                                                           {
-                                                               return cell_avg_2d(
-                                                                   cell,
-                                                                   [](double x)
-                                                                   {
-                                                                       const double x2 = x * x;
-                                                                       const double x3 = x2 * x;
-                                                                       return x + (x2 / 2.0) + (x3 / 3.0);
-                                                                   },
-                                                                   [](double y)
-                                                                   {
-                                                                       const double y2 = y * y;
-                                                                       const double y3 = y2 * y;
-                                                                       return y + (y2 / 2.0) + (y3 / 3.0);
-                                                                   });
-                                                           });
-        EXPECT_LE(err, 1e-13) << "vec2 2D degree-4 roundtrip error too large: " << err;
-    }
-
-    TEST(ProjectionPredictionRoundtrip, vec2_s2_3D_degree4)
-    {
-        auto antideriv = [](double t)
-        {
-            const double t2 = t * t;
-            const double t3 = t2 * t;
-            return t + (t2 / 2.0) + (t3 / 3.0);
-        };
-        const double err = roundtrip_error_vector<2, 2, 3>(4,
-                                                           [&antideriv](const auto& cell)
-                                                           {
-                                                               return cell_avg_nd<3>(cell,
-                                                                                     [&antideriv](std::size_t /*i*/)
-                                                                                     {
-                                                                                         return antideriv;
-                                                                                     });
-                                                           });
-        EXPECT_LE(err, 1e-13) << "vec2 3D degree-4 roundtrip error too large: " << err;
-    }
-
-    TEST(ProjectionPredictionRoundtrip, vec2_s2_4D_degree4)
-    {
-        auto antideriv = [](double t)
-        {
-            const double t2 = t * t;
-            const double t3 = t2 * t;
-            return t + (t2 / 2.0) + (t3 / 3.0);
-        };
-        const double err = roundtrip_error_vector<2, 2, 4>(3,
-                                                           [&antideriv](const auto& cell)
-                                                           {
-                                                               return cell_avg_nd<4>(cell,
-                                                                                     [&antideriv](std::size_t /*i*/)
-                                                                                     {
-                                                                                         return antideriv;
-                                                                                     });
-                                                           });
-        EXPECT_LE(err, 5e-13) << "vec2 4D degree-4 roundtrip error too large: " << err;
-    }
-
-    TEST(ProjectionPredictionRoundtrip, vec2_s2_5D_degree4)
-    {
-        auto antideriv = [](double t)
-        {
-            const double t2 = t * t;
-            const double t3 = t2 * t;
-            return t + (t2 / 2.0) + (t3 / 3.0);
-        };
-        const double err = roundtrip_error_vector<2, 2, 5>(2,
-                                                           [&antideriv](const auto& cell)
-                                                           {
-                                                               return cell_avg_nd<5>(cell,
-                                                                                     [&antideriv](std::size_t /*i*/)
-                                                                                     {
-                                                                                         return antideriv;
-                                                                                     });
-                                                           });
-        EXPECT_LE(err, 5e-12) << "vec2 5D degree-4 roundtrip error too large: " << err;
-    }
-
-    TEST(ProjectionPredictionRoundtrip, vec2_s2_6D_degree4)
-    {
-        auto antideriv = [](double t)
-        {
-            const double t2 = t * t;
-            const double t3 = t2 * t;
-            return t + (t2 / 2.0) + (t3 / 3.0);
-        };
-        const double err = roundtrip_error_vector<2, 2, 6>(2,
-                                                           [&antideriv](const auto& cell)
-                                                           {
-                                                               return cell_avg_nd<6>(cell,
-                                                                                     [&antideriv](std::size_t /*i*/)
-                                                                                     {
-                                                                                         return antideriv;
-                                                                                     });
-                                                           });
-        EXPECT_LE(err, 5e-11) << "vec2 6D degree-4 roundtrip error too large: " << err;
-    }
-
-    // --- s=3: degree-6 separable ---
-
-    TEST(ProjectionPredictionRoundtrip, vec2_s3_1D_degree6)
-    {
-        const double err = roundtrip_error_vector<2, 3, 1>(5,
-                                                           [](const auto& cell)
-                                                           {
-                                                               return cell_avg_1d(cell,
-                                                                                  [](double x)
-                                                                                  {
-                                                                                      const double x2 = x * x;
-                                                                                      const double x3 = x2 * x;
-                                                                                      const double x4 = x3 * x;
-                                                                                      const double x5 = x4 * x;
-                                                                                      const double x6 = x5 * x;
-                                                                                      const double x7 = x6 * x;
-                                                                                      return x + (x2 / 2.0) + (x3 / 3.0) + (x4 / 4.0)
-                                                                                           + (x5 / 5.0) + (x6 / 6.0) + (x7 / 7.0);
-                                                                                  });
-                                                           });
-        EXPECT_LE(err, 1e-13) << "vec2 1D degree-6 roundtrip error too large: " << err;
-    }
-
-    TEST(ProjectionPredictionRoundtrip, vec2_s3_2D_degree6)
-    {
-        const double err = roundtrip_error_vector<2, 3, 2>(5,
-                                                           [](const auto& cell)
-                                                           {
-                                                               return cell_avg_2d(
-                                                                   cell,
-                                                                   [](double x)
-                                                                   {
-                                                                       const double x2 = x * x;
-                                                                       const double x3 = x2 * x;
-                                                                       const double x4 = x3 * x;
-                                                                       return x + (x2 / 2.0) + (x3 / 3.0) + (x4 / 4.0);
-                                                                   },
-                                                                   [](double y)
-                                                                   {
-                                                                       const double y2 = y * y;
-                                                                       const double y3 = y2 * y;
-                                                                       const double y4 = y3 * y;
-                                                                       return y + (y2 / 2.0) + (y3 / 3.0) + (y4 / 4.0);
-                                                                   });
-                                                           });
-        EXPECT_LE(err, 5e-13) << "vec2 2D degree-6 roundtrip error too large: " << err;
-    }
-
-    TEST(ProjectionPredictionRoundtrip, vec2_s3_3D_degree6)
-    {
-        auto antideriv = [](double t)
-        {
-            const double t2 = t * t;
-            const double t3 = t2 * t;
-            const double t4 = t3 * t;
-            return t + (t2 / 2.0) + (t3 / 3.0) + (t4 / 4.0);
-        };
-        const double err = roundtrip_error_vector<2, 3, 3>(5,
-                                                           [&antideriv](const auto& cell)
-                                                           {
-                                                               return cell_avg_nd<3>(cell,
-                                                                                     [&antideriv](std::size_t /*i*/)
-                                                                                     {
-                                                                                         return antideriv;
-                                                                                     });
-                                                           });
-        EXPECT_LE(err, 2e-12) << "vec2 3D degree-6 roundtrip error too large: " << err;
-    }
-
-    TEST(ProjectionPredictionRoundtrip, vec2_s3_4D_degree6)
-    {
-        auto antideriv = [](double t)
-        {
-            const double t2 = t * t;
-            const double t3 = t2 * t;
-            const double t4 = t3 * t;
-            return t + (t2 / 2.0) + (t3 / 3.0) + (t4 / 4.0);
-        };
-        const double err = roundtrip_error_vector<2, 3, 4>(3,
-                                                           [&antideriv](const auto& cell)
-                                                           {
-                                                               return cell_avg_nd<4>(cell,
-                                                                                     [&antideriv](std::size_t /*i*/)
-                                                                                     {
-                                                                                         return antideriv;
-                                                                                     });
-                                                           });
-        EXPECT_LE(err, 2e-12) << "vec2 4D degree-6 roundtrip error too large: " << err;
-    }
-
-    TEST(ProjectionPredictionRoundtrip, vec2_s3_5D_degree6)
-    {
-        auto antideriv = [](double t)
-        {
-            const double t2 = t * t;
-            const double t3 = t2 * t;
-            const double t4 = t3 * t;
-            return t + (t2 / 2.0) + (t3 / 3.0) + (t4 / 4.0);
-        };
-        const double err = roundtrip_error_vector<2, 3, 5>(2,
-                                                           [&antideriv](const auto& cell)
-                                                           {
-                                                               return cell_avg_nd<5>(cell,
-                                                                                     [&antideriv](std::size_t /*i*/)
-                                                                                     {
-                                                                                         return antideriv;
-                                                                                     });
-                                                           });
-        EXPECT_LE(err, 1e-11) << "vec2 5D degree-6 roundtrip error too large: " << err;
-    }
-
-    TEST(ProjectionPredictionRoundtrip, vec2_s3_6D_degree6)
-    {
-        auto antideriv = [](double t)
-        {
-            const double t2 = t * t;
-            const double t3 = t2 * t;
-            const double t4 = t3 * t;
-            return t + (t2 / 2.0) + (t3 / 3.0) + (t4 / 4.0);
-        };
-        const double err = roundtrip_error_vector<2, 3, 6>(2,
-                                                           [&antideriv](const auto& cell)
-                                                           {
-                                                               return cell_avg_nd<6>(cell,
-                                                                                     [&antideriv](std::size_t /*i*/)
-                                                                                     {
-                                                                                         return antideriv;
-                                                                                     });
-                                                           });
-        EXPECT_LE(err, 5e-10) << "vec2 6D degree-6 roundtrip error too large: " << err;
-    }
+    INSTANTIATE_TEST_SUITE_P(ProjectionPredictionRoundtrip,
+                             RoundtripTest,
+                             ::testing::ValuesIn(make_params()),
+                             [](const ::testing::TestParamInfo<RoundtripParams>& info)
+                             {
+                                 return info.param.name();
+                             });
 
 } // namespace samurai

--- a/tests/test_projection_prediction_roundtrip.cpp
+++ b/tests/test_projection_prediction_roundtrip.cpp
@@ -1,0 +1,1194 @@
+// Copyright 2018-2025 the samurai's authors
+// SPDX-License-Identifier:  BSD-3-Clause
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+
+#include <samurai/box.hpp>
+#include <samurai/field.hpp>
+#include <samurai/mr/mesh.hpp>
+#include <samurai/numeric/prediction.hpp>
+#include <samurai/numeric/projection.hpp>
+#include <samurai/subset/node.hpp>
+
+namespace samurai
+{
+    namespace
+    {
+        //=========================================================================
+        // Helper: mesh creation
+        //
+        // Creates a uniform MR mesh with min_level = L-1, max_level = L,
+        // so that all cells begin at the fine level L.
+        // Generic for any dim >= 1: builds the unit hypercube [0,1]^dim.
+        //=========================================================================
+        template <std::size_t dim, int s>
+        auto make_two_level_mesh(std::size_t L)
+        {
+            auto mesh_cfg = mesh_config<dim, s>().min_level(L - 1).max_level(L).max_stencil_radius(std::max(2, s)).disable_args_parse();
+            // Build unit-hypercube box generically: [0,1]^dim
+            using point_t = xt::xtensor_fixed<double, xt::xshape<dim>>;
+            point_t lo, hi;
+            lo.fill(0.0);
+            hi.fill(1.0);
+            auto box = Box<double, dim>(lo, hi);
+            return mra::make_mesh(box, mesh_cfg);
+        }
+
+        //=========================================================================
+        // Helper: 1D cell average
+        //
+        // Computes (1/h) * integral_{xc-h/2}^{xc+h/2} p(x) dx using the
+        // antiderivative of p.  Exact in floating-point for polynomial antiderivs.
+        //=========================================================================
+        template <class Cell, class AntiderivFn>
+        double cell_avg_1d(const Cell& cell, const AntiderivFn& antideriv)
+        {
+            const double xc   = cell.center()[0];
+            const double half = cell.length / 2.0;
+            return (antideriv(xc + half) - antideriv(xc - half)) / cell.length;
+        }
+
+        //=========================================================================
+        // Helper: 2D cell average for separable polynomial f(x)*g(y)
+        //
+        // avg = avg_x(f) * avg_y(g), computed via antiderivatives.
+        //=========================================================================
+        template <class Cell, class AntiderivX, class AntiderivY>
+        double cell_avg_2d(const Cell& cell, const AntiderivX& antideriv_x, const AntiderivY& antideriv_y)
+        {
+            const double xc   = cell.center()[0];
+            const double yc   = cell.center()[1];
+            const double half = cell.length / 2.0;
+            const double h    = cell.length;
+            const double ax   = (antideriv_x(xc + half) - antideriv_x(xc - half)) / h;
+            const double ay   = (antideriv_y(yc + half) - antideriv_y(yc - half)) / h;
+            return ax * ay;
+        }
+
+        //=========================================================================
+        // Helper: N-dimensional cell average for separable polynomial
+        //
+        // Given a cell and a callable antiderivs(i) -> antideriv function for
+        // axis i, computes product_{i=0}^{dim-1} avg_i(antiderivs(i)).
+        // Separability means cell_avg(f) = prod_i cell_avg_1d(f_i).
+        //=========================================================================
+        template <std::size_t dim, class Cell, class AntiderivArray>
+        double cell_avg_nd(const Cell& cell, const AntiderivArray& antiderivs)
+        {
+            const double half = cell.length / 2.0;
+            const double h    = cell.length;
+            double result     = 1.0;
+            for (std::size_t i = 0; i < dim; ++i)
+            {
+                const double ci = cell.center()[i];
+                result *= (antiderivs(i)(ci + half) - antiderivs(i)(ci - half)) / h;
+            }
+            return result;
+        }
+
+        //=========================================================================
+        // Helper: error calculation — scalar field
+        //
+        // Returns the maximum absolute difference between field values at level L
+        // and the reference cell-average function applied to each cell.
+        //=========================================================================
+        template <class Field, class CellAvgFn>
+        double max_abs_error(const Field& u, std::size_t L, const CellAvgFn& cell_avg_fn)
+        {
+            using mesh_id_t = typename Field::mesh_t::mesh_id_t;
+            double max_err  = 0.0;
+            for_each_cell(u.mesh()[mesh_id_t::cells][L],
+                          [&](const auto& cell)
+                          {
+                              const double expected = cell_avg_fn(cell);
+                              const double actual   = u[cell];
+                              const double err      = std::abs(actual - expected);
+                              max_err               = std::max(max_err, err);
+                          });
+            return max_err;
+        }
+
+        //=========================================================================
+        // Helper: error calculation — vector field
+        //
+        // Checks every component c: expected value is (c+1) * cell_avg_fn(cell).
+        // Returns the maximum absolute difference over all cells and components.
+        //=========================================================================
+        template <std::size_t n_comp, class Field, class CellAvgFn>
+        double max_abs_error_vector(const Field& u, std::size_t L, const CellAvgFn& cell_avg_fn)
+        {
+            using mesh_id_t = typename Field::mesh_t::mesh_id_t;
+            double max_err  = 0.0;
+            for_each_cell(u.mesh()[mesh_id_t::cells][L],
+                          [&](const auto& cell)
+                          {
+                              const double base = cell_avg_fn(cell);
+                              for (std::size_t c = 0; c < n_comp; ++c)
+                              {
+                                  const double expected = static_cast<double>(c + 1) * base;
+                                  const double actual   = u[cell][static_cast<int>(c)];
+                                  const double err      = std::abs(actual - expected);
+                                  max_err               = std::max(max_err, err);
+                              }
+                          });
+            return max_err;
+        }
+
+        //=========================================================================
+        // Helper: roundtrip test body
+        //
+        // 1. Build uniform mesh (levels L-1 and L).
+        // 2. Fill ALL cells and ghosts at every level with exact cell averages.
+        //    Ghost cells at L-1 need exact values so that the prediction stencil
+        //    (which reads s coarse neighbors on each side) operates correctly.
+        // 3. Project level L -> L-1 (overwrites interior L-1 cells with cell averages
+        //    computed from fine children — exact for any polynomial).
+        // 4. Predict level L-1 -> L  (exact for polynomials of degree < 2s+1).
+        // 5. Return max absolute error vs. exact cell averages at level L.
+        //
+        // Subset algebra pattern (Design Decision 4):
+        //   projection:  intersection(mesh[cells][L], mesh[reference][L-1]).on(L-1)
+        //   prediction:  intersection(mesh[cells][L], mesh[reference][L-1]).on(L)
+        //=========================================================================
+        template <std::size_t s, std::size_t dim, class CellAvgFn>
+        double roundtrip_error(std::size_t L, const CellAvgFn& cell_avg_fn)
+        {
+            using mesh_id_t = typename decltype(make_two_level_mesh<dim, static_cast<int>(s)>(L))::mesh_id_t;
+
+            auto mesh = make_two_level_mesh<dim, static_cast<int>(s)>(L);
+
+            auto u = make_scalar_field<double>("u", mesh);
+            u.resize();
+
+            // Initialize ALL cells and ghosts at every level with exact cell averages.
+            // Ghost cells at L-1 must hold correct values so that the prediction stencil
+            // has valid coarse-level neighbors at the domain boundary.
+            for (std::size_t lvl = mesh.min_level(); lvl <= mesh.max_level(); ++lvl)
+            {
+                for_each_cell(mesh[mesh_id_t::reference][lvl],
+                              [&](const auto& cell)
+                              {
+                                  u[cell] = cell_avg_fn(cell);
+                              });
+            }
+
+            // Project: level L -> L-1 (average fine children to get coarse cell average)
+            auto proj_set = intersection(mesh[mesh_id_t::cells][L], mesh[mesh_id_t::reference][L - 1]).on(L - 1);
+            proj_set.apply_op(projection(u));
+
+            // Predict: level L-1 -> L  (dest_on_level=false: reads from level-1, writes to level)
+            auto pred_set = intersection(mesh[mesh_id_t::cells][L], mesh[mesh_id_t::reference][L - 1]).on(L);
+            pred_set.apply_op(prediction<s, false>(u));
+
+            return max_abs_error(u, L, cell_avg_fn);
+        }
+
+        //=========================================================================
+        // Helper: VectorField roundtrip
+        //
+        // Same logic as roundtrip_error, but uses a VectorField with n_comp
+        // components. Component c is initialised with (c+1) * cell_avg_fn(cell),
+        // so each component carries a distinct non-trivial polynomial and we verify
+        // all components are recovered after projection + prediction.
+        //=========================================================================
+        template <std::size_t n_comp, std::size_t s, std::size_t dim, class CellAvgFn>
+        double roundtrip_error_vector(std::size_t L, const CellAvgFn& cell_avg_fn)
+        {
+            using mesh_id_t = typename decltype(make_two_level_mesh<dim, static_cast<int>(s)>(L))::mesh_id_t;
+
+            auto mesh = make_two_level_mesh<dim, static_cast<int>(s)>(L);
+
+            auto u = make_vector_field<double, n_comp>("u", mesh);
+            u.resize();
+
+            // Initialize ALL cells and ghosts: component c gets (c+1) * cell_avg_fn(cell)
+            for (std::size_t lvl = mesh.min_level(); lvl <= mesh.max_level(); ++lvl)
+            {
+                for_each_cell(mesh[mesh_id_t::reference][lvl],
+                              [&](const auto& cell)
+                              {
+                                  const double base = cell_avg_fn(cell);
+                                  for (std::size_t c = 0; c < n_comp; ++c)
+                                  {
+                                      u[cell][static_cast<int>(c)] = static_cast<double>(c + 1) * base;
+                                  }
+                              });
+            }
+
+            // Project: level L -> L-1
+            auto proj_set = intersection(mesh[mesh_id_t::cells][L], mesh[mesh_id_t::reference][L - 1]).on(L - 1);
+            proj_set.apply_op(projection(u));
+
+            // Predict: level L-1 -> L
+            auto pred_set = intersection(mesh[mesh_id_t::cells][L], mesh[mesh_id_t::reference][L - 1]).on(L);
+            pred_set.apply_op(prediction<s, false>(u));
+
+            return max_abs_error_vector<n_comp>(u, L, cell_avg_fn);
+        }
+
+    } // anonymous namespace
+
+    //=========================================================================
+    // Stencil radius 0 — constant polynomials
+    // Prediction order 1: roundtrip is exact for degree 0 (constants).
+    // Cell average of a constant equals the constant itself.
+    //=========================================================================
+
+    TEST(ProjectionPredictionRoundtrip, s0_1D_constant)
+    {
+        // u(x) = 3.14  — cell average equals 3.14 at all cells
+        const double err = roundtrip_error<0, 1>(4,
+                                                 [](const auto& /*cell*/)
+                                                 {
+                                                     return 3.14;
+                                                 });
+        EXPECT_LE(err, 1e-14) << "1D constant polynomial roundtrip error too large: " << err;
+    }
+
+    TEST(ProjectionPredictionRoundtrip, s0_2D_constant)
+    {
+        const double err = roundtrip_error<0, 2>(4,
+                                                 [](const auto& /*cell*/)
+                                                 {
+                                                     return 3.14;
+                                                 });
+        EXPECT_LE(err, 1e-14) << "2D constant polynomial roundtrip error too large: " << err;
+    }
+
+    TEST(ProjectionPredictionRoundtrip, s0_3D_constant)
+    {
+        const double err = roundtrip_error<0, 3>(4,
+                                                 [](const auto& /*cell*/)
+                                                 {
+                                                     return 3.14;
+                                                 });
+        EXPECT_LE(err, 1e-14) << "3D constant polynomial roundtrip error too large: " << err;
+    }
+
+    //=========================================================================
+    // Stencil radius 1 — polynomials up to degree 2
+    // Prediction order 3: roundtrip is exact for cell averages of degree < 3.
+    //
+    // Fields store cell averages; we initialize using exact antiderivative
+    // integration so that the data is consistent with the FV interpretation.
+    //=========================================================================
+
+    TEST(ProjectionPredictionRoundtrip, s1_1D_linear)
+    {
+        // u(x) = 1 + 2x,  antideriv P(x) = x + x^2
+        // Cell average over [xc-h/2, xc+h/2] = 1 + 2*xc  (no O(h^2) correction for linears)
+        const double err = roundtrip_error<1, 1>(4,
+                                                 [](const auto& cell)
+                                                 {
+                                                     return cell_avg_1d(cell,
+                                                                        [](double x)
+                                                                        {
+                                                                            const double x2 = x * x;
+                                                                            return x + x2; // P(x) = x + x^2  (antideriv of 1+2x)
+                                                                        });
+                                                 });
+        EXPECT_LE(err, 1e-13) << "1D linear polynomial roundtrip error too large: " << err;
+    }
+
+    TEST(ProjectionPredictionRoundtrip, s1_1D_quadratic)
+    {
+        // u(x) = 1 + 2x + 3x^2,  antideriv P(x) = x + x^2 + x^3
+        // Cell avg = 1 + 2*xc + 3*(xc^2 + h^2/12)  — differs from point value at center
+        const double err = roundtrip_error<1, 1>(4,
+                                                 [](const auto& cell)
+                                                 {
+                                                     return cell_avg_1d(cell,
+                                                                        [](double x)
+                                                                        {
+                                                                            const double x2 = x * x;
+                                                                            const double x3 = x2 * x;
+                                                                            return x + x2 + x3; // antideriv of (1 + 2x + 3x^2)
+                                                                        });
+                                                 });
+        EXPECT_LE(err, 1e-13) << "1D quadratic polynomial roundtrip error too large: " << err;
+    }
+
+    TEST(ProjectionPredictionRoundtrip, s1_2D_degree2)
+    {
+        // u(x,y) = (1+x)*(1+y)  — separable, degree 2
+        // Antiderivs: Ax(x) = x + x^2/2,  Ay(y) = y + y^2/2
+        const double err = roundtrip_error<1, 2>(4,
+                                                 [](const auto& cell)
+                                                 {
+                                                     return cell_avg_2d(
+                                                         cell,
+                                                         [](double x)
+                                                         {
+                                                             const double x2 = x * x;
+                                                             return x + (x2 / 2.0); // antideriv of (1+x)
+                                                         },
+                                                         [](double y)
+                                                         {
+                                                             const double y2 = y * y;
+                                                             return y + (y2 / 2.0); // antideriv of (1+y)
+                                                         });
+                                                 });
+        EXPECT_LE(err, 1e-13) << "2D degree-2 polynomial roundtrip error too large: " << err;
+    }
+
+    TEST(ProjectionPredictionRoundtrip, s1_3D_degree2)
+    {
+        // u(x,y,z) = (1+x)*(1+y)*(1+z)  — fully separable, degree 3 (each factor linear)
+        // Antideriv for each: A(t) = t + t^2/2
+        const double err = roundtrip_error<1, 3>(4,
+                                                 [](const auto& cell)
+                                                 {
+                                                     const double xc   = cell.center()[0];
+                                                     const double yc   = cell.center()[1];
+                                                     const double zc   = cell.center()[2];
+                                                     const double half = cell.length / 2.0;
+                                                     const double h    = cell.length;
+                                                     auto antideriv    = [](double t)
+                                                     {
+                                                         const double t2 = t * t;
+                                                         return t + (t2 / 2.0);
+                                                     };
+                                                     const double ax = (antideriv(xc + half) - antideriv(xc - half)) / h;
+                                                     const double ay = (antideriv(yc + half) - antideriv(yc - half)) / h;
+                                                     const double az = (antideriv(zc + half) - antideriv(zc - half)) / h;
+                                                     return ax * ay * az;
+                                                 });
+        EXPECT_LE(err, 1e-13) << "3D degree-2 polynomial roundtrip error too large: " << err;
+    }
+
+    //=========================================================================
+    // Stencil radius 2 — polynomials up to degree 4
+    // Prediction order 5: roundtrip is exact for cell averages of degree < 5.
+    //
+    // Separable polynomials: cell avg factors as avg_x(f) * avg_y(g) * ...
+    //=========================================================================
+
+    TEST(ProjectionPredictionRoundtrip, s2_1D_degree4)
+    {
+        // u(x) = 1 + x + x^2 + x^3 + x^4
+        // Antideriv P(x) = x + x^2/2 + x^3/3 + x^4/4 + x^5/5
+        const double err = roundtrip_error<2, 1>(4,
+                                                 [](const auto& cell)
+                                                 {
+                                                     return cell_avg_1d(cell,
+                                                                        [](double x)
+                                                                        {
+                                                                            const double x2 = x * x;
+                                                                            const double x3 = x2 * x;
+                                                                            const double x4 = x3 * x;
+                                                                            const double x5 = x4 * x;
+                                                                            return x + (x2 / 2.0) + (x3 / 3.0) + (x4 / 4.0) + (x5 / 5.0);
+                                                                        });
+                                                 });
+        EXPECT_LE(err, 1e-13) << "1D degree-4 polynomial roundtrip error too large: " << err;
+    }
+
+    TEST(ProjectionPredictionRoundtrip, s2_2D_degree4)
+    {
+        // u(x,y) = (1 + x + x^2) * (1 + y + y^2) — separable, max degree per variable = 2, total = 4
+        // Antideriv_x: Ax(x) = x + x^2/2 + x^3/3;  Antideriv_y: Ay(y) = y + y^2/2 + y^3/3
+        const double err = roundtrip_error<2, 2>(4,
+                                                 [](const auto& cell)
+                                                 {
+                                                     return cell_avg_2d(
+                                                         cell,
+                                                         [](double x)
+                                                         {
+                                                             const double x2 = x * x;
+                                                             const double x3 = x2 * x;
+                                                             return x + (x2 / 2.0) + (x3 / 3.0); // antideriv of (1+x+x^2)
+                                                         },
+                                                         [](double y)
+                                                         {
+                                                             const double y2 = y * y;
+                                                             const double y3 = y2 * y;
+                                                             return y + (y2 / 2.0) + (y3 / 3.0); // antideriv of (1+y+y^2)
+                                                         });
+                                                 });
+        EXPECT_LE(err, 1e-13) << "2D degree-4 polynomial roundtrip error too large: " << err;
+    }
+
+    TEST(ProjectionPredictionRoundtrip, s2_3D_degree4)
+    {
+        // u(x,y,z) = (1+x+x^2)*(1+y)*(1+z) — separable, degree 4
+        const double err = roundtrip_error<2, 3>(4,
+                                                 [](const auto& cell)
+                                                 {
+                                                     const double xc   = cell.center()[0];
+                                                     const double yc   = cell.center()[1];
+                                                     const double zc   = cell.center()[2];
+                                                     const double half = cell.length / 2.0;
+                                                     const double h    = cell.length;
+                                                     auto antideriv_x  = [](double x)
+                                                     {
+                                                         const double x2 = x * x;
+                                                         const double x3 = x2 * x;
+                                                         return x + (x2 / 2.0) + (x3 / 3.0);
+                                                     };
+                                                     auto antideriv_yz = [](double t)
+                                                     {
+                                                         const double t2 = t * t;
+                                                         return t + (t2 / 2.0);
+                                                     };
+                                                     const double ax = (antideriv_x(xc + half) - antideriv_x(xc - half)) / h;
+                                                     const double ay = (antideriv_yz(yc + half) - antideriv_yz(yc - half)) / h;
+                                                     const double az = (antideriv_yz(zc + half) - antideriv_yz(zc - half)) / h;
+                                                     return ax * ay * az;
+                                                 });
+        EXPECT_LE(err, 1e-13) << "3D degree-4 polynomial roundtrip error too large: " << err;
+    }
+
+    //=========================================================================
+    // Stencil radius 3 — polynomials up to degree 6
+    // Prediction order 7: roundtrip is exact for cell averages of degree < 7.
+    //=========================================================================
+
+    TEST(ProjectionPredictionRoundtrip, s3_1D_degree6)
+    {
+        // u(x) = 1 + x + x^2 + x^3 + x^4 + x^5 + x^6
+        // Antideriv P(x) = x + x^2/2 + x^3/3 + x^4/4 + x^5/5 + x^6/6 + x^7/7
+        const double err = roundtrip_error<3, 1>(5,
+                                                 [](const auto& cell)
+                                                 {
+                                                     return cell_avg_1d(cell,
+                                                                        [](double x)
+                                                                        {
+                                                                            const double x2 = x * x;
+                                                                            const double x3 = x2 * x;
+                                                                            const double x4 = x3 * x;
+                                                                            const double x5 = x4 * x;
+                                                                            const double x6 = x5 * x;
+                                                                            const double x7 = x6 * x;
+                                                                            return x + (x2 / 2.0) + (x3 / 3.0) + (x4 / 4.0) + (x5 / 5.0)
+                                                                                 + (x6 / 6.0) + (x7 / 7.0);
+                                                                        });
+                                                 });
+        EXPECT_LE(err, 1e-13) << "1D degree-6 polynomial roundtrip error too large: " << err;
+    }
+
+    TEST(ProjectionPredictionRoundtrip, s3_2D_degree6)
+    {
+        // u(x,y) = (1 + x + x^2 + x^3) * (1 + y + y^2 + y^3) — separable, degree 6
+        // Antiderivs: A(t) = t + t^2/2 + t^3/3 + t^4/4
+        const double err = roundtrip_error<3, 2>(5,
+                                                 [](const auto& cell)
+                                                 {
+                                                     return cell_avg_2d(
+                                                         cell,
+                                                         [](double x)
+                                                         {
+                                                             const double x2 = x * x;
+                                                             const double x3 = x2 * x;
+                                                             const double x4 = x3 * x;
+                                                             return x + (x2 / 2.0) + (x3 / 3.0) + (x4 / 4.0);
+                                                         },
+                                                         [](double y)
+                                                         {
+                                                             const double y2 = y * y;
+                                                             const double y3 = y2 * y;
+                                                             const double y4 = y3 * y;
+                                                             return y + (y2 / 2.0) + (y3 / 3.0) + (y4 / 4.0);
+                                                         });
+                                                 });
+        EXPECT_LE(err, 1e-13) << "2D degree-6 polynomial roundtrip error too large: " << err;
+    }
+
+    TEST(ProjectionPredictionRoundtrip, s3_3D_degree6)
+    {
+        // u(x,y,z) = (1+x+x^2+x^3)*(1+y+y^2)*(1+z+z^2) — separable, degree 7 per-variable max 3,2,2
+        // Each variable's max degree is within prediction exactness range for s=3.
+        const double err = roundtrip_error<3, 3>(5,
+                                                 [](const auto& cell)
+                                                 {
+                                                     const double xc   = cell.center()[0];
+                                                     const double yc   = cell.center()[1];
+                                                     const double zc   = cell.center()[2];
+                                                     const double half = cell.length / 2.0;
+                                                     const double h    = cell.length;
+                                                     auto antideriv_x  = [](double x)
+                                                     {
+                                                         const double x2 = x * x;
+                                                         const double x3 = x2 * x;
+                                                         const double x4 = x3 * x;
+                                                         return x + (x2 / 2.0) + (x3 / 3.0) + (x4 / 4.0);
+                                                     };
+                                                     auto antideriv_yz = [](double t)
+                                                     {
+                                                         const double t2 = t * t;
+                                                         const double t3 = t2 * t;
+                                                         return t + (t2 / 2.0) + (t3 / 3.0);
+                                                     };
+                                                     const double ax = (antideriv_x(xc + half) - antideriv_x(xc - half)) / h;
+                                                     const double ay = (antideriv_yz(yc + half) - antideriv_yz(yc - half)) / h;
+                                                     const double az = (antideriv_yz(zc + half) - antideriv_yz(zc - half)) / h;
+                                                     return ax * ay * az;
+                                                 });
+        // 3D high-order case: allow slightly larger tolerance due to floating-point accumulation
+        EXPECT_LE(err, 5e-13) << "3D degree-6 polynomial roundtrip error too large: " << err;
+    }
+
+    //=========================================================================
+    // 4D, 5D, 6D tests
+    //
+    // For high-dimensional cases we use L=3 (8 fine cells per axis) to keep
+    // compilation and runtime manageable.  All polynomials are separable so
+    // that the exact cell-average factors per axis.
+    //=========================================================================
+
+    // --- s=0: constants ---
+
+    TEST(ProjectionPredictionRoundtrip, s0_4D_constant)
+    {
+        const double err = roundtrip_error<0, 4>(3,
+                                                 [](const auto& /*cell*/)
+                                                 {
+                                                     return 3.14;
+                                                 });
+        EXPECT_LE(err, 1e-14) << "4D constant polynomial roundtrip error too large: " << err;
+    }
+
+    TEST(ProjectionPredictionRoundtrip, s0_5D_constant)
+    {
+        const double err = roundtrip_error<0, 5>(3,
+                                                 [](const auto& /*cell*/)
+                                                 {
+                                                     return 3.14;
+                                                 });
+        EXPECT_LE(err, 1e-14) << "5D constant polynomial roundtrip error too large: " << err;
+    }
+
+    TEST(ProjectionPredictionRoundtrip, s0_6D_constant)
+    {
+        const double err = roundtrip_error<0, 6>(3,
+                                                 [](const auto& /*cell*/)
+                                                 {
+                                                     return 3.14;
+                                                 });
+        EXPECT_LE(err, 1e-14) << "6D constant polynomial roundtrip error too large: " << err;
+    }
+
+    // --- s=1: degree-2 separable polynomial (each axis factor: 1+t, antideriv: t+t^2/2) ---
+
+    TEST(ProjectionPredictionRoundtrip, s1_4D_degree2)
+    {
+        // u = prod_{i=0}^{3} (1 + x_i),  antideriv per axis: A(t) = t + t^2/2
+        auto antideriv = [](double t)
+        {
+            return t + (t * t / 2.0);
+        };
+        const double err = roundtrip_error<1, 4>(3,
+                                                 [&antideriv](const auto& cell)
+                                                 {
+                                                     return cell_avg_nd<4>(cell,
+                                                                           [&antideriv](std::size_t /*i*/)
+                                                                           {
+                                                                               return antideriv;
+                                                                           });
+                                                 });
+        EXPECT_LE(err, 1e-13) << "4D degree-2 polynomial roundtrip error too large: " << err;
+    }
+
+    TEST(ProjectionPredictionRoundtrip, s1_5D_degree2)
+    {
+        auto antideriv = [](double t)
+        {
+            return t + (t * t / 2.0);
+        };
+        const double err = roundtrip_error<1, 5>(3,
+                                                 [&antideriv](const auto& cell)
+                                                 {
+                                                     return cell_avg_nd<5>(cell,
+                                                                           [&antideriv](std::size_t /*i*/)
+                                                                           {
+                                                                               return antideriv;
+                                                                           });
+                                                 });
+        EXPECT_LE(err, 1e-13) << "5D degree-2 polynomial roundtrip error too large: " << err;
+    }
+
+    TEST(ProjectionPredictionRoundtrip, s1_6D_degree2)
+    {
+        auto antideriv = [](double t)
+        {
+            return t + (t * t / 2.0);
+        };
+        const double err = roundtrip_error<1, 6>(3,
+                                                 [&antideriv](const auto& cell)
+                                                 {
+                                                     return cell_avg_nd<6>(cell,
+                                                                           [&antideriv](std::size_t /*i*/)
+                                                                           {
+                                                                               return antideriv;
+                                                                           });
+                                                 });
+        EXPECT_LE(err, 1e-13) << "6D degree-2 polynomial roundtrip error too large: " << err;
+    }
+
+    // --- s=2: degree-4 separable polynomial (each axis: 1+t+t^2, antideriv: t+t^2/2+t^3/3) ---
+
+    TEST(ProjectionPredictionRoundtrip, s2_4D_degree4)
+    {
+        auto antideriv = [](double t)
+        {
+            const double t2 = t * t;
+            const double t3 = t2 * t;
+            return t + (t2 / 2.0) + (t3 / 3.0);
+        };
+        const double err = roundtrip_error<2, 4>(3,
+                                                 [&antideriv](const auto& cell)
+                                                 {
+                                                     return cell_avg_nd<4>(cell,
+                                                                           [&antideriv](std::size_t /*i*/)
+                                                                           {
+                                                                               return antideriv;
+                                                                           });
+                                                 });
+        EXPECT_LE(err, 5e-13) << "4D degree-4 polynomial roundtrip error too large: " << err;
+    }
+
+    TEST(ProjectionPredictionRoundtrip, s2_5D_degree4)
+    {
+        auto antideriv = [](double t)
+        {
+            const double t2 = t * t;
+            const double t3 = t2 * t;
+            return t + (t2 / 2.0) + (t3 / 3.0);
+        };
+        const double err = roundtrip_error<2, 5>(2,
+                                                 [&antideriv](const auto& cell)
+                                                 {
+                                                     return cell_avg_nd<5>(cell,
+                                                                           [&antideriv](std::size_t /*i*/)
+                                                                           {
+                                                                               return antideriv;
+                                                                           });
+                                                 });
+        EXPECT_LE(err, 5e-12) << "5D degree-4 polynomial roundtrip error too large: " << err;
+    }
+
+    TEST(ProjectionPredictionRoundtrip, s2_6D_degree4)
+    {
+        auto antideriv = [](double t)
+        {
+            const double t2 = t * t;
+            const double t3 = t2 * t;
+            return t + (t2 / 2.0) + (t3 / 3.0);
+        };
+        const double err = roundtrip_error<2, 6>(2,
+                                                 [&antideriv](const auto& cell)
+                                                 {
+                                                     return cell_avg_nd<6>(cell,
+                                                                           [&antideriv](std::size_t /*i*/)
+                                                                           {
+                                                                               return antideriv;
+                                                                           });
+                                                 });
+        EXPECT_LE(err, 5e-11) << "6D degree-4 polynomial roundtrip error too large: " << err;
+    }
+
+    // --- s=3: degree-6 separable polynomial (each axis: 1+t+t^2+t^3, antideriv: t+t^2/2+t^3/3+t^4/4) ---
+
+    TEST(ProjectionPredictionRoundtrip, s3_4D_degree6)
+    {
+        auto antideriv = [](double t)
+        {
+            const double t2 = t * t;
+            const double t3 = t2 * t;
+            const double t4 = t3 * t;
+            return t + (t2 / 2.0) + (t3 / 3.0) + (t4 / 4.0);
+        };
+        const double err = roundtrip_error<3, 4>(3,
+                                                 [&antideriv](const auto& cell)
+                                                 {
+                                                     return cell_avg_nd<4>(cell,
+                                                                           [&antideriv](std::size_t /*i*/)
+                                                                           {
+                                                                               return antideriv;
+                                                                           });
+                                                 });
+        EXPECT_LE(err, 2e-12) << "4D degree-6 polynomial roundtrip error too large: " << err;
+    }
+
+    TEST(ProjectionPredictionRoundtrip, s3_5D_degree6)
+    {
+        auto antideriv = [](double t)
+        {
+            const double t2 = t * t;
+            const double t3 = t2 * t;
+            const double t4 = t3 * t;
+            return t + (t2 / 2.0) + (t3 / 3.0) + (t4 / 4.0);
+        };
+        const double err = roundtrip_error<3, 5>(2,
+                                                 [&antideriv](const auto& cell)
+                                                 {
+                                                     return cell_avg_nd<5>(cell,
+                                                                           [&antideriv](std::size_t /*i*/)
+                                                                           {
+                                                                               return antideriv;
+                                                                           });
+                                                 });
+        EXPECT_LE(err, 1e-11) << "5D degree-6 polynomial roundtrip error too large: " << err;
+    }
+
+    TEST(ProjectionPredictionRoundtrip, s3_6D_degree6)
+    {
+        auto antideriv = [](double t)
+        {
+            const double t2 = t * t;
+            const double t3 = t2 * t;
+            const double t4 = t3 * t;
+            return t + (t2 / 2.0) + (t3 / 3.0) + (t4 / 4.0);
+        };
+        const double err = roundtrip_error<3, 6>(2,
+                                                 [&antideriv](const auto& cell)
+                                                 {
+                                                     return cell_avg_nd<6>(cell,
+                                                                           [&antideriv](std::size_t /*i*/)
+                                                                           {
+                                                                               return antideriv;
+                                                                           });
+                                                 });
+        EXPECT_LE(err, 5e-10) << "6D degree-6 polynomial roundtrip error too large: " << err;
+    }
+
+    //=========================================================================
+    // VectorField roundtrip tests
+    //
+    // Mirror of the scalar tests above using a 2-component VectorField.
+    // Component 0 carries 1*cell_avg, component 1 carries 2*cell_avg,
+    // so both components carry distinct non-trivial data and we verify
+    // all are recovered after projection + prediction.
+    //
+    // Tolerances and levels are identical to the corresponding scalar tests.
+    //=========================================================================
+
+    // --- s=0: constants ---
+
+    TEST(ProjectionPredictionRoundtrip, vec2_s0_1D_constant)
+    {
+        const double err = roundtrip_error_vector<2, 0, 1>(4,
+                                                           [](const auto& /*cell*/)
+                                                           {
+                                                               return 3.14;
+                                                           });
+        EXPECT_LE(err, 1e-14) << "vec2 1D constant roundtrip error too large: " << err;
+    }
+
+    TEST(ProjectionPredictionRoundtrip, vec2_s0_2D_constant)
+    {
+        const double err = roundtrip_error_vector<2, 0, 2>(4,
+                                                           [](const auto& /*cell*/)
+                                                           {
+                                                               return 3.14;
+                                                           });
+        EXPECT_LE(err, 1e-14) << "vec2 2D constant roundtrip error too large: " << err;
+    }
+
+    TEST(ProjectionPredictionRoundtrip, vec2_s0_3D_constant)
+    {
+        const double err = roundtrip_error_vector<2, 0, 3>(4,
+                                                           [](const auto& /*cell*/)
+                                                           {
+                                                               return 3.14;
+                                                           });
+        EXPECT_LE(err, 1e-14) << "vec2 3D constant roundtrip error too large: " << err;
+    }
+
+    TEST(ProjectionPredictionRoundtrip, vec2_s0_4D_constant)
+    {
+        const double err = roundtrip_error_vector<2, 0, 4>(3,
+                                                           [](const auto& /*cell*/)
+                                                           {
+                                                               return 3.14;
+                                                           });
+        EXPECT_LE(err, 1e-14) << "vec2 4D constant roundtrip error too large: " << err;
+    }
+
+    TEST(ProjectionPredictionRoundtrip, vec2_s0_5D_constant)
+    {
+        const double err = roundtrip_error_vector<2, 0, 5>(3,
+                                                           [](const auto& /*cell*/)
+                                                           {
+                                                               return 3.14;
+                                                           });
+        EXPECT_LE(err, 1e-14) << "vec2 5D constant roundtrip error too large: " << err;
+    }
+
+    TEST(ProjectionPredictionRoundtrip, vec2_s0_6D_constant)
+    {
+        const double err = roundtrip_error_vector<2, 0, 6>(3,
+                                                           [](const auto& /*cell*/)
+                                                           {
+                                                               return 3.14;
+                                                           });
+        EXPECT_LE(err, 1e-14) << "vec2 6D constant roundtrip error too large: " << err;
+    }
+
+    // --- s=1: degree-2 separable ---
+
+    TEST(ProjectionPredictionRoundtrip, vec2_s1_1D_degree2)
+    {
+        const double err = roundtrip_error_vector<2, 1, 1>(4,
+                                                           [](const auto& cell)
+                                                           {
+                                                               return cell_avg_1d(cell,
+                                                                                  [](double x)
+                                                                                  {
+                                                                                      return x + (x * x);
+                                                                                  });
+                                                           });
+        EXPECT_LE(err, 1e-13) << "vec2 1D degree-2 roundtrip error too large: " << err;
+    }
+
+    TEST(ProjectionPredictionRoundtrip, vec2_s1_2D_degree2)
+    {
+        const double err = roundtrip_error_vector<2, 1, 2>(4,
+                                                           [](const auto& cell)
+                                                           {
+                                                               return cell_avg_2d(
+                                                                   cell,
+                                                                   [](double x)
+                                                                   {
+                                                                       return x + (x * x / 2.0);
+                                                                   },
+                                                                   [](double y)
+                                                                   {
+                                                                       return y + (y * y / 2.0);
+                                                                   });
+                                                           });
+        EXPECT_LE(err, 1e-13) << "vec2 2D degree-2 roundtrip error too large: " << err;
+    }
+
+    TEST(ProjectionPredictionRoundtrip, vec2_s1_3D_degree2)
+    {
+        auto antideriv = [](double t)
+        {
+            return t + (t * t / 2.0);
+        };
+        const double err = roundtrip_error_vector<2, 1, 3>(4,
+                                                           [&antideriv](const auto& cell)
+                                                           {
+                                                               return cell_avg_nd<3>(cell,
+                                                                                     [&antideriv](std::size_t /*i*/)
+                                                                                     {
+                                                                                         return antideriv;
+                                                                                     });
+                                                           });
+        EXPECT_LE(err, 1e-13) << "vec2 3D degree-2 roundtrip error too large: " << err;
+    }
+
+    TEST(ProjectionPredictionRoundtrip, vec2_s1_4D_degree2)
+    {
+        auto antideriv = [](double t)
+        {
+            return t + (t * t / 2.0);
+        };
+        const double err = roundtrip_error_vector<2, 1, 4>(3,
+                                                           [&antideriv](const auto& cell)
+                                                           {
+                                                               return cell_avg_nd<4>(cell,
+                                                                                     [&antideriv](std::size_t /*i*/)
+                                                                                     {
+                                                                                         return antideriv;
+                                                                                     });
+                                                           });
+        EXPECT_LE(err, 1e-13) << "vec2 4D degree-2 roundtrip error too large: " << err;
+    }
+
+    TEST(ProjectionPredictionRoundtrip, vec2_s1_5D_degree2)
+    {
+        auto antideriv = [](double t)
+        {
+            return t + (t * t / 2.0);
+        };
+        const double err = roundtrip_error_vector<2, 1, 5>(3,
+                                                           [&antideriv](const auto& cell)
+                                                           {
+                                                               return cell_avg_nd<5>(cell,
+                                                                                     [&antideriv](std::size_t /*i*/)
+                                                                                     {
+                                                                                         return antideriv;
+                                                                                     });
+                                                           });
+        EXPECT_LE(err, 1e-13) << "vec2 5D degree-2 roundtrip error too large: " << err;
+    }
+
+    TEST(ProjectionPredictionRoundtrip, vec2_s1_6D_degree2)
+    {
+        auto antideriv = [](double t)
+        {
+            return t + (t * t / 2.0);
+        };
+        const double err = roundtrip_error_vector<2, 1, 6>(3,
+                                                           [&antideriv](const auto& cell)
+                                                           {
+                                                               return cell_avg_nd<6>(cell,
+                                                                                     [&antideriv](std::size_t /*i*/)
+                                                                                     {
+                                                                                         return antideriv;
+                                                                                     });
+                                                           });
+        EXPECT_LE(err, 1e-13) << "vec2 6D degree-2 roundtrip error too large: " << err;
+    }
+
+    // --- s=2: degree-4 separable ---
+
+    TEST(ProjectionPredictionRoundtrip, vec2_s2_1D_degree4)
+    {
+        const double err = roundtrip_error_vector<2, 2, 1>(4,
+                                                           [](const auto& cell)
+                                                           {
+                                                               return cell_avg_1d(cell,
+                                                                                  [](double x)
+                                                                                  {
+                                                                                      const double x2 = x * x;
+                                                                                      const double x3 = x2 * x;
+                                                                                      const double x4 = x3 * x;
+                                                                                      const double x5 = x4 * x;
+                                                                                      return x + (x2 / 2.0) + (x3 / 3.0) + (x4 / 4.0)
+                                                                                           + (x5 / 5.0);
+                                                                                  });
+                                                           });
+        EXPECT_LE(err, 1e-13) << "vec2 1D degree-4 roundtrip error too large: " << err;
+    }
+
+    TEST(ProjectionPredictionRoundtrip, vec2_s2_2D_degree4)
+    {
+        const double err = roundtrip_error_vector<2, 2, 2>(4,
+                                                           [](const auto& cell)
+                                                           {
+                                                               return cell_avg_2d(
+                                                                   cell,
+                                                                   [](double x)
+                                                                   {
+                                                                       const double x2 = x * x;
+                                                                       const double x3 = x2 * x;
+                                                                       return x + (x2 / 2.0) + (x3 / 3.0);
+                                                                   },
+                                                                   [](double y)
+                                                                   {
+                                                                       const double y2 = y * y;
+                                                                       const double y3 = y2 * y;
+                                                                       return y + (y2 / 2.0) + (y3 / 3.0);
+                                                                   });
+                                                           });
+        EXPECT_LE(err, 1e-13) << "vec2 2D degree-4 roundtrip error too large: " << err;
+    }
+
+    TEST(ProjectionPredictionRoundtrip, vec2_s2_3D_degree4)
+    {
+        auto antideriv = [](double t)
+        {
+            const double t2 = t * t;
+            const double t3 = t2 * t;
+            return t + (t2 / 2.0) + (t3 / 3.0);
+        };
+        const double err = roundtrip_error_vector<2, 2, 3>(4,
+                                                           [&antideriv](const auto& cell)
+                                                           {
+                                                               return cell_avg_nd<3>(cell,
+                                                                                     [&antideriv](std::size_t /*i*/)
+                                                                                     {
+                                                                                         return antideriv;
+                                                                                     });
+                                                           });
+        EXPECT_LE(err, 1e-13) << "vec2 3D degree-4 roundtrip error too large: " << err;
+    }
+
+    TEST(ProjectionPredictionRoundtrip, vec2_s2_4D_degree4)
+    {
+        auto antideriv = [](double t)
+        {
+            const double t2 = t * t;
+            const double t3 = t2 * t;
+            return t + (t2 / 2.0) + (t3 / 3.0);
+        };
+        const double err = roundtrip_error_vector<2, 2, 4>(3,
+                                                           [&antideriv](const auto& cell)
+                                                           {
+                                                               return cell_avg_nd<4>(cell,
+                                                                                     [&antideriv](std::size_t /*i*/)
+                                                                                     {
+                                                                                         return antideriv;
+                                                                                     });
+                                                           });
+        EXPECT_LE(err, 5e-13) << "vec2 4D degree-4 roundtrip error too large: " << err;
+    }
+
+    TEST(ProjectionPredictionRoundtrip, vec2_s2_5D_degree4)
+    {
+        auto antideriv = [](double t)
+        {
+            const double t2 = t * t;
+            const double t3 = t2 * t;
+            return t + (t2 / 2.0) + (t3 / 3.0);
+        };
+        const double err = roundtrip_error_vector<2, 2, 5>(2,
+                                                           [&antideriv](const auto& cell)
+                                                           {
+                                                               return cell_avg_nd<5>(cell,
+                                                                                     [&antideriv](std::size_t /*i*/)
+                                                                                     {
+                                                                                         return antideriv;
+                                                                                     });
+                                                           });
+        EXPECT_LE(err, 5e-12) << "vec2 5D degree-4 roundtrip error too large: " << err;
+    }
+
+    TEST(ProjectionPredictionRoundtrip, vec2_s2_6D_degree4)
+    {
+        auto antideriv = [](double t)
+        {
+            const double t2 = t * t;
+            const double t3 = t2 * t;
+            return t + (t2 / 2.0) + (t3 / 3.0);
+        };
+        const double err = roundtrip_error_vector<2, 2, 6>(2,
+                                                           [&antideriv](const auto& cell)
+                                                           {
+                                                               return cell_avg_nd<6>(cell,
+                                                                                     [&antideriv](std::size_t /*i*/)
+                                                                                     {
+                                                                                         return antideriv;
+                                                                                     });
+                                                           });
+        EXPECT_LE(err, 5e-11) << "vec2 6D degree-4 roundtrip error too large: " << err;
+    }
+
+    // --- s=3: degree-6 separable ---
+
+    TEST(ProjectionPredictionRoundtrip, vec2_s3_1D_degree6)
+    {
+        const double err = roundtrip_error_vector<2, 3, 1>(5,
+                                                           [](const auto& cell)
+                                                           {
+                                                               return cell_avg_1d(cell,
+                                                                                  [](double x)
+                                                                                  {
+                                                                                      const double x2 = x * x;
+                                                                                      const double x3 = x2 * x;
+                                                                                      const double x4 = x3 * x;
+                                                                                      const double x5 = x4 * x;
+                                                                                      const double x6 = x5 * x;
+                                                                                      const double x7 = x6 * x;
+                                                                                      return x + (x2 / 2.0) + (x3 / 3.0) + (x4 / 4.0)
+                                                                                           + (x5 / 5.0) + (x6 / 6.0) + (x7 / 7.0);
+                                                                                  });
+                                                           });
+        EXPECT_LE(err, 1e-13) << "vec2 1D degree-6 roundtrip error too large: " << err;
+    }
+
+    TEST(ProjectionPredictionRoundtrip, vec2_s3_2D_degree6)
+    {
+        const double err = roundtrip_error_vector<2, 3, 2>(5,
+                                                           [](const auto& cell)
+                                                           {
+                                                               return cell_avg_2d(
+                                                                   cell,
+                                                                   [](double x)
+                                                                   {
+                                                                       const double x2 = x * x;
+                                                                       const double x3 = x2 * x;
+                                                                       const double x4 = x3 * x;
+                                                                       return x + (x2 / 2.0) + (x3 / 3.0) + (x4 / 4.0);
+                                                                   },
+                                                                   [](double y)
+                                                                   {
+                                                                       const double y2 = y * y;
+                                                                       const double y3 = y2 * y;
+                                                                       const double y4 = y3 * y;
+                                                                       return y + (y2 / 2.0) + (y3 / 3.0) + (y4 / 4.0);
+                                                                   });
+                                                           });
+        EXPECT_LE(err, 5e-13) << "vec2 2D degree-6 roundtrip error too large: " << err;
+    }
+
+    TEST(ProjectionPredictionRoundtrip, vec2_s3_3D_degree6)
+    {
+        auto antideriv = [](double t)
+        {
+            const double t2 = t * t;
+            const double t3 = t2 * t;
+            const double t4 = t3 * t;
+            return t + (t2 / 2.0) + (t3 / 3.0) + (t4 / 4.0);
+        };
+        const double err = roundtrip_error_vector<2, 3, 3>(5,
+                                                           [&antideriv](const auto& cell)
+                                                           {
+                                                               return cell_avg_nd<3>(cell,
+                                                                                     [&antideriv](std::size_t /*i*/)
+                                                                                     {
+                                                                                         return antideriv;
+                                                                                     });
+                                                           });
+        EXPECT_LE(err, 2e-12) << "vec2 3D degree-6 roundtrip error too large: " << err;
+    }
+
+    TEST(ProjectionPredictionRoundtrip, vec2_s3_4D_degree6)
+    {
+        auto antideriv = [](double t)
+        {
+            const double t2 = t * t;
+            const double t3 = t2 * t;
+            const double t4 = t3 * t;
+            return t + (t2 / 2.0) + (t3 / 3.0) + (t4 / 4.0);
+        };
+        const double err = roundtrip_error_vector<2, 3, 4>(3,
+                                                           [&antideriv](const auto& cell)
+                                                           {
+                                                               return cell_avg_nd<4>(cell,
+                                                                                     [&antideriv](std::size_t /*i*/)
+                                                                                     {
+                                                                                         return antideriv;
+                                                                                     });
+                                                           });
+        EXPECT_LE(err, 2e-12) << "vec2 4D degree-6 roundtrip error too large: " << err;
+    }
+
+    TEST(ProjectionPredictionRoundtrip, vec2_s3_5D_degree6)
+    {
+        auto antideriv = [](double t)
+        {
+            const double t2 = t * t;
+            const double t3 = t2 * t;
+            const double t4 = t3 * t;
+            return t + (t2 / 2.0) + (t3 / 3.0) + (t4 / 4.0);
+        };
+        const double err = roundtrip_error_vector<2, 3, 5>(2,
+                                                           [&antideriv](const auto& cell)
+                                                           {
+                                                               return cell_avg_nd<5>(cell,
+                                                                                     [&antideriv](std::size_t /*i*/)
+                                                                                     {
+                                                                                         return antideriv;
+                                                                                     });
+                                                           });
+        EXPECT_LE(err, 1e-11) << "vec2 5D degree-6 roundtrip error too large: " << err;
+    }
+
+    TEST(ProjectionPredictionRoundtrip, vec2_s3_6D_degree6)
+    {
+        auto antideriv = [](double t)
+        {
+            const double t2 = t * t;
+            const double t3 = t2 * t;
+            const double t4 = t3 * t;
+            return t + (t2 / 2.0) + (t3 / 3.0) + (t4 / 4.0);
+        };
+        const double err = roundtrip_error_vector<2, 3, 6>(2,
+                                                           [&antideriv](const auto& cell)
+                                                           {
+                                                               return cell_avg_nd<6>(cell,
+                                                                                     [&antideriv](std::size_t /*i*/)
+                                                                                     {
+                                                                                         return antideriv;
+                                                                                     });
+                                                           });
+        EXPECT_LE(err, 5e-10) << "vec2 6D degree-6 roundtrip error too large: " << err;
+    }
+
+} // namespace samurai


### PR DESCRIPTION
## Description
This PR extends samurai’s numeric operators to support N-dimensional (generic dim) projection and prediction by introducing reusable utilities for coordinate-to-linear-index computation and compile-time index range generation.

**Changes:**

- Add CellCoord plus memory_offset(s) helpers to compute flat mesh indices from (level, coords...) descriptors.
- Generalize projection and prediction operators to work for arbitrary dim using static_nested_loop and contiguous-memory assumptions in the i direction.
- Add a consteval helper (make_index_ranges) to generate compile-time index combinations.

## How has this been tested?
see `test_projection_prediction_roundtrip.cpp` where prediction and projection operators are tested until 6D.

## Code of Conduct
By submitting this PR, you agree to follow our [Code of Conduct](https://github.com/hpc-maths/samurai/blob/master/docs/CODE_OF_CONDUCT.md)
- [x] I agree to follow this project's Code of Conduct
