### PR TITLE
perf: improve tag computation

### DIFF
--- a/include/samurai/mr/adapt.hpp
+++ b/include/samurai/mr/adapt.hpp
@@ -321,7 +321,7 @@ namespace samurai
         }
         times::timers.stop("detail computation");
 
-        update_ghost_subdomains(m_detail);
+        // update_ghost_subdomains(m_detail);
 
         times::timers.start("tag cells");
         for (std::size_t level = min_level; level <= max_level - ite; ++level)

--- a/include/samurai/mr/adapt.hpp
+++ b/include/samurai/mr/adapt.hpp
@@ -353,8 +353,8 @@ namespace samurai
 
             // These two lines seems unnecessary. It's needed to be confirm and
             // we will remove them definitely if all the applications work without them.
-            // update_tag_periodic(level, m_tag);
-            // update_tag_subdomains(level, m_tag);
+            update_tag_periodic(level, m_tag);
+            update_tag_subdomains(level, m_tag);
 
             keep_subset.apply_op(maximum(m_tag));
         }

--- a/include/samurai/mr/adapt.hpp
+++ b/include/samurai/mr/adapt.hpp
@@ -242,7 +242,7 @@ namespace samurai
     }
 
     template <class Mesh>
-    void keep_boundary_refined(const Mesh& mesh, ScalarField<Mesh, std::uint8_t>& tag, const DirectionVector<Mesh::dim>& direction)
+    void keep_boundary_refined(const Mesh& mesh, auto& tag, const DirectionVector<Mesh::dim>& direction)
     {
         // Since the adaptation process starts at max_level, we just need to flag to `keep` the boundary cells at max_level only.
         // There will never be boundary cells at lower levels.
@@ -256,7 +256,7 @@ namespace samurai
     }
 
     template <class Mesh>
-    void keep_boundary_refined(const Mesh& mesh, ScalarField<Mesh, std::uint8_t>& tag)
+    void keep_boundary_refined(const Mesh& mesh, auto& tag)
     {
         constexpr std::size_t dim = Mesh::dim;
 
@@ -339,7 +339,7 @@ namespace samurai
             auto subset_1 = intersection(mesh[mesh_id_t::cells][level], mesh[mesh_id_t::all_cells][level - 1]).on(level - 1);
 
             subset_1.apply_op(mr_criteria(m_detail, m_tag, eps_l, regularity_to_use));
-            update_tag_subdomains(level, m_tag);
+            update_tag_subdomains(level, m_tag, true);
         }
         times::timers.stop("tag cells");
 
@@ -351,15 +351,32 @@ namespace samurai
         times::timers.stop("refine boundary");
 
         times::timers.start("tag computation");
-        for (std::size_t level = max_level; level > 0; --level)
-        {
-            auto keep_subset = intersection(mesh[mesh_id_t::cells][level], mesh[mesh_id_t::all_cells][level - 1]).on(level - 1);
+        // for (std::size_t level = min_level; level <= max_level - ite; ++level)
+        // {
+        //     auto subset_2 = intersection(mesh[mesh_id_t::cells][level], mesh[mesh_id_t::cells][level]);
 
-            update_tag_periodic(level, m_tag);
-            update_tag_subdomains(level, m_tag);
+        //     subset_2.apply_op(keep_around_refine(m_tag));
 
-            keep_subset.apply_op(maximum(m_tag));
-        }
+        //     if constexpr (enlarge_v)
+        //     {
+        //         auto subset_3 = intersection(mesh[mesh_id_t::cells_and_ghosts][level], mesh[mesh_id_t::cells_and_ghosts][level]);
+        //         subset_2.apply_op(enlarge(m_tag));
+        //         subset_3.apply_op(tag_to_keep<0>(m_tag, CellFlag::enlarge));
+        //     }
+
+        //     update_tag_periodic(level, m_tag);
+        //     update_tag_subdomains(level, m_tag);
+        // }
+
+        // for (std::size_t level = max_level; level > 0; --level)
+        // {
+        //     auto keep_subset = intersection(mesh[mesh_id_t::cells][level], mesh[mesh_id_t::all_cells][level - 1]).on(level - 1);
+
+        //     update_tag_periodic(level, m_tag);
+        //     update_tag_subdomains(level, m_tag);
+
+        //     keep_subset.apply_op(maximum(m_tag));
+        // }
         times::timers.stop("tag computation");
 
         times::timers.start("mesh update");

--- a/include/samurai/mr/adapt.hpp
+++ b/include/samurai/mr/adapt.hpp
@@ -288,11 +288,6 @@ namespace samurai
                           m_tag[cell] = static_cast<std::uint8_t>(CellFlag::keep);
                       });
 
-        for (std::size_t level = min_level; level <= max_level; ++level)
-        {
-            update_tag_subdomains(level, m_tag, true);
-        }
-
         update_ghost_mr(m_fields);
 
         //--------------------//
@@ -326,7 +321,7 @@ namespace samurai
         }
         times::timers.stop("detail computation");
 
-        update_ghost_subdomains(m_detail);
+        // update_ghost_subdomains(m_detail);
 
         times::timers.start("tag cells");
         for (std::size_t level = min_level; level <= max_level - ite; ++level)
@@ -339,6 +334,7 @@ namespace samurai
             auto subset_1 = intersection(mesh[mesh_id_t::cells][level], mesh[mesh_id_t::all_cells][level - 1]).on(level - 1);
 
             subset_1.apply_op(mr_criteria(m_detail, m_tag, eps_l, regularity_to_use));
+            // TODO: make this update outside the loop with only one communication instead of one per level
             update_tag_subdomains(level, m_tag, true);
         }
         times::timers.stop("tag cells");
@@ -350,17 +346,19 @@ namespace samurai
         }
         times::timers.stop("refine boundary");
 
-        times::timers.start("tag finalization");
-        for (std::size_t level = max_level; level > 0; --level)
-        {
-            auto keep_subset = intersection(mesh[mesh_id_t::cells][level], mesh[mesh_id_t::all_cells][level - 1]).on(level - 1);
+        // times::timers.start("tag finalization");
+        // for (std::size_t level = max_level; level > 0; --level)
+        // {
+        //     auto keep_subset = intersection(mesh[mesh_id_t::cells][level], mesh[mesh_id_t::all_cells][level - 1]).on(level - 1);
 
-            update_tag_periodic(level, m_tag);
-            update_tag_subdomains(level, m_tag);
+        //     // These two lines seems unnecessary. It's needed to be confirm and
+        //     // we will remove them definitely if all the applications work without them.
+        //     // update_tag_periodic(level, m_tag);
+        //     // update_tag_subdomains(level, m_tag);
 
-            keep_subset.apply_op(maximum(m_tag));
-        }
-        times::timers.stop("tag finalization");
+        //     // keep_subset.apply_op(maximum(m_tag));
+        // }
+        // times::timers.stop("tag finalization");
 
         times::timers.start("mesh update");
         using ca_type = typename mesh_t::ca_type;

--- a/include/samurai/mr/adapt.hpp
+++ b/include/samurai/mr/adapt.hpp
@@ -321,8 +321,6 @@ namespace samurai
         }
         times::timers.stop("detail computation");
 
-        // update_ghost_subdomains(m_detail);
-
         times::timers.start("tag cells");
         for (std::size_t level = min_level; level <= max_level - ite; ++level)
         {
@@ -351,8 +349,6 @@ namespace samurai
         {
             auto keep_subset = intersection(mesh[mesh_id_t::cells][level], mesh[mesh_id_t::all_cells][level - 1]).on(level - 1);
 
-            // These two lines seems unnecessary. It's needed to be confirm and
-            // we will remove them definitely if all the applications work without them.
             update_tag_periodic(level, m_tag);
             update_tag_subdomains(level, m_tag);
 

--- a/include/samurai/mr/adapt.hpp
+++ b/include/samurai/mr/adapt.hpp
@@ -375,15 +375,15 @@ namespace samurai
         //     update_tag_subdomains(level, m_tag);
         // }
 
-        // for (std::size_t level = max_level; level > 0; --level)
-        // {
-        //     auto keep_subset = intersection(mesh[mesh_id_t::cells][level], mesh[mesh_id_t::all_cells][level - 1]).on(level - 1);
+        for (std::size_t level = max_level; level > 0; --level)
+        {
+            auto keep_subset = intersection(mesh[mesh_id_t::cells][level], mesh[mesh_id_t::all_cells][level - 1]).on(level - 1);
 
-        //     update_tag_periodic(level, m_tag);
-        //     update_tag_subdomains(level, m_tag);
+            update_tag_periodic(level, m_tag);
+            update_tag_subdomains(level, m_tag);
 
-        //     keep_subset.apply_op(maximum(m_tag));
-        // }
+            keep_subset.apply_op(maximum(m_tag));
+        }
         times::timers.stop("tag computation");
 
         times::timers.start("mesh update");

--- a/include/samurai/mr/adapt.hpp
+++ b/include/samurai/mr/adapt.hpp
@@ -321,7 +321,7 @@ namespace samurai
         }
         times::timers.stop("detail computation");
 
-        // update_ghost_subdomains(m_detail);
+        update_ghost_subdomains(m_detail);
 
         times::timers.start("tag cells");
         for (std::size_t level = min_level; level <= max_level - ite; ++level)

--- a/include/samurai/mr/adapt.hpp
+++ b/include/samurai/mr/adapt.hpp
@@ -368,15 +368,15 @@ namespace samurai
         //     update_tag_subdomains(level, m_tag);
         // }
 
-        // for (std::size_t level = max_level; level > 0; --level)
-        // {
-        //     auto keep_subset = intersection(mesh[mesh_id_t::cells][level], mesh[mesh_id_t::all_cells][level - 1]).on(level - 1);
+        for (std::size_t level = max_level; level > 0; --level)
+        {
+            auto keep_subset = intersection(mesh[mesh_id_t::cells][level], mesh[mesh_id_t::all_cells][level - 1]).on(level - 1);
 
-        //     update_tag_periodic(level, m_tag);
-        //     update_tag_subdomains(level, m_tag);
+            update_tag_periodic(level, m_tag);
+            update_tag_subdomains(level, m_tag);
 
-        //     keep_subset.apply_op(maximum(m_tag));
-        // }
+            keep_subset.apply_op(maximum(m_tag));
+        }
         times::timers.stop("tag computation");
 
         times::timers.start("mesh update");

--- a/include/samurai/mr/adapt.hpp
+++ b/include/samurai/mr/adapt.hpp
@@ -346,19 +346,19 @@ namespace samurai
         }
         times::timers.stop("refine boundary");
 
-        // times::timers.start("tag finalization");
-        // for (std::size_t level = max_level; level > 0; --level)
-        // {
-        //     auto keep_subset = intersection(mesh[mesh_id_t::cells][level], mesh[mesh_id_t::all_cells][level - 1]).on(level - 1);
+        times::timers.start("tag finalization");
+        for (std::size_t level = max_level; level > 0; --level)
+        {
+            auto keep_subset = intersection(mesh[mesh_id_t::cells][level], mesh[mesh_id_t::all_cells][level - 1]).on(level - 1);
 
-        //     // These two lines seems unnecessary. It's needed to be confirm and
-        //     // we will remove them definitely if all the applications work without them.
-        //     // update_tag_periodic(level, m_tag);
-        //     // update_tag_subdomains(level, m_tag);
+            // These two lines seems unnecessary. It's needed to be confirm and
+            // we will remove them definitely if all the applications work without them.
+            // update_tag_periodic(level, m_tag);
+            // update_tag_subdomains(level, m_tag);
 
-        //     // keep_subset.apply_op(maximum(m_tag));
-        // }
-        // times::timers.stop("tag finalization");
+            keep_subset.apply_op(maximum(m_tag));
+        }
+        times::timers.stop("tag finalization");
 
         times::timers.start("mesh update");
         using ca_type = typename mesh_t::ca_type;

--- a/include/samurai/mr/adapt.hpp
+++ b/include/samurai/mr/adapt.hpp
@@ -111,7 +111,7 @@ namespace samurai
         using mesh_t            = typename inner_fields_type::mesh_t;
         using mesh_id_t         = typename mesh_t::mesh_id_t;
         using detail_t          = typename inner_fields_type::detail_t;
-        using tag_t             = ScalarField<mesh_t, int>;
+        using tag_t             = ScalarField<mesh_t, std::uint8_t>;
 
         static constexpr std::size_t dim = mesh_t::dim;
         static constexpr bool enlarge_v  = enlarge_;
@@ -242,7 +242,7 @@ namespace samurai
     }
 
     template <class Mesh>
-    void keep_boundary_refined(const Mesh& mesh, ScalarField<Mesh, int>& tag, const DirectionVector<Mesh::dim>& direction)
+    void keep_boundary_refined(const Mesh& mesh, ScalarField<Mesh, std::uint8_t>& tag, const DirectionVector<Mesh::dim>& direction)
     {
         // Since the adaptation process starts at max_level, we just need to flag to `keep` the boundary cells at max_level only.
         // There will never be boundary cells at lower levels.
@@ -251,12 +251,12 @@ namespace samurai
                       bdry,
                       [&](auto& cell)
                       {
-                          tag[cell] = static_cast<int>(CellFlag::keep);
+                          tag[cell] = static_cast<std::uint8_t>(CellFlag::keep);
                       });
     }
 
     template <class Mesh>
-    void keep_boundary_refined(const Mesh& mesh, ScalarField<Mesh, int>& tag)
+    void keep_boundary_refined(const Mesh& mesh, ScalarField<Mesh, std::uint8_t>& tag)
     {
         constexpr std::size_t dim = Mesh::dim;
 
@@ -285,7 +285,7 @@ namespace samurai
         for_each_cell(mesh[mesh_id_t::cells],
                       [&](auto& cell)
                       {
-                          m_tag[cell] = static_cast<int>(CellFlag::keep);
+                          m_tag[cell] = static_cast<std::uint8_t>(CellFlag::keep);
                       });
 
         for (std::size_t level = min_level; level <= max_level; ++level)
@@ -328,7 +328,7 @@ namespace samurai
 
         update_ghost_subdomains(m_detail);
 
-        times::timers.start("tag computation");
+        times::timers.start("tag cells");
         for (std::size_t level = min_level; level <= max_level - ite; ++level)
         {
             std::size_t exponent = dim * (max_level - level);
@@ -338,45 +338,52 @@ namespace samurai
 
             auto subset_1 = intersection(mesh[mesh_id_t::cells][level], mesh[mesh_id_t::all_cells][level - 1]).on(level - 1);
 
-            subset_1.apply_op(to_coarsen_mr(m_detail, m_tag, eps_l, min_level),
-                              to_refine_mr(m_detail,
-                                           m_tag,
-                                           (pow(2.0, regularity_to_use)) * eps_l,
-                                           max_level)); // Refinement according to Harten
+            subset_1.apply_op(mr_criteria(m_detail, m_tag, eps_l, regularity_to_use));
+
+            // subset_1.apply_op(to_coarsen_mr(m_detail, m_tag, eps_l, min_level),
+            //                   to_refine_mr(m_detail,
+            //                                m_tag,
+            //                                (pow(2.0, regularity_to_use)) * eps_l,
+            //                                max_level)); // Refinement according to Harten
             update_tag_subdomains(level, m_tag, true);
         }
+        times::timers.stop("tag cells");
 
+        times::timers.start("refine boundary");
         if (args::refine_boundary) // cppcheck-suppress knownConditionTrueFalse
         {
             keep_boundary_refined(mesh, m_tag);
         }
+        times::timers.stop("refine boundary");
 
-        for (std::size_t level = min_level; level <= max_level - ite; ++level)
-        {
-            auto subset_2 = intersection(mesh[mesh_id_t::cells][level], mesh[mesh_id_t::cells][level]);
+        times::timers.start("tag computation");
 
-            subset_2.apply_op(keep_around_refine(m_tag));
+        // for (std::size_t level = min_level; level <= max_level - ite; ++level)
+        // {
+        //     auto subset_2 = intersection(mesh[mesh_id_t::cells][level], mesh[mesh_id_t::cells][level]);
 
-            if constexpr (enlarge_v)
-            {
-                auto subset_3 = intersection(mesh[mesh_id_t::cells_and_ghosts][level], mesh[mesh_id_t::cells_and_ghosts][level]);
-                subset_2.apply_op(enlarge(m_tag));
-                subset_3.apply_op(tag_to_keep<0>(m_tag, CellFlag::enlarge));
-            }
+        //     subset_2.apply_op(keep_around_refine(m_tag));
 
-            update_tag_periodic(level, m_tag);
-            update_tag_subdomains(level, m_tag);
-        }
+        //     if constexpr (enlarge_v)
+        //     {
+        //         auto subset_3 = intersection(mesh[mesh_id_t::cells_and_ghosts][level], mesh[mesh_id_t::cells_and_ghosts][level]);
+        //         subset_2.apply_op(enlarge(m_tag));
+        //         subset_3.apply_op(tag_to_keep<0>(m_tag, CellFlag::enlarge));
+        //     }
 
-        for (std::size_t level = max_level; level > 0; --level)
-        {
-            auto keep_subset = intersection(mesh[mesh_id_t::cells][level], mesh[mesh_id_t::all_cells][level - 1]).on(level - 1);
+        //     update_tag_periodic(level, m_tag);
+        //     update_tag_subdomains(level, m_tag);
+        // }
 
-            update_tag_periodic(level, m_tag);
-            update_tag_subdomains(level, m_tag);
+        // for (std::size_t level = max_level; level > 0; --level)
+        // {
+        //     auto keep_subset = intersection(mesh[mesh_id_t::cells][level], mesh[mesh_id_t::all_cells][level - 1]).on(level - 1);
 
-            keep_subset.apply_op(maximum(m_tag));
-        }
+        //     update_tag_periodic(level, m_tag);
+        //     update_tag_subdomains(level, m_tag);
+
+        //     keep_subset.apply_op(maximum(m_tag));
+        // }
         times::timers.stop("tag computation");
 
         times::timers.start("mesh update");

--- a/include/samurai/mr/adapt.hpp
+++ b/include/samurai/mr/adapt.hpp
@@ -339,6 +339,7 @@ namespace samurai
             auto subset_1 = intersection(mesh[mesh_id_t::cells][level], mesh[mesh_id_t::all_cells][level - 1]).on(level - 1);
 
             subset_1.apply_op(mr_criteria(m_detail, m_tag, eps_l, regularity_to_use));
+            update_tag_subdomains(level, m_tag);
         }
         times::timers.stop("tag cells");
 

--- a/include/samurai/mr/adapt.hpp
+++ b/include/samurai/mr/adapt.hpp
@@ -339,13 +339,6 @@ namespace samurai
             auto subset_1 = intersection(mesh[mesh_id_t::cells][level], mesh[mesh_id_t::all_cells][level - 1]).on(level - 1);
 
             subset_1.apply_op(mr_criteria(m_detail, m_tag, eps_l, regularity_to_use));
-
-            // subset_1.apply_op(to_coarsen_mr(m_detail, m_tag, eps_l, min_level),
-            //                   to_refine_mr(m_detail,
-            //                                m_tag,
-            //                                (pow(2.0, regularity_to_use)) * eps_l,
-            //                                max_level)); // Refinement according to Harten
-            update_tag_subdomains(level, m_tag, true);
         }
         times::timers.stop("tag cells");
 
@@ -357,24 +350,6 @@ namespace samurai
         times::timers.stop("refine boundary");
 
         times::timers.start("tag computation");
-
-        // for (std::size_t level = min_level; level <= max_level - ite; ++level)
-        // {
-        //     auto subset_2 = intersection(mesh[mesh_id_t::cells][level], mesh[mesh_id_t::cells][level]);
-
-        //     subset_2.apply_op(keep_around_refine(m_tag));
-
-        //     if constexpr (enlarge_v)
-        //     {
-        //         auto subset_3 = intersection(mesh[mesh_id_t::cells_and_ghosts][level], mesh[mesh_id_t::cells_and_ghosts][level]);
-        //         subset_2.apply_op(enlarge(m_tag));
-        //         subset_3.apply_op(tag_to_keep<0>(m_tag, CellFlag::enlarge));
-        //     }
-
-        //     update_tag_periodic(level, m_tag);
-        //     update_tag_subdomains(level, m_tag);
-        // }
-
         for (std::size_t level = max_level; level > 0; --level)
         {
             auto keep_subset = intersection(mesh[mesh_id_t::cells][level], mesh[mesh_id_t::all_cells][level - 1]).on(level - 1);

--- a/include/samurai/mr/adapt.hpp
+++ b/include/samurai/mr/adapt.hpp
@@ -350,24 +350,7 @@ namespace samurai
         }
         times::timers.stop("refine boundary");
 
-        times::timers.start("tag computation");
-        // for (std::size_t level = min_level; level <= max_level - ite; ++level)
-        // {
-        //     auto subset_2 = intersection(mesh[mesh_id_t::cells][level], mesh[mesh_id_t::cells][level]);
-
-        //     subset_2.apply_op(keep_around_refine(m_tag));
-
-        //     if constexpr (enlarge_v)
-        //     {
-        //         auto subset_3 = intersection(mesh[mesh_id_t::cells_and_ghosts][level], mesh[mesh_id_t::cells_and_ghosts][level]);
-        //         subset_2.apply_op(enlarge(m_tag));
-        //         subset_3.apply_op(tag_to_keep<0>(m_tag, CellFlag::enlarge));
-        //     }
-
-        //     update_tag_periodic(level, m_tag);
-        //     update_tag_subdomains(level, m_tag);
-        // }
-
+        times::timers.start("tag finalization");
         for (std::size_t level = max_level; level > 0; --level)
         {
             auto keep_subset = intersection(mesh[mesh_id_t::cells][level], mesh[mesh_id_t::all_cells][level - 1]).on(level - 1);
@@ -377,7 +360,7 @@ namespace samurai
 
             keep_subset.apply_op(maximum(m_tag));
         }
-        times::timers.stop("tag computation");
+        times::timers.stop("tag finalization");
 
         times::timers.start("mesh update");
         using ca_type = typename mesh_t::ca_type;

--- a/include/samurai/mr/criteria.hpp
+++ b/include/samurai/mr/criteria.hpp
@@ -9,319 +9,6 @@
 
 namespace samurai
 {
-
-    template <std::size_t dim, class TInterval>
-    class to_coarsen_mr_op : public field_operator_base<dim, TInterval>
-    {
-      public:
-
-        INIT_OPERATOR(to_coarsen_mr_op)
-
-        template <class T1, class T2>
-        // SAMURAI_INLINE void operator()(Dim<1>, const T1& detail, const T3&
-        // max_detail, T2 &tag, double eps, std::size_t min_lev) const
-        SAMURAI_INLINE void operator()(Dim<1>, const T1& detail, T2& tag, double eps, std::size_t min_lev) const
-        {
-            using namespace math;
-            std::size_t fine_level = level + 1;
-
-            if (fine_level > min_lev)
-            {
-                // auto maxd = xt::view(max_detail, level);
-
-                if constexpr (T1::is_scalar)
-                {
-                    // auto mask = abs(detail(level, 2*i))/maxd < eps;
-                    auto mask = abs(detail(fine_level, 2 * i)) < eps; // NO normalization
-
-                    apply_on_masked(mask,
-                                    [&](auto imask)
-                                    {
-                                        tag(fine_level, 2 * i)(imask)     = static_cast<int>(CellFlag::coarsen);
-                                        tag(fine_level, 2 * i + 1)(imask) = static_cast<int>(CellFlag::coarsen);
-                                    });
-                }
-                else
-                {
-                    constexpr auto n_comp = T1::n_comp;
-
-                    // auto mask = xt::sum((abs(detail(level, 2*i))/maxd <
-                    // eps), {1}) > (n_comp-1);
-                    constexpr std::size_t axis = detail::static_size_first_v<n_comp, detail::is_soa_v<T1>, T1::is_scalar, T1::static_layout>
-                                                   ? 0
-                                                   : 1;
-
-                    auto mask = sum<axis>((abs(detail(fine_level, 2 * i)) < eps)) > (n_comp - 1); // No normalization
-
-                    apply_on_masked(mask,
-                                    [&](auto imask)
-                                    {
-                                        tag(fine_level, 2 * i)(imask)     = static_cast<int>(CellFlag::coarsen);
-                                        tag(fine_level, 2 * i + 1)(imask) = static_cast<int>(CellFlag::coarsen);
-                                    });
-                }
-            }
-        }
-
-        template <class T1, class T2>
-        SAMURAI_INLINE void operator()(Dim<2>, const T1& detail, T2& tag, double eps, std::size_t min_lev) const
-        {
-            using namespace math;
-
-            std::size_t fine_level = level + 1;
-
-            if (fine_level > min_lev)
-            {
-                if constexpr (T1::is_scalar)
-                {
-                    auto mask = (abs(detail(fine_level, 2 * i, 2 * j)) < eps) && (abs(detail(fine_level, 2 * i + 1, 2 * j)) < eps)
-                             && (abs(detail(fine_level, 2 * i, 2 * j + 1)) < eps) && (abs(detail(fine_level, 2 * i + 1, 2 * j + 1)) < eps);
-
-                    apply_on_masked(
-                        mask,
-                        [&](auto imask)
-                        {
-                            static_nested_loop<dim - 1, 0, 2>(
-                                [&](auto stencil)
-                                {
-                                    for (int ii = 0; ii < 2; ++ii)
-                                    {
-                                        tag(fine_level, 2 * i + ii, 2 * index + stencil)(imask) = static_cast<int>(CellFlag::coarsen);
-                                    }
-                                });
-                        });
-                    // xt::masked_view(tag(fine_level, 2 * i, 2 * j), mask)         = static_cast<int>(CellFlag::coarsen);
-                    // xt::masked_view(tag(fine_level, 2 * i + 1, 2 * j), mask)     = static_cast<int>(CellFlag::coarsen);
-                    // xt::masked_view(tag(fine_level, 2 * i, 2 * j + 1), mask)     = static_cast<int>(CellFlag::coarsen);
-                    // xt::masked_view(tag(fine_level, 2 * i + 1, 2 * j + 1), mask) = static_cast<int>(CellFlag::coarsen);
-                }
-                else
-                {
-                    constexpr auto n_comp = T1::n_comp;
-
-                    // auto mask = xt::sum((abs(detail(level, 2*i  ,
-                    // 2*j))/maxd < eps) &&
-                    //                     (abs(detail(level, 2*i+1,
-                    //                     2*j))/maxd < eps) &&
-                    //                     (abs(detail(level, 2*i  ,
-                    //                     2*j+1))/maxd < eps) &&
-                    //                     (abs(detail(level, 2*i+1,
-                    //                     2*j+1))/maxd < eps), {1}) > (n_comp-1);
-                    constexpr std::size_t axis = detail::static_size_first_v<n_comp, detail::is_soa_v<T1>, T1::is_scalar, T1::static_layout>
-                                                   ? 0
-                                                   : 1;
-
-                    auto mask = all_true<axis, n_comp>(
-                        (abs(detail(fine_level, 2 * i, 2 * j)) < eps) && (abs(detail(fine_level, 2 * i + 1, 2 * j)) < eps)
-                        && (abs(detail(fine_level, 2 * i, 2 * j + 1)) < eps) && (abs(detail(fine_level, 2 * i + 1, 2 * j + 1)) < eps));
-
-                    apply_on_masked(
-                        mask,
-                        [&](auto imask)
-                        {
-                            static_nested_loop<dim - 1, 0, 2>(
-                                [&](auto stencil)
-                                {
-                                    for (int ii = 0; ii < 2; ++ii)
-                                    {
-                                        tag(fine_level, 2 * i + ii, 2 * index + stencil)(imask) = static_cast<int>(CellFlag::coarsen);
-                                    }
-                                });
-                        });
-                    // xt::masked_view(tag(fine_level, 2 * i, 2 * j), mask)         = static_cast<int>(CellFlag::coarsen);
-                    // xt::masked_view(tag(fine_level, 2 * i + 1, 2 * j), mask)     = static_cast<int>(CellFlag::coarsen);
-                    // xt::masked_view(tag(fine_level, 2 * i, 2 * j + 1), mask)     = static_cast<int>(CellFlag::coarsen);
-                    // xt::masked_view(tag(fine_level, 2 * i + 1, 2 * j + 1), mask) = static_cast<int>(CellFlag::coarsen);
-                }
-            }
-        }
-
-        template <class T1, class T2>
-        SAMURAI_INLINE void operator()(Dim<3>, const T1& detail, T2& tag, double eps, std::size_t min_lev) const
-        {
-            using namespace math;
-
-            std::size_t fine_level = level + 1;
-
-            if (fine_level > min_lev)
-            {
-                // auto maxd = xt::view(max_detail, level);
-
-                if constexpr (T1::is_scalar)
-                {
-                    // auto mask = (abs(detail(level, 2*i  ,   2*j))/maxd <
-                    // eps) and
-                    //             (abs(detail(level, 2*i+1,   2*j))/maxd <
-                    //             eps) and (abs(detail(level, 2*i  ,
-                    //             2*j+1))/maxd < eps) and
-                    //             (abs(detail(level, 2*i+1, 2*j+1))/maxd <
-                    //             eps);
-                    auto mask = eval((abs(detail(fine_level, 2 * i, 2 * j, 2 * k)) < eps)
-                                     && (abs(detail(fine_level, 2 * i + 1, 2 * j, 2 * k)) < eps)
-                                     && (abs(detail(fine_level, 2 * i, 2 * j + 1, 2 * k)) < eps)
-                                     && (abs(detail(fine_level, 2 * i + 1, 2 * j + 1, 2 * k)) < eps)
-                                     && (abs(detail(fine_level, 2 * i, 2 * j, 2 * k + 1)) < eps)
-                                     && (abs(detail(fine_level, 2 * i + 1, 2 * j, 2 * k + 1)) < eps)
-                                     && (abs(detail(fine_level, 2 * i, 2 * j + 1, 2 * k + 1)) < eps)
-                                     && (abs(detail(fine_level, 2 * i + 1, 2 * j + 1, 2 * k + 1)) < eps));
-
-                    apply_on_masked(mask,
-                                    [&](auto imask)
-                                    {
-                                        tag(fine_level, 2 * i, 2 * j, 2 * k)(imask)             = static_cast<int>(CellFlag::coarsen);
-                                        tag(fine_level, 2 * i + 1, 2 * j, 2 * k)(imask)         = static_cast<int>(CellFlag::coarsen);
-                                        tag(fine_level, 2 * i, 2 * j + 1, 2 * k)(imask)         = static_cast<int>(CellFlag::coarsen);
-                                        tag(fine_level, 2 * i + 1, 2 * j + 1, 2 * k)(imask)     = static_cast<int>(CellFlag::coarsen);
-                                        tag(fine_level, 2 * i, 2 * j, 2 * k + 1)(imask)         = static_cast<int>(CellFlag::coarsen);
-                                        tag(fine_level, 2 * i + 1, 2 * j, 2 * k + 1)(imask)     = static_cast<int>(CellFlag::coarsen);
-                                        tag(fine_level, 2 * i, 2 * j + 1, 2 * k + 1)(imask)     = static_cast<int>(CellFlag::coarsen);
-                                        tag(fine_level, 2 * i + 1, 2 * j + 1, 2 * k + 1)(imask) = static_cast<int>(CellFlag::coarsen);
-                                    });
-                }
-                else
-                {
-                    constexpr auto n_comp = T1::n_comp;
-
-                    // auto mask = xt::sum((abs(detail(level, 2*i  ,
-                    // 2*j))/maxd < eps) and
-                    //                     (abs(detail(level, 2*i+1,
-                    //                     2*j))/maxd < eps) and
-                    //                     (abs(detail(level, 2*i  ,
-                    //                     2*j+1))/maxd < eps) and
-                    //                     (abs(detail(level, 2*i+1,
-                    //                     2*j+1))/maxd < eps), {1}) > (n_comp-1);
-
-                    constexpr std::size_t axis = detail::static_size_first_v<n_comp, detail::is_soa_v<T1>, T1::is_scalar, T1::static_layout>
-                                                   ? 0
-                                                   : 1;
-
-                    auto mask = sum<axis>((abs(detail(fine_level, 2 * i, 2 * j, 2 * k)) < eps)
-                                          && (abs(detail(fine_level, 2 * i + 1, 2 * j, 2 * k)) < eps)
-                                          && (abs(detail(fine_level, 2 * i, 2 * j + 1, 2 * k)) < eps)
-                                          && (abs(detail(fine_level, 2 * i + 1, 2 * j + 1, 2 * k)) < eps)
-                                          && (abs(detail(fine_level, 2 * i, 2 * j, 2 * k + 1)) < eps)
-                                          && (abs(detail(fine_level, 2 * i + 1, 2 * j, 2 * k + 1)) < eps)
-                                          && (abs(detail(fine_level, 2 * i, 2 * j + 1, 2 * k + 1)) < eps)
-                                          && (abs(detail(fine_level, 2 * i + 1, 2 * j + 1, 2 * k + 1)) < eps))
-                              > (n_comp - 1);
-
-                    apply_on_masked(mask,
-                                    [&](auto imask)
-                                    {
-                                        tag(fine_level, 2 * i, 2 * j, 2 * k)(imask)             = static_cast<int>(CellFlag::coarsen);
-                                        tag(fine_level, 2 * i + 1, 2 * j, 2 * k)(imask)         = static_cast<int>(CellFlag::coarsen);
-                                        tag(fine_level, 2 * i, 2 * j + 1, 2 * k)(imask)         = static_cast<int>(CellFlag::coarsen);
-                                        tag(fine_level, 2 * i + 1, 2 * j + 1, 2 * k)(imask)     = static_cast<int>(CellFlag::coarsen);
-                                        tag(fine_level, 2 * i, 2 * j, 2 * k + 1)(imask)         = static_cast<int>(CellFlag::coarsen);
-                                        tag(fine_level, 2 * i + 1, 2 * j, 2 * k + 1)(imask)     = static_cast<int>(CellFlag::coarsen);
-                                        tag(fine_level, 2 * i, 2 * j + 1, 2 * k + 1)(imask)     = static_cast<int>(CellFlag::coarsen);
-                                        tag(fine_level, 2 * i + 1, 2 * j + 1, 2 * k + 1)(imask) = static_cast<int>(CellFlag::coarsen);
-                                    });
-                }
-            }
-        }
-    };
-
-    template <class... CT>
-    SAMURAI_INLINE auto to_coarsen_mr(CT&&... e)
-    {
-        return make_field_operator_function<to_coarsen_mr_op>(std::forward<CT>(e)...);
-    }
-
-    template <std::size_t dim, class TInterval>
-    class to_refine_mr_op : public field_operator_base<dim, TInterval>
-    {
-      public:
-
-        INIT_OPERATOR(to_refine_mr_op)
-
-        template <std::size_t n_comp, bool is_soa, class T1>
-        SAMURAI_INLINE auto get_mask(const T1& detail_view, double eps) const
-        {
-            using namespace math;
-
-            if constexpr (n_comp == 1)
-            {
-                return eval(abs(detail_view) > eps); // No normalization
-            }
-            else
-            {
-                constexpr std::size_t axis = detail::static_size_first_v<n_comp, is_soa, false, SAMURAI_DEFAULT_LAYOUT> ? 0 : 1;
-                return eval(sum<axis>(abs(detail_view) > eps) > 0);
-            }
-        }
-
-        template <class T1, class T2>
-        SAMURAI_INLINE void operator()(Dim<dim>, const T1& detail, T2& tag, double eps, std::size_t max_level) const
-        {
-            using namespace math;
-            constexpr auto n_comp  = T1::n_comp;
-            std::size_t fine_level = level + 1;
-
-            auto mask_ghost = get_mask<n_comp, detail::is_soa_v<T1>>(detail(fine_level - 1, i, index), eps / (1 << dim));
-
-            apply_on_masked(mask_ghost,
-                            [&](auto imask)
-                            {
-                                static_nested_loop<dim - 1, 0, 2>(
-                                    [&](auto stencil)
-                                    {
-                                        tag(fine_level, 2 * i, 2 * index + stencil)(imask) |= static_cast<int>(CellFlag::keep);
-                                        tag(fine_level, 2 * i + 1, 2 * index + stencil)(imask) |= static_cast<int>(CellFlag::keep);
-                                    });
-                            });
-
-            if (fine_level < max_level)
-            {
-                static_nested_loop<dim - 1, 0, 2>(
-                    [&](auto stencil)
-                    {
-                        for (int ii = 0; ii < 2; ++ii)
-                        {
-                            auto mask = get_mask<n_comp, detail::is_soa_v<T1>>(detail(fine_level, 2 * i + ii, 2 * index + stencil), eps);
-
-                            apply_on_masked(tag(fine_level, 2 * i + ii, 2 * index + stencil),
-                                            mask,
-                                            [](auto& e)
-                                            {
-                                                e |= static_cast<int>(CellFlag::refine);
-                                            });
-                        }
-                    });
-            }
-        }
-    };
-
-    template <class... CT>
-    SAMURAI_INLINE auto to_refine_mr(CT&&... e)
-    {
-        return make_field_operator_function<to_refine_mr_op>(std::forward<CT>(e)...);
-    }
-
-    template <std::size_t dim, class TInterval>
-    class max_detail_mr_op : public field_operator_base<dim, TInterval>
-    {
-      public:
-
-        INIT_OPERATOR(max_detail_mr_op)
-
-        template <class T1>
-        SAMURAI_INLINE void operator()(Dim<2>, const T1& detail, double& max_detail) const
-        {
-            auto ii = 2 * i;
-            ii.step = 1;
-
-            max_detail = std::max(max_detail,
-                                  xt::amax(xt::maximum(abs(detail(level + 1, ii, 2 * j)), abs(detail(level + 1, ii, 2 * j + 1))))[0]);
-        }
-    };
-
-    template <class... CT>
-    SAMURAI_INLINE auto max_detail_mr(CT&&... e)
-    {
-        return make_field_operator_function<max_detail_mr_op>(std::forward<CT>(e)...);
-    }
-
     template <std::size_t dim, class TInterval>
     class mr_criteria_op : public field_operator_base<dim, TInterval>
     {
@@ -360,50 +47,47 @@ namespace samurai
             {
                 if (fine_level > min_level)
                 {
-                    auto coarsen_check = std::apply(
-                        [&](auto... offsets)
-                        {
-                            auto check_comp = [&](auto offset)
-                            {
-                                for (std::size_t n = 0; n < T1::n_comp; ++n)
-                                {
-                                    if (std::abs(data[(offset + 2 * ii) * T1::n_comp + n]) > eps)
-                                    {
-                                        return false;
-                                    }
-                                }
-                                return true;
-                            };
-                            return (check_comp(offsets) && ...);
-                        },
-                        fine_offsets);
-
-                    if (coarsen_check)
+                    bool cond = false;
+                    for (std::size_t n = 0; n < T1::n_comp; ++n)
                     {
-                        std::apply(
+                        if (std::abs(data[(coarse_offset + ii) * T1::n_comp + n]) > coarse_eps)
+                        {
+                            cond = true;
+                            break;
+                        }
+                    }
+
+                    if (!cond)
+                    {
+                        auto coarsen_check = std::apply(
                             [&](auto... offsets)
                             {
-                                ((tag_data[offsets + 2 * ii] = static_cast<std::uint8_t>(CellFlag::coarsen)), ...);
+                                auto check_comp = [&](auto offset)
+                                {
+                                    for (std::size_t n = 0; n < T1::n_comp; ++n)
+                                    {
+                                        if (std::abs(data[(offset + 2 * ii) * T1::n_comp + n]) > eps)
+                                        {
+                                            return false;
+                                        }
+                                    }
+                                    return true;
+                                };
+                                return (check_comp(offsets) && ...);
                             },
                             fine_offsets);
-                    }
-                }
 
-                bool cond = false;
-                for (std::size_t n = 0; n < T1::n_comp; ++n)
-                {
-                    if (std::abs(data[(coarse_offset + ii) * T1::n_comp + n]) > coarse_eps)
-                    {
-                        cond = true;
-                        break;
+                        if (coarsen_check)
+                        {
+                            std::apply(
+                                [&](auto... offsets)
+                                {
+                                    ((tag_data[offsets + 2 * ii] = static_cast<std::uint8_t>(CellFlag::coarsen)), ...);
+                                },
+                                fine_offsets);
+                        }
                     }
                 }
-                std::apply(
-                    [&](auto... offsets)
-                    {
-                        ((tag_data[offsets + 2 * ii] |= cond * static_cast<std::uint8_t>(CellFlag::keep)), ...);
-                    },
-                    fine_offsets);
 
                 if (fine_level < max_level)
                 {

--- a/include/samurai/mr/criteria.hpp
+++ b/include/samurai/mr/criteria.hpp
@@ -351,9 +351,9 @@ namespace samurai
             {
                 if (fine_level > min_level)
                 {
-                    auto to_coarsen = std::abs(data[ind_f1 + 2 * ii]) < eps && std::abs(data[ind_f1 + 2 * ii + 1]) < eps
-                                   && (std::abs(data[ind_f2 + 2 * ii]) < eps) && (std::abs(data[ind_f2 + 2 * ii + 1]) < eps);
-                    if (to_coarsen)
+                    auto coarsen_check = std::abs(data[ind_f1 + 2 * ii]) < eps && std::abs(data[ind_f1 + 2 * ii + 1]) < eps
+                                      && (std::abs(data[ind_f2 + 2 * ii]) < eps) && (std::abs(data[ind_f2 + 2 * ii + 1]) < eps);
+                    if (coarsen_check)
                     {
                         tag_data[ind_f1 + 2 * ii]     = static_cast<std::uint8_t>(CellFlag::coarsen);
                         tag_data[ind_f1 + 2 * ii + 1] = static_cast<std::uint8_t>(CellFlag::coarsen);

--- a/include/samurai/mr/criteria.hpp
+++ b/include/samurai/mr/criteria.hpp
@@ -321,4 +321,72 @@ namespace samurai
     {
         return make_field_operator_function<max_detail_mr_op>(std::forward<CT>(e)...);
     }
+
+    template <std::size_t dim, class TInterval>
+    class mr_criteria_op : public field_operator_base<dim, TInterval>
+    {
+      public:
+
+        INIT_OPERATOR(mr_criteria_op)
+
+        template <class T1, class T2>
+        SAMURAI_INLINE void operator()(Dim<dim>, const T1& detail, T2& tag, double eps, double regularity) const
+        {
+            std::size_t fine_level = level + 1;
+
+            auto& mesh     = tag.mesh();
+            auto min_level = mesh.min_level();
+            auto max_level = mesh.max_level();
+
+            const auto* data = detail.data();
+            auto* tag_data   = tag.data();
+
+            auto fine_eps   = pow(2.0, regularity) * eps;
+            auto ind_c_base = memory_offset(mesh, {level, i.start, index});
+
+            auto ind_f1 = memory_offset(mesh, {fine_level, 2 * i.start, 2 * j});
+            auto ind_f2 = memory_offset(mesh, {fine_level, 2 * i.start, 2 * j + 1});
+
+            for (std::size_t ii = 0; ii < i.size(); ++ii)
+            {
+                if (fine_level > min_level)
+                {
+                    auto to_coarsen = std::abs(data[ind_f1 + 2 * ii]) < eps && std::abs(data[ind_f1 + 2 * ii + 1]) < eps
+                                   && (std::abs(data[ind_f2 + 2 * ii]) < eps) && (std::abs(data[ind_f2 + 2 * ii + 1]) < eps);
+                    if (to_coarsen)
+                    {
+                        tag_data[ind_f1 + 2 * ii]     = static_cast<std::uint8_t>(CellFlag::coarsen);
+                        tag_data[ind_f1 + 2 * ii + 1] = static_cast<std::uint8_t>(CellFlag::coarsen);
+                        tag_data[ind_f2 + 2 * ii]     = static_cast<std::uint8_t>(CellFlag::coarsen);
+                        tag_data[ind_f2 + 2 * ii + 1] = static_cast<std::uint8_t>(CellFlag::coarsen);
+                    }
+                }
+
+                auto eps_coarse = fine_eps / (1 << dim); // No normalization
+                auto ind_c      = ind_c_base + ii;       // Advance to the next coarse cell
+                auto test1      = (std::abs(data[ind_c]) > eps_coarse) * static_cast<std::uint8_t>(CellFlag::keep);
+                tag_data[ind_f1 + 2 * ii] |= test1;
+                tag_data[ind_f1 + 2 * ii + 1] |= test1;
+                tag_data[ind_f2 + 2 * ii] |= test1;
+                tag_data[ind_f2 + 2 * ii + 1] |= test1;
+
+                if (fine_level < max_level)
+                {
+                    tag_data[ind_f1 + 2 * ii] |= (std::abs(data[ind_f1 + 2 * ii]) > fine_eps) * static_cast<std::uint8_t>(CellFlag::refine);
+                    tag_data[ind_f1 + 2 * ii + 1] |= (std::abs(data[ind_f1 + 2 * ii + 1]) > fine_eps)
+                                                   * static_cast<std::uint8_t>(CellFlag::refine);
+                    tag_data[ind_f2 + 2 * ii] |= (std::abs(data[ind_f2 + 2 * ii]) > fine_eps) * static_cast<std::uint8_t>(CellFlag::refine);
+                    tag_data[ind_f2 + 2 * ii + 1] |= (std::abs(data[ind_f2 + 2 * ii + 1]) > fine_eps)
+                                                   * static_cast<std::uint8_t>(CellFlag::refine);
+                }
+            }
+        }
+    };
+
+    template <class... CT>
+    SAMURAI_INLINE auto mr_criteria(CT&&... e)
+    {
+        return make_field_operator_function<mr_criteria_op>(std::forward<CT>(e)...);
+    }
+
 } // namespace samurai

--- a/include/samurai/mr/criteria.hpp
+++ b/include/samurai/mr/criteria.hpp
@@ -351,7 +351,7 @@ namespace samurai
                 [&](const auto& stencil)
                 {
                     auto new_index        = 2 * index + stencil;
-                    fine_offsets[ind]     = memory_offset(detail.mesh(), {level + 1, 2 * i.start, new_index});
+                    fine_offsets[ind]     = memory_offset(detail.mesh(), {fine_level, 2 * i.start, new_index});
                     fine_offsets[ind + 1] = fine_offsets[ind] + 1;
                     ind += 2;
                 });
@@ -363,7 +363,18 @@ namespace samurai
                     auto coarsen_check = std::apply(
                         [&](auto... offsets)
                         {
-                            return ((std::abs(data[offsets + 2 * ii]) < eps) && ...);
+                            auto check_comp = [&](auto offset)
+                            {
+                                for (std::size_t n = 0; n < T1::n_comp; ++n)
+                                {
+                                    if (std::abs(data[(offset + 2 * ii) * T1::n_comp + n]) > eps)
+                                    {
+                                        return false;
+                                    }
+                                }
+                                return true;
+                            };
+                            return (check_comp(offsets) && ...);
                         },
                         fine_offsets);
 
@@ -378,11 +389,19 @@ namespace samurai
                     }
                 }
 
-                auto cond = (std::abs(data[coarse_offset + ii]) > coarse_eps) * static_cast<std::uint8_t>(CellFlag::keep);
+                bool cond = false;
+                for (std::size_t n = 0; n < T1::n_comp; ++n)
+                {
+                    if (std::abs(data[(coarse_offset + ii) * T1::n_comp + n]) > coarse_eps)
+                    {
+                        cond = true;
+                        break;
+                    }
+                }
                 std::apply(
                     [&](auto... offsets)
                     {
-                        ((tag_data[offsets + 2 * ii] |= cond), ...);
+                        ((tag_data[offsets + 2 * ii] |= cond * static_cast<std::uint8_t>(CellFlag::keep)), ...);
                     },
                     fine_offsets);
 
@@ -391,9 +410,18 @@ namespace samurai
                     std::apply(
                         [&](auto... offsets)
                         {
-                            ((tag_data[offsets + 2 * ii] |= (std::abs(data[offsets + 2 * ii]) > fine_eps)
-                                                          * static_cast<std::uint8_t>(CellFlag::refine)),
-                             ...);
+                            auto tag2refine = [&](auto offset)
+                            {
+                                for (std::size_t n = 0; n < T1::n_comp; ++n)
+                                {
+                                    if (std::abs(data[(offset + 2 * ii) * T1::n_comp + n]) > fine_eps)
+                                    {
+                                        return true;
+                                    }
+                                }
+                                return false;
+                            };
+                            ((tag_data[offsets + 2 * ii] |= (tag2refine(offsets)) * static_cast<std::uint8_t>(CellFlag::refine)), ...);
                         },
                         fine_offsets);
                 }

--- a/include/samurai/mr/criteria.hpp
+++ b/include/samurai/mr/criteria.hpp
@@ -341,43 +341,61 @@ namespace samurai
             const auto* data = detail.data();
             auto* tag_data   = tag.data();
 
-            auto fine_eps   = pow(2.0, regularity) * eps;
-            auto ind_c_base = memory_offset(mesh, {level, i.start, index});
+            auto fine_eps      = pow(2.0, regularity) * eps;
+            auto coarse_eps    = fine_eps / (1 << dim);
+            auto coarse_offset = memory_offset(mesh, {level, i.start, index});
 
-            auto ind_f1 = memory_offset(mesh, {fine_level, 2 * i.start, 2 * j});
-            auto ind_f2 = memory_offset(mesh, {fine_level, 2 * i.start, 2 * j + 1});
+            std::array<std::size_t, 1ULL << dim> fine_offsets;
+            std::size_t ind = 0;
+            static_nested_loop<dim - 1, 0, 2>(
+                [&](const auto& stencil)
+                {
+                    auto new_index        = 2 * index + stencil;
+                    fine_offsets[ind]     = memory_offset(detail.mesh(), {level + 1, 2 * i.start, new_index});
+                    fine_offsets[ind + 1] = fine_offsets[ind] + 1;
+                    ind += 2;
+                });
 
             for (std::size_t ii = 0; ii < i.size(); ++ii)
             {
                 if (fine_level > min_level)
                 {
-                    auto coarsen_check = std::abs(data[ind_f1 + 2 * ii]) < eps && std::abs(data[ind_f1 + 2 * ii + 1]) < eps
-                                      && (std::abs(data[ind_f2 + 2 * ii]) < eps) && (std::abs(data[ind_f2 + 2 * ii + 1]) < eps);
+                    auto coarsen_check = std::apply(
+                        [&](auto... offsets)
+                        {
+                            return ((std::abs(data[offsets + 2 * ii]) < eps) && ...);
+                        },
+                        fine_offsets);
+
                     if (coarsen_check)
                     {
-                        tag_data[ind_f1 + 2 * ii]     = static_cast<std::uint8_t>(CellFlag::coarsen);
-                        tag_data[ind_f1 + 2 * ii + 1] = static_cast<std::uint8_t>(CellFlag::coarsen);
-                        tag_data[ind_f2 + 2 * ii]     = static_cast<std::uint8_t>(CellFlag::coarsen);
-                        tag_data[ind_f2 + 2 * ii + 1] = static_cast<std::uint8_t>(CellFlag::coarsen);
+                        std::apply(
+                            [&](auto... offsets)
+                            {
+                                ((tag_data[offsets + 2 * ii] = static_cast<std::uint8_t>(CellFlag::coarsen)), ...);
+                            },
+                            fine_offsets);
                     }
                 }
 
-                auto eps_coarse = fine_eps / (1 << dim); // No normalization
-                auto ind_c      = ind_c_base + ii;       // Advance to the next coarse cell
-                auto test1      = (std::abs(data[ind_c]) > eps_coarse) * static_cast<std::uint8_t>(CellFlag::keep);
-                tag_data[ind_f1 + 2 * ii] |= test1;
-                tag_data[ind_f1 + 2 * ii + 1] |= test1;
-                tag_data[ind_f2 + 2 * ii] |= test1;
-                tag_data[ind_f2 + 2 * ii + 1] |= test1;
+                auto cond = (std::abs(data[coarse_offset + ii]) > coarse_eps) * static_cast<std::uint8_t>(CellFlag::keep);
+                std::apply(
+                    [&](auto... offsets)
+                    {
+                        ((tag_data[offsets + 2 * ii] |= cond), ...);
+                    },
+                    fine_offsets);
 
                 if (fine_level < max_level)
                 {
-                    tag_data[ind_f1 + 2 * ii] |= (std::abs(data[ind_f1 + 2 * ii]) > fine_eps) * static_cast<std::uint8_t>(CellFlag::refine);
-                    tag_data[ind_f1 + 2 * ii + 1] |= (std::abs(data[ind_f1 + 2 * ii + 1]) > fine_eps)
-                                                   * static_cast<std::uint8_t>(CellFlag::refine);
-                    tag_data[ind_f2 + 2 * ii] |= (std::abs(data[ind_f2 + 2 * ii]) > fine_eps) * static_cast<std::uint8_t>(CellFlag::refine);
-                    tag_data[ind_f2 + 2 * ii + 1] |= (std::abs(data[ind_f2 + 2 * ii + 1]) > fine_eps)
-                                                   * static_cast<std::uint8_t>(CellFlag::refine);
+                    std::apply(
+                        [&](auto... offsets)
+                        {
+                            ((tag_data[offsets + 2 * ii] |= (std::abs(data[offsets + 2 * ii]) > fine_eps)
+                                                          * static_cast<std::uint8_t>(CellFlag::refine)),
+                             ...);
+                        },
+                        fine_offsets);
                 }
             }
         }

--- a/include/samurai/mr/operators.hpp
+++ b/include/samurai/mr/operators.hpp
@@ -76,6 +76,15 @@ namespace samurai
                 {
                     tag_data[coarse_offset + ii] |= static_cast<std::uint8_t>(CellFlag::keep);
                 }
+                else
+                {
+                    std::apply(
+                        [&](auto... offsets)
+                        {
+                            ((tag_data[offsets + 2 * ii] &= ~static_cast<std::uint8_t>(CellFlag::coarsen)), ...);
+                        },
+                        fine_offsets);
+                }
             }
         }
     };

--- a/include/samurai/mr/operators.hpp
+++ b/include/samurai/mr/operators.hpp
@@ -29,43 +29,43 @@ namespace samurai
         template <class T>
         SAMURAI_INLINE void operator()(Dim<1>, T& field) const
         {
-            auto mask = (field(level + 1, 2 * i) & static_cast<int>(CellFlag::keep))
-                      | (field(level + 1, 2 * i + 1) & static_cast<int>(CellFlag::keep));
+            auto mask = (field(level + 1, 2 * i) & static_cast<std::uint8_t>(CellFlag::keep))
+                      | (field(level + 1, 2 * i + 1) & static_cast<std::uint8_t>(CellFlag::keep));
 
             apply_on_masked(mask,
                             [&](auto imask)
                             {
-                                field(level + 1, 2 * i)(imask) |= static_cast<int>(CellFlag::keep);
-                                field(level + 1, 2 * i + 1)(imask) |= static_cast<int>(CellFlag::keep);
-                                field(level, i)(imask) |= static_cast<int>(CellFlag::keep);
+                                field(level + 1, 2 * i)(imask) |= static_cast<std::uint8_t>(CellFlag::keep);
+                                field(level + 1, 2 * i + 1)(imask) |= static_cast<std::uint8_t>(CellFlag::keep);
+                                field(level, i)(imask) |= static_cast<std::uint8_t>(CellFlag::keep);
                             });
 
-            auto coarsen_mask = ((field(level + 1, 2 * i) & static_cast<int>(CellFlag::coarsen))
-                                 & (field(level + 1, 2 * i + 1) & static_cast<int>(CellFlag::coarsen)));
+            auto coarsen_mask = ((field(level + 1, 2 * i) & static_cast<std::uint8_t>(CellFlag::coarsen))
+                                 & (field(level + 1, 2 * i + 1) & static_cast<std::uint8_t>(CellFlag::coarsen)));
 
             apply_on_masked(field(level, i),
                             coarsen_mask,
                             [&](auto& e)
                             {
-                                e |= static_cast<int>(CellFlag::keep);
+                                e |= static_cast<std::uint8_t>(CellFlag::keep);
                             });
         }
 
         template <class T>
         SAMURAI_INLINE void operator()(Dim<2>, T& field) const
         {
-            auto mask_keep = eval((field(level + 1, 2 * i, 2 * j) & static_cast<int>(CellFlag::keep))
-                                  | (field(level + 1, 2 * i + 1, 2 * j) & static_cast<int>(CellFlag::keep))
-                                  | (field(level + 1, 2 * i, 2 * j + 1) & static_cast<int>(CellFlag::keep))
-                                  | (field(level + 1, 2 * i + 1, 2 * j + 1) & static_cast<int>(CellFlag::keep)));
+            auto mask_keep = eval((field(level + 1, 2 * i, 2 * j) & static_cast<std::uint8_t>(CellFlag::keep))
+                                  | (field(level + 1, 2 * i + 1, 2 * j) & static_cast<std::uint8_t>(CellFlag::keep))
+                                  | (field(level + 1, 2 * i, 2 * j + 1) & static_cast<std::uint8_t>(CellFlag::keep))
+                                  | (field(level + 1, 2 * i + 1, 2 * j + 1) & static_cast<std::uint8_t>(CellFlag::keep)));
 
             // version 1
-            // xt::masked_view(field(level + 1, 2 * i, 2 * j), mask_keep) |= static_cast<int>(CellFlag::keep);
-            // xt::masked_view(field(level + 1, 2 * i + 1, 2 * j), mask_keep) |= static_cast<int>(CellFlag::keep);
-            // xt::masked_view(field(level + 1, 2 * i, 2 * j + 1), mask_keep) |= static_cast<int>(CellFlag::keep);
-            // xt::masked_view(field(level + 1, 2 * i + 1, 2 * j + 1), mask_keep) |= static_cast<int>(CellFlag::keep);
+            // xt::masked_view(field(level + 1, 2 * i, 2 * j), mask_keep) |= static_cast<std::uint8_t>(CellFlag::keep);
+            // xt::masked_view(field(level + 1, 2 * i + 1, 2 * j), mask_keep) |= static_cast<std::uint8_t>(CellFlag::keep);
+            // xt::masked_view(field(level + 1, 2 * i, 2 * j + 1), mask_keep) |= static_cast<std::uint8_t>(CellFlag::keep);
+            // xt::masked_view(field(level + 1, 2 * i + 1, 2 * j + 1), mask_keep) |= static_cast<std::uint8_t>(CellFlag::keep);
 
-            // xt::masked_view(field(level, i, j), mask_keep) |= static_cast<int>(CellFlag::keep);
+            // xt::masked_view(field(level, i, j), mask_keep) |= static_cast<std::uint8_t>(CellFlag::keep);
 
             // version 2
             // static_nested_loop<dim - 1, 0, 2>(
@@ -73,33 +73,33 @@ namespace samurai
             //     {
             //         for (int ii = 0; ii < 2; ++ii)
             //         {
-            //             field(level + 1, 2 * i + ii, 2 * index + stencil) |= mask_keep * static_cast<int>(CellFlag::keep);
+            //             field(level + 1, 2 * i + ii, 2 * index + stencil) |= mask_keep * static_cast<std::uint8_t>(CellFlag::keep);
             //         }
             //     });
-            // field(level, i, index) |= mask_keep * static_cast<int>(CellFlag::keep);
+            // field(level, i, index) |= mask_keep * static_cast<std::uint8_t>(CellFlag::keep);
 
             // version 3
             apply_on_masked(mask_keep,
                             [&](auto imask)
                             {
-                                field(level + 1, 2 * i, 2 * j)(imask) |= static_cast<int>(CellFlag::keep);
-                                field(level + 1, 2 * i + 1, 2 * j)(imask) |= static_cast<int>(CellFlag::keep);
-                                field(level + 1, 2 * i, 2 * j + 1)(imask) |= static_cast<int>(CellFlag::keep);
-                                field(level + 1, 2 * i + 1, 2 * j + 1)(imask) |= static_cast<int>(CellFlag::keep);
-                                field(level, i, j)(imask) |= static_cast<int>(CellFlag::keep);
+                                field(level + 1, 2 * i, 2 * j)(imask) |= static_cast<std::uint8_t>(CellFlag::keep);
+                                field(level + 1, 2 * i + 1, 2 * j)(imask) |= static_cast<std::uint8_t>(CellFlag::keep);
+                                field(level + 1, 2 * i, 2 * j + 1)(imask) |= static_cast<std::uint8_t>(CellFlag::keep);
+                                field(level + 1, 2 * i + 1, 2 * j + 1)(imask) |= static_cast<std::uint8_t>(CellFlag::keep);
+                                field(level, i, j)(imask) |= static_cast<std::uint8_t>(CellFlag::keep);
                             });
 
-            auto mask_coarsen = eval((field(level + 1, 2 * i, 2 * j) & static_cast<int>(CellFlag::coarsen))
-                                     & (field(level + 1, 2 * i + 1, 2 * j) & static_cast<int>(CellFlag::coarsen))
-                                     & (field(level + 1, 2 * i, 2 * j + 1) & static_cast<int>(CellFlag::coarsen))
-                                     & (field(level + 1, 2 * i + 1, 2 * j + 1) & static_cast<int>(CellFlag::coarsen)));
+            auto mask_coarsen = eval((field(level + 1, 2 * i, 2 * j) & static_cast<std::uint8_t>(CellFlag::coarsen))
+                                     & (field(level + 1, 2 * i + 1, 2 * j) & static_cast<std::uint8_t>(CellFlag::coarsen))
+                                     & (field(level + 1, 2 * i, 2 * j + 1) & static_cast<std::uint8_t>(CellFlag::coarsen))
+                                     & (field(level + 1, 2 * i + 1, 2 * j + 1) & static_cast<std::uint8_t>(CellFlag::coarsen)));
 
             // version 1
             // xt::masked_view(field(level + 1, 2 * i, 2 * j), !mask_coarsen) &= ~static_cast<unsigned int>(CellFlag::coarsen);
             // xt::masked_view(field(level + 1, 2 * i + 1, 2 * j), !mask_coarsen) &= ~static_cast<unsigned int>(CellFlag::coarsen);
             // xt::masked_view(field(level + 1, 2 * i, 2 * j + 1), !mask_coarsen) &= ~static_cast<unsigned int>(CellFlag::coarsen);
             // xt::masked_view(field(level + 1, 2 * i + 1, 2 * j + 1), !mask_coarsen) &= ~static_cast<unsigned int>(CellFlag::coarsen);
-            // xt::masked_view(field(level, i, j), mask_coarsen) |= static_cast<int>(CellFlag::keep);
+            // xt::masked_view(field(level, i, j), mask_coarsen) |= static_cast<std::uint8_t>(CellFlag::keep);
 
             // version 2
             // static_nested_loop<dim - 1, 0, 2>(
@@ -118,78 +118,78 @@ namespace samurai
             //         }
             //     });
 
-            // field(level, i, j) |= mask_coarsen * static_cast<int>(CellFlag::keep);
+            // field(level, i, j) |= mask_coarsen * static_cast<std::uint8_t>(CellFlag::keep);
 
             // version 3
             apply_on_masked(!mask_coarsen,
                             [&](auto imask)
                             {
-                                field(level + 1, 2 * i, 2 * j)(imask) &= ~static_cast<int>(CellFlag::coarsen);
-                                field(level + 1, 2 * i + 1, 2 * j)(imask) &= ~static_cast<int>(CellFlag::coarsen);
-                                field(level + 1, 2 * i, 2 * j + 1)(imask) &= ~static_cast<int>(CellFlag::coarsen);
-                                field(level + 1, 2 * i + 1, 2 * j + 1)(imask) &= ~static_cast<int>(CellFlag::coarsen);
+                                field(level + 1, 2 * i, 2 * j)(imask) &= ~static_cast<std::uint8_t>(CellFlag::coarsen);
+                                field(level + 1, 2 * i + 1, 2 * j)(imask) &= ~static_cast<std::uint8_t>(CellFlag::coarsen);
+                                field(level + 1, 2 * i, 2 * j + 1)(imask) &= ~static_cast<std::uint8_t>(CellFlag::coarsen);
+                                field(level + 1, 2 * i + 1, 2 * j + 1)(imask) &= ~static_cast<std::uint8_t>(CellFlag::coarsen);
                             });
             apply_on_masked(field(level, i, j),
                             mask_coarsen,
                             [](auto& e)
                             {
-                                e |= static_cast<int>(CellFlag::keep);
+                                e |= static_cast<std::uint8_t>(CellFlag::keep);
                             });
         }
 
         template <class T>
         SAMURAI_INLINE void operator()(Dim<3>, T& field) const
         {
-            auto mask1 = (field(level + 1, 2 * i, 2 * j, 2 * k) & static_cast<int>(CellFlag::keep))
-                       | (field(level + 1, 2 * i + 1, 2 * j, 2 * k) & static_cast<int>(CellFlag::keep))
-                       | (field(level + 1, 2 * i, 2 * j + 1, 2 * k) & static_cast<int>(CellFlag::keep))
-                       | (field(level + 1, 2 * i + 1, 2 * j + 1, 2 * k) & static_cast<int>(CellFlag::keep))
-                       | (field(level + 1, 2 * i, 2 * j, 2 * k + 1) & static_cast<int>(CellFlag::keep))
-                       | (field(level + 1, 2 * i + 1, 2 * j, 2 * k + 1) & static_cast<int>(CellFlag::keep))
-                       | (field(level + 1, 2 * i, 2 * j + 1, 2 * k + 1) & static_cast<int>(CellFlag::keep))
-                       | (field(level + 1, 2 * i + 1, 2 * j + 1, 2 * k + 1) & static_cast<int>(CellFlag::keep));
+            auto mask1 = (field(level + 1, 2 * i, 2 * j, 2 * k) & static_cast<std::uint8_t>(CellFlag::keep))
+                       | (field(level + 1, 2 * i + 1, 2 * j, 2 * k) & static_cast<std::uint8_t>(CellFlag::keep))
+                       | (field(level + 1, 2 * i, 2 * j + 1, 2 * k) & static_cast<std::uint8_t>(CellFlag::keep))
+                       | (field(level + 1, 2 * i + 1, 2 * j + 1, 2 * k) & static_cast<std::uint8_t>(CellFlag::keep))
+                       | (field(level + 1, 2 * i, 2 * j, 2 * k + 1) & static_cast<std::uint8_t>(CellFlag::keep))
+                       | (field(level + 1, 2 * i + 1, 2 * j, 2 * k + 1) & static_cast<std::uint8_t>(CellFlag::keep))
+                       | (field(level + 1, 2 * i, 2 * j + 1, 2 * k + 1) & static_cast<std::uint8_t>(CellFlag::keep))
+                       | (field(level + 1, 2 * i + 1, 2 * j + 1, 2 * k + 1) & static_cast<std::uint8_t>(CellFlag::keep));
 
             apply_on_masked(mask1,
                             [&](auto imask)
                             {
-                                field(level + 1, 2 * i, 2 * j, 2 * k)(imask) |= static_cast<int>(CellFlag::keep);
-                                field(level + 1, 2 * i + 1, 2 * j, 2 * k)(imask) |= static_cast<int>(CellFlag::keep);
-                                field(level + 1, 2 * i, 2 * j + 1, 2 * k)(imask) |= static_cast<int>(CellFlag::keep);
-                                field(level + 1, 2 * i + 1, 2 * j + 1, 2 * k)(imask) |= static_cast<int>(CellFlag::keep);
-                                field(level + 1, 2 * i, 2 * j, 2 * k + 1)(imask) |= static_cast<int>(CellFlag::keep);
-                                field(level + 1, 2 * i + 1, 2 * j, 2 * k + 1)(imask) |= static_cast<int>(CellFlag::keep);
-                                field(level + 1, 2 * i, 2 * j + 1, 2 * k + 1)(imask) |= static_cast<int>(CellFlag::keep);
-                                field(level + 1, 2 * i + 1, 2 * j + 1, 2 * k + 1)(imask) |= static_cast<int>(CellFlag::keep);
-                                field(level, i, j, k)(imask) |= static_cast<int>(CellFlag::keep);
+                                field(level + 1, 2 * i, 2 * j, 2 * k)(imask) |= static_cast<std::uint8_t>(CellFlag::keep);
+                                field(level + 1, 2 * i + 1, 2 * j, 2 * k)(imask) |= static_cast<std::uint8_t>(CellFlag::keep);
+                                field(level + 1, 2 * i, 2 * j + 1, 2 * k)(imask) |= static_cast<std::uint8_t>(CellFlag::keep);
+                                field(level + 1, 2 * i + 1, 2 * j + 1, 2 * k)(imask) |= static_cast<std::uint8_t>(CellFlag::keep);
+                                field(level + 1, 2 * i, 2 * j, 2 * k + 1)(imask) |= static_cast<std::uint8_t>(CellFlag::keep);
+                                field(level + 1, 2 * i + 1, 2 * j, 2 * k + 1)(imask) |= static_cast<std::uint8_t>(CellFlag::keep);
+                                field(level + 1, 2 * i, 2 * j + 1, 2 * k + 1)(imask) |= static_cast<std::uint8_t>(CellFlag::keep);
+                                field(level + 1, 2 * i + 1, 2 * j + 1, 2 * k + 1)(imask) |= static_cast<std::uint8_t>(CellFlag::keep);
+                                field(level, i, j, k)(imask) |= static_cast<std::uint8_t>(CellFlag::keep);
                             });
 
-            auto mask2 = (field(level + 1, 2 * i, 2 * j, 2 * k) & static_cast<int>(CellFlag::coarsen))
-                       & (field(level + 1, 2 * i + 1, 2 * j, 2 * k) & static_cast<int>(CellFlag::coarsen))
-                       & (field(level + 1, 2 * i, 2 * j + 1, 2 * k) & static_cast<int>(CellFlag::coarsen))
-                       & (field(level + 1, 2 * i + 1, 2 * j + 1, 2 * k) & static_cast<int>(CellFlag::coarsen))
-                       & (field(level + 1, 2 * i, 2 * j, 2 * k + 1) & static_cast<int>(CellFlag::coarsen))
-                       & (field(level + 1, 2 * i + 1, 2 * j, 2 * k + 1) & static_cast<int>(CellFlag::coarsen))
-                       & (field(level + 1, 2 * i, 2 * j + 1, 2 * k + 1) & static_cast<int>(CellFlag::coarsen))
-                       & (field(level + 1, 2 * i + 1, 2 * j + 1, 2 * k + 1) & static_cast<int>(CellFlag::coarsen));
+            auto mask2 = (field(level + 1, 2 * i, 2 * j, 2 * k) & static_cast<std::uint8_t>(CellFlag::coarsen))
+                       & (field(level + 1, 2 * i + 1, 2 * j, 2 * k) & static_cast<std::uint8_t>(CellFlag::coarsen))
+                       & (field(level + 1, 2 * i, 2 * j + 1, 2 * k) & static_cast<std::uint8_t>(CellFlag::coarsen))
+                       & (field(level + 1, 2 * i + 1, 2 * j + 1, 2 * k) & static_cast<std::uint8_t>(CellFlag::coarsen))
+                       & (field(level + 1, 2 * i, 2 * j, 2 * k + 1) & static_cast<std::uint8_t>(CellFlag::coarsen))
+                       & (field(level + 1, 2 * i + 1, 2 * j, 2 * k + 1) & static_cast<std::uint8_t>(CellFlag::coarsen))
+                       & (field(level + 1, 2 * i, 2 * j + 1, 2 * k + 1) & static_cast<std::uint8_t>(CellFlag::coarsen))
+                       & (field(level + 1, 2 * i + 1, 2 * j + 1, 2 * k + 1) & static_cast<std::uint8_t>(CellFlag::coarsen));
 
             apply_on_masked(!mask2,
                             [&](auto imask)
                             {
-                                field(level + 1, 2 * i, 2 * j, 2 * k)(imask) &= ~static_cast<int>(CellFlag::coarsen);
-                                field(level + 1, 2 * i + 1, 2 * j, 2 * k)(imask) &= ~static_cast<int>(CellFlag::coarsen);
-                                field(level + 1, 2 * i, 2 * j + 1, 2 * k)(imask) &= ~static_cast<int>(CellFlag::coarsen);
-                                field(level + 1, 2 * i + 1, 2 * j + 1, 2 * k)(imask) &= ~static_cast<int>(CellFlag::coarsen);
-                                field(level + 1, 2 * i, 2 * j, 2 * k + 1)(imask) &= ~static_cast<int>(CellFlag::coarsen);
-                                field(level + 1, 2 * i + 1, 2 * j, 2 * k + 1)(imask) &= ~static_cast<int>(CellFlag::coarsen);
-                                field(level + 1, 2 * i, 2 * j + 1, 2 * k + 1)(imask) &= ~static_cast<int>(CellFlag::coarsen);
-                                field(level + 1, 2 * i + 1, 2 * j + 1, 2 * k + 1)(imask) &= ~static_cast<int>(CellFlag::coarsen);
+                                field(level + 1, 2 * i, 2 * j, 2 * k)(imask) &= ~static_cast<std::uint8_t>(CellFlag::coarsen);
+                                field(level + 1, 2 * i + 1, 2 * j, 2 * k)(imask) &= ~static_cast<std::uint8_t>(CellFlag::coarsen);
+                                field(level + 1, 2 * i, 2 * j + 1, 2 * k)(imask) &= ~static_cast<std::uint8_t>(CellFlag::coarsen);
+                                field(level + 1, 2 * i + 1, 2 * j + 1, 2 * k)(imask) &= ~static_cast<std::uint8_t>(CellFlag::coarsen);
+                                field(level + 1, 2 * i, 2 * j, 2 * k + 1)(imask) &= ~static_cast<std::uint8_t>(CellFlag::coarsen);
+                                field(level + 1, 2 * i + 1, 2 * j, 2 * k + 1)(imask) &= ~static_cast<std::uint8_t>(CellFlag::coarsen);
+                                field(level + 1, 2 * i, 2 * j + 1, 2 * k + 1)(imask) &= ~static_cast<std::uint8_t>(CellFlag::coarsen);
+                                field(level + 1, 2 * i + 1, 2 * j + 1, 2 * k + 1)(imask) &= ~static_cast<std::uint8_t>(CellFlag::coarsen);
                             });
 
             apply_on_masked(field(level, i, j, k),
                             mask2,
                             [](auto& e)
                             {
-                                e |= static_cast<int>(CellFlag::keep);
+                                e |= static_cast<std::uint8_t>(CellFlag::keep);
                             });
         }
     };
@@ -372,8 +372,10 @@ namespace samurai
 #ifdef SAMURAI_CHECK_NAN
                                 if (std::isnan(src))
                                 {
-                                    std::cerr << "NaN detected in compute_detail_op at level " << level << ", i " << (i.start + ii)
-                                              << ", j " << (j + static_cast<double>(kj) - static_cast<double>(order)) << std::endl;
+                                    using value_t = typename TInterval::value_t;
+                                    std::cerr << "NaN detected in compute_detail_op at level " << level << ", i "
+                                              << (i.start + static_cast<value_t>(ii)) << ", j "
+                                              << (j + static_cast<double>(kj) - static_cast<double>(order)) << std::endl;
                                     exit(1);
                                 }
 #endif
@@ -420,8 +422,10 @@ namespace samurai
 #ifdef SAMURAI_CHECK_NAN
                                     if (std::isnan(src))
                                     {
-                                        std::cerr << "NaN detected in compute_detail_op at level " << level << ", i " << (i.start + ii)
-                                                  << ", j " << (j + static_cast<double>(kj) - static_cast<double>(order)) << ", nc " << nc
+                                        using value_t = typename TInterval::value_t;
+                                        std::cerr << "NaN detected in compute_detail_op at level " << level << ", i "
+                                                  << (i.start + static_cast<value_t>(ii)) << ", j "
+                                                  << (j + static_cast<double>(kj) - static_cast<double>(order)) << ", nc " << nc
                                                   << std::endl;
                                         exit(1);
                                     }
@@ -884,8 +888,8 @@ namespace samurai
             apply_on_masked(mask,
                             [&](auto imask)
                             {
-                                keep(level + 1, 2 * i)(imask)     = static_cast<int>(CellFlag::coarsen);
-                                keep(level + 1, 2 * i + 1)(imask) = static_cast<int>(CellFlag::coarsen);
+                                keep(level + 1, 2 * i)(imask)     = static_cast<std::uint8_t>(CellFlag::coarsen);
+                                keep(level + 1, 2 * i + 1)(imask) = static_cast<std::uint8_t>(CellFlag::coarsen);
                             });
         }
 
@@ -908,7 +912,7 @@ namespace samurai
                                 {
                                     for (coord_index_t ii = 0; ii < 2; ++ii)
                                     {
-                                        keep(level + 1, 2 * i + ii, 2 * j + jj)(imask) = static_cast<int>(CellFlag::coarsen);
+                                        keep(level + 1, 2 * i + ii, 2 * j + jj)(imask) = static_cast<std::uint8_t>(CellFlag::coarsen);
                                     }
                                 }
                             });
@@ -919,20 +923,21 @@ namespace samurai
         {
             auto mask = abs(detail(level + 1, 2 * i, 2 * j, 2 * k)) < eps;
 
-            apply_on_masked(mask,
-                            [&](auto imask)
+            apply_on_masked(
+                mask,
+                [&](auto imask)
+                {
+                    for (coord_index_t kk = 0; kk < 2; ++kk)
+                    {
+                        for (coord_index_t jj = 0; jj < 2; ++jj)
+                        {
+                            for (coord_index_t ii = 0; ii < 2; ++ii)
                             {
-                                for (coord_index_t kk = 0; kk < 2; ++kk)
-                                {
-                                    for (coord_index_t jj = 0; jj < 2; ++jj)
-                                    {
-                                        for (coord_index_t ii = 0; ii < 2; ++ii)
-                                        {
-                                            keep(level + 1, 2 * i + ii, 2 * j + jj, 2 * k + kk)(imask) = static_cast<int>(CellFlag::coarsen);
-                                        }
-                                    }
-                                }
-                            });
+                                keep(level + 1, 2 * i + ii, 2 * j + jj, 2 * k + kk)(imask) = static_cast<std::uint8_t>(CellFlag::coarsen);
+                            }
+                        }
+                    }
+                });
         }
     };
 
@@ -956,36 +961,36 @@ namespace samurai
         template <class T>
         SAMURAI_INLINE void operator()(Dim<1>, T& flag) const
         {
-            auto mask = flag(level + 1, i) & static_cast<int>(CellFlag::keep);
+            auto mask = flag(level + 1, i) & static_cast<std::uint8_t>(CellFlag::keep);
             apply_on_masked(flag(level, i / 2),
                             mask,
                             [](auto& e)
                             {
-                                e = static_cast<int>(CellFlag::refine);
+                                e = static_cast<std::uint8_t>(CellFlag::refine);
                             });
         }
 
         template <class T>
         SAMURAI_INLINE void operator()(Dim<2>, T& flag) const
         {
-            auto mask = flag(level + 1, i, j) & static_cast<int>(CellFlag::keep);
+            auto mask = flag(level + 1, i, j) & static_cast<std::uint8_t>(CellFlag::keep);
             apply_on_masked(flag(level, i / 2, j / 2),
                             mask,
                             [](auto& e)
                             {
-                                e = static_cast<int>(CellFlag::refine);
+                                e = static_cast<std::uint8_t>(CellFlag::refine);
                             });
         }
 
         template <class T>
         SAMURAI_INLINE void operator()(Dim<3>, T& flag) const
         {
-            auto mask = flag(level + 1, i, j, k) & static_cast<int>(CellFlag::keep);
+            auto mask = flag(level + 1, i, j, k) & static_cast<std::uint8_t>(CellFlag::keep);
             apply_on_masked(flag(level, i / 2, j / 2, k / 2),
                             mask,
                             [](auto& e)
                             {
-                                e = static_cast<int>(CellFlag::refine);
+                                e = static_cast<std::uint8_t>(CellFlag::refine);
                             });
         }
     };
@@ -1010,14 +1015,14 @@ namespace samurai
         template <class T>
         SAMURAI_INLINE void operator()(Dim<1>, T& cell_flag) const
         {
-            auto keep_mask = cell_flag(level, i) & static_cast<int>(CellFlag::keep);
+            auto keep_mask = cell_flag(level, i) & static_cast<std::uint8_t>(CellFlag::keep);
 
             apply_on_masked(keep_mask,
                             [&](auto imask)
                             {
                                 for (int ii = -1; ii < 2; ++ii)
                                 {
-                                    cell_flag(level, i + ii)(imask) |= static_cast<int>(CellFlag::enlarge);
+                                    cell_flag(level, i + ii)(imask) |= static_cast<std::uint8_t>(CellFlag::enlarge);
                                 }
                             });
         }
@@ -1025,7 +1030,7 @@ namespace samurai
         template <class T>
         SAMURAI_INLINE void operator()(Dim<2>, T& cell_flag) const
         {
-            auto keep_mask = cell_flag(level, i, j) & static_cast<int>(CellFlag::keep);
+            auto keep_mask = cell_flag(level, i, j) & static_cast<std::uint8_t>(CellFlag::keep);
 
             apply_on_masked(keep_mask,
                             [&](auto imask)
@@ -1034,7 +1039,7 @@ namespace samurai
                                 {
                                     for (int ii = -1; ii < 2; ++ii)
                                     {
-                                        cell_flag(level, i + ii, j + jj)(imask) |= static_cast<int>(CellFlag::enlarge);
+                                        cell_flag(level, i + ii, j + jj)(imask) |= static_cast<std::uint8_t>(CellFlag::enlarge);
                                     }
                                 }
                             });
@@ -1043,7 +1048,7 @@ namespace samurai
         template <class T>
         SAMURAI_INLINE void operator()(Dim<3>, T& cell_flag) const
         {
-            auto keep_mask = cell_flag(level, i, j, k) & static_cast<int>(CellFlag::keep);
+            auto keep_mask = cell_flag(level, i, j, k) & static_cast<std::uint8_t>(CellFlag::keep);
 
             apply_on_masked(keep_mask,
                             [&](auto imask)
@@ -1054,7 +1059,7 @@ namespace samurai
                                     {
                                         for (int ii = -1; ii < 2; ++ii)
                                         {
-                                            cell_flag(level, i + ii, j + jj, k + kk)(imask) |= static_cast<int>(CellFlag::enlarge);
+                                            cell_flag(level, i + ii, j + jj, k + kk)(imask) |= static_cast<std::uint8_t>(CellFlag::enlarge);
                                         }
                                     }
                                 }
@@ -1082,14 +1087,14 @@ namespace samurai
         template <class T>
         SAMURAI_INLINE void operator()(Dim<1>, T& cell_flag) const
         {
-            auto refine_mask = cell_flag(level, i) & static_cast<int>(CellFlag::refine);
+            auto refine_mask = cell_flag(level, i) & static_cast<std::uint8_t>(CellFlag::refine);
 
             apply_on_masked(refine_mask,
                             [&](auto imask)
                             {
                                 for (int ii = -1; ii < 2; ++ii)
                                 {
-                                    cell_flag(level, i + ii)(imask) |= static_cast<int>(CellFlag::keep);
+                                    cell_flag(level, i + ii)(imask) |= static_cast<std::uint8_t>(CellFlag::keep);
                                 }
                             });
         }
@@ -1097,7 +1102,7 @@ namespace samurai
         template <class T>
         SAMURAI_INLINE void operator()(Dim<2>, T& cell_flag) const
         {
-            auto refine_mask = cell_flag(level, i, j) & static_cast<int>(CellFlag::refine);
+            auto refine_mask = cell_flag(level, i, j) & static_cast<std::uint8_t>(CellFlag::refine);
 
             apply_on_masked(refine_mask,
                             [&](auto imask)
@@ -1107,7 +1112,7 @@ namespace samurai
                                     {
                                         for (int ii = -1; ii < 2; ++ii)
                                         {
-                                            cell_flag(level, i + ii, index + stencil)(imask) |= static_cast<int>(CellFlag::keep);
+                                            cell_flag(level, i + ii, index + stencil)(imask) |= static_cast<std::uint8_t>(CellFlag::keep);
                                         }
                                     });
                             });
@@ -1116,7 +1121,7 @@ namespace samurai
         template <class T>
         SAMURAI_INLINE void operator()(Dim<3>, T& cell_flag) const
         {
-            auto refine_mask = cell_flag(level, i, j, k) & static_cast<int>(CellFlag::refine);
+            auto refine_mask = cell_flag(level, i, j, k) & static_cast<std::uint8_t>(CellFlag::refine);
 
             apply_on_masked(refine_mask,
                             [&](auto imask)
@@ -1127,7 +1132,7 @@ namespace samurai
                                     {
                                         for (int ii = -1; ii < 2; ++ii)
                                         {
-                                            cell_flag(level, i + ii, j + jj, k + kk)(imask) |= static_cast<int>(CellFlag::keep);
+                                            cell_flag(level, i + ii, j + jj, k + kk)(imask) |= static_cast<std::uint8_t>(CellFlag::keep);
                                         }
                                     }
                                 }
@@ -1279,24 +1284,24 @@ namespace samurai
             auto i_even = i.even_elements();
             if (i_even.is_valid())
             {
-                auto mask = tag(level, i_even) & static_cast<int>(CellFlag::keep);
+                auto mask = tag(level, i_even) & static_cast<std::uint8_t>(CellFlag::keep);
                 apply_on_masked(tag(level - 1, i_even >> 1),
                                 mask,
                                 [](auto& e)
                                 {
-                                    e |= static_cast<int>(CellFlag::refine);
+                                    e |= static_cast<std::uint8_t>(CellFlag::refine);
                                 });
             }
 
             auto i_odd = i.odd_elements();
             if (i_odd.is_valid())
             {
-                auto mask = tag(level, i_odd) & static_cast<int>(CellFlag::keep);
+                auto mask = tag(level, i_odd) & static_cast<std::uint8_t>(CellFlag::keep);
                 apply_on_masked(tag(level - 1, i_odd >> 1),
                                 mask,
                                 [](auto& e)
                                 {
-                                    e |= static_cast<int>(CellFlag::refine);
+                                    e |= static_cast<std::uint8_t>(CellFlag::refine);
                                 });
             }
         }
@@ -1307,28 +1312,28 @@ namespace samurai
             auto i_even = i.even_elements();
             if (i_even.is_valid())
             {
-                auto mask = tag(level, i_even, j) & static_cast<int>(CellFlag::keep);
+                auto mask = tag(level, i_even, j) & static_cast<std::uint8_t>(CellFlag::keep);
                 apply_on_masked(tag(level - 1, i_even >> 1, j >> 1),
                                 mask,
                                 [](auto& e)
                                 {
-                                    e |= static_cast<int>(CellFlag::refine);
+                                    e |= static_cast<std::uint8_t>(CellFlag::refine);
                                 });
 
-                // xt::masked_view(tag(level - 1, i_even >> 1, j >> 1), mask) |= static_cast<int>(CellFlag::refine);
+                // xt::masked_view(tag(level - 1, i_even >> 1, j >> 1), mask) |= static_cast<std::uint8_t>(CellFlag::refine);
             }
 
             auto i_odd = i.odd_elements();
             if (i_odd.is_valid())
             {
-                auto mask = tag(level, i_odd, j) & static_cast<int>(CellFlag::keep);
+                auto mask = tag(level, i_odd, j) & static_cast<std::uint8_t>(CellFlag::keep);
                 apply_on_masked(tag(level - 1, i_odd >> 1, j >> 1),
                                 mask,
                                 [](auto& e)
                                 {
-                                    e |= static_cast<int>(CellFlag::refine);
+                                    e |= static_cast<std::uint8_t>(CellFlag::refine);
                                 });
-                // xt::masked_view(tag(level - 1, i_odd >> 1, j >> 1), mask) |= static_cast<int>(CellFlag::refine);
+                // xt::masked_view(tag(level - 1, i_odd >> 1, j >> 1), mask) |= static_cast<std::uint8_t>(CellFlag::refine);
             }
         }
 
@@ -1338,24 +1343,24 @@ namespace samurai
             auto i_even = i.even_elements();
             if (i_even.is_valid())
             {
-                auto mask = tag(level, i_even, j, k) & static_cast<int>(CellFlag::keep);
+                auto mask = tag(level, i_even, j, k) & static_cast<std::uint8_t>(CellFlag::keep);
                 apply_on_masked(tag(level - 1, i_even >> 1, j >> 1, k >> 1),
                                 mask,
                                 [](auto& e)
                                 {
-                                    e |= static_cast<int>(CellFlag::refine);
+                                    e |= static_cast<std::uint8_t>(CellFlag::refine);
                                 });
             }
 
             auto i_odd = i.odd_elements();
             if (i_odd.is_valid())
             {
-                auto mask = tag(level, i_odd, j, k) & static_cast<int>(CellFlag::keep);
+                auto mask = tag(level, i_odd, j, k) & static_cast<std::uint8_t>(CellFlag::keep);
                 apply_on_masked(tag(level - 1, i_odd >> 1, j >> 1, k >> 1),
                                 mask,
                                 [](auto& e)
                                 {
-                                    e |= static_cast<int>(CellFlag::refine);
+                                    e |= static_cast<std::uint8_t>(CellFlag::refine);
                                 });
             }
         }

--- a/include/samurai/mr/operators.hpp
+++ b/include/samurai/mr/operators.hpp
@@ -27,170 +27,56 @@ namespace samurai
         INIT_OPERATOR(maximum_op)
 
         template <class T>
-        SAMURAI_INLINE void operator()(Dim<1>, T& field) const
+        SAMURAI_INLINE void operator()(Dim<dim>, T& tag) const
         {
-            auto mask = (field(level + 1, 2 * i) & static_cast<std::uint8_t>(CellFlag::keep))
-                      | (field(level + 1, 2 * i + 1) & static_cast<std::uint8_t>(CellFlag::keep));
+            auto& mesh     = tag.mesh();
+            auto* tag_data = tag.data();
 
-            apply_on_masked(mask,
-                            [&](auto imask)
-                            {
-                                field(level + 1, 2 * i)(imask) |= static_cast<std::uint8_t>(CellFlag::keep);
-                                field(level + 1, 2 * i + 1)(imask) |= static_cast<std::uint8_t>(CellFlag::keep);
-                                field(level, i)(imask) |= static_cast<std::uint8_t>(CellFlag::keep);
-                            });
+            auto coarse_offset = memory_offset(mesh, {level, i.start, index});
+            std::array<std::size_t, 1ULL << dim> fine_offsets;
+            std::size_t ind = 0;
+            static_nested_loop<dim - 1, 0, 2>(
+                [&](const auto& stencil)
+                {
+                    auto new_index        = 2 * index + stencil;
+                    fine_offsets[ind]     = memory_offset(tag.mesh(), {level + 1, 2 * i.start, new_index});
+                    fine_offsets[ind + 1] = fine_offsets[ind] + 1;
+                    ind += 2;
+                });
 
-            auto coarsen_mask = ((field(level + 1, 2 * i) & static_cast<std::uint8_t>(CellFlag::coarsen))
-                                 & (field(level + 1, 2 * i + 1) & static_cast<std::uint8_t>(CellFlag::coarsen)));
+            for (std::size_t ii = 0; ii < i.size(); ++ii)
+            {
+                bool at_least_one_keep_check = std::apply(
+                    [&](auto... offsets)
+                    {
+                        return ((tag_data[offsets + 2 * ii] & static_cast<std::uint8_t>(CellFlag::keep)) | ...);
+                    },
+                    fine_offsets);
 
-            apply_on_masked(field(level, i),
-                            coarsen_mask,
-                            [&](auto& e)
-                            {
-                                e |= static_cast<std::uint8_t>(CellFlag::keep);
-                            });
-        }
+                if (at_least_one_keep_check)
+                {
+                    std::apply(
+                        [&](auto... offsets)
+                        {
+                            ((tag_data[offsets + 2 * ii] |= static_cast<std::uint8_t>(CellFlag::keep)), ...);
+                        },
+                        fine_offsets);
+                    tag_data[coarse_offset + ii] |= static_cast<std::uint8_t>(CellFlag::keep);
+                    continue;
+                }
 
-        template <class T>
-        SAMURAI_INLINE void operator()(Dim<2>, T& field) const
-        {
-            auto mask_keep = eval((field(level + 1, 2 * i, 2 * j) & static_cast<std::uint8_t>(CellFlag::keep))
-                                  | (field(level + 1, 2 * i + 1, 2 * j) & static_cast<std::uint8_t>(CellFlag::keep))
-                                  | (field(level + 1, 2 * i, 2 * j + 1) & static_cast<std::uint8_t>(CellFlag::keep))
-                                  | (field(level + 1, 2 * i + 1, 2 * j + 1) & static_cast<std::uint8_t>(CellFlag::keep)));
+                bool all_coarsen_check = std::apply(
+                    [&](auto... offsets)
+                    {
+                        return ((tag_data[offsets + 2 * ii] & static_cast<std::uint8_t>(CellFlag::coarsen)) & ...);
+                    },
+                    fine_offsets);
 
-            // version 1
-            // xt::masked_view(field(level + 1, 2 * i, 2 * j), mask_keep) |= static_cast<std::uint8_t>(CellFlag::keep);
-            // xt::masked_view(field(level + 1, 2 * i + 1, 2 * j), mask_keep) |= static_cast<std::uint8_t>(CellFlag::keep);
-            // xt::masked_view(field(level + 1, 2 * i, 2 * j + 1), mask_keep) |= static_cast<std::uint8_t>(CellFlag::keep);
-            // xt::masked_view(field(level + 1, 2 * i + 1, 2 * j + 1), mask_keep) |= static_cast<std::uint8_t>(CellFlag::keep);
-
-            // xt::masked_view(field(level, i, j), mask_keep) |= static_cast<std::uint8_t>(CellFlag::keep);
-
-            // version 2
-            // static_nested_loop<dim - 1, 0, 2>(
-            //     [&](auto stencil)
-            //     {
-            //         for (int ii = 0; ii < 2; ++ii)
-            //         {
-            //             field(level + 1, 2 * i + ii, 2 * index + stencil) |= mask_keep * static_cast<std::uint8_t>(CellFlag::keep);
-            //         }
-            //     });
-            // field(level, i, index) |= mask_keep * static_cast<std::uint8_t>(CellFlag::keep);
-
-            // version 3
-            apply_on_masked(mask_keep,
-                            [&](auto imask)
-                            {
-                                field(level + 1, 2 * i, 2 * j)(imask) |= static_cast<std::uint8_t>(CellFlag::keep);
-                                field(level + 1, 2 * i + 1, 2 * j)(imask) |= static_cast<std::uint8_t>(CellFlag::keep);
-                                field(level + 1, 2 * i, 2 * j + 1)(imask) |= static_cast<std::uint8_t>(CellFlag::keep);
-                                field(level + 1, 2 * i + 1, 2 * j + 1)(imask) |= static_cast<std::uint8_t>(CellFlag::keep);
-                                field(level, i, j)(imask) |= static_cast<std::uint8_t>(CellFlag::keep);
-                            });
-
-            auto mask_coarsen = eval((field(level + 1, 2 * i, 2 * j) & static_cast<std::uint8_t>(CellFlag::coarsen))
-                                     & (field(level + 1, 2 * i + 1, 2 * j) & static_cast<std::uint8_t>(CellFlag::coarsen))
-                                     & (field(level + 1, 2 * i, 2 * j + 1) & static_cast<std::uint8_t>(CellFlag::coarsen))
-                                     & (field(level + 1, 2 * i + 1, 2 * j + 1) & static_cast<std::uint8_t>(CellFlag::coarsen)));
-
-            // version 1
-            // xt::masked_view(field(level + 1, 2 * i, 2 * j), !mask_coarsen) &= ~static_cast<unsigned int>(CellFlag::coarsen);
-            // xt::masked_view(field(level + 1, 2 * i + 1, 2 * j), !mask_coarsen) &= ~static_cast<unsigned int>(CellFlag::coarsen);
-            // xt::masked_view(field(level + 1, 2 * i, 2 * j + 1), !mask_coarsen) &= ~static_cast<unsigned int>(CellFlag::coarsen);
-            // xt::masked_view(field(level + 1, 2 * i + 1, 2 * j + 1), !mask_coarsen) &= ~static_cast<unsigned int>(CellFlag::coarsen);
-            // xt::masked_view(field(level, i, j), mask_coarsen) |= static_cast<std::uint8_t>(CellFlag::keep);
-
-            // version 2
-            // static_nested_loop<dim - 1, 0, 2>(
-            //     [&](auto stencil)
-            //     {
-            //         for (int ii = 0; ii < 2; ++ii)
-            //         {
-            //             noalias(field(level + 1, 2 * i + ii, 2 * index + stencil)) = (!mask_coarsen)
-            //                                                                            * (field(level + 1, 2 * i + ii, 2 * index +
-            //                                                                            stencil)
-            //                                                                               & (~static_cast<unsigned
-            //                                                                               int>(CellFlag::coarsen)))
-            //                                                                        + mask_coarsen
-            //                                                                              * field(level + 1, 2 * i + ii, 2 * index +
-            //                                                                              stencil);
-            //         }
-            //     });
-
-            // field(level, i, j) |= mask_coarsen * static_cast<std::uint8_t>(CellFlag::keep);
-
-            // version 3
-            apply_on_masked(!mask_coarsen,
-                            [&](auto imask)
-                            {
-                                field(level + 1, 2 * i, 2 * j)(imask) &= ~static_cast<std::uint8_t>(CellFlag::coarsen);
-                                field(level + 1, 2 * i + 1, 2 * j)(imask) &= ~static_cast<std::uint8_t>(CellFlag::coarsen);
-                                field(level + 1, 2 * i, 2 * j + 1)(imask) &= ~static_cast<std::uint8_t>(CellFlag::coarsen);
-                                field(level + 1, 2 * i + 1, 2 * j + 1)(imask) &= ~static_cast<std::uint8_t>(CellFlag::coarsen);
-                            });
-            apply_on_masked(field(level, i, j),
-                            mask_coarsen,
-                            [](auto& e)
-                            {
-                                e |= static_cast<std::uint8_t>(CellFlag::keep);
-                            });
-        }
-
-        template <class T>
-        SAMURAI_INLINE void operator()(Dim<3>, T& field) const
-        {
-            auto mask1 = (field(level + 1, 2 * i, 2 * j, 2 * k) & static_cast<std::uint8_t>(CellFlag::keep))
-                       | (field(level + 1, 2 * i + 1, 2 * j, 2 * k) & static_cast<std::uint8_t>(CellFlag::keep))
-                       | (field(level + 1, 2 * i, 2 * j + 1, 2 * k) & static_cast<std::uint8_t>(CellFlag::keep))
-                       | (field(level + 1, 2 * i + 1, 2 * j + 1, 2 * k) & static_cast<std::uint8_t>(CellFlag::keep))
-                       | (field(level + 1, 2 * i, 2 * j, 2 * k + 1) & static_cast<std::uint8_t>(CellFlag::keep))
-                       | (field(level + 1, 2 * i + 1, 2 * j, 2 * k + 1) & static_cast<std::uint8_t>(CellFlag::keep))
-                       | (field(level + 1, 2 * i, 2 * j + 1, 2 * k + 1) & static_cast<std::uint8_t>(CellFlag::keep))
-                       | (field(level + 1, 2 * i + 1, 2 * j + 1, 2 * k + 1) & static_cast<std::uint8_t>(CellFlag::keep));
-
-            apply_on_masked(mask1,
-                            [&](auto imask)
-                            {
-                                field(level + 1, 2 * i, 2 * j, 2 * k)(imask) |= static_cast<std::uint8_t>(CellFlag::keep);
-                                field(level + 1, 2 * i + 1, 2 * j, 2 * k)(imask) |= static_cast<std::uint8_t>(CellFlag::keep);
-                                field(level + 1, 2 * i, 2 * j + 1, 2 * k)(imask) |= static_cast<std::uint8_t>(CellFlag::keep);
-                                field(level + 1, 2 * i + 1, 2 * j + 1, 2 * k)(imask) |= static_cast<std::uint8_t>(CellFlag::keep);
-                                field(level + 1, 2 * i, 2 * j, 2 * k + 1)(imask) |= static_cast<std::uint8_t>(CellFlag::keep);
-                                field(level + 1, 2 * i + 1, 2 * j, 2 * k + 1)(imask) |= static_cast<std::uint8_t>(CellFlag::keep);
-                                field(level + 1, 2 * i, 2 * j + 1, 2 * k + 1)(imask) |= static_cast<std::uint8_t>(CellFlag::keep);
-                                field(level + 1, 2 * i + 1, 2 * j + 1, 2 * k + 1)(imask) |= static_cast<std::uint8_t>(CellFlag::keep);
-                                field(level, i, j, k)(imask) |= static_cast<std::uint8_t>(CellFlag::keep);
-                            });
-
-            auto mask2 = (field(level + 1, 2 * i, 2 * j, 2 * k) & static_cast<std::uint8_t>(CellFlag::coarsen))
-                       & (field(level + 1, 2 * i + 1, 2 * j, 2 * k) & static_cast<std::uint8_t>(CellFlag::coarsen))
-                       & (field(level + 1, 2 * i, 2 * j + 1, 2 * k) & static_cast<std::uint8_t>(CellFlag::coarsen))
-                       & (field(level + 1, 2 * i + 1, 2 * j + 1, 2 * k) & static_cast<std::uint8_t>(CellFlag::coarsen))
-                       & (field(level + 1, 2 * i, 2 * j, 2 * k + 1) & static_cast<std::uint8_t>(CellFlag::coarsen))
-                       & (field(level + 1, 2 * i + 1, 2 * j, 2 * k + 1) & static_cast<std::uint8_t>(CellFlag::coarsen))
-                       & (field(level + 1, 2 * i, 2 * j + 1, 2 * k + 1) & static_cast<std::uint8_t>(CellFlag::coarsen))
-                       & (field(level + 1, 2 * i + 1, 2 * j + 1, 2 * k + 1) & static_cast<std::uint8_t>(CellFlag::coarsen));
-
-            apply_on_masked(!mask2,
-                            [&](auto imask)
-                            {
-                                field(level + 1, 2 * i, 2 * j, 2 * k)(imask) &= ~static_cast<std::uint8_t>(CellFlag::coarsen);
-                                field(level + 1, 2 * i + 1, 2 * j, 2 * k)(imask) &= ~static_cast<std::uint8_t>(CellFlag::coarsen);
-                                field(level + 1, 2 * i, 2 * j + 1, 2 * k)(imask) &= ~static_cast<std::uint8_t>(CellFlag::coarsen);
-                                field(level + 1, 2 * i + 1, 2 * j + 1, 2 * k)(imask) &= ~static_cast<std::uint8_t>(CellFlag::coarsen);
-                                field(level + 1, 2 * i, 2 * j, 2 * k + 1)(imask) &= ~static_cast<std::uint8_t>(CellFlag::coarsen);
-                                field(level + 1, 2 * i + 1, 2 * j, 2 * k + 1)(imask) &= ~static_cast<std::uint8_t>(CellFlag::coarsen);
-                                field(level + 1, 2 * i, 2 * j + 1, 2 * k + 1)(imask) &= ~static_cast<std::uint8_t>(CellFlag::coarsen);
-                                field(level + 1, 2 * i + 1, 2 * j + 1, 2 * k + 1)(imask) &= ~static_cast<std::uint8_t>(CellFlag::coarsen);
-                            });
-
-            apply_on_masked(field(level, i, j, k),
-                            mask2,
-                            [](auto& e)
-                            {
-                                e |= static_cast<std::uint8_t>(CellFlag::keep);
-                            });
+                if (all_coarsen_check)
+                {
+                    tag_data[coarse_offset + ii] |= static_cast<std::uint8_t>(CellFlag::keep);
+                }
+            }
         }
     };
 


### PR DESCRIPTION
## Description
This PR refactors MR tag computation to reduce per-cell overhead by replacing expression/masked operations with direct pointer/offset-based loops, and updates tagging storage to use `std::uint8_t` flags.

**Changes:**

- Replace per-dimension maximum_op implementations with a single `Dim<dim>` implementation using contiguous-memory offsets.
- Collapse the former refine/coarsen operators into a single `mr_criteria` operator using raw pointer indexing.
- Switch MR tag field storage from int to `std::uint8_t` and adjust related tag-writing code paths and timers.

## Code of Conduct
By submitting this PR, you agree to follow our [Code of Conduct](https://github.com/hpc-maths/samurai/blob/master/docs/CODE_OF_CONDUCT.md)
- [x] I agree to follow this project's Code of Conduct
