### PR TITLE
fix: set tag type to `uint8_t`

### DIFF
--- a/include/samurai/algorithm/graduation.hpp
+++ b/include/samurai/algorithm/graduation.hpp
@@ -94,21 +94,21 @@ namespace samurai
 
             auto tag_func = [&](auto& i_f)
             {
-                auto mask = tag(level, i_f - s[0], index - view(s, xt::range(1, _))) & static_cast<int>(CellFlag::refine);
+                auto mask = tag(level, i_f - s[0], index - view(s, xt::range(1, _))) & static_cast<std::uint8_t>(CellFlag::refine);
                 auto i_c  = i_f >> 1;
                 apply_on_masked(tag(level - 1, i_c, index >> 1),
                                 mask,
                                 [](auto& e)
                                 {
-                                    e |= static_cast<int>(CellFlag::refine);
+                                    e |= static_cast<std::uint8_t>(CellFlag::refine);
                                 });
 
-                auto mask2 = tag(level, i_f - s[0], index - view(s, xt::range(1, _))) & static_cast<int>(CellFlag::keep);
+                auto mask2 = tag(level, i_f - s[0], index - view(s, xt::range(1, _))) & static_cast<std::uint8_t>(CellFlag::keep);
                 apply_on_masked(tag(level - 1, i_c, index >> 1),
                                 mask2,
                                 [](auto& e)
                                 {
-                                    e |= static_cast<int>(CellFlag::keep);
+                                    e |= static_cast<std::uint8_t>(CellFlag::keep);
                                 });
             };
 
@@ -692,9 +692,9 @@ namespace samurai
                 for (value_t x = x_interval.start; x < x_interval.end; ++x)
                 {
                     const size_type itag         = static_cast<size_type>(x_interval.index) + static_cast<unsigned_value_t>(x);
-                    const bool refine            = tag[itag] & static_cast<int>(CellFlag::refine);
-                    const bool coarsenAndNotKeep = tag[itag] & static_cast<int>(CellFlag::coarsen)
-                                               and not(tag[itag] & static_cast<int>(CellFlag::keep));
+                    const bool refine            = tag[itag] & static_cast<std::uint8_t>(CellFlag::refine);
+                    const bool coarsenAndNotKeep = tag[itag] & static_cast<std::uint8_t>(CellFlag::coarsen)
+                                               and not(tag[itag] & static_cast<std::uint8_t>(CellFlag::keep));
                     if (refine and level < mesh.max_level())
                     {
                         ca_remove_p[level].add_point_back(x, yz);

--- a/include/samurai/algorithm/update.hpp
+++ b/include/samurai/algorithm/update.hpp
@@ -873,10 +873,10 @@ namespace samurai
                         {
                             if constexpr (dim == 1)
                             {
-                                auto mask1 = (tag(level, 2 * i) & static_cast<int>(CellFlag::coarsen))
-                                           & (tag(level, 2 * i + 1) & static_cast<int>(CellFlag::coarsen));
-                                auto mask2 = (tag(level, 2 * i) & static_cast<int>(CellFlag::keep))
-                                           | (tag(level, 2 * i + 1) & static_cast<int>(CellFlag::keep));
+                                auto mask1 = (tag(level, 2 * i) & static_cast<std::uint8_t>(CellFlag::coarsen))
+                                           & (tag(level, 2 * i + 1) & static_cast<std::uint8_t>(CellFlag::coarsen));
+                                auto mask2 = (tag(level, 2 * i) & static_cast<std::uint8_t>(CellFlag::keep))
+                                           | (tag(level, 2 * i + 1) & static_cast<std::uint8_t>(CellFlag::keep));
                                 auto mask = xt::eval(mask1 && !mask2);
 
                                 xt::masked_view(tag(level, 2 * i), mask)     = 0;
@@ -885,14 +885,14 @@ namespace samurai
                             if constexpr (dim == 2)
                             {
                                 auto j     = index[0];
-                                auto mask1 = (tag(level, 2 * i, 2 * j) & static_cast<int>(CellFlag::coarsen))
-                                           & (tag(level, 2 * i + 1, 2 * j) & static_cast<int>(CellFlag::coarsen))
-                                           & (tag(level, 2 * i, 2 * j + 1) & static_cast<int>(CellFlag::coarsen))
-                                           & (tag(level, 2 * i + 1, 2 * j + 1) & static_cast<int>(CellFlag::coarsen));
-                                auto mask2 = (tag(level, 2 * i, 2 * j) & static_cast<int>(CellFlag::keep))
-                                           | (tag(level, 2 * i + 1, 2 * j) & static_cast<int>(CellFlag::keep))
-                                           | (tag(level, 2 * i, 2 * j + 1) & static_cast<int>(CellFlag::keep))
-                                           | (tag(level, 2 * i + 1, 2 * j + 1) & static_cast<int>(CellFlag::keep));
+                                auto mask1 = (tag(level, 2 * i, 2 * j) & static_cast<std::uint8_t>(CellFlag::coarsen))
+                                           & (tag(level, 2 * i + 1, 2 * j) & static_cast<std::uint8_t>(CellFlag::coarsen))
+                                           & (tag(level, 2 * i, 2 * j + 1) & static_cast<std::uint8_t>(CellFlag::coarsen))
+                                           & (tag(level, 2 * i + 1, 2 * j + 1) & static_cast<std::uint8_t>(CellFlag::coarsen));
+                                auto mask2 = (tag(level, 2 * i, 2 * j) & static_cast<std::uint8_t>(CellFlag::keep))
+                                           | (tag(level, 2 * i + 1, 2 * j) & static_cast<std::uint8_t>(CellFlag::keep))
+                                           | (tag(level, 2 * i, 2 * j + 1) & static_cast<std::uint8_t>(CellFlag::keep))
+                                           | (tag(level, 2 * i + 1, 2 * j + 1) & static_cast<std::uint8_t>(CellFlag::keep));
                                 auto mask = xt::eval(mask1 && !mask2);
 
                                 xt::masked_view(tag(level, 2 * i, 2 * j), mask)         = 0;
@@ -904,22 +904,22 @@ namespace samurai
                             {
                                 auto j     = index[0];
                                 auto k     = index[1];
-                                auto mask1 = (tag(level, 2 * i, 2 * j, 2 * k) & static_cast<int>(CellFlag::coarsen))
-                                           & (tag(level, 2 * i + 1, 2 * j, 2 * k) & static_cast<int>(CellFlag::coarsen))
-                                           & (tag(level, 2 * i, 2 * j + 1, 2 * k) & static_cast<int>(CellFlag::coarsen))
-                                           & (tag(level, 2 * i + 1, 2 * j + 1, 2 * k) & static_cast<int>(CellFlag::coarsen))
-                                           & (tag(level, 2 * i, 2 * j, 2 * k + 1) & static_cast<int>(CellFlag::coarsen))
-                                           & (tag(level, 2 * i + 1, 2 * j, 2 * k + 1) & static_cast<int>(CellFlag::coarsen))
-                                           & (tag(level, 2 * i, 2 * j + 1, 2 * k + 1) & static_cast<int>(CellFlag::coarsen))
-                                           & (tag(level, 2 * i + 1, 2 * j + 1, 2 * k + 1) & static_cast<int>(CellFlag::coarsen));
-                                auto mask2 = (tag(level, 2 * i, 2 * j, 2 * k) & static_cast<int>(CellFlag::keep))
-                                           | (tag(level, 2 * i + 1, 2 * j, 2 * k) & static_cast<int>(CellFlag::keep))
-                                           | (tag(level, 2 * i, 2 * j + 1, 2 * k) & static_cast<int>(CellFlag::keep))
-                                           | (tag(level, 2 * i + 1, 2 * j + 1, 2 * k) & static_cast<int>(CellFlag::keep))
-                                           | (tag(level, 2 * i, 2 * j, 2 * k + 1) & static_cast<int>(CellFlag::keep))
-                                           | (tag(level, 2 * i + 1, 2 * j, 2 * k + 1) & static_cast<int>(CellFlag::keep))
-                                           | (tag(level, 2 * i, 2 * j + 1, 2 * k + 1) & static_cast<int>(CellFlag::keep))
-                                           | (tag(level, 2 * i + 1, 2 * j + 1, 2 * k + 1) & static_cast<int>(CellFlag::keep));
+                                auto mask1 = (tag(level, 2 * i, 2 * j, 2 * k) & static_cast<std::uint8_t>(CellFlag::coarsen))
+                                           & (tag(level, 2 * i + 1, 2 * j, 2 * k) & static_cast<std::uint8_t>(CellFlag::coarsen))
+                                           & (tag(level, 2 * i, 2 * j + 1, 2 * k) & static_cast<std::uint8_t>(CellFlag::coarsen))
+                                           & (tag(level, 2 * i + 1, 2 * j + 1, 2 * k) & static_cast<std::uint8_t>(CellFlag::coarsen))
+                                           & (tag(level, 2 * i, 2 * j, 2 * k + 1) & static_cast<std::uint8_t>(CellFlag::coarsen))
+                                           & (tag(level, 2 * i + 1, 2 * j, 2 * k + 1) & static_cast<std::uint8_t>(CellFlag::coarsen))
+                                           & (tag(level, 2 * i, 2 * j + 1, 2 * k + 1) & static_cast<std::uint8_t>(CellFlag::coarsen))
+                                           & (tag(level, 2 * i + 1, 2 * j + 1, 2 * k + 1) & static_cast<std::uint8_t>(CellFlag::coarsen));
+                                auto mask2 = (tag(level, 2 * i, 2 * j, 2 * k) & static_cast<std::uint8_t>(CellFlag::keep))
+                                           | (tag(level, 2 * i + 1, 2 * j, 2 * k) & static_cast<std::uint8_t>(CellFlag::keep))
+                                           | (tag(level, 2 * i, 2 * j + 1, 2 * k) & static_cast<std::uint8_t>(CellFlag::keep))
+                                           | (tag(level, 2 * i + 1, 2 * j + 1, 2 * k) & static_cast<std::uint8_t>(CellFlag::keep))
+                                           | (tag(level, 2 * i, 2 * j, 2 * k + 1) & static_cast<std::uint8_t>(CellFlag::keep))
+                                           | (tag(level, 2 * i + 1, 2 * j, 2 * k + 1) & static_cast<std::uint8_t>(CellFlag::keep))
+                                           | (tag(level, 2 * i, 2 * j + 1, 2 * k + 1) & static_cast<std::uint8_t>(CellFlag::keep))
+                                           | (tag(level, 2 * i + 1, 2 * j + 1, 2 * k + 1) & static_cast<std::uint8_t>(CellFlag::keep));
                                 auto mask = xt::eval(mask1 && !mask2);
 
                                 xt::masked_view(tag(level, 2 * i, 2 * j, 2 * k), mask)             = 0;
@@ -1454,7 +1454,7 @@ namespace samurai
                               auto itag = static_cast<size_type>(interval.start + interval.index);
                               for (auto i = interval.start; i < interval.end; ++i)
                               {
-                                  if (tag[itag] & static_cast<int>(CellFlag::refine))
+                                  if (tag[itag] & static_cast<std::uint8_t>(CellFlag::refine))
                                   {
                                       if (level < mesh.max_level())
                                       {
@@ -1470,11 +1470,11 @@ namespace samurai
                                           cl[level][index].add_point(i);
                                       }
                                   }
-                                  else if (tag[itag] & static_cast<int>(CellFlag::keep))
+                                  else if (tag[itag] & static_cast<std::uint8_t>(CellFlag::keep))
                                   {
                                       cl[level][index].add_point(i);
                                   }
-                                  else if (tag[itag] & static_cast<int>(CellFlag::coarsen))
+                                  else if (tag[itag] & static_cast<std::uint8_t>(CellFlag::coarsen))
                                   {
                                       if (level > mesh.min_level())
                                       {

--- a/include/samurai/algorithm/utils.hpp
+++ b/include/samurai/algorithm/utils.hpp
@@ -62,7 +62,7 @@ namespace samurai
             static_nested_loop<1, -s, s + 1>(
                 [&](const auto& stencil)
                 {
-                    tag(level, i + stencil[0]) |= static_cast<int>(CellFlag::keep);
+                    tag(level, i + stencil[0]) |= static_cast<std::uint8_t>(CellFlag::keep);
                 });
         }
 
@@ -77,7 +77,7 @@ namespace samurai
                                 static_nested_loop<1, -s, s + 1>(
                                     [&](const auto& stencil)
                                     {
-                                        tag(level, i + stencil[0])(imask) |= static_cast<int>(CellFlag::keep);
+                                        tag(level, i + stencil[0])(imask) |= static_cast<std::uint8_t>(CellFlag::keep);
                                     });
                             });
         }
@@ -88,7 +88,7 @@ namespace samurai
             static_nested_loop<2, -s, s + 1>(
                 [&](const auto& stencil)
                 {
-                    tag(level, i + stencil[0], j + stencil[1]) |= static_cast<int>(CellFlag::keep);
+                    tag(level, i + stencil[0], j + stencil[1]) |= static_cast<std::uint8_t>(CellFlag::keep);
                 });
         }
 
@@ -103,7 +103,7 @@ namespace samurai
                                 static_nested_loop<2, -s, s + 1>(
                                     [&](const auto& stencil)
                                     {
-                                        tag(level, i + stencil[0], j + stencil[1])(imask) |= static_cast<int>(CellFlag::keep);
+                                        tag(level, i + stencil[0], j + stencil[1])(imask) |= static_cast<std::uint8_t>(CellFlag::keep);
                                     });
                             });
         }
@@ -114,7 +114,7 @@ namespace samurai
             static_nested_loop<3, -s, s + 1>(
                 [&](const auto& stencil)
                 {
-                    tag(level, i + stencil[0], j + stencil[1], k + stencil[2]) |= static_cast<int>(CellFlag::keep);
+                    tag(level, i + stencil[0], j + stencil[1], k + stencil[2]) |= static_cast<std::uint8_t>(CellFlag::keep);
                 });
         }
 
@@ -123,15 +123,16 @@ namespace samurai
         {
             auto mask = (tag(level, i, j, k) & static_cast<int>(flag));
 
-            apply_on_masked(mask,
-                            [&](auto imask)
-                            {
-                                static_nested_loop<3, -s, s + 1>(
-                                    [&](const auto& stencil)
-                                    {
-                                        tag(level, i + stencil[0], j + stencil[1], k + stencil[2])(imask) |= static_cast<int>(CellFlag::keep);
-                                    });
-                            });
+            apply_on_masked(
+                mask,
+                [&](auto imask)
+                {
+                    static_nested_loop<3, -s, s + 1>(
+                        [&](const auto& stencil)
+                        {
+                            tag(level, i + stencil[0], j + stencil[1], k + stencil[2])(imask) |= static_cast<std::uint8_t>(CellFlag::keep);
+                        });
+                });
         }
     };
 
@@ -161,58 +162,58 @@ namespace samurai
         template <class T>
         SAMURAI_INLINE void operator()(Dim<1>, T& tag) const
         {
-            auto mask = (tag(level + 1, 2 * i) & static_cast<int>(CellFlag::keep))
-                      | (tag(level + 1, 2 * i + 1) & static_cast<int>(CellFlag::keep));
+            auto mask = (tag(level + 1, 2 * i) & static_cast<std::uint8_t>(CellFlag::keep))
+                      | (tag(level + 1, 2 * i + 1) & static_cast<std::uint8_t>(CellFlag::keep));
 
             apply_on_masked(mask,
                             [&](auto imask)
                             {
-                                tag(level + 1, 2 * i)(imask) |= static_cast<int>(CellFlag::keep);
-                                tag(level + 1, 2 * i + 1)(imask) |= static_cast<int>(CellFlag::keep);
+                                tag(level + 1, 2 * i)(imask) |= static_cast<std::uint8_t>(CellFlag::keep);
+                                tag(level + 1, 2 * i + 1)(imask) |= static_cast<std::uint8_t>(CellFlag::keep);
                             });
         }
 
         template <class T>
         SAMURAI_INLINE void operator()(Dim<2>, T& tag) const
         {
-            auto mask = (tag(level + 1, 2 * i, 2 * j) & static_cast<int>(CellFlag::keep))
-                      | (tag(level + 1, 2 * i + 1, 2 * j) & static_cast<int>(CellFlag::keep))
-                      | (tag(level + 1, 2 * i, 2 * j + 1) & static_cast<int>(CellFlag::keep))
-                      | (tag(level + 1, 2 * i + 1, 2 * j + 1) & static_cast<int>(CellFlag::keep));
+            auto mask = (tag(level + 1, 2 * i, 2 * j) & static_cast<std::uint8_t>(CellFlag::keep))
+                      | (tag(level + 1, 2 * i + 1, 2 * j) & static_cast<std::uint8_t>(CellFlag::keep))
+                      | (tag(level + 1, 2 * i, 2 * j + 1) & static_cast<std::uint8_t>(CellFlag::keep))
+                      | (tag(level + 1, 2 * i + 1, 2 * j + 1) & static_cast<std::uint8_t>(CellFlag::keep));
 
             apply_on_masked(mask,
                             [&](auto imask)
                             {
-                                tag(level + 1, 2 * i, 2 * j)(imask) |= static_cast<int>(CellFlag::keep);
-                                tag(level + 1, 2 * i + 1, 2 * j)(imask) |= static_cast<int>(CellFlag::keep);
-                                tag(level + 1, 2 * i, 2 * j + 1)(imask) |= static_cast<int>(CellFlag::keep);
-                                tag(level + 1, 2 * i + 1, 2 * j + 1)(imask) |= static_cast<int>(CellFlag::keep);
+                                tag(level + 1, 2 * i, 2 * j)(imask) |= static_cast<std::uint8_t>(CellFlag::keep);
+                                tag(level + 1, 2 * i + 1, 2 * j)(imask) |= static_cast<std::uint8_t>(CellFlag::keep);
+                                tag(level + 1, 2 * i, 2 * j + 1)(imask) |= static_cast<std::uint8_t>(CellFlag::keep);
+                                tag(level + 1, 2 * i + 1, 2 * j + 1)(imask) |= static_cast<std::uint8_t>(CellFlag::keep);
                             });
         }
 
         template <class T>
         SAMURAI_INLINE void operator()(Dim<3>, T& tag) const
         {
-            auto mask = (tag(level + 1, 2 * i, 2 * j, 2 * k) & static_cast<int>(CellFlag::keep))
-                      | (tag(level + 1, 2 * i + 1, 2 * j, 2 * k) & static_cast<int>(CellFlag::keep))
-                      | (tag(level + 1, 2 * i, 2 * j + 1, 2 * k) & static_cast<int>(CellFlag::keep))
-                      | (tag(level + 1, 2 * i + 1, 2 * j + 1, 2 * k) & static_cast<int>(CellFlag::keep))
-                      | (tag(level + 1, 2 * i, 2 * j, 2 * k + 1) & static_cast<int>(CellFlag::keep))
-                      | (tag(level + 1, 2 * i + 1, 2 * j, 2 * k + 1) & static_cast<int>(CellFlag::keep))
-                      | (tag(level + 1, 2 * i, 2 * j + 1, 2 * k + 1) & static_cast<int>(CellFlag::keep))
-                      | (tag(level + 1, 2 * i + 1, 2 * j + 1, 2 * k + 1) & static_cast<int>(CellFlag::keep));
+            auto mask = (tag(level + 1, 2 * i, 2 * j, 2 * k) & static_cast<std::uint8_t>(CellFlag::keep))
+                      | (tag(level + 1, 2 * i + 1, 2 * j, 2 * k) & static_cast<std::uint8_t>(CellFlag::keep))
+                      | (tag(level + 1, 2 * i, 2 * j + 1, 2 * k) & static_cast<std::uint8_t>(CellFlag::keep))
+                      | (tag(level + 1, 2 * i + 1, 2 * j + 1, 2 * k) & static_cast<std::uint8_t>(CellFlag::keep))
+                      | (tag(level + 1, 2 * i, 2 * j, 2 * k + 1) & static_cast<std::uint8_t>(CellFlag::keep))
+                      | (tag(level + 1, 2 * i + 1, 2 * j, 2 * k + 1) & static_cast<std::uint8_t>(CellFlag::keep))
+                      | (tag(level + 1, 2 * i, 2 * j + 1, 2 * k + 1) & static_cast<std::uint8_t>(CellFlag::keep))
+                      | (tag(level + 1, 2 * i + 1, 2 * j + 1, 2 * k + 1) & static_cast<std::uint8_t>(CellFlag::keep));
 
             apply_on_masked(mask,
                             [&](auto imask)
                             {
-                                tag(level + 1, 2 * i, 2 * j, 2 * k)(imask) |= static_cast<int>(CellFlag::keep);
-                                tag(level + 1, 2 * i + 1, 2 * j, 2 * k)(imask) |= static_cast<int>(CellFlag::keep);
-                                tag(level + 1, 2 * i, 2 * j + 1, 2 * k)(imask) |= static_cast<int>(CellFlag::keep);
-                                tag(level + 1, 2 * i + 1, 2 * j + 1, 2 * k)(imask) |= static_cast<int>(CellFlag::keep);
-                                tag(level + 1, 2 * i, 2 * j, 2 * k + 1)(imask) |= static_cast<int>(CellFlag::keep);
-                                tag(level + 1, 2 * i + 1, 2 * j, 2 * k + 1)(imask) |= static_cast<int>(CellFlag::keep);
-                                tag(level + 1, 2 * i, 2 * j + 1, 2 * k + 1)(imask) |= static_cast<int>(CellFlag::keep);
-                                tag(level + 1, 2 * i + 1, 2 * j + 1, 2 * k + 1)(imask) |= static_cast<int>(CellFlag::keep);
+                                tag(level + 1, 2 * i, 2 * j, 2 * k)(imask) |= static_cast<std::uint8_t>(CellFlag::keep);
+                                tag(level + 1, 2 * i + 1, 2 * j, 2 * k)(imask) |= static_cast<std::uint8_t>(CellFlag::keep);
+                                tag(level + 1, 2 * i, 2 * j + 1, 2 * k)(imask) |= static_cast<std::uint8_t>(CellFlag::keep);
+                                tag(level + 1, 2 * i + 1, 2 * j + 1, 2 * k)(imask) |= static_cast<std::uint8_t>(CellFlag::keep);
+                                tag(level + 1, 2 * i, 2 * j, 2 * k + 1)(imask) |= static_cast<std::uint8_t>(CellFlag::keep);
+                                tag(level + 1, 2 * i + 1, 2 * j, 2 * k + 1)(imask) |= static_cast<std::uint8_t>(CellFlag::keep);
+                                tag(level + 1, 2 * i, 2 * j + 1, 2 * k + 1)(imask) |= static_cast<std::uint8_t>(CellFlag::keep);
+                                tag(level + 1, 2 * i + 1, 2 * j + 1, 2 * k + 1)(imask) |= static_cast<std::uint8_t>(CellFlag::keep);
                             });
         }
     };

--- a/include/samurai/algorithm/utils.hpp
+++ b/include/samurai/algorithm/utils.hpp
@@ -69,7 +69,7 @@ namespace samurai
         template <class T, class Flag, int s>
         SAMURAI_INLINE void operator()(Dim<1>, T& tag, const Flag& flag, std::integral_constant<int, s>) const
         {
-            auto mask = (tag(level, i) & static_cast<int>(flag));
+            auto mask = (tag(level, i) & static_cast<std::uint8_t>(flag));
 
             apply_on_masked(mask,
                             [&](auto imask)
@@ -95,7 +95,7 @@ namespace samurai
         template <class T, class Flag, int s>
         SAMURAI_INLINE void operator()(Dim<2>, T& tag, const Flag& flag, std::integral_constant<int, s>) const
         {
-            auto mask = (tag(level, i, j) & static_cast<int>(flag));
+            auto mask = (tag(level, i, j) & static_cast<std::uint8_t>(flag));
 
             apply_on_masked(mask,
                             [&](auto imask)
@@ -121,7 +121,7 @@ namespace samurai
         template <class T, class Flag, int s>
         SAMURAI_INLINE void operator()(Dim<3>, T& tag, const Flag& flag, std::integral_constant<int, s>) const
         {
-            auto mask = (tag(level, i, j, k) & static_cast<int>(flag));
+            auto mask = (tag(level, i, j, k) & static_cast<std::uint8_t>(flag));
 
             apply_on_masked(
                 mask,

--- a/include/samurai/cell_flag.hpp
+++ b/include/samurai/cell_flag.hpp
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <cstdint>
+
 namespace samurai
 {
     enum class CellFlag : std::uint8_t

--- a/include/samurai/cell_flag.hpp
+++ b/include/samurai/cell_flag.hpp
@@ -6,7 +6,7 @@
 
 namespace samurai
 {
-    enum class CellFlag
+    enum class CellFlag : std::uint8_t
     {
         keep    = 1,
         coarsen = 2,

--- a/include/samurai/io/from_geometry.hpp
+++ b/include/samurai/io/from_geometry.hpp
@@ -52,7 +52,7 @@ namespace samurai
         std::size_t current_level = start_level;
         while (current_level != max_level + 1)
         {
-            auto tag = make_scalar_field<int>("tag", mesh);
+            auto tag = make_scalar_field<std::uint8_t>("tag", mesh);
             tag.fill(0);
 
             for (std::size_t level = mesh.min_level(); level < current_level; ++level)

--- a/include/samurai/io/from_geometry.hpp
+++ b/include/samurai/io/from_geometry.hpp
@@ -60,7 +60,7 @@ namespace samurai
                 for_each_interval(mesh[level],
                                   [&](std::size_t level, const auto& i, const auto& index)
                                   {
-                                      tag(level, i, index[0], index[1]) = static_cast<int>(CellFlag::keep);
+                                      tag(level, i, index[0], index[1]) = static_cast<std::uint8_t>(CellFlag::keep);
                                   });
             }
 
@@ -92,11 +92,11 @@ namespace samurai
                 {
                     if (current_level != max_level)
                     {
-                        tag[cells[b.id() - start_id]] = static_cast<int>(CellFlag::refine);
+                        tag[cells[b.id() - start_id]] = static_cast<std::uint8_t>(CellFlag::refine);
                     }
                     else
                     {
-                        tag[cells[b.id() - start_id]] = static_cast<int>(CellFlag::keep);
+                        tag[cells[b.id() - start_id]] = static_cast<std::uint8_t>(CellFlag::keep);
                     }
                 }
             };
@@ -110,11 +110,11 @@ namespace samurai
                               res = inside({center(0), center(1), center(2)});
                               if (res == CGAL::ON_BOUNDED_SIDE && keep_inside)
                               {
-                                  tag[cell] |= static_cast<int>(CellFlag::keep);
+                                  tag[cell] |= static_cast<std::uint8_t>(CellFlag::keep);
                               }
                               if (res == CGAL::ON_UNBOUNDED_SIDE && keep_outside)
                               {
-                                  tag[cell] |= static_cast<int>(CellFlag::keep);
+                                  tag[cell] |= static_cast<std::uint8_t>(CellFlag::keep);
                               }
                           });
 
@@ -131,7 +131,7 @@ namespace samurai
                                       auto itag = interval.start + interval.index;
                                       for (typename interval_t::value_t i = interval.start; i < interval.end; ++i, ++itag)
                                       {
-                                          if ((tag[itag] & static_cast<int>(CellFlag::refine)) && level < max_level)
+                                          if ((tag[itag] & static_cast<std::uint8_t>(CellFlag::refine)) && level < max_level)
                                           {
                                               static_nested_loop<2, 0, 2>(
                                                   [&](auto stencil)
@@ -140,7 +140,7 @@ namespace samurai
                                                       cl[level + 1][index].add_interval({2 * i, 2 * i + 2});
                                                   });
                                           }
-                                          else if (tag[itag] & static_cast<int>(CellFlag::keep))
+                                          else if (tag[itag] & static_cast<std::uint8_t>(CellFlag::keep))
                                           {
                                               cl[level][index_yz].add_point(i);
                                           }


### PR DESCRIPTION
## Description

This PR updates the internal representation of cell tagging flags by making `samurai::CellFlag` use an 8-bit underlying type and adjusting call sites to cast to `std::uint8_t` when writing/reading tag bitmasks.

**Changes:**

- Change `CellFlag` to `enum class CellFlag : std::uint8_t`.
- Update tagging code paths to use `static_cast<std::uint8_t>(CellFlag::...)` instead of `static_cast<int>(...)`.

## Code of Conduct
By submitting this PR, you agree to follow our [Code of Conduct](https://github.com/hpc-maths/samurai/blob/master/docs/CODE_OF_CONDUCT.md)
- [x] I agree to follow this project's Code of Conduct
