### PR TITLE
fix: mesh_config in load

### DIFF
--- a/include/samurai/io/restart.hpp
+++ b/include/samurai/io/restart.hpp
@@ -415,8 +415,7 @@ namespace samurai
 
         ca_type ca;
         load(file, ca);
-        using config_t = typename Mesh::config_t;
-        auto mesh_cfg  = config_t().min_level(min_level).max_level(max_level).disable_args_parse();
+        auto mesh_cfg  = mesh.cfg().min_level(min_level).max_level(max_level).disable_args_parse();
         Mesh new_mesh{ca, mesh_cfg};
         std::swap(mesh, new_mesh);
         load_fields(file, mesh, fields...);

--- a/include/samurai/io/restart.hpp
+++ b/include/samurai/io/restart.hpp
@@ -415,7 +415,7 @@ namespace samurai
 
         ca_type ca;
         load(file, ca);
-        auto mesh_cfg  = mesh.cfg().min_level(min_level).max_level(max_level).disable_args_parse();
+        auto mesh_cfg = mesh.cfg().min_level(min_level).max_level(max_level).disable_args_parse();
         Mesh new_mesh{ca, mesh_cfg};
         std::swap(mesh, new_mesh);
         load_fields(file, mesh, fields...);

--- a/include/samurai/io/restart.hpp
+++ b/include/samurai/io/restart.hpp
@@ -415,7 +415,8 @@ namespace samurai
 
         ca_type ca;
         load(file, ca);
-        auto mesh_cfg = mesh.cfg().min_level(min_level).max_level(max_level).disable_args_parse();
+        auto mesh_cfg = mesh.cfg();
+        mesh_cfg.min_level(min_level).max_level(max_level).disable_args_parse();
         Mesh new_mesh{ca, mesh_cfg};
         std::swap(mesh, new_mesh);
         load_fields(file, mesh, fields...);


### PR DESCRIPTION
## Description
Updates restart loading to build the reconstructed mesh config from the existing mesh’s config rather than default-constructing a new config.

## Code of Conduct
By submitting this PR, you agree to follow our [Code of Conduct](https://github.com/hpc-maths/samurai/blob/master/docs/CODE_OF_CONDUCT.md)
- [x] I agree to follow this project's Code of Conduct
