### PR TITLE
refactor: mesh base ctors

### DIFF
--- a/include/samurai/mesh.hpp
+++ b/include/samurai/mesh.hpp
@@ -274,6 +274,14 @@ namespace samurai
 
         void compute_gravity_center();
 
+        // Common tail shared by every non-default constructor.
+        // exchange_neighbour_meshes() wraps the MPI neighbour exchange, and
+        // finalize_mesh() performs the post-construction steps (sub-mesh update,
+        // corners, renumbering, origin/scaling propagation, ghost exchange and,
+        // under MPI+PETSc, the gravity-center computation).
+        void exchange_neighbour_meshes();
+        void finalize_mesh(const coords_t& origin_point, double scaling_factor);
+
         void partition_mesh(std::size_t start_level, const Box<double, dim>& global_box);
         std::size_t max_nb_cells(std::size_t level) const;
 
@@ -350,20 +358,8 @@ namespace samurai
 
         construct_subdomain();
         construct_union();
-#ifdef SAMURAI_WITH_MPI
-        find_neighbourhood();
-        update_neighbour_subdomain();
-#endif
-        update_meshid_neighbour(mesh_id_t::cells);
-        update_sub_mesh();
-        construct_corners();
-        renumbering();
-        set_origin_point(origin_point());
-        set_scaling_factor(scaling_factor());
-        update_mesh_neighbour();
-#if defined(SAMURAI_WITH_MPI) && defined(SAMURAI_WITH_PETSC)
-        compute_gravity_center();
-#endif
+        exchange_neighbour_meshes();
+        finalize_mesh(origin_point(), scaling_factor());
     }
 
     template <class D, class Config>
@@ -401,47 +397,14 @@ namespace samurai
         construct_subdomain();
         m_domain = m_subdomain;
         construct_union();
-#ifdef SAMURAI_WITH_MPI
-        find_neighbourhood();
-        update_neighbour_subdomain();
-#endif
-        update_meshid_neighbour(mesh_id_t::cells);
-        update_sub_mesh();
-        construct_corners();
-        renumbering();
-        set_origin_point(domain_builder.origin_point());
-        set_scaling_factor(m_config.scaling_factor());
-        update_mesh_neighbour();
-#if defined(SAMURAI_WITH_MPI) && defined(SAMURAI_WITH_PETSC)
-        compute_gravity_center();
-        // set_scaling_factor(scaling_factor_);
-#endif
+        exchange_neighbour_meshes();
+        finalize_mesh(domain_builder.origin_point(), m_config.scaling_factor());
     }
 
     template <class D, class Config>
     SAMURAI_INLINE Mesh_base<D, Config>::Mesh_base(const cl_type& cl, const config_t& config)
-        : m_config(config)
+        : Mesh_base(ca_type{cl, false}, config)
     {
-        m_cells[mesh_id_t::cells] = {cl, false};
-
-        construct_subdomain();
-        construct_domain();
-#ifdef SAMURAI_WITH_MPI
-        find_neighbourhood();
-        update_neighbour_subdomain();
-#endif
-        construct_union();
-        update_meshid_neighbour(mesh_id_t::cells);
-        update_sub_mesh();
-        construct_corners();
-        renumbering();
-        set_origin_point(cl.origin_point());
-        set_scaling_factor(cl.scaling_factor());
-        update_mesh_neighbour();
-
-#if defined(SAMURAI_WITH_MPI) && defined(SAMURAI_WITH_PETSC)
-        compute_gravity_center();
-#endif
     }
 
     template <class D, class Config>
@@ -452,21 +415,9 @@ namespace samurai
 
         construct_subdomain();
         construct_domain();
-#ifdef SAMURAI_WITH_MPI
-        find_neighbourhood();
-        update_neighbour_subdomain();
-#endif
+        exchange_neighbour_meshes();
         construct_union();
-        update_meshid_neighbour(mesh_id_t::cells);
-        update_sub_mesh();
-        construct_corners();
-        renumbering();
-        set_origin_point(ca.origin_point());
-        set_scaling_factor(ca.scaling_factor());
-        update_mesh_neighbour();
-#if defined(SAMURAI_WITH_MPI) && defined(SAMURAI_WITH_PETSC)
-        compute_gravity_center();
-#endif
+        finalize_mesh(ca.origin_point(), ca.scaling_factor());
     }
 
     template <class D, class Config>
@@ -479,42 +430,34 @@ namespace samurai
 
         construct_subdomain();
         construct_union();
-#ifdef SAMURAI_WITH_MPI
-        find_neighbourhood();
-        update_neighbour_subdomain();
-#endif
-        update_meshid_neighbour(mesh_id_t::cells);
-        update_sub_mesh();
-        construct_corners();
-        renumbering();
-        set_origin_point(ref_mesh.origin_point());
-        set_scaling_factor(ref_mesh.scaling_factor());
-        update_mesh_neighbour();
-#if defined(SAMURAI_WITH_MPI) && defined(SAMURAI_WITH_PETSC)
-        compute_gravity_center();
-#endif
+        exchange_neighbour_meshes();
+        finalize_mesh(ref_mesh.origin_point(), ref_mesh.scaling_factor());
     }
 
     template <class D, class Config>
     SAMURAI_INLINE Mesh_base<D, Config>::Mesh_base(const cl_type& cl, const self_type& ref_mesh)
-        : m_domain(ref_mesh.m_domain)
-        , m_mpi_neighbourhood(ref_mesh.m_mpi_neighbourhood)
-        , m_config(ref_mesh.m_config)
+        : Mesh_base(ca_type{cl, false}, ref_mesh)
     {
-        m_cells[mesh_id_t::cells] = {cl, false};
+    }
 
-        construct_subdomain();
-        construct_union();
+    template <class D, class Config>
+    SAMURAI_INLINE void Mesh_base<D, Config>::exchange_neighbour_meshes()
+    {
 #ifdef SAMURAI_WITH_MPI
         find_neighbourhood();
         update_neighbour_subdomain();
 #endif
+    }
+
+    template <class D, class Config>
+    SAMURAI_INLINE void Mesh_base<D, Config>::finalize_mesh(const coords_t& origin_point, double scaling_factor)
+    {
         update_meshid_neighbour(mesh_id_t::cells);
         update_sub_mesh();
         construct_corners();
         renumbering();
-        set_origin_point(ref_mesh.origin_point());
-        set_scaling_factor(ref_mesh.scaling_factor());
+        set_origin_point(origin_point);
+        set_scaling_factor(scaling_factor);
         update_mesh_neighbour();
 #if defined(SAMURAI_WITH_MPI) && defined(SAMURAI_WITH_PETSC)
         compute_gravity_center();

--- a/include/samurai/mesh.hpp
+++ b/include/samurai/mesh.hpp
@@ -228,32 +228,9 @@ namespace samurai
         Mesh_base(const cl_type& cl, const self_type& ref_mesh);
         Mesh_base(const cl_type& cl, const config_t& config);
         Mesh_base(const ca_type& ca, const config_t& config);
+
         Mesh_base(const samurai::Box<double, dim>& b, const config_t& config);
-
         Mesh_base(const samurai::DomainBuilder<dim>& domain_builder, const config_t& config);
-
-        // cppcheck-suppress uninitMemberVar
-        Mesh_base(const samurai::Box<double, dim>&, std::size_t, std::size_t, std::size_t, double, double)
-        {
-            std::cerr << "Delete min_level and max_level from CLI11 options and use mesh_config object and the make_mesh function"
-                      << std::endl;
-            exit(EXIT_FAILURE);
-        }
-
-        Mesh_base(const samurai::DomainBuilder<dim>& domain_builder,
-                  std::size_t start_level,
-                  std::size_t min_level,
-                  std::size_t max_level,
-                  double approx_box_tol = lca_type::default_approx_box_tol,
-                  double scaling_factor = 0);
-
-        // cppcheck-suppress uninitMemberVar
-        Mesh_base(const samurai::Box<double, dim>&, std::size_t, std::size_t, std::size_t, const std::array<bool, dim>&, double, double)
-        {
-            std::cerr << "Delete min_level and max_level from CLI11 options and use mesh_config object and the make_mesh function"
-                      << std::endl;
-            exit(EXIT_FAILURE);
-        }
 
         derived_type& derived_cast() & noexcept;
         const derived_type& derived_cast() const& noexcept;
@@ -357,9 +334,8 @@ namespace samurai
 #endif
 
         construct_subdomain();
-        construct_union();
         exchange_neighbour_meshes();
-        finalize_mesh(origin_point(), scaling_factor());
+        finalize_mesh(domain_ref.origin_point(), domain_ref.scaling_factor());
     }
 
     template <class D, class Config>
@@ -396,7 +372,6 @@ namespace samurai
 
         construct_subdomain();
         m_domain = m_subdomain;
-        construct_union();
         exchange_neighbour_meshes();
         finalize_mesh(domain_builder.origin_point(), m_config.scaling_factor());
     }
@@ -416,7 +391,6 @@ namespace samurai
         construct_subdomain();
         construct_domain();
         exchange_neighbour_meshes();
-        construct_union();
         finalize_mesh(ca.origin_point(), ca.scaling_factor());
     }
 
@@ -429,7 +403,6 @@ namespace samurai
         m_cells[mesh_id_t::cells] = ca;
 
         construct_subdomain();
-        construct_union();
         exchange_neighbour_meshes();
         finalize_mesh(ref_mesh.origin_point(), ref_mesh.scaling_factor());
     }
@@ -452,6 +425,7 @@ namespace samurai
     template <class D, class Config>
     SAMURAI_INLINE void Mesh_base<D, Config>::finalize_mesh(const coords_t& origin_point, double scaling_factor)
     {
+        construct_union();
         update_meshid_neighbour(mesh_id_t::cells);
         update_sub_mesh();
         construct_corners();
@@ -1159,49 +1133,66 @@ namespace samurai
     SAMURAI_INLINE void Mesh_base<D, Config>::construct_domain()
     {
 #ifdef SAMURAI_WITH_MPI
-        lcl_type lcl = {max_level()};
         mpi::communicator world;
-        std::vector<lca_type> all_subdomains(static_cast<std::size_t>(world.size()));
-        mpi::all_gather(world, m_subdomain[max_level()], all_subdomains);
-
-        for (std::size_t k = 0; k < all_subdomains.size(); ++k)
+        if (world.size() > 1)
         {
-            for_each_interval(all_subdomains[k],
-                              [&](auto, const auto& i, const auto& index)
-                              {
-                                  lcl[index].add_interval(i);
-                              });
-        }
+            lcl_type lcl = {max_level()};
+            mpi::communicator world;
+            std::vector<lca_type> all_subdomains(static_cast<std::size_t>(world.size()));
+            mpi::all_gather(world, m_subdomain[max_level()], all_subdomains);
 
-        build_pyramid(m_domain, lca_type{lcl});
-#else
-        m_domain = m_subdomain;
+            for (std::size_t k = 0; k < all_subdomains.size(); ++k)
+            {
+                for_each_interval(all_subdomains[k],
+                                  [&](auto, const auto& i, const auto& index)
+                                  {
+                                      lcl[index].add_interval(i);
+                                  });
+            }
+
+            build_pyramid(m_domain, lca_type{lcl});
+            return;
+        }
 #endif
+        m_domain = m_subdomain;
     }
 
     template <class D, class Config>
     SAMURAI_INLINE void Mesh_base<D, Config>::construct_subdomain()
     {
-        // TODO: Don't build subdomain when we are in serial or in parallel with only one rank. This is a waste of memory and time.
-        // Just use the domain as subdomain in this case.
-        lcl_type lcl = {max_level(), m_domain.origin_point(), m_domain.scaling_factor()};
+#ifdef SAMURAI_WITH_MPI
+        mpi::communicator world;
+        if (world.size() > 1)
+        {
+#else
+        if (m_domain.empty())
+        {
+#endif
+            // TODO: Don't build subdomain when we are in serial or in parallel with only one rank. This is a waste of memory and time.
+            // Just use the domain as subdomain in this case.
+            lcl_type lcl = {max_level(), m_domain.origin_point(), m_domain.scaling_factor()};
 
-        for_each_interval(m_cells[mesh_id_t::cells],
-                          [&](std::size_t level, const auto& i, const auto& index)
-                          {
-                              std::size_t shift = max_level() - level;
-                              interval_t to_add = i << shift;
-                              auto shift_index  = index << shift;
-                              static_nested_loop<dim - 1>(0,
-                                                          1 << shift,
-                                                          1,
-                                                          [&](auto stencil)
-                                                          {
-                                                              auto new_index = shift_index + stencil;
-                                                              lcl[new_index].add_interval(to_add);
-                                                          });
-                          });
-        build_pyramid(m_subdomain, lca_type{lcl});
+            for_each_interval(m_cells[mesh_id_t::cells],
+                              [&](std::size_t level, const auto& i, const auto& index)
+                              {
+                                  std::size_t shift = max_level() - level;
+                                  interval_t to_add = i << shift;
+                                  auto shift_index  = index << shift;
+                                  static_nested_loop<dim - 1>(0,
+                                                              1 << shift,
+                                                              1,
+                                                              [&](auto stencil)
+                                                              {
+                                                                  auto new_index = shift_index + stencil;
+                                                                  lcl[new_index].add_interval(to_add);
+                                                              });
+                              });
+            build_pyramid(m_subdomain, lca_type{lcl});
+        }
+        else
+        {
+            m_subdomain = m_domain;
+        }
     }
 
     // Materialises `reference` (a full-resolution LCA defined at its own

--- a/include/samurai/mesh.hpp
+++ b/include/samurai/mesh.hpp
@@ -1137,7 +1137,6 @@ namespace samurai
         if (world.size() > 1)
         {
             lcl_type lcl = {max_level()};
-            mpi::communicator world;
             std::vector<lca_type> all_subdomains(static_cast<std::size_t>(world.size()));
             mpi::all_gather(world, m_subdomain[max_level()], all_subdomains);
 
@@ -1162,7 +1161,7 @@ namespace samurai
     {
 #ifdef SAMURAI_WITH_MPI
         mpi::communicator world;
-        if (world.size() > 1)
+        if (world.size() > 1 || m_domain.empty())
         {
 #else
         if (m_domain.empty())


### PR DESCRIPTION
## Description
This PR refactors `Mesh_base` construction in `samurai::mesh.hpp` to reduce duplicated post-construction logic by introducing shared helper methods, and slightly adjusts domain/subdomain construction behavior under MPI.

**Changes:**

- Consolidates repeated constructor “tail” logic into `exchange_neighbour_meshes()` and `finalize_mesh(...)`.
- Simplifies some constructors via delegation (e.g., `cl_type` constructor delegates to ca_type constructor).
- Updates `construct_domain()` / `construct_subdomain()` logic to avoid some work when running with a single MPI rank.

## Code of Conduct
By submitting this PR, you agree to follow our [Code of Conduct](https://github.com/hpc-maths/samurai/blob/master/docs/CODE_OF_CONDUCT.md)
- [x] I agree to follow this project's Code of Conduct
