### PR TITLE
perf: update fields refactor

### DIFF
--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -53,10 +53,7 @@ target_link_libraries(bench_samurai samurai benchmark::benchmark)
 #     COMMAND benchmark_samurai
 #     DEPENDS ${SAMURAI_BENCHMARK_TARGET})
 
-# update_fields set-algebra micro-benchmark (OLD vs NEW field-batching strategy).
-if (CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
-    find_package(samurai REQUIRED CONFIG)
-endif()
+# update_fields set-algebra micro-benchmark (OLD vs FOLD vs VAR field-batching strategy).
 add_executable(bench_update_fields benchmark_update_fields.cpp)
 target_link_libraries(bench_update_fields samurai benchmark::benchmark)
 

--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -53,6 +53,13 @@ target_link_libraries(bench_samurai samurai benchmark::benchmark)
 #     COMMAND benchmark_samurai
 #     DEPENDS ${SAMURAI_BENCHMARK_TARGET})
 
+# update_fields set-algebra micro-benchmark (OLD vs NEW field-batching strategy).
+if (CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
+    find_package(samurai REQUIRED CONFIG)
+endif()
+add_executable(bench_update_fields benchmark_update_fields.cpp)
+target_link_libraries(bench_update_fields samurai benchmark::benchmark)
+
 # Load balancing micro-benchmarks (MPI-only; provides its own MPI-aware main).
 if(WITH_MPI)
     add_executable(bench_load_balancing benchmark_load_balancing.cpp)

--- a/benchmark/benchmark_update_fields.cpp
+++ b/benchmark/benchmark_update_fields.cpp
@@ -1,0 +1,350 @@
+// Copyright 2018-2025 the samurai's authors
+// SPDX-License-Identifier:  BSD-3-Clause
+//
+// Benchmark comparing the OLD vs NEW implementation of the field-update
+// set algebra in `update_fields`:
+//
+//   - OLD: for each field, run its *own* level loops, rebuilding the
+//     `intersection` sets once per field (N fields => N set constructions
+//     per level).
+//   - NEW: run the level loops *once* and, inside each level, apply the
+//     operator to ALL fields through a fold expression (N fields => 1 set
+//     construction per level).
+//
+// The workload is built from the first AMR adaptation of the 2D advection
+// demo: two adapted meshes (a bump at two slightly different positions, as
+// if the solution had been advected by one time step) are captured, then
+// the copy / projection / prediction operators are timed from `mesh_old`
+// to `mesh_new` with varying numbers of scalar and vector fields.
+
+#include <cstddef>
+#include <string>
+#include <tuple>
+#include <utility>
+
+#include <benchmark/benchmark.h>
+
+#include <samurai/algorithm.hpp>
+#include <samurai/algorithm/utils.hpp>
+#include <samurai/field.hpp>
+#include <samurai/mesh_config.hpp>
+#include <samurai/mr/adapt.hpp>
+#include <samurai/mr/mesh.hpp>
+#include <samurai/numeric/prediction.hpp>
+#include <samurai/numeric/projection.hpp>
+#include <samurai/samurai.hpp>
+
+namespace
+{
+    constexpr std::size_t dim = 2;
+
+    using config_t  = samurai::mesh_config<dim>;
+    using mesh_t    = samurai::MRMesh<config_t>;
+    using mesh_id_t = typename mesh_t::mesh_id_t;
+
+    // ---------------------------------------------------------------------
+    // Build an adapted mesh for a "bump" centred at (cx, cy), exactly like
+    // the first MR adaptation performed in demos/FiniteVolume/advection_2d.
+    // ---------------------------------------------------------------------
+    mesh_t make_adapted_mesh(double cx, double cy, double eps)
+    {
+        samurai::Box<double, dim> box({0., 0.}, {1., 1.});
+        auto config = samurai::mesh_config<dim>().min_level(3).max_level(8);
+        auto mesh   = samurai::mra::make_mesh(box, config);
+
+        auto u = samurai::make_scalar_field<double>("u", mesh);
+        samurai::for_each_cell(
+            mesh,
+            [&](auto& cell)
+            {
+                const auto center   = cell.center();
+                const double radius = 0.2;
+                u[cell] = (((center[0] - cx) * (center[0] - cx) + (center[1] - cy) * (center[1] - cy)) <= radius * radius) ? 1.0 : 0.0;
+            });
+
+        auto adapt = samurai::make_MRAdapt(u);
+        adapt(samurai::mra_config().epsilon(eps));
+        return mesh; // field.mesh() has been swapped to the adapted mesh
+    }
+
+    // Shared adapted meshes (built once, lazily): the bump moved from
+    // (0.30, 0.30) to (0.35, 0.30) so the two meshes differ across levels.
+    struct MeshPair
+    {
+        mesh_t mesh_old;
+        mesh_t mesh_new;
+    };
+
+    const MeshPair& meshes()
+    {
+        static const MeshPair p{make_adapted_mesh(0.30, 0.30, 2e-4),
+                                make_adapted_mesh(0.35, 0.30, 2e-4)};
+        return p;
+    }
+
+    // ---------------------------------------------------------------------
+    // Generic helpers to build a tuple of fields living on a mesh.
+    // ---------------------------------------------------------------------
+    template <class Mesh, std::size_t... Is>
+    auto make_scalars_impl(Mesh& m, double init, std::index_sequence<Is...>)
+    {
+        return std::make_tuple(samurai::make_scalar_field<double>("s" + std::to_string(Is), m, init)...);
+    }
+
+    template <std::size_t N>
+    auto make_scalars(mesh_t& m, double init)
+    {
+        return make_scalars_impl(m, init, std::make_index_sequence<N>{});
+    }
+
+    auto make_mixed(mesh_t& m, double init)
+    {
+        return std::make_tuple(samurai::make_scalar_field<double>("ms0", m, init),
+                               samurai::make_scalar_field<double>("ms1", m, init),
+                               samurai::make_vector_field<double, dim>("mv0", m, init),
+                               samurai::make_vector_field<double, dim>("mv1", m, init));
+    }
+
+    // Force the timed writes to be observable: sum every value stored in the
+    // new fields and escape the result. Applied identically to OLD and NEW, so
+    // it does not bias the comparison (it adds the same read cost to both).
+    template <class Tuple, std::size_t... Is>
+    double tuple_checksum(const Tuple& t, std::index_sequence<Is...>)
+    {
+        double s = 0.0;
+        auto add_one = [&](const auto& f)
+        {
+            const auto& arr = f.array();
+            const auto* p   = arr.data();
+            for (std::size_t k = 0, n = arr.size(); k < n; ++k)
+            {
+                s += static_cast<double>(p[k]);
+            }
+        };
+        (add_one(std::get<Is>(t)), ...);
+        return s;
+    }
+
+    // =====================================================================
+    //                      OLD STYLE (one field at a time)
+    // =====================================================================
+    template <class Mesh, class Old, class New>
+    void old_copy_one(Mesh& om, Mesh& nm, Old& of, New& nf)
+    {
+        const auto min_l = om.min_level();
+        const auto max_l = om.max_level();
+        for (std::size_t l = min_l; l <= max_l; ++l)
+        {
+            auto set = samurai::intersection(om[mesh_id_t::reference][l], nm[mesh_id_t::cells][l]);
+            set.apply_op(samurai::copy(nf, of));
+        }
+    }
+
+    struct OldCopy
+    {
+        template <class Mesh, class OldT, class NewT, class Seq>
+        void operator()(Mesh& om, Mesh& nm, OldT& old, NewT& nw, Seq)
+        {
+            [&]<std::size_t... Is>(std::index_sequence<Is...>)
+            {
+                (old_copy_one(om, nm, std::get<Is>(old), std::get<Is>(nw)), ...);
+            }(Seq{});
+        }
+    };
+
+    struct Pred
+    {
+        template <class New, class Old>
+        auto operator()(New& nf, const Old& of) const
+        {
+            constexpr std::size_t pred_order = std::decay_t<New>::mesh_t::config_t::prediction_stencil_radius;
+            return samurai::prediction<pred_order, true>(nf, of);
+        }
+    };
+
+    template <class Mesh, class Old, class New>
+    void old_update_one(Mesh& om, Mesh& nm, Old& of, New& nf)
+    {
+        Pred pred;
+        const auto min_l = om.min_level();
+        const auto max_l = om.max_level();
+        for (std::size_t l = min_l; l <= max_l; ++l)
+        {
+            auto set = samurai::intersection(om[mesh_id_t::reference][l], nm[mesh_id_t::cells][l]);
+            set.apply_op(samurai::copy(nf, of));
+        }
+        for (std::size_t l = min_l + 1; l <= max_l; ++l)
+        {
+            auto set_coarsen = samurai::intersection(om[mesh_id_t::cells][l], nm[mesh_id_t::cells][l - 1]).on(l - 1);
+            set_coarsen.apply_op(samurai::projection(nf, of));
+
+            auto set_refine = samurai::intersection(nm[mesh_id_t::cells][l], om[mesh_id_t::cells][l - 1]).on(l - 1);
+            set_refine.apply_op(pred(nf, of));
+        }
+    }
+
+    struct OldUpdate
+    {
+        template <class Mesh, class OldT, class NewT, class Seq>
+        void operator()(Mesh& om, Mesh& nm, OldT& old, NewT& nw, Seq)
+        {
+            [&]<std::size_t... Is>(std::index_sequence<Is...>)
+            {
+                (old_update_one(om, nm, std::get<Is>(old), std::get<Is>(nw)), ...);
+            }(Seq{});
+        }
+    };
+
+    // =====================================================================
+    //                  NEW STYLE (single loop, fold over fields)
+    // =====================================================================
+    // NEW_COPY_FOLD: single loop, one apply per field (fold over fields) —
+    // the implementation of `update_fields` on this branch before the
+    // variadic-copy operator was introduced.
+    struct NewCopyFold
+    {
+        template <class Mesh, class OldT, class NewT, std::size_t... Is>
+        void run(Mesh& om, Mesh& nm, OldT& old, NewT& nw, std::index_sequence<Is...>)
+        {
+            const auto min_l = om.min_level();
+            const auto max_l = om.max_level();
+            for (std::size_t l = min_l; l <= max_l; ++l)
+            {
+                auto set = samurai::intersection(om[mesh_id_t::reference][l], nm[mesh_id_t::cells][l]);
+                (set.apply_op(samurai::copy(std::get<Is>(nw), std::get<Is>(old))), ...);
+            }
+        }
+
+        template <class Mesh, class OldT, class NewT, class Seq>
+        void operator()(Mesh& om, Mesh& nm, OldT& old, NewT& nw, Seq)
+        {
+            run(om, nm, old, nw, Seq{});
+        }
+    };
+
+    // NEW_COPY_VARIADIC: single loop, ONE apply_op carrying every (dest, src)
+    // pair at once (the variadic `copy(tuples)` operator) — a single traversal
+    // of the set copies all fields together.
+    struct NewCopyVariadic
+    {
+        template <class Mesh, class OldT, class NewT, class Seq>
+        void operator()(Mesh& om, Mesh& nm, OldT& old, NewT& nw, Seq)
+        {
+            const auto min_l = om.min_level();
+            const auto max_l = om.max_level();
+            for (std::size_t l = min_l; l <= max_l; ++l)
+            {
+                auto set = samurai::intersection(om[mesh_id_t::reference][l], nm[mesh_id_t::cells][l]);
+                set.apply_op(samurai::copy(nw, old));
+            }
+        }
+    };
+
+    struct NewUpdate
+    {
+        template <class Mesh, class OldT, class NewT, class Seq>
+        void operator()(Mesh& om, Mesh& nm, OldT& old, NewT& nw, Seq)
+        {
+            const auto min_l = om.min_level();
+            const auto max_l = om.max_level();
+            
+            // Copy phase
+            for (std::size_t l = min_l; l <= max_l; ++l)
+            {
+                auto set = samurai::intersection(om[mesh_id_t::reference][l], nm[mesh_id_t::cells][l]);
+                set.apply_op(samurai::copy(nw, old));
+            }
+            
+            // Projection and prediction phases
+            constexpr std::size_t pred_order = mesh_t::config_t::prediction_stencil_radius;
+            for (std::size_t l = min_l + 1; l <= max_l; ++l)
+            {
+                auto set_coarsen = samurai::intersection(om[mesh_id_t::cells][l], nm[mesh_id_t::cells][l - 1]).on(l - 1);
+                set_coarsen.apply_op(samurai::projection(nw, old));
+
+                auto set_refine = samurai::intersection(nm[mesh_id_t::cells][l], om[mesh_id_t::cells][l - 1]).on(l - 1);
+                set_refine.apply_op(samurai::prediction<pred_order, true>(nw, old));
+            }
+        }
+    };
+
+    // =====================================================================
+    //                       Benchmark body
+    // =====================================================================
+    template <class Runner, class BuildOld, class BuildNew, class SeqType>
+    void bench_body(benchmark::State& state, const char* style,
+                    Runner runner, BuildOld build_old, BuildNew build_new, SeqType)
+    {
+        const auto& mp = meshes();
+        auto om  = mp.mesh_old;
+        auto nm  = mp.mesh_new;
+        auto old = build_old(om, 1.0);
+        auto nw  = build_new(nm, 0.0);
+        SeqType seq{};
+        const std::size_t nfields = std::tuple_size_v<std::decay_t<decltype(nw)>>;
+
+        for (auto _ : state)
+        {
+            runner(om, nm, old, nw, seq);
+            benchmark::DoNotOptimize(tuple_checksum(nw, seq));
+            benchmark::ClobberMemory();
+        }
+        state.SetItemsProcessed(static_cast<int64_t>(state.iterations()) * static_cast<int64_t>(nfields));
+        state.SetLabel(std::string(style) + " n=" + std::to_string(nfields));
+    }
+
+#define SAMURAI_REG3(BenchName, OldRunner, FoldRunner, VarRunner, BuildOld, BuildNew, SeqType)     \
+    static void BenchName##_old(benchmark::State& state)                                         \
+    {                                                                                            \
+        bench_body(state, "OLD", OldRunner{}, BuildOld, BuildNew, SeqType{});                   \
+    }                                                                                            \
+    static void BenchName##_fold(benchmark::State& state)                                        \
+    {                                                                                            \
+        bench_body(state, "FOLD", FoldRunner{}, BuildOld, BuildNew, SeqType{});                  \
+    }                                                                                            \
+    static void BenchName##_var(benchmark::State& state)                                         \
+    {                                                                                            \
+        bench_body(state, "VAR", VarRunner{}, BuildOld, BuildNew, SeqType{});                    \
+    }                                                                                            \
+    BENCHMARK(BenchName##_old)->Unit(benchmark::kMillisecond)->UseRealTime();                     \
+    BENCHMARK(BenchName##_fold)->Unit(benchmark::kMillisecond)->UseRealTime();                    \
+    BENCHMARK(BenchName##_var)->Unit(benchmark::kMillisecond)->UseRealTime()
+
+#define SAMURAI_REG2(BenchName, OldRunner, VarRunner, BuildOld, BuildNew, SeqType)                \
+    static void BenchName##_old(benchmark::State& state)                                         \
+    {                                                                                            \
+        bench_body(state, "OLD", OldRunner{}, BuildOld, BuildNew, SeqType{});                   \
+    }                                                                                            \
+    static void BenchName##_var(benchmark::State& state)                                         \
+    {                                                                                            \
+        bench_body(state, "VAR", VarRunner{}, BuildOld, BuildNew, SeqType{});                    \
+    }                                                                                            \
+    BENCHMARK(BenchName##_old)->Unit(benchmark::kMillisecond)->UseRealTime();                     \
+    BENCHMARK(BenchName##_var)->Unit(benchmark::kMillisecond)->UseRealTime()
+
+    // Copy operator only — three strategies.
+    SAMURAI_REG3(Copy_1scalar,  OldCopy, NewCopyFold, NewCopyVariadic, make_scalars<1>,  make_scalars<1>,  std::make_index_sequence<1>);
+    SAMURAI_REG3(Copy_4scalar,  OldCopy, NewCopyFold, NewCopyVariadic, make_scalars<4>,  make_scalars<4>,  std::make_index_sequence<4>);
+    SAMURAI_REG3(Copy_8scalar,  OldCopy, NewCopyFold, NewCopyVariadic, make_scalars<8>,  make_scalars<8>,  std::make_index_sequence<8>);
+    SAMURAI_REG3(Copy_16scalar, OldCopy, NewCopyFold, NewCopyVariadic, make_scalars<16>, make_scalars<16>, std::make_index_sequence<16>);
+    SAMURAI_REG3(Copy_mixed,   OldCopy, NewCopyFold, NewCopyVariadic, make_mixed,      make_mixed,      std::make_index_sequence<std::tuple_size_v<std::decay_t<decltype(make_mixed(std::declval<mesh_t&>(), 0.0))>>>);
+
+    // Full update (variadic copy + per-field projection + per-field prediction).
+    SAMURAI_REG2(Update_1scalar,  OldUpdate, NewUpdate, make_scalars<1>,  make_scalars<1>,  std::make_index_sequence<1>);
+    SAMURAI_REG2(Update_4scalar,  OldUpdate, NewUpdate, make_scalars<4>,  make_scalars<4>,  std::make_index_sequence<4>);
+    SAMURAI_REG2(Update_8scalar,  OldUpdate, NewUpdate, make_scalars<8>,  make_scalars<8>,  std::make_index_sequence<8>);
+    SAMURAI_REG2(Update_16scalar, OldUpdate, NewUpdate, make_scalars<16>, make_scalars<16>, std::make_index_sequence<16>);
+    SAMURAI_REG2(Update_mixed,   OldUpdate, NewUpdate, make_mixed,      make_mixed,      std::make_index_sequence<std::tuple_size_v<std::decay_t<decltype(make_mixed(std::declval<mesh_t&>(), 0.0))>>>);
+
+#undef SAMURAI_REG3
+#undef SAMURAI_REG2
+}
+
+int main(int argc, char** argv)
+{
+    samurai::initialize();
+    ::benchmark::Initialize(&argc, argv);
+    ::benchmark::RunSpecifiedBenchmarks();
+    samurai::finalize();
+    return 0;
+}

--- a/benchmark/benchmark_update_fields.cpp
+++ b/benchmark/benchmark_update_fields.cpp
@@ -77,8 +77,7 @@ namespace
 
     const MeshPair& meshes()
     {
-        static const MeshPair p{make_adapted_mesh(0.30, 0.30, 2e-4),
-                                make_adapted_mesh(0.35, 0.30, 2e-4)};
+        static const MeshPair p{make_adapted_mesh(0.30, 0.30, 2e-4), make_adapted_mesh(0.35, 0.30, 2e-4)};
         return p;
     }
 
@@ -111,7 +110,7 @@ namespace
     template <class Tuple, std::size_t... Is>
     double tuple_checksum(const Tuple& t, std::index_sequence<Is...>)
     {
-        double s = 0.0;
+        double s     = 0.0;
         auto add_one = [&](const auto& f)
         {
             const auto& arr = f.array();
@@ -247,14 +246,14 @@ namespace
         {
             const auto min_l = om.min_level();
             const auto max_l = om.max_level();
-            
+
             // Copy phase
             for (std::size_t l = min_l; l <= max_l; ++l)
             {
                 auto set = samurai::intersection(om[mesh_id_t::reference][l], nm[mesh_id_t::cells][l]);
                 set.apply_op(samurai::copy(nw, old));
             }
-            
+
             // Projection and prediction phases
             constexpr std::size_t pred_order = mesh_t::config_t::prediction_stencil_radius;
             for (std::size_t l = min_l + 1; l <= max_l; ++l)
@@ -272,14 +271,13 @@ namespace
     //                       Benchmark body
     // =====================================================================
     template <class Runner, class BuildOld, class BuildNew, class SeqType>
-    void bench_body(benchmark::State& state, const char* style,
-                    Runner runner, BuildOld build_old, BuildNew build_new, SeqType)
+    void bench_body(benchmark::State& state, const char* style, Runner runner, BuildOld build_old, BuildNew build_new, SeqType)
     {
         const auto& mp = meshes();
-        auto om  = mp.mesh_old;
-        auto nm  = mp.mesh_new;
-        auto old = build_old(om, 1.0);
-        auto nw  = build_new(nm, 0.0);
+        auto om        = mp.mesh_old;
+        auto nm        = mp.mesh_new;
+        auto old       = build_old(om, 1.0);
+        auto nw        = build_new(nm, 0.0);
         SeqType seq{};
         const std::size_t nfields = std::tuple_size_v<std::decay_t<decltype(nw)>>;
 
@@ -293,48 +291,59 @@ namespace
         state.SetLabel(std::string(style) + " n=" + std::to_string(nfields));
     }
 
-#define SAMURAI_REG3(BenchName, OldRunner, FoldRunner, VarRunner, BuildOld, BuildNew, SeqType)     \
-    static void BenchName##_old(benchmark::State& state)                                         \
-    {                                                                                            \
-        bench_body(state, "OLD", OldRunner{}, BuildOld, BuildNew, SeqType{});                   \
-    }                                                                                            \
-    static void BenchName##_fold(benchmark::State& state)                                        \
-    {                                                                                            \
-        bench_body(state, "FOLD", FoldRunner{}, BuildOld, BuildNew, SeqType{});                  \
-    }                                                                                            \
-    static void BenchName##_var(benchmark::State& state)                                         \
-    {                                                                                            \
-        bench_body(state, "VAR", VarRunner{}, BuildOld, BuildNew, SeqType{});                    \
-    }                                                                                            \
-    BENCHMARK(BenchName##_old)->Unit(benchmark::kMillisecond)->UseRealTime();                     \
-    BENCHMARK(BenchName##_fold)->Unit(benchmark::kMillisecond)->UseRealTime();                    \
+#define SAMURAI_REG3(BenchName, OldRunner, FoldRunner, VarRunner, BuildOld, BuildNew, SeqType) \
+    static void BenchName##_old(benchmark::State& state)                                       \
+    {                                                                                          \
+        bench_body(state, "OLD", OldRunner{}, BuildOld, BuildNew, SeqType{});                  \
+    }                                                                                          \
+    static void BenchName##_fold(benchmark::State& state)                                      \
+    {                                                                                          \
+        bench_body(state, "FOLD", FoldRunner{}, BuildOld, BuildNew, SeqType{});                \
+    }                                                                                          \
+    static void BenchName##_var(benchmark::State& state)                                       \
+    {                                                                                          \
+        bench_body(state, "VAR", VarRunner{}, BuildOld, BuildNew, SeqType{});                  \
+    }                                                                                          \
+    BENCHMARK(BenchName##_old)->Unit(benchmark::kMillisecond)->UseRealTime();                  \
+    BENCHMARK(BenchName##_fold)->Unit(benchmark::kMillisecond)->UseRealTime();                 \
     BENCHMARK(BenchName##_var)->Unit(benchmark::kMillisecond)->UseRealTime()
 
-#define SAMURAI_REG2(BenchName, OldRunner, VarRunner, BuildOld, BuildNew, SeqType)                \
-    static void BenchName##_old(benchmark::State& state)                                         \
-    {                                                                                            \
-        bench_body(state, "OLD", OldRunner{}, BuildOld, BuildNew, SeqType{});                   \
-    }                                                                                            \
-    static void BenchName##_var(benchmark::State& state)                                         \
-    {                                                                                            \
-        bench_body(state, "VAR", VarRunner{}, BuildOld, BuildNew, SeqType{});                    \
-    }                                                                                            \
-    BENCHMARK(BenchName##_old)->Unit(benchmark::kMillisecond)->UseRealTime();                     \
+#define SAMURAI_REG2(BenchName, OldRunner, VarRunner, BuildOld, BuildNew, SeqType) \
+    static void BenchName##_old(benchmark::State& state)                           \
+    {                                                                              \
+        bench_body(state, "OLD", OldRunner{}, BuildOld, BuildNew, SeqType{});      \
+    }                                                                              \
+    static void BenchName##_var(benchmark::State& state)                           \
+    {                                                                              \
+        bench_body(state, "VAR", VarRunner{}, BuildOld, BuildNew, SeqType{});      \
+    }                                                                              \
+    BENCHMARK(BenchName##_old)->Unit(benchmark::kMillisecond)->UseRealTime();      \
     BENCHMARK(BenchName##_var)->Unit(benchmark::kMillisecond)->UseRealTime()
 
     // Copy operator only — three strategies.
-    SAMURAI_REG3(Copy_1scalar,  OldCopy, NewCopyFold, NewCopyVariadic, make_scalars<1>,  make_scalars<1>,  std::make_index_sequence<1>);
-    SAMURAI_REG3(Copy_4scalar,  OldCopy, NewCopyFold, NewCopyVariadic, make_scalars<4>,  make_scalars<4>,  std::make_index_sequence<4>);
-    SAMURAI_REG3(Copy_8scalar,  OldCopy, NewCopyFold, NewCopyVariadic, make_scalars<8>,  make_scalars<8>,  std::make_index_sequence<8>);
+    SAMURAI_REG3(Copy_1scalar, OldCopy, NewCopyFold, NewCopyVariadic, make_scalars<1>, make_scalars<1>, std::make_index_sequence<1>);
+    SAMURAI_REG3(Copy_4scalar, OldCopy, NewCopyFold, NewCopyVariadic, make_scalars<4>, make_scalars<4>, std::make_index_sequence<4>);
+    SAMURAI_REG3(Copy_8scalar, OldCopy, NewCopyFold, NewCopyVariadic, make_scalars<8>, make_scalars<8>, std::make_index_sequence<8>);
     SAMURAI_REG3(Copy_16scalar, OldCopy, NewCopyFold, NewCopyVariadic, make_scalars<16>, make_scalars<16>, std::make_index_sequence<16>);
-    SAMURAI_REG3(Copy_mixed,   OldCopy, NewCopyFold, NewCopyVariadic, make_mixed,      make_mixed,      std::make_index_sequence<std::tuple_size_v<std::decay_t<decltype(make_mixed(std::declval<mesh_t&>(), 0.0))>>>);
+    SAMURAI_REG3(Copy_mixed,
+                 OldCopy,
+                 NewCopyFold,
+                 NewCopyVariadic,
+                 make_mixed,
+                 make_mixed,
+                 std::make_index_sequence<std::tuple_size_v<std::decay_t<decltype(make_mixed(std::declval<mesh_t&>(), 0.0))>>>);
 
     // Full update (variadic copy + per-field projection + per-field prediction).
-    SAMURAI_REG2(Update_1scalar,  OldUpdate, NewUpdate, make_scalars<1>,  make_scalars<1>,  std::make_index_sequence<1>);
-    SAMURAI_REG2(Update_4scalar,  OldUpdate, NewUpdate, make_scalars<4>,  make_scalars<4>,  std::make_index_sequence<4>);
-    SAMURAI_REG2(Update_8scalar,  OldUpdate, NewUpdate, make_scalars<8>,  make_scalars<8>,  std::make_index_sequence<8>);
+    SAMURAI_REG2(Update_1scalar, OldUpdate, NewUpdate, make_scalars<1>, make_scalars<1>, std::make_index_sequence<1>);
+    SAMURAI_REG2(Update_4scalar, OldUpdate, NewUpdate, make_scalars<4>, make_scalars<4>, std::make_index_sequence<4>);
+    SAMURAI_REG2(Update_8scalar, OldUpdate, NewUpdate, make_scalars<8>, make_scalars<8>, std::make_index_sequence<8>);
     SAMURAI_REG2(Update_16scalar, OldUpdate, NewUpdate, make_scalars<16>, make_scalars<16>, std::make_index_sequence<16>);
-    SAMURAI_REG2(Update_mixed,   OldUpdate, NewUpdate, make_mixed,      make_mixed,      std::make_index_sequence<std::tuple_size_v<std::decay_t<decltype(make_mixed(std::declval<mesh_t&>(), 0.0))>>>);
+    SAMURAI_REG2(Update_mixed,
+                 OldUpdate,
+                 NewUpdate,
+                 make_mixed,
+                 make_mixed,
+                 std::make_index_sequence<std::tuple_size_v<std::decay_t<decltype(make_mixed(std::declval<mesh_t&>(), 0.0))>>>);
 
 #undef SAMURAI_REG3
 #undef SAMURAI_REG2

--- a/include/samurai/algorithm/update_fields.hpp
+++ b/include/samurai/algorithm/update_fields.hpp
@@ -48,7 +48,7 @@ namespace samurai
                 set_coarsen.apply_op(projection(dests, srcs));
 
                 auto set_refine = intersection(new_mesh[mesh_id_t::cells][level], mesh[mesh_id_t::cells][level - 1]).on(level - 1);
-                (set_refine.apply_op(std::forward<PredictionFn>(prediction_fn)(std::get<Is>(dests), std::get<Is>(srcs))), ...);
+                (set_refine.apply_op(prediction_fn(std::get<Is>(dests), std::get<Is>(srcs))), ...);
             }
         }
 

--- a/include/samurai/algorithm/update_fields.hpp
+++ b/include/samurai/algorithm/update_fields.hpp
@@ -58,8 +58,56 @@ namespace samurai
 
             swap(field, new_field);
         }
+
+        template <class Field, class Mesh>
+        Field make_new_field(const std::string& name, Mesh& mesh)
+        {
+            Field new_field(name, mesh);
+#ifdef SAMURAI_CHECK_NAN
+            new_field.fill(std::nan(""));
+#else
+            new_field.fill(0);
+#endif
+            return new_field;
+        }
+
+        template <class PredictionOp, class Mesh, class FieldsTuple, class NewFieldsTuple, std::size_t... Is>
+        void update_fields_impl(PredictionOp&& prediction_op,
+                                Mesh& new_mesh,
+                                FieldsTuple& fields,
+                                NewFieldsTuple& new_fields,
+                                std::index_sequence<Is...>)
+        {
+            ScopedTimer timer("fields update");
+            using mesh_id_t = typename Mesh::mesh_id_t;
+
+            auto& mesh = std::get<0>(fields).mesh();
+            auto min_level = mesh.min_level();
+            auto max_level = mesh.max_level();
+
+            // Single loop over levels: copy reference -> cells for ALL fields
+            for (std::size_t level = min_level; level <= max_level; ++level)
+            {
+                auto set = intersection(mesh[mesh_id_t::reference][level], new_mesh[mesh_id_t::cells][level]);
+                (set.apply_op(copy(std::get<Is>(new_fields), std::get<Is>(fields))), ...);
+            }
+
+            // Single loop over levels: coarsen and refine for ALL fields
+            for (std::size_t level = min_level + 1; level <= max_level; ++level)
+            {
+                auto set_coarsen = intersection(mesh[mesh_id_t::cells][level], new_mesh[mesh_id_t::cells][level - 1]).on(level - 1);
+                (set_coarsen.apply_op(projection(std::get<Is>(new_fields), std::get<Is>(fields))), ...);
+
+                auto set_refine = intersection(new_mesh[mesh_id_t::cells][level], mesh[mesh_id_t::cells][level - 1]).on(level - 1);
+                (set_refine.apply_op(std::forward<PredictionOp>(prediction_op)(std::get<Is>(new_fields), std::get<Is>(fields))), ...);
+            }
+
+            // Swap all old fields with their new versions
+            (swap(std::get<Is>(fields), std::get<Is>(new_fields)), ...);
+        }
     }
 
+    // Base cases: no fields to update
     template <class PredictionFn, class Mesh>
         requires mesh_like<Mesh>
     void update_fields(PredictionFn&&, Mesh&)
@@ -72,48 +120,58 @@ namespace samurai
     {
     }
 
-    template <class PredictionFn, class Mesh, class Fields, std::size_t... Is>
-    void update_fields(PredictionFn&& prediction_fn, Mesh& new_mesh, Fields& fields, std::index_sequence<Is...>)
-    {
-        (detail::update_field(std::forward<PredictionFn>(prediction_fn), new_mesh, std::get<Is>(fields)), ...);
-    }
-
-    template <class Mesh, class Fields, std::size_t... Is>
-    void update_fields(Mesh& new_mesh, Fields& fields, std::index_sequence<Is...>)
-    {
-        using prediction_fn_t = decltype(default_config::default_prediction_fn);
-        (detail::update_field(std::forward<prediction_fn_t>(default_config::default_prediction_fn), new_mesh, std::get<Is>(fields)), ...);
-    }
-
+    // Field_tuple overloads (no other fields)
     template <class PredictionFn, class Mesh, class... T>
         requires mesh_like<Mesh> && (field_like<T> && ...)
     void update_fields(PredictionFn&& prediction_fn, Mesh& new_mesh, Field_tuple<T...>& fields)
     {
-        update_fields(std::forward<PredictionFn>(prediction_fn), new_mesh, fields.elements(), std::make_index_sequence<sizeof...(T)>{});
+        auto new_fields = std::make_tuple(detail::make_new_field<T>("new_f", new_mesh)...);
+        detail::update_fields_impl(std::forward<PredictionFn>(prediction_fn),
+                                   new_mesh,
+                                   fields.elements(),
+                                   new_fields,
+                                   std::make_index_sequence<sizeof...(T)>{});
     }
 
     template <class Mesh, class... T>
         requires mesh_like<Mesh> && (field_like<T> && ...)
     void update_fields(Mesh& new_mesh, Field_tuple<T...>& fields)
     {
-        update_fields(new_mesh, fields.elements(), std::make_index_sequence<sizeof...(T)>{});
+        using prediction_fn_t = decltype(default_config::default_prediction_fn);
+        auto new_fields = std::make_tuple(detail::make_new_field<T>("new_f", new_mesh)...);
+        detail::update_fields_impl(std::forward<prediction_fn_t>(default_config::default_prediction_fn),
+                                   new_mesh,
+                                   fields.elements(),
+                                   new_fields,
+                                   std::make_index_sequence<sizeof...(T)>{});
     }
 
-    template <class Mesh, class Field, class... Fields>
-        requires mesh_like<Mesh> && field_like<Field> && (field_like<Fields> && ...)
-    void update_fields(Mesh& new_mesh, Field& field, Fields&... fields)
+    // Variadic field overloads: single loop over levels for ALL fields
+    template <class PredictionFn, class Mesh, class... Fields>
+        requires mesh_like<Mesh> && (field_like<Fields> && ...) && (sizeof...(Fields) > 0)
+    void update_fields(PredictionFn&& prediction_fn, Mesh& new_mesh, Fields&... fields)
+    {
+        auto new_fields  = std::make_tuple(detail::make_new_field<Fields>("new_f", new_mesh)...);
+        auto tied_fields = std::tie(fields...);
+        detail::update_fields_impl(std::forward<PredictionFn>(prediction_fn),
+                                   new_mesh,
+                                   tied_fields,
+                                   new_fields,
+                                   std::index_sequence_for<Fields...>{});
+    }
+
+    template <class Mesh, class... Fields>
+        requires mesh_like<Mesh> && (field_like<Fields> && ...) && (sizeof...(Fields) > 0)
+    void update_fields(Mesh& new_mesh, Fields&... fields)
     {
         using prediction_fn_t = decltype(default_config::default_prediction_fn);
-        detail::update_field(std::forward<prediction_fn_t>(default_config::default_prediction_fn), new_mesh, field);
-        update_fields(new_mesh, fields...);
-    }
-
-    template <class PredictionFn, class Mesh, class Field, class... Fields>
-        requires mesh_like<Mesh> && field_like<Field> && (field_like<Fields> && ...)
-    void update_fields(PredictionFn&& prediction_fn, Mesh& new_mesh, Field& field, Fields&... fields)
-    {
-        detail::update_field(std::forward<PredictionFn>(prediction_fn), new_mesh, field);
-        update_fields(std::forward<PredictionFn>(prediction_fn), new_mesh, fields...);
+        auto new_fields  = std::make_tuple(detail::make_new_field<Fields>("new_f", new_mesh)...);
+        auto tied_fields = std::tie(fields...);
+        detail::update_fields_impl(std::forward<prediction_fn_t>(default_config::default_prediction_fn),
+                                   new_mesh,
+                                   tied_fields,
+                                   new_fields,
+                                   std::index_sequence_for<Fields...>{});
     }
 
     template <class Tag, class... Fields>

--- a/include/samurai/algorithm/update_fields.hpp
+++ b/include/samurai/algorithm/update_fields.hpp
@@ -89,7 +89,7 @@ namespace samurai
         auto dst_tuple = std::apply(
             [&](auto&... args)
             {
-                return std::make_tuple(std::decay_t<decltype(args)>(args)...);
+                return std::make_tuple(detail::make_new_field<std::decay_t<decltype(args)>>("new_f", new_mesh)...);
             },
             src_tuple);
 

--- a/include/samurai/algorithm/update_fields.hpp
+++ b/include/samurai/algorithm/update_fields.hpp
@@ -23,40 +23,33 @@ namespace samurai
 {
     namespace detail
     {
-        template <class PredictionOp, class Mesh, class Field>
-        void update_field(PredictionOp&& prediction_op, Mesh& new_mesh, Field& field)
+        template <class PredictionFn, class DestTuple, class SrcTuple, class Mesh, std::size_t... Is>
+        void update_fields_impl(PredictionFn&& prediction_fn, Mesh& new_mesh, DestTuple& dests, SrcTuple& srcs, std::index_sequence<Is...>)
         {
             ScopedTimer timer("fields update");
             using mesh_id_t = typename Mesh::mesh_id_t;
 
-            Field new_field("new_f", new_mesh);
-#ifdef SAMURAI_CHECK_NAN
-            new_field.fill(std::nan(""));
-#else
-            new_field.fill(0);
-#endif
-
-            auto& mesh = field.mesh();
-
+            auto& mesh     = std::get<0>(srcs).mesh();
             auto min_level = mesh.min_level();
             auto max_level = mesh.max_level();
 
+            // Single loop over levels: copy reference -> cells for ALL fields in
+            // a single traversal of the set (variadic copy over the two tuples).
             for (std::size_t level = min_level; level <= max_level; ++level)
             {
                 auto set = intersection(mesh[mesh_id_t::reference][level], new_mesh[mesh_id_t::cells][level]);
-                set.apply_op(copy(new_field, field));
+                set.apply_op(copy(dests, srcs));
             }
 
+            // Single loop over levels: coarsen and refine for ALL fields
             for (std::size_t level = min_level + 1; level <= max_level; ++level)
             {
                 auto set_coarsen = intersection(mesh[mesh_id_t::cells][level], new_mesh[mesh_id_t::cells][level - 1]).on(level - 1);
-                set_coarsen.apply_op(projection(new_field, field));
+                set_coarsen.apply_op(projection(dests, srcs));
 
                 auto set_refine = intersection(new_mesh[mesh_id_t::cells][level], mesh[mesh_id_t::cells][level - 1]).on(level - 1);
-                set_refine.apply_op(std::forward<PredictionOp>(prediction_op)(new_field, field));
+                (set_refine.apply_op(std::forward<PredictionFn>(prediction_fn)(std::get<Is>(dests), std::get<Is>(srcs))), ...);
             }
-
-            swap(field, new_field);
         }
 
         template <class Field, class Mesh>
@@ -70,108 +63,50 @@ namespace samurai
 #endif
             return new_field;
         }
-
-        template <class PredictionOp, class Mesh, class FieldsTuple, class NewFieldsTuple, std::size_t... Is>
-        void update_fields_impl(PredictionOp&& prediction_op,
-                                Mesh& new_mesh,
-                                FieldsTuple& fields,
-                                NewFieldsTuple& new_fields,
-                                std::index_sequence<Is...>)
-        {
-            ScopedTimer timer("fields update");
-            using mesh_id_t = typename Mesh::mesh_id_t;
-
-            auto& mesh = std::get<0>(fields).mesh();
-            auto min_level = mesh.min_level();
-            auto max_level = mesh.max_level();
-
-            // Single loop over levels: copy reference -> cells for ALL fields
-            for (std::size_t level = min_level; level <= max_level; ++level)
-            {
-                auto set = intersection(mesh[mesh_id_t::reference][level], new_mesh[mesh_id_t::cells][level]);
-                (set.apply_op(copy(std::get<Is>(new_fields), std::get<Is>(fields))), ...);
-            }
-
-            // Single loop over levels: coarsen and refine for ALL fields
-            for (std::size_t level = min_level + 1; level <= max_level; ++level)
-            {
-                auto set_coarsen = intersection(mesh[mesh_id_t::cells][level], new_mesh[mesh_id_t::cells][level - 1]).on(level - 1);
-                (set_coarsen.apply_op(projection(std::get<Is>(new_fields), std::get<Is>(fields))), ...);
-
-                auto set_refine = intersection(new_mesh[mesh_id_t::cells][level], mesh[mesh_id_t::cells][level - 1]).on(level - 1);
-                (set_refine.apply_op(std::forward<PredictionOp>(prediction_op)(std::get<Is>(new_fields), std::get<Is>(fields))), ...);
-            }
-
-            // Swap all old fields with their new versions
-            (swap(std::get<Is>(fields), std::get<Is>(new_fields)), ...);
-        }
     }
 
-    // Base cases: no fields to update
-    template <class PredictionFn, class Mesh>
-        requires mesh_like<Mesh>
-    void update_fields(PredictionFn&&, Mesh&)
+    // Update fields with custom prediction function
+    template <class PredictionFn, class DestTuple, class SrcTuple, class Mesh>
+    void update_fields(PredictionFn&& prediction_fn, Mesh& new_mesh, DestTuple& dests, SrcTuple& srcs)
     {
-    }
-
-    template <class Mesh>
-        requires mesh_like<Mesh>
-    void update_fields(Mesh&)
-    {
-    }
-
-    // Field_tuple overloads (no other fields)
-    template <class PredictionFn, class Mesh, class... T>
-        requires mesh_like<Mesh> && (field_like<T> && ...)
-    void update_fields(PredictionFn&& prediction_fn, Mesh& new_mesh, Field_tuple<T...>& fields)
-    {
-        auto new_fields = std::make_tuple(detail::make_new_field<T>("new_f", new_mesh)...);
-        detail::update_fields_impl(std::forward<PredictionFn>(prediction_fn),
-                                   new_mesh,
-                                   fields.elements(),
-                                   new_fields,
-                                   std::make_index_sequence<sizeof...(T)>{});
-    }
-
-    template <class Mesh, class... T>
-        requires mesh_like<Mesh> && (field_like<T> && ...)
-    void update_fields(Mesh& new_mesh, Field_tuple<T...>& fields)
-    {
-        using prediction_fn_t = decltype(default_config::default_prediction_fn);
-        auto new_fields = std::make_tuple(detail::make_new_field<T>("new_f", new_mesh)...);
-        detail::update_fields_impl(std::forward<prediction_fn_t>(default_config::default_prediction_fn),
-                                   new_mesh,
-                                   fields.elements(),
-                                   new_fields,
-                                   std::make_index_sequence<sizeof...(T)>{});
-    }
-
-    // Variadic field overloads: single loop over levels for ALL fields
-    template <class PredictionFn, class Mesh, class... Fields>
-        requires mesh_like<Mesh> && (field_like<Fields> && ...) && (sizeof...(Fields) > 0)
-    void update_fields(PredictionFn&& prediction_fn, Mesh& new_mesh, Fields&... fields)
-    {
-        auto new_fields  = std::make_tuple(detail::make_new_field<Fields>("new_f", new_mesh)...);
-        auto tied_fields = std::tie(fields...);
-        detail::update_fields_impl(std::forward<PredictionFn>(prediction_fn),
-                                   new_mesh,
-                                   tied_fields,
-                                   new_fields,
-                                   std::index_sequence_for<Fields...>{});
+        constexpr std::size_t n = std::tuple_size_v<std::remove_cvref_t<DestTuple>>;
+        static_assert(n == std::tuple_size_v<std::remove_cvref_t<SrcTuple>>,
+                      "update_fields: dest and src tuples must have the same number of fields");
+        detail::update_fields_impl(std::forward<PredictionFn>(prediction_fn), new_mesh, dests, srcs, std::make_index_sequence<n>{});
     }
 
     template <class Mesh, class... Fields>
-        requires mesh_like<Mesh> && (field_like<Fields> && ...) && (sizeof...(Fields) > 0)
     void update_fields(Mesh& new_mesh, Fields&... fields)
     {
         using prediction_fn_t = decltype(default_config::default_prediction_fn);
-        auto new_fields  = std::make_tuple(detail::make_new_field<Fields>("new_f", new_mesh)...);
-        auto tied_fields = std::tie(fields...);
-        detail::update_fields_impl(std::forward<prediction_fn_t>(default_config::default_prediction_fn),
-                                   new_mesh,
-                                   tied_fields,
-                                   new_fields,
-                                   std::index_sequence_for<Fields...>{});
+        update_fields(std::forward<prediction_fn_t>(default_config::default_prediction_fn), new_mesh, fields...);
+    }
+
+    template <class PredictionFn, class Mesh, class Field, class... Fields>
+    void update_fields(PredictionFn&& prediction_fn, Mesh& new_mesh, Field& field, Fields&... fields)
+    {
+        auto src_tuple = std::tuple_cat(get_elements(field), std::tie(fields...));
+        auto dst_tuple = std::apply(
+            [&](auto&... args)
+            {
+                return std::make_tuple(std::decay_t<decltype(args)>(args)...);
+            },
+            src_tuple);
+
+        update_fields(std::forward<PredictionFn>(prediction_fn), new_mesh, dst_tuple, src_tuple);
+
+        // Swap all fields
+        std::apply(
+            [&](auto&... dsts)
+            {
+                std::apply(
+                    [&](auto&... srcs)
+                    {
+                        ((swap(srcs, dsts)), ...);
+                    },
+                    src_tuple);
+            },
+            dst_tuple);
     }
 
     template <class Tag, class... Fields>

--- a/include/samurai/algorithm/update_fields.hpp
+++ b/include/samurai/algorithm/update_fields.hpp
@@ -65,8 +65,22 @@ namespace samurai
         }
     }
 
-    // Update fields with custom prediction function
+    namespace detail
+    {
+        template <class T, class = void>
+        struct is_std_tuple : std::false_type
+        {
+        };
+
+        template <class... Ts>
+        struct is_std_tuple<std::tuple<Ts...>, void> : std::true_type
+        {
+        };
+    }
+
+    // Update fields with custom prediction function (tuple version)
     template <class PredictionFn, class DestTuple, class SrcTuple, class Mesh>
+        requires(detail::is_std_tuple<std::remove_cvref_t<DestTuple>>::value && detail::is_std_tuple<std::remove_cvref_t<SrcTuple>>::value)
     void update_fields(PredictionFn&& prediction_fn, Mesh& new_mesh, DestTuple& dests, SrcTuple& srcs)
     {
         constexpr std::size_t n = std::tuple_size_v<std::remove_cvref_t<DestTuple>>;
@@ -83,6 +97,7 @@ namespace samurai
     }
 
     template <class PredictionFn, class Mesh, class Field, class... Fields>
+        requires(!mesh_like<std::remove_cvref_t<PredictionFn>> && !detail::is_std_tuple<std::remove_cvref_t<Field>>::value)
     void update_fields(PredictionFn&& prediction_fn, Mesh& new_mesh, Field& field, Fields&... fields)
     {
         auto src_tuple = std::tuple_cat(get_elements(field), std::tie(fields...));

--- a/include/samurai/algorithm/utils.hpp
+++ b/include/samurai/algorithm/utils.hpp
@@ -3,12 +3,26 @@
 
 #pragma once
 
+#include <cstddef>
+#include <tuple>
+#include <type_traits>
+#include <utility>
+
 #include "../cell_flag.hpp"
+#include "../field/concepts.hpp"
 #include "../operators_base.hpp"
 #include "../static_algorithm.hpp"
 
 namespace samurai
 {
+    // ---------------------------------------------------------------------
+    // Forward declaration so that the tuple overload of copy() (below) can
+    // accept a Field_tuple without including the full definition.
+    // ---------------------------------------------------------------------
+    template <class TField, class... TFields>
+        requires(field_like<TField> && (field_like<TFields> && ...))
+    class Field_tuple;
+
     ///////////////////
     // copy operator //
     ///////////////////
@@ -21,28 +35,125 @@ namespace samurai
         INIT_OPERATOR(copy_op)
 
         template <class T>
-        SAMURAI_INLINE void operator()(Dim<1>, T& dest, const T& src) const
+        SAMURAI_INLINE void operator()(Dim<dim>, T& dest, const T& src) const
         {
-            dest(level, i) = src(level, i);
-        }
-
-        template <class T>
-        SAMURAI_INLINE void operator()(Dim<2>, T& dest, const T& src) const
-        {
-            dest(level, i, j) = src(level, i, j);
-        }
-
-        template <class T>
-        SAMURAI_INLINE void operator()(Dim<3>, T& dest, const T& src) const
-        {
-            dest(level, i, j, k) = src(level, i, j, k);
+            dest(level, i, index) = src(level, i, index);
         }
     };
 
     template <class T>
+        requires field_like<std::remove_cvref_t<T>>
     SAMURAI_INLINE auto copy(T&& dest, T&& src)
     {
         return make_field_operator_function<copy_op>(std::forward<T>(dest), std::forward<T>(src));
+    }
+
+    //////////////////////////////
+    // tuple_copy_op (batch copy)
+    //
+    // Copies every (dest, src) pair of fields given as two tuples, in a single
+    // traversal of the interval set. The operator is nD by construction: it
+    // never calls `field(level, i, index)` (which performs a `find`), but
+    // resolves the offset of the first cell of the interval with
+    // `mesh.get_index(level, i.start, index...)` (via `memory_offset`) and then
+    // walks the interval with a plain loop `ii = 0 .. i.size()`. For vector
+    // fields it additionally loops over the components; storage is assumed AoS
+    // (cell-major), i.e. the flat buffer index is `cell * n_comp + comp`.
+    //////////////////////////////
+    template <std::size_t dim, class TInterval>
+    class tuple_copy_op : public field_operator_base<dim, TInterval>
+    {
+      public:
+
+        INIT_OPERATOR(tuple_copy_op)
+
+        // Offset of the first cell of the current interval, for the given mesh.
+        template <class Mesh>
+        SAMURAI_INLINE std::size_t cell_offset(const Mesh& mesh) const
+        {
+            return memory_offset(mesh, {level, i.start, index});
+        }
+
+        // nD entry point: walk the (dest, src) pairs inside the two tuples.
+        // The first_field argument is only used as a type carrier for `dim`
+        // and `mesh_t` by the enclosing field_operator_function; it is not
+        // accessed here.
+        template <class Dsts, class Srcs, class FirstField>
+        SAMURAI_INLINE void operator()(Dim<dim>, Dsts& dests, const Srcs& srcs, const FirstField&) const
+        {
+            const std::size_t off_d = cell_offset(std::get<0>(dests));
+            const std::size_t off_s = cell_offset(std::get<0>(srcs));
+            const std::size_t n     = static_cast<std::size_t>(i.size());
+
+            auto copy_one = [&](auto& dest, const auto& src)
+            {
+                using Dest = std::remove_cvref_t<decltype(dest)>;
+                using Src  = std::remove_cvref_t<decltype(src)>;
+
+                static_assert(Dest::n_comp == Src::n_comp,
+                              "tuple_copy: dest and src fields must have the same number of components");
+                constexpr std::size_t nc = Dest::n_comp;
+
+                auto* d_data       = dest.data();
+                const auto* s_data = src.data();
+
+                if constexpr (nc == 1)
+                {
+                    for (std::size_t ii = 0; ii < n; ++ii)
+                    {
+                        d_data[off_d + ii] = s_data[off_s + ii];
+                    }
+                }
+                else if constexpr (detail::is_soa_v<Dest>) // SoA: data()[comp * nb_cells + cell]
+                {
+                    const std::size_t nb_d = static_cast<std::size_t>(dest.array().shape()[1]);
+                    const std::size_t nb_s = static_cast<std::size_t>(src.array().shape()[1]);
+                    for (std::size_t ii = 0; ii < n; ++ii)
+                    {
+                        for (std::size_t c = 0; c < nc; ++c)
+                        {
+                            d_data[c * nb_d + off_d + ii] = s_data[c * nb_s + off_s + ii];
+                        }
+                    }
+                }
+                else // AoS (cell-major): data()[cell * n_comp + comp]
+                {
+                    for (std::size_t ii = 0; ii < n; ++ii)
+                    {
+                        for (std::size_t c = 0; c < nc; ++c)
+                        {
+                            d_data[(off_d + ii) * nc + c] = s_data[(off_s + ii) * nc + c];
+                        }
+                    }
+                }
+            };
+
+            std::apply(
+                [&](auto&... dest)
+                {
+                    std::apply(
+                        [&](auto&... src)
+                        {
+                            ((copy_one(dest, src)), ...);
+                        },
+                        srcs);
+                },
+                dests);
+        }
+    };
+
+    // Copy a tuple of destination fields from a tuple of source fields, every
+    // pair in a single traversal of the interval set.
+    //
+    // The first field of dests is passed as an extra argument to
+    // make_field_operator_function so that detail::compute_dim<CT...>() and
+    // detail::extract_mesh() can find the dimension and the mesh from the
+    // argument types (the plain std::tuple arguments carry neither).
+    template <class DestTuple, class SrcTuple>
+        requires(!field_like<std::remove_cvref_t<DestTuple>> && !field_like<std::remove_cvref_t<SrcTuple>>)
+    SAMURAI_INLINE auto copy(DestTuple&& dests, SrcTuple&& srcs)
+    {
+        return make_field_operator_function<tuple_copy_op>(dests, srcs, std::get<0>(dests));
     }
 
     //////////////////////////

--- a/include/samurai/algorithm/utils.hpp
+++ b/include/samurai/algorithm/utils.hpp
@@ -15,14 +15,6 @@
 
 namespace samurai
 {
-    // ---------------------------------------------------------------------
-    // Forward declaration so that the tuple overload of copy() (below) can
-    // accept a Field_tuple without including the full definition.
-    // ---------------------------------------------------------------------
-    template <class TField, class... TFields>
-        requires(field_like<TField> && (field_like<TFields> && ...))
-    class Field_tuple;
-
     ///////////////////
     // copy operator //
     ///////////////////
@@ -81,8 +73,8 @@ namespace samurai
         template <class Dsts, class Srcs, class FirstField>
         SAMURAI_INLINE void operator()(Dim<dim>, Dsts& dests, const Srcs& srcs, const FirstField&) const
         {
-            const std::size_t off_d = cell_offset(std::get<0>(dests));
-            const std::size_t off_s = cell_offset(std::get<0>(srcs));
+            const std::size_t off_d = cell_offset(std::get<0>(dests).mesh());
+            const std::size_t off_s = cell_offset(std::get<0>(srcs).mesh());
             const std::size_t n     = static_cast<std::size_t>(i.size());
 
             auto copy_one = [&](auto& dest, const auto& src)
@@ -90,8 +82,7 @@ namespace samurai
                 using Dest = std::remove_cvref_t<decltype(dest)>;
                 using Src  = std::remove_cvref_t<decltype(src)>;
 
-                static_assert(Dest::n_comp == Src::n_comp,
-                              "tuple_copy: dest and src fields must have the same number of components");
+                static_assert(Dest::n_comp == Src::n_comp, "tuple_copy: dest and src fields must have the same number of components");
                 constexpr std::size_t nc = Dest::n_comp;
 
                 auto* d_data       = dest.data();

--- a/include/samurai/field.hpp
+++ b/include/samurai/field.hpp
@@ -10,4 +10,5 @@
 #include "field/scalar_field.hpp"
 #include "field/swap.hpp"
 #include "field/tuple_field.hpp"
+#include "field/utils.hpp"
 #include "field/vector_field.hpp"

--- a/include/samurai/field/tuple_field.hpp
+++ b/include/samurai/field/tuple_field.hpp
@@ -15,18 +15,6 @@ namespace samurai
         requires(field_like<TField> && (field_like<TFields> && ...))
     class Field_tuple;
 
-    namespace detail
-    {
-        // Unwrap a Field_tuple into its underlying std::tuple of field
-        // references, so that the tuple overload of `copy()` can treat a
-        // Field_tuple and a plain std::tuple uniformly.
-        template <class TField, class... TFields>
-        auto& tuple_refs(Field_tuple<TField, TFields...>& ft)
-        {
-            return ft.elements();
-        }
-    }
-
     template <class TField, class... TFields>
         requires(field_like<TField> && (field_like<TFields> && ...))
     class Field_tuple

--- a/include/samurai/field/tuple_field.hpp
+++ b/include/samurai/field/tuple_field.hpp
@@ -13,6 +13,22 @@ namespace samurai
 
     template <class TField, class... TFields>
         requires(field_like<TField> && (field_like<TFields> && ...))
+    class Field_tuple;
+
+    namespace detail
+    {
+        // Unwrap a Field_tuple into its underlying std::tuple of field
+        // references, so that the tuple overload of `copy()` can treat a
+        // Field_tuple and a plain std::tuple uniformly.
+        template <class TField, class... TFields>
+        auto& tuple_refs(Field_tuple<TField, TFields...>& ft)
+        {
+            return ft.elements();
+        }
+    }
+
+    template <class TField, class... TFields>
+        requires(field_like<TField> && (field_like<TFields> && ...))
     class Field_tuple
     {
       public:
@@ -23,6 +39,10 @@ namespace samurai
         using mesh_t                 = typename TField::mesh_t;
         using mesh_id_t              = typename mesh_t::mesh_id_t;
         using size_type              = typename TField::size_type;
+
+        // dim is exposed so that set-algebra helpers (e.g. the variadic copy
+        // operator) can deduce the dimensionality from a Field_tuple argument.
+        static constexpr std::size_t dim = mesh_t::dim;
 
         Field_tuple(TField& field, TFields&... fields)
             : m_fields(field, fields...)

--- a/include/samurai/field/utils.hpp
+++ b/include/samurai/field/utils.hpp
@@ -1,0 +1,24 @@
+// Copyright 2018-2025 the samurai's authors
+// SPDX-License-Identifier:  BSD-3-Clause
+
+#pragma once
+
+#include <tuple>
+
+#include "tuple_field.hpp"
+
+namespace samurai
+{
+
+    template <class TField, class... TFields>
+    auto& get_elements(Field_tuple<TField, TFields...>& ft)
+    {
+        return ft.elements();
+    }
+
+    template <class TField>
+    auto get_elements(TField& f)
+    {
+        return std::tie(f);
+    }
+}

--- a/include/samurai/indices.hpp
+++ b/include/samurai/indices.hpp
@@ -185,7 +185,7 @@ namespace samurai
 
         for (std::size_t level = min_level; level <= max_level; ++level)
         {
-            auto set = difference(mesh[mesh_id_t::reference][level], mesh.domain()).on(level);
+            auto set = difference(mesh[mesh_id_t::reference][level], mesh.domain(level)).on(level);
 
             for_each_cell(mesh, set, std::forward<Func>(f));
         }

--- a/include/samurai/numeric/prediction.hpp
+++ b/include/samurai/numeric/prediction.hpp
@@ -397,10 +397,10 @@ namespace samurai
         template <std::size_t order, bool dest_on_level, class Dest, class Src>
         SAMURAI_INLINE void predict_one(Dest& dest, const Src& src) const
         {
-            prediction_op<dim, interval_t>(level, i, index)(
-                Dim<dim>{}, dest, src,
-                std::integral_constant<std::size_t, order>{},
-                std::integral_constant<bool, dest_on_level>{});
+            prediction_op<dim, interval_t>(
+                level,
+                i,
+                index)(Dim<dim>{}, dest, src, std::integral_constant<std::size_t, order>{}, std::integral_constant<bool, dest_on_level>{});
         }
 
         // nD entry point: walk the (dest, src) pairs inside the two tuples.
@@ -468,11 +468,10 @@ namespace samurai
         constexpr std::size_t n = std::tuple_size_v<std::remove_cvref_t<DestTuple>>;
         static_assert(n == std::tuple_size_v<std::remove_cvref_t<SrcTuple>>,
                       "prediction(tuples): the dest and src tuples must contain the same number of fields");
-        return make_field_operator_function<tuple_prediction_op>(
-            std::integral_constant<std::size_t, order>{},
-            std::integral_constant<bool, dest_on_level>{},
-            dests,
-            srcs,
-            std::get<0>(dests));
+        return make_field_operator_function<tuple_prediction_op>(std::integral_constant<std::size_t, order>{},
+                                                                 std::integral_constant<bool, dest_on_level>{},
+                                                                 dests,
+                                                                 srcs,
+                                                                 std::get<0>(dests));
     }
 }

--- a/include/samurai/numeric/prediction.hpp
+++ b/include/samurai/numeric/prediction.hpp
@@ -12,6 +12,7 @@
 
 #include <xtensor/views/xview.hpp>
 
+#include "../field/concepts.hpp"
 #include "../operators_base.hpp"
 #include "../static_algorithm.hpp"
 #include "../utils.hpp"

--- a/include/samurai/numeric/prediction.hpp
+++ b/include/samurai/numeric/prediction.hpp
@@ -383,6 +383,46 @@ namespace samurai
         }
     };
 
+    // Tuple-based prediction: predicts pairs (dest, src) in a single traversal
+    template <std::size_t dim, class TInterval>
+    class tuple_prediction_op : public field_operator_base<dim, TInterval>
+    {
+      public:
+
+        INIT_OPERATOR(tuple_prediction_op)
+
+        // Predict one (dest, src) field pair over the current interval.
+        // This uses the base prediction_op for each pair.
+        template <std::size_t order, bool dest_on_level, class Dest, class Src>
+        SAMURAI_INLINE void predict_one(Dest& dest, const Src& src) const
+        {
+            prediction_op<dim, interval_t>(level, i, index)(
+                Dim<dim>{}, dest, src,
+                std::integral_constant<std::size_t, order>{},
+                std::integral_constant<bool, dest_on_level>{});
+        }
+
+        // nD entry point: walk the interleaved (dest, src, dest, src, ...) pack
+        // one pair at a time.
+        template <std::size_t order, bool dest_on_level, class DHead, class SHead, class... Tail>
+        SAMURAI_INLINE void operator()(Dim<dim>,
+                                       std::integral_constant<std::size_t, order>,
+                                       std::integral_constant<bool, dest_on_level>,
+                                       DHead& dest_head,
+                                       const SHead& src_head,
+                                       Tail&... tail) const
+        {
+            predict_one<order, dest_on_level>(dest_head, src_head);
+            if constexpr (sizeof...(Tail) > 0)
+            {
+                (*this)(Dim<dim>{},
+                       std::integral_constant<std::size_t, order>{},
+                       std::integral_constant<bool, dest_on_level>{},
+                       tail...);
+            }
+        }
+    };
+
     template <std::size_t order, bool dest_on_level, class... T>
     SAMURAI_INLINE auto variadic_prediction(T&&... fields)
     {
@@ -407,5 +447,37 @@ namespace samurai
                                                            field_src,
                                                            std::integral_constant<std::size_t, order>{},
                                                            std::integral_constant<bool, dest_on_level>{});
+    }
+
+    namespace detail
+    {
+        template <std::size_t order, bool dest_on_level, class DestTuple, class SrcTuple, std::size_t... Is>
+        SAMURAI_INLINE auto make_tuple_prediction(DestTuple& dests, SrcTuple& srcs, std::index_sequence<Is...>)
+        {
+            // Build the interleaved argument list (dest0, src0, dest1, src1, ...).
+            auto interleaved = std::tuple_cat(std::tie(std::get<Is>(dests), std::get<Is>(srcs))...);
+            return std::apply(
+                [](auto&... args)
+                {
+                    return make_field_operator_function<tuple_prediction_op>(
+                        std::integral_constant<std::size_t, order>{},
+                        std::integral_constant<bool, dest_on_level>{},
+                        args...);
+                },
+                interleaved);
+        }
+    }
+
+    // Predict a tuple of destination fields from a tuple of source fields
+    template <std::size_t order, bool dest_on_level, class DestTuple, class SrcTuple>
+        requires(!field_like<std::remove_cvref_t<DestTuple>> && !field_like<std::remove_cvref_t<SrcTuple>>)
+    SAMURAI_INLINE auto prediction(DestTuple&& dests, SrcTuple&& srcs)
+    {
+        auto& dt = detail::tuple_refs(dests);
+        auto& st = detail::tuple_refs(srcs);
+        constexpr std::size_t n = std::tuple_size_v<std::remove_cvref_t<decltype(dt)>>;
+        static_assert(n == std::tuple_size_v<std::remove_cvref_t<decltype(st)>>,
+                      "prediction(tuples): the dest and src tuples must contain the same number of fields");
+        return detail::make_tuple_prediction<order, dest_on_level>(dt, st, std::make_index_sequence<n>{});
     }
 }

--- a/include/samurai/numeric/prediction.hpp
+++ b/include/samurai/numeric/prediction.hpp
@@ -383,7 +383,8 @@ namespace samurai
         }
     };
 
-    // Tuple-based prediction: predicts pairs (dest, src) in a single traversal
+    // Tuple-based prediction: predicts pairs (dest, src) given as two tuples
+    // in a single traversal of the interval set.
     template <std::size_t dim, class TInterval>
     class tuple_prediction_op : public field_operator_base<dim, TInterval>
     {
@@ -392,7 +393,7 @@ namespace samurai
         INIT_OPERATOR(tuple_prediction_op)
 
         // Predict one (dest, src) field pair over the current interval.
-        // This uses the base prediction_op for each pair.
+        // Uses the base prediction_op for each pair.
         template <std::size_t order, bool dest_on_level, class Dest, class Src>
         SAMURAI_INLINE void predict_one(Dest& dest, const Src& src) const
         {
@@ -402,24 +403,28 @@ namespace samurai
                 std::integral_constant<bool, dest_on_level>{});
         }
 
-        // nD entry point: walk the interleaved (dest, src, dest, src, ...) pack
-        // one pair at a time.
-        template <std::size_t order, bool dest_on_level, class DHead, class SHead, class... Tail>
+        // nD entry point: walk the (dest, src) pairs inside the two tuples.
+        // The first_field argument is only used as a type carrier for `dim`
+        // and `mesh_t` by the enclosing field_operator_function.
+        template <std::size_t order, bool dest_on_level, class Dsts, class Srcs, class FirstField>
         SAMURAI_INLINE void operator()(Dim<dim>,
                                        std::integral_constant<std::size_t, order>,
                                        std::integral_constant<bool, dest_on_level>,
-                                       DHead& dest_head,
-                                       const SHead& src_head,
-                                       Tail&... tail) const
+                                       Dsts& dests,
+                                       const Srcs& srcs,
+                                       const FirstField&) const
         {
-            predict_one<order, dest_on_level>(dest_head, src_head);
-            if constexpr (sizeof...(Tail) > 0)
-            {
-                (*this)(Dim<dim>{},
-                       std::integral_constant<std::size_t, order>{},
-                       std::integral_constant<bool, dest_on_level>{},
-                       tail...);
-            }
+            std::apply(
+                [&](auto&... dest)
+                {
+                    std::apply(
+                        [&](auto&... src)
+                        {
+                            ((predict_one<order, dest_on_level>(dest, src)), ...);
+                        },
+                        srcs);
+                },
+                dests);
         }
     };
 
@@ -449,35 +454,25 @@ namespace samurai
                                                            std::integral_constant<bool, dest_on_level>{});
     }
 
-    namespace detail
-    {
-        template <std::size_t order, bool dest_on_level, class DestTuple, class SrcTuple, std::size_t... Is>
-        SAMURAI_INLINE auto make_tuple_prediction(DestTuple& dests, SrcTuple& srcs, std::index_sequence<Is...>)
-        {
-            // Build the interleaved argument list (dest0, src0, dest1, src1, ...).
-            auto interleaved = std::tuple_cat(std::tie(std::get<Is>(dests), std::get<Is>(srcs))...);
-            return std::apply(
-                [](auto&... args)
-                {
-                    return make_field_operator_function<tuple_prediction_op>(
-                        std::integral_constant<std::size_t, order>{},
-                        std::integral_constant<bool, dest_on_level>{},
-                        args...);
-                },
-                interleaved);
-        }
-    }
-
-    // Predict a tuple of destination fields from a tuple of source fields
+    // Predict a tuple of destination fields from a tuple of source fields,
+    // every pair in a single traversal of the interval set.
+    //
+    // The first field of dests is passed as an extra argument to
+    // make_field_operator_function so that detail::compute_dim<CT...>() and
+    // detail::extract_mesh() can find the dimension and the mesh from the
+    // argument types (the plain std::tuple arguments carry neither).
     template <std::size_t order, bool dest_on_level, class DestTuple, class SrcTuple>
         requires(!field_like<std::remove_cvref_t<DestTuple>> && !field_like<std::remove_cvref_t<SrcTuple>>)
     SAMURAI_INLINE auto prediction(DestTuple&& dests, SrcTuple&& srcs)
     {
-        auto& dt = detail::tuple_refs(dests);
-        auto& st = detail::tuple_refs(srcs);
-        constexpr std::size_t n = std::tuple_size_v<std::remove_cvref_t<decltype(dt)>>;
-        static_assert(n == std::tuple_size_v<std::remove_cvref_t<decltype(st)>>,
+        constexpr std::size_t n = std::tuple_size_v<std::remove_cvref_t<DestTuple>>;
+        static_assert(n == std::tuple_size_v<std::remove_cvref_t<SrcTuple>>,
                       "prediction(tuples): the dest and src tuples must contain the same number of fields");
-        return detail::make_tuple_prediction<order, dest_on_level>(dt, st, std::make_index_sequence<n>{});
+        return make_field_operator_function<tuple_prediction_op>(
+            std::integral_constant<std::size_t, order>{},
+            std::integral_constant<bool, dest_on_level>{},
+            dests,
+            srcs,
+            std::get<0>(dests));
     }
 }

--- a/include/samurai/numeric/projection.hpp
+++ b/include/samurai/numeric/projection.hpp
@@ -98,6 +98,89 @@ namespace samurai
         }
     };
 
+    // Tuple-based projection: projects pairs (dest, src) in a single traversal
+    template <std::size_t dim, class TInterval>
+    class tuple_projection_op_ : public field_operator_base<dim, TInterval>
+    {
+      public:
+
+        INIT_OPERATOR(tuple_projection_op_)
+
+        // Offset of the first cell of the current interval, for the given mesh.
+        template <class Mesh>
+        SAMURAI_INLINE std::size_t cell_offset(const Mesh& mesh) const
+        {
+            if constexpr (dim == 1)
+            {
+                return memory_offset(mesh, {level, i.start});
+            }
+            else
+            {
+                return memory_offset(mesh, {level, i.start, index});
+            }
+        }
+
+        // Project one (dest, src) field pair over the current interval.
+        template <class Dest, class Src>
+        SAMURAI_INLINE void project_one(Dest& dest, const Src& src) const
+        {
+            static_assert(Dest::n_comp == Src::n_comp, "Source and destination fields must have the same number of components");
+
+            const std::size_t off_d = cell_offset(dest.mesh());
+            constexpr std::size_t nc = Dest::n_comp;
+            const std::size_t n = static_cast<std::size_t>(i.size());
+
+            std::array<std::size_t, 1ULL << (dim - 1)> src_offsets;
+            if constexpr (dim == 1)
+            {
+                src_offsets[0] = memory_offset(src.mesh(), {level + 1, 2 * i.start});
+            }
+            else
+            {
+                std::size_t ind = 0;
+                static_nested_loop<dim - 1, 0, 2>(
+                    [&](const auto& stencil)
+                    {
+                        auto new_index     = 2 * index + stencil;
+                        src_offsets[ind++] = memory_offset(src.mesh(), {level + 1, 2 * i.start, new_index});
+                    });
+            }
+
+            const auto* src_data = src.data();
+            auto* dest_data      = dest.data();
+            constexpr double inv = 1.0 / static_cast<double>(1ULL << dim);
+
+            for (std::size_t ii = 0, i_f = 0; ii < n; ++ii, i_f += 2)
+            {
+                std::array<double, nc> sum;
+                sum.fill(0);
+                for (std::size_t s = 0; s < src_offsets.size(); ++s)
+                {
+                    for (std::size_t c = 0; c < nc; ++c)
+                    {
+                        sum[c] += src_data[(src_offsets[s] + i_f) * nc + c] + src_data[(src_offsets[s] + i_f + 1) * nc + c];
+                    }
+                }
+                for (std::size_t c = 0; c < nc; ++c)
+                {
+                    dest_data[(off_d + ii) * nc + c] = sum[c] * inv;
+                }
+            }
+        }
+
+        // nD entry point: walk the interleaved (dest, src, dest, src, ...) pack
+        // one pair at a time.
+        template <class DHead, class SHead, class... Tail>
+        SAMURAI_INLINE void operator()(Dim<dim>, DHead& dest_head, const SHead& src_head, Tail&... tail) const
+        {
+            project_one(dest_head, src_head);
+            if constexpr (sizeof...(Tail) > 0)
+            {
+                (*this)(Dim<dim>{}, tail...);
+            }
+        }
+    };
+
     template <class T>
     SAMURAI_INLINE auto projection(T&& field)
     {
@@ -114,5 +197,34 @@ namespace samurai
     SAMURAI_INLINE auto projection(T1&& field_dest, T2&& field_src)
     {
         return make_field_operator_function<projection_op_>(std::forward<T1>(field_dest), std::forward<T2>(field_src));
+    }
+
+    namespace detail
+    {
+        template <class DestTuple, class SrcTuple, std::size_t... Is>
+        SAMURAI_INLINE auto make_tuple_projection(DestTuple& dests, SrcTuple& srcs, std::index_sequence<Is...>)
+        {
+            // Build the interleaved argument list (dest0, src0, dest1, src1, ...).
+            auto interleaved = std::tuple_cat(std::tie(std::get<Is>(dests), std::get<Is>(srcs))...);
+            return std::apply(
+                [](auto&... args)
+                {
+                    return make_field_operator_function<tuple_projection_op_>(args...);
+                },
+                interleaved);
+        }
+    }
+
+    // Project a tuple of destination fields from a tuple of source fields
+    template <class DestTuple, class SrcTuple>
+        requires(!field_like<std::remove_cvref_t<DestTuple>> && !field_like<std::remove_cvref_t<SrcTuple>>)
+    SAMURAI_INLINE auto projection(DestTuple&& dests, SrcTuple&& srcs)
+    {
+        auto& dt = detail::tuple_refs(dests);
+        auto& st = detail::tuple_refs(srcs);
+        constexpr std::size_t n = std::tuple_size_v<std::remove_cvref_t<decltype(dt)>>;
+        static_assert(n == std::tuple_size_v<std::remove_cvref_t<decltype(st)>>,
+                      "projection(tuples): the dest and src tuples must contain the same number of fields");
+        return detail::make_tuple_projection(dt, st, std::make_index_sequence<n>{});
     }
 }

--- a/include/samurai/numeric/projection.hpp
+++ b/include/samurai/numeric/projection.hpp
@@ -161,7 +161,7 @@ namespace samurai
             const std::size_t off_d = cell_offset(std::get<0>(dests).mesh());
 
             std::array<std::size_t, 1ULL << (dim - 1)> off_s;
-            auto& src_mesh = std::get<0>(srcs).mesh();
+            const auto& src_mesh = std::get<0>(srcs).mesh();
             if constexpr (dim == 1)
             {
                 off_s[0] = memory_offset(src_mesh, {level + 1, 2 * i.start});

--- a/include/samurai/numeric/projection.hpp
+++ b/include/samurai/numeric/projection.hpp
@@ -98,7 +98,8 @@ namespace samurai
         }
     };
 
-    // Tuple-based projection: projects pairs (dest, src) in a single traversal
+    // Tuple-based projection: projects pairs (dest, src) given as two tuples
+    // in a single traversal of the interval set.
     template <std::size_t dim, class TInterval>
     class tuple_projection_op_ : public field_operator_base<dim, TInterval>
     {
@@ -122,29 +123,12 @@ namespace samurai
 
         // Project one (dest, src) field pair over the current interval.
         template <class Dest, class Src>
-        SAMURAI_INLINE void project_one(Dest& dest, const Src& src) const
+        SAMURAI_INLINE void project_one(Dest& dest, const Src& src, const auto& off_d, const auto& off_s) const
         {
             static_assert(Dest::n_comp == Src::n_comp, "Source and destination fields must have the same number of components");
 
-            const std::size_t off_d = cell_offset(dest.mesh());
             constexpr std::size_t nc = Dest::n_comp;
-            const std::size_t n = static_cast<std::size_t>(i.size());
-
-            std::array<std::size_t, 1ULL << (dim - 1)> src_offsets;
-            if constexpr (dim == 1)
-            {
-                src_offsets[0] = memory_offset(src.mesh(), {level + 1, 2 * i.start});
-            }
-            else
-            {
-                std::size_t ind = 0;
-                static_nested_loop<dim - 1, 0, 2>(
-                    [&](const auto& stencil)
-                    {
-                        auto new_index     = 2 * index + stencil;
-                        src_offsets[ind++] = memory_offset(src.mesh(), {level + 1, 2 * i.start, new_index});
-                    });
-            }
+            const std::size_t n      = static_cast<std::size_t>(i.size());
 
             const auto* src_data = src.data();
             auto* dest_data      = dest.data();
@@ -154,11 +138,11 @@ namespace samurai
             {
                 std::array<double, nc> sum;
                 sum.fill(0);
-                for (std::size_t s = 0; s < src_offsets.size(); ++s)
+                for (std::size_t s = 0; s < off_s.size(); ++s)
                 {
                     for (std::size_t c = 0; c < nc; ++c)
                     {
-                        sum[c] += src_data[(src_offsets[s] + i_f) * nc + c] + src_data[(src_offsets[s] + i_f + 1) * nc + c];
+                        sum[c] += src_data[(off_s[s] + i_f) * nc + c] + src_data[(off_s[s] + i_f + 1) * nc + c];
                     }
                 }
                 for (std::size_t c = 0; c < nc; ++c)
@@ -168,16 +152,42 @@ namespace samurai
             }
         }
 
-        // nD entry point: walk the interleaved (dest, src, dest, src, ...) pack
-        // one pair at a time.
-        template <class DHead, class SHead, class... Tail>
-        SAMURAI_INLINE void operator()(Dim<dim>, DHead& dest_head, const SHead& src_head, Tail&... tail) const
+        // nD entry point: walk the (dest, src) pairs inside the two tuples.
+        // The first_field argument is only used as a type carrier for `dim`
+        // and `mesh_t` by the enclosing field_operator_function.
+        template <class Dsts, class Srcs, class FirstField>
+        SAMURAI_INLINE void operator()(Dim<dim>, Dsts& dests, const Srcs& srcs, const FirstField&) const
         {
-            project_one(dest_head, src_head);
-            if constexpr (sizeof...(Tail) > 0)
+            const std::size_t off_d = cell_offset(std::get<0>(dests).mesh());
+
+            std::array<std::size_t, 1ULL << (dim - 1)> off_s;
+            auto& src_mesh = std::get<0>(srcs).mesh();
+            if constexpr (dim == 1)
             {
-                (*this)(Dim<dim>{}, tail...);
+                off_s[0] = memory_offset(src_mesh, {level + 1, 2 * i.start});
             }
+            else
+            {
+                std::size_t ind = 0;
+                static_nested_loop<dim - 1, 0, 2>(
+                    [&](const auto& stencil)
+                    {
+                        auto new_index = 2 * index + stencil;
+                        off_s[ind++]   = memory_offset(src_mesh, {level + 1, 2 * i.start, new_index});
+                    });
+            }
+
+            std::apply(
+                [&](auto&... dest)
+                {
+                    std::apply(
+                        [&](auto&... src)
+                        {
+                            ((project_one(dest, src, off_d, off_s)), ...);
+                        },
+                        srcs);
+                },
+                dests);
         }
     };
 
@@ -199,32 +209,20 @@ namespace samurai
         return make_field_operator_function<projection_op_>(std::forward<T1>(field_dest), std::forward<T2>(field_src));
     }
 
-    namespace detail
-    {
-        template <class DestTuple, class SrcTuple, std::size_t... Is>
-        SAMURAI_INLINE auto make_tuple_projection(DestTuple& dests, SrcTuple& srcs, std::index_sequence<Is...>)
-        {
-            // Build the interleaved argument list (dest0, src0, dest1, src1, ...).
-            auto interleaved = std::tuple_cat(std::tie(std::get<Is>(dests), std::get<Is>(srcs))...);
-            return std::apply(
-                [](auto&... args)
-                {
-                    return make_field_operator_function<tuple_projection_op_>(args...);
-                },
-                interleaved);
-        }
-    }
-
-    // Project a tuple of destination fields from a tuple of source fields
+    // Project a tuple of destination fields from a tuple of source fields,
+    // every pair in a single traversal of the interval set.
+    //
+    // The first field of dests is passed as an extra argument to
+    // make_field_operator_function so that detail::compute_dim<CT...>() and
+    // detail::extract_mesh() can find the dimension and the mesh from the
+    // argument types (the plain std::tuple arguments carry neither).
     template <class DestTuple, class SrcTuple>
         requires(!field_like<std::remove_cvref_t<DestTuple>> && !field_like<std::remove_cvref_t<SrcTuple>>)
     SAMURAI_INLINE auto projection(DestTuple&& dests, SrcTuple&& srcs)
     {
-        auto& dt = detail::tuple_refs(dests);
-        auto& st = detail::tuple_refs(srcs);
-        constexpr std::size_t n = std::tuple_size_v<std::remove_cvref_t<decltype(dt)>>;
-        static_assert(n == std::tuple_size_v<std::remove_cvref_t<decltype(st)>>,
+        constexpr std::size_t n = std::tuple_size_v<std::remove_cvref_t<DestTuple>>;
+        static_assert(n == std::tuple_size_v<std::remove_cvref_t<SrcTuple>>,
                       "projection(tuples): the dest and src tuples must contain the same number of fields");
-        return detail::make_tuple_projection(dt, st, std::make_index_sequence<n>{});
+        return make_field_operator_function<tuple_projection_op_>(dests, srcs, std::get<0>(dests));
     }
 }

--- a/include/samurai/utils.hpp
+++ b/include/samurai/utils.hpp
@@ -270,20 +270,6 @@ namespace samurai
         template <class... T>
         using common_type_t = typename common_type<T...>::type;
 
-        // Identity overload for plain tuples (used by projection, prediction).
-        // Specialised for Field_tuple in tuple_field.hpp.
-        template <class... T>
-        SAMURAI_INLINE std::tuple<T&...>& tuple_refs(std::tuple<T&...>& t)
-        {
-            return t;
-        }
-
-        template <class... T>
-        SAMURAI_INLINE const std::tuple<T&...>& tuple_refs(const std::tuple<T&...>& t)
-        {
-            return t;
-        }
-
         template <class Head, class... Tail>
         auto& extract_mesh(Head&& h, Tail&&... t)
         {

--- a/include/samurai/utils.hpp
+++ b/include/samurai/utils.hpp
@@ -270,6 +270,20 @@ namespace samurai
         template <class... T>
         using common_type_t = typename common_type<T...>::type;
 
+        // Identity overload for plain tuples (used by projection, prediction).
+        // Specialised for Field_tuple in tuple_field.hpp.
+        template <class... T>
+        SAMURAI_INLINE std::tuple<T&...>& tuple_refs(std::tuple<T&...>& t)
+        {
+            return t;
+        }
+
+        template <class... T>
+        SAMURAI_INLINE const std::tuple<T&...>& tuple_refs(const std::tuple<T&...>& t)
+        {
+            return t;
+        }
+
         template <class Head, class... Tail>
         auto& extract_mesh(Head&& h, Tail&&... t)
         {

--- a/tests/test_adapt.cpp
+++ b/tests/test_adapt.cpp
@@ -41,6 +41,12 @@ namespace samurai
         auto adapt      = make_MRAdapt(u_1, u_2, u_3);
         auto mra_config = samurai::mra_config().regularity(2.);
         adapt(mra_config);
+
+        // After adaptation the fields must live on the new mesh topology.
+        EXPECT_EQ(u_1.array().size(), u_1.mesh().nb_cells());
+        EXPECT_EQ(u_2.array().size(), u_2.mesh().nb_cells() * u_2.n_comp);
+        EXPECT_EQ(u_3.array().size(), u_3.mesh().nb_cells() * u_3.n_comp);
+
         ::samurai::finalize();
     }
 }


### PR DESCRIPTION
## Description

This PR refactors the `update_fields` workflow to reduce set-algebra overhead by batching multi-field operations (copy/projection/prediction) via tuple-based operators, and adds a micro-benchmark plus a regression test around field storage after adaptation.

**Changes:**

- Introduces tuple-based copy, projection, and prediction operators intended to process multiple (dest, src) field pairs in a single interval-set traversal.
- Refactors `update_fields` to build tuples of fields, apply batched operators, and swap updated fields back.
- Adds a benchmark (bench_update_fields) and a test assertion to validate field storage sizing after MR adaptation.

## Code of Conduct
By submitting this PR, you agree to follow our [Code of Conduct](https://github.com/hpc-maths/samurai/blob/master/docs/CODE_OF_CONDUCT.md)
- [x] I agree to follow this project's Code of Conduct
