### PR TITLE
build: fix windows build

### DIFF
--- a/demos/FiniteVolume/CMakeLists.txt
+++ b/demos/FiniteVolume/CMakeLists.txt
@@ -69,7 +69,8 @@ endforeach()
 # Specific options for MSVC
 if(MSVC)
     target_compile_options(finite-volume-level-set-from-scratch PUBLIC /bigobj)
-    target_compile_options(finite-volume-level-set PUBLIC /bigobj)
+    target_compile_options(finite-volume-level-set-amr PUBLIC /bigobj)
+    target_compile_options(finite-volume-level-set-mra PUBLIC /bigobj)
 endif()
 
 # add_subdirectory(BZ)


### PR DESCRIPTION
## Description
This pull request fixes an error in the CMakeLists.txt file for the finite volume demos, where the old name of the “level set” example had not been updated.

## Code of Conduct
By submitting this PR, you agree to follow our [Code of Conduct](https://github.com/hpc-maths/samurai/blob/master/docs/CODE_OF_CONDUCT.md)
- [x] I agree to follow this project's Code of Conduct
