### PR TITLE
fix: update_fields ambiguity

### DIFF
--- a/include/samurai/algorithm/update_fields.hpp
+++ b/include/samurai/algorithm/update_fields.hpp
@@ -90,7 +90,7 @@ namespace samurai
     }
 
     template <class Mesh, class... Fields>
-      requires(mesh_like<Mesh> && (field_like<Fields> && ...))
+        requires(mesh_like<Mesh> && (field_like<Fields> && ...))
     void update_fields(Mesh& new_mesh, Fields&... fields)
     {
         using prediction_fn_t = decltype(default_config::default_prediction_fn);

--- a/include/samurai/algorithm/update_fields.hpp
+++ b/include/samurai/algorithm/update_fields.hpp
@@ -90,6 +90,7 @@ namespace samurai
     }
 
     template <class Mesh, class... Fields>
+      requires(mesh_like<Mesh> && (field_like<Fields> && ...))
     void update_fields(Mesh& new_mesh, Fields&... fields)
     {
         using prediction_fn_t = decltype(default_config::default_prediction_fn);


### PR DESCRIPTION
## Description
This PR fixes an ambiguity with `update_fields` when the prediction function is provided by the user.

## Code of Conduct
By submitting this PR, you agree to follow our [Code of Conduct](https://github.com/hpc-maths/samurai/blob/master/docs/CODE_OF_CONDUCT.md)
- [x] I agree to follow this project's Code of Conduct
