### PR TITLE
feat: get samurai version and its dependencies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -109,6 +109,28 @@ target_compile_definitions(samurai INTERFACE
   SAMURAI_VERSION_MINOR=${samurai_VERSION_MINOR}
   SAMURAI_VERSION_PATCH=${samurai_VERSION_PATCH})
 
+# When the current commit is not exactly on a tag (i.e. not a release), also
+# expose its short SHA so that `--info` can display it. Captured at configure
+# time; harmless when git is unavailable (e.g. building from a source tarball).
+find_package(Git QUIET)
+if(Git_FOUND AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/.git")
+  execute_process(
+    COMMAND ${GIT_EXECUTABLE} describe --tags --exact-match
+    WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+    RESULT_VARIABLE SAMURAI_GIT_ON_TAG
+    OUTPUT_QUIET ERROR_QUIET)
+  if(NOT SAMURAI_GIT_ON_TAG EQUAL 0)
+    execute_process(
+      COMMAND ${GIT_EXECUTABLE} rev-parse --short HEAD
+      WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+      OUTPUT_VARIABLE SAMURAI_GIT_SHA
+      OUTPUT_STRIP_TRAILING_WHITESPACE ERROR_QUIET)
+    if(SAMURAI_GIT_SHA)
+      target_compile_definitions(samurai INTERFACE SAMURAI_GIT_SHA="${SAMURAI_GIT_SHA}")
+    endif()
+  endif()
+endif()
+
 # Includes
 set(INCLUDE_DIR "include") # must be relative paths
 target_include_directories(samurai INTERFACE "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/${INCLUDE_DIR}>"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -103,6 +103,12 @@ add_library(samurai INTERFACE)
 target_compile_features(samurai INTERFACE cxx_std_20)
 target_link_libraries(samurai INTERFACE project_options project_warnings)
 
+# Expose the samurai version to the C++ code (see include/samurai/version.hpp)
+target_compile_definitions(samurai INTERFACE
+  SAMURAI_VERSION_MAJOR=${samurai_VERSION_MAJOR}
+  SAMURAI_VERSION_MINOR=${samurai_VERSION_MINOR}
+  SAMURAI_VERSION_PATCH=${samurai_VERSION_PATCH})
+
 # Includes
 set(INCLUDE_DIR "include") # must be relative paths
 target_include_directories(samurai INTERFACE "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/${INCLUDE_DIR}>"

--- a/include/samurai/arguments.hpp
+++ b/include/samurai/arguments.hpp
@@ -18,6 +18,7 @@ namespace samurai
         static int max_stencil_radius       = std::numeric_limits<int>::max();
 
         static bool timers = false;
+        static bool info   = false;
 #ifdef SAMURAI_WITH_MPI
         static bool dont_redirect_output = false;
 #endif
@@ -51,6 +52,8 @@ namespace samurai
             ->group("IO");
 #endif
         app.add_flag("--timers", args::timers, "Print timers at the end of the program")->capture_default_str()->group("Tools");
+        app.add_flag("--info", args::info, "Print samurai's version, its dependencies and the build configuration, then exit")
+            ->group("Tools");
         app.add_option("--sleep-at-startup",
                        args::sleep_at_startup,
                        "Sleep for a given number of seconds at startup (useful to attach a debugger when running with mpirun/mpiexec)")

--- a/include/samurai/arguments.hpp
+++ b/include/samurai/arguments.hpp
@@ -52,8 +52,7 @@ namespace samurai
             ->group("IO");
 #endif
         app.add_flag("--timers", args::timers, "Print timers at the end of the program")->capture_default_str()->group("Tools");
-        app.add_flag("--info", args::info, "Print samurai's version, its dependencies and the build configuration, then exit")
-            ->group("Tools");
+        app.add_flag("--info", args::info, "Print samurai's version, its dependencies and the build configuration, then exit")->group("Tools");
         app.add_option("--sleep-at-startup",
                        args::sleep_at_startup,
                        "Sleep for a given number of seconds at startup (useful to attach a debugger when running with mpirun/mpiexec)")

--- a/include/samurai/samurai.hpp
+++ b/include/samurai/samurai.hpp
@@ -13,6 +13,8 @@ namespace mpi = boost::mpi;
 
 #include "arguments.hpp"
 #include "timers.hpp"
+#include "version.hpp"
+#include <cstdlib>
 #include <thread>
 
 namespace samurai
@@ -47,6 +49,12 @@ namespace samurai
         app.description(description);
         app.set_config("--config");
         read_samurai_arguments(app, argc, argv);
+
+        if (args::info)
+        {
+            print_info();
+            std::exit(EXIT_SUCCESS);
+        }
 
         std::this_thread::sleep_for(std::chrono::seconds(args::sleep_at_startup));
 

--- a/include/samurai/version.hpp
+++ b/include/samurai/version.hpp
@@ -1,0 +1,241 @@
+// Copyright 2018-2025 the samurai's authors
+// SPDX-License-Identifier:  BSD-3-Clause
+#pragma once
+
+#include <algorithm>
+#include <cstddef>
+#include <iostream>
+#include <ostream>
+#include <string>
+#include <vector>
+
+#include <fmt/color.h>
+#include <fmt/format.h>
+
+#include "samurai_config.hpp" // samurai::disable_color
+
+// --------------------------------------------------------------------------
+// samurai's own version, injected by CMake through target_compile_definitions
+// (see the top-level CMakeLists.txt). Fallback to 0.0.0 so that the header
+// stays usable even when built outside of the CMake project.
+// --------------------------------------------------------------------------
+#ifndef SAMURAI_VERSION_MAJOR
+#define SAMURAI_VERSION_MAJOR 0
+#endif
+#ifndef SAMURAI_VERSION_MINOR
+#define SAMURAI_VERSION_MINOR 0
+#endif
+#ifndef SAMURAI_VERSION_PATCH
+#define SAMURAI_VERSION_PATCH 0
+#endif
+
+// --------------------------------------------------------------------------
+// Best-effort detection of the dependencies' version headers. Each header is
+// small and self-contained; `__has_include` (guaranteed since C++17) keeps the
+// detection fully optional and portable: a dependency that is not part of the
+// build simply does not appear in the report.
+// --------------------------------------------------------------------------
+#if __has_include(<fmt/base.h>)
+#include <fmt/base.h> // FMT_VERSION
+#elif __has_include(<fmt/core.h>)
+#include <fmt/core.h>
+#endif
+#if __has_include(<CLI/Version.hpp>)
+#include <CLI/Version.hpp> // CLI11_VERSION
+#endif
+#if __has_include(<pugixml.hpp>)
+#include <pugixml.hpp> // PUGIXML_VERSION
+#endif
+#if __has_include(<highfive/H5Version.hpp>)
+#include <highfive/H5Version.hpp> // HIGHFIVE_VERSION_STRING
+#endif
+#if __has_include(<H5public.h>)
+#include <H5public.h> // H5_VERS_*
+#endif
+#if __has_include(<xtensor/core/xtensor_config.hpp>)
+#include <xtensor/core/xtensor_config.hpp> // XTENSOR_VERSION_*
+#endif
+#if __has_include(<xtl/xtl_config.hpp>)
+#include <xtl/xtl_config.hpp> // XTL_VERSION_*
+#endif
+#if __has_include(<nlohmann/detail/abi_macros.hpp>)
+#include <nlohmann/detail/abi_macros.hpp> // NLOHMANN_JSON_VERSION_*
+#endif
+#if __has_include(<boost/version.hpp>)
+#include <boost/version.hpp> // BOOST_VERSION / BOOST_LIB_VERSION
+#endif
+
+#ifdef SAMURAI_WITH_PETSC
+#include <petscversion.h> // PETSC_VERSION_*
+#endif
+#ifdef SAMURAI_WITH_MPI
+#include <mpi.h> // MPI_VERSION / MPI_SUBVERSION
+#endif
+#if defined(SAMURAI_FIELD_CONTAINER_EIGEN3) || defined(SAMURAI_FLUX_CONTAINER_EIGEN3) || defined(SAMURAI_STATIC_MAT_CONTAINER_EIGEN3)
+#if __has_include(<Eigen/Core>)
+#include <Eigen/Core> // EIGEN_WORLD_VERSION / EIGEN_MAJOR_VERSION / EIGEN_MINOR_VERSION
+#endif
+#endif
+
+namespace samurai
+{
+    /// A single (name, version) entry of the dependency report.
+    struct dependency_info
+    {
+        std::string name;
+        std::string version;
+    };
+
+    /// samurai's version, e.g. "0.31.2".
+    inline std::string version()
+    {
+        return fmt::format("{}.{}.{}", SAMURAI_VERSION_MAJOR, SAMURAI_VERSION_MINOR, SAMURAI_VERSION_PATCH);
+    }
+
+    /// The compiler used to build the current translation unit, e.g. "Clang 18.1.0".
+    inline std::string compiler_info()
+    {
+#if defined(__clang__)
+        return fmt::format("Clang {}.{}.{}", __clang_major__, __clang_minor__, __clang_patchlevel__);
+#elif defined(__GNUC__)
+        return fmt::format("GCC {}.{}.{}", __GNUC__, __GNUC_MINOR__, __GNUC_PATCHLEVEL__);
+#elif defined(_MSC_VER)
+        return fmt::format("MSVC {}", _MSC_VER);
+#else
+        return "unknown";
+#endif
+    }
+
+    /// The version of every dependency detected at compile time.
+    inline std::vector<dependency_info> dependencies_info()
+    {
+        std::vector<dependency_info> deps;
+
+#ifdef FMT_VERSION
+        deps.push_back({"fmt", fmt::format("{}.{}.{}", FMT_VERSION / 10000, (FMT_VERSION % 10000) / 100, FMT_VERSION % 100)});
+#endif
+#ifdef CLI11_VERSION
+        deps.push_back({"CLI11", CLI11_VERSION});
+#endif
+#ifdef PUGIXML_VERSION
+        deps.push_back({"pugixml", fmt::format("{}.{}", PUGIXML_VERSION / 1000, (PUGIXML_VERSION % 1000) / 10)});
+#endif
+#ifdef HIGHFIVE_VERSION_STRING
+        deps.push_back({"HighFive", HIGHFIVE_VERSION_STRING});
+#endif
+#ifdef H5_VERS_MAJOR
+        deps.push_back({"HDF5", fmt::format("{}.{}.{}", H5_VERS_MAJOR, H5_VERS_MINOR, H5_VERS_RELEASE)});
+#endif
+#ifdef XTENSOR_VERSION_MAJOR
+        deps.push_back({"xtensor", fmt::format("{}.{}.{}", XTENSOR_VERSION_MAJOR, XTENSOR_VERSION_MINOR, XTENSOR_VERSION_PATCH)});
+#endif
+#ifdef XTL_VERSION_MAJOR
+        deps.push_back({"xtl", fmt::format("{}.{}.{}", XTL_VERSION_MAJOR, XTL_VERSION_MINOR, XTL_VERSION_PATCH)});
+#endif
+#ifdef EIGEN_WORLD_VERSION
+        deps.push_back({"Eigen", fmt::format("{}.{}.{}", EIGEN_WORLD_VERSION, EIGEN_MAJOR_VERSION, EIGEN_MINOR_VERSION)});
+#endif
+        // Feature-gated dependencies: reported only when the corresponding build
+        // option is enabled, so the list mirrors what this build actually uses
+        // (and not merely what happens to be installed in the environment).
+#if (defined(SAMURAI_WITH_PARMETIS) || defined(SAMURAI_WITH_PTSCOTCH)) && defined(NLOHMANN_JSON_VERSION_MAJOR)
+        deps.push_back(
+            {"nlohmann_json", fmt::format("{}.{}.{}", NLOHMANN_JSON_VERSION_MAJOR, NLOHMANN_JSON_VERSION_MINOR, NLOHMANN_JSON_VERSION_PATCH)});
+#endif
+#if defined(SAMURAI_WITH_MPI) && defined(BOOST_VERSION)
+        deps.push_back({"Boost", fmt::format("{}.{}.{}", BOOST_VERSION / 100000, (BOOST_VERSION / 100) % 1000, BOOST_VERSION % 100)});
+#endif
+#if defined(SAMURAI_WITH_PETSC) && defined(PETSC_VERSION_MAJOR)
+        deps.push_back({"PETSc", fmt::format("{}.{}.{}", PETSC_VERSION_MAJOR, PETSC_VERSION_MINOR, PETSC_VERSION_SUBMINOR)});
+#endif
+#if defined(SAMURAI_WITH_MPI) && defined(MPI_VERSION)
+        deps.push_back({"MPI (standard)", fmt::format("{}.{}", MPI_VERSION, MPI_SUBVERSION)});
+#endif
+
+        return deps;
+    }
+
+    /// The build-time configuration (enabled features, selected containers, ...).
+    inline std::vector<dependency_info> build_info()
+    {
+        std::vector<dependency_info> info;
+
+        const auto on_off = [](bool enabled)
+        {
+            return enabled ? "ON" : "OFF";
+        };
+
+#if defined(SAMURAI_FIELD_CONTAINER_EIGEN3)
+        info.push_back({"field container", "eigen3"});
+#else
+        info.push_back({"field container", "xtensor"});
+#endif
+
+        bool with_mpi = false;
+#ifdef SAMURAI_WITH_MPI
+        with_mpi = true;
+#endif
+        info.push_back({"MPI", on_off(with_mpi)});
+
+        bool with_petsc = false;
+#ifdef SAMURAI_WITH_PETSC
+        with_petsc = true;
+#endif
+        info.push_back({"PETSc", on_off(with_petsc)});
+
+        bool with_openmp = false;
+#ifdef SAMURAI_WITH_OPENMP
+        with_openmp = true;
+#endif
+        info.push_back({"OpenMP", on_off(with_openmp)});
+
+        bool with_parmetis = false;
+#ifdef SAMURAI_WITH_PARMETIS
+        with_parmetis = true;
+#endif
+        info.push_back({"ParMETIS", on_off(with_parmetis)});
+
+        bool with_ptscotch = false;
+#ifdef SAMURAI_WITH_PTSCOTCH
+        with_ptscotch = true;
+#endif
+        info.push_back({"PT-Scotch", on_off(with_ptscotch)});
+
+        return info;
+    }
+
+    /// Pretty-print samurai's version, its dependencies and the build configuration.
+    inline void print_info(std::ostream& os = std::cout)
+    {
+        const auto deps  = dependencies_info();
+        const auto build = build_info();
+
+        // Column width computed from the widest label so the two colons align.
+        std::size_t width = std::string("samurai").size();
+        for (const auto& d : deps)
+        {
+            width = std::max(width, d.name.size());
+        }
+        for (const auto& b : build)
+        {
+            width = std::max(width, b.name.size());
+        }
+
+        const auto title = disable_color ? fmt::text_style() : fmt::emphasis::bold;
+
+        os << fmt::format(title, "samurai {}\n", version());
+        os << "\n";
+        os << fmt::format(title, "Dependencies\n");
+        for (const auto& d : deps)
+        {
+            os << fmt::format("  {:<{}} : {}\n", d.name, width, d.version);
+        }
+        os << "\n";
+        os << fmt::format(title, "Build configuration\n");
+        for (const auto& b : build)
+        {
+            os << fmt::format("  {:<{}} : {}\n", b.name, width, b.version);
+        }
+        os << fmt::format("  {:<{}} : {} (C++{})\n", "compiler", width, compiler_info(), __cplusplus / 100 % 100);
+    }
+}

--- a/include/samurai/version.hpp
+++ b/include/samurai/version.hpp
@@ -87,10 +87,19 @@ namespace samurai
         std::string version;
     };
 
+    namespace detail
+    {
+        /// Format a "major.minor.patch" version triplet.
+        inline std::string format_triplet(long major, long minor, long patch)
+        {
+            return fmt::format("{}.{}.{}", major, minor, patch);
+        }
+    }
+
     /// samurai's version, e.g. "0.31.2".
     inline std::string version()
     {
-        return fmt::format("{}.{}.{}", SAMURAI_VERSION_MAJOR, SAMURAI_VERSION_MINOR, SAMURAI_VERSION_PATCH);
+        return detail::format_triplet(SAMURAI_VERSION_MAJOR, SAMURAI_VERSION_MINOR, SAMURAI_VERSION_PATCH);
     }
 
     /// The compiler used to build the current translation unit, e.g. "Clang 18.1.0".
@@ -108,46 +117,57 @@ namespace samurai
     }
 
     /// The version of every dependency detected at compile time.
+    ///
+    /// Each version is read from the dependency's own macros, so the report always
+    /// matches the headers that were actually compiled. The integer-encoded macros
+    /// (fmt, pugixml, Boost) are decoded following each library's documented scheme.
     inline std::vector<dependency_info> dependencies_info()
     {
+        using detail::format_triplet;
         std::vector<dependency_info> deps;
 
-#ifdef FMT_VERSION
-        deps.push_back({"fmt", fmt::format("{}.{}.{}", FMT_VERSION / 10000, (FMT_VERSION % 10000) / 100, FMT_VERSION % 100)});
+        // --- Mandatory dependencies (always part of the build) ---
+#ifdef FMT_VERSION // encoded as major * 10000 + minor * 100 + patch
+        deps.push_back({"fmt", format_triplet(FMT_VERSION / 10000, (FMT_VERSION % 10000) / 100, FMT_VERSION % 100)});
 #endif
 #ifdef CLI11_VERSION
         deps.push_back({"CLI11", CLI11_VERSION});
 #endif
-#ifdef PUGIXML_VERSION
+#ifdef PUGIXML_VERSION // encoded as major * 1000 + minor * 10
         deps.push_back({"pugixml", fmt::format("{}.{}", PUGIXML_VERSION / 1000, (PUGIXML_VERSION % 1000) / 10)});
 #endif
 #ifdef HIGHFIVE_VERSION_STRING
         deps.push_back({"HighFive", HIGHFIVE_VERSION_STRING});
 #endif
 #ifdef H5_VERS_MAJOR
-        deps.push_back({"HDF5", fmt::format("{}.{}.{}", H5_VERS_MAJOR, H5_VERS_MINOR, H5_VERS_RELEASE)});
+        deps.push_back({"HDF5", format_triplet(H5_VERS_MAJOR, H5_VERS_MINOR, H5_VERS_RELEASE)});
 #endif
 #ifdef XTENSOR_VERSION_MAJOR
-        deps.push_back({"xtensor", fmt::format("{}.{}.{}", XTENSOR_VERSION_MAJOR, XTENSOR_VERSION_MINOR, XTENSOR_VERSION_PATCH)});
+        deps.push_back({"xtensor", format_triplet(XTENSOR_VERSION_MAJOR, XTENSOR_VERSION_MINOR, XTENSOR_VERSION_PATCH)});
 #endif
 #ifdef XTL_VERSION_MAJOR
-        deps.push_back({"xtl", fmt::format("{}.{}.{}", XTL_VERSION_MAJOR, XTL_VERSION_MINOR, XTL_VERSION_PATCH)});
+        deps.push_back({"xtl", format_triplet(XTL_VERSION_MAJOR, XTL_VERSION_MINOR, XTL_VERSION_PATCH)});
 #endif
 #ifdef EIGEN_WORLD_VERSION
-        deps.push_back({"Eigen", fmt::format("{}.{}.{}", EIGEN_WORLD_VERSION, EIGEN_MAJOR_VERSION, EIGEN_MINOR_VERSION)});
+        deps.push_back({"Eigen", format_triplet(EIGEN_WORLD_VERSION, EIGEN_MAJOR_VERSION, EIGEN_MINOR_VERSION)});
 #endif
-        // Feature-gated dependencies: reported only when the corresponding build
-        // option is enabled, so the list mirrors what this build actually uses
-        // (and not merely what happens to be installed in the environment).
-#if (defined(SAMURAI_WITH_PARMETIS) || defined(SAMURAI_WITH_PTSCOTCH)) && defined(NLOHMANN_JSON_VERSION_MAJOR)
-        deps.push_back({"nlohmann_json",
-                        fmt::format("{}.{}.{}", NLOHMANN_JSON_VERSION_MAJOR, NLOHMANN_JSON_VERSION_MINOR, NLOHMANN_JSON_VERSION_PATCH)});
+
+        // --- Feature-gated dependencies ---
+        // Reported only when the build option that pulls them in is enabled, so
+        // the list mirrors what this build actually links (and not merely what
+        // happens to be installed in the environment). The corresponding build
+        // options are, per the top-level CMakeLists.txt:
+        //   - nlohmann_json : WITH_STATS         (statistics.hpp)
+        //   - Boost / MPI   : SAMURAI_WITH_MPI   (serialization + boost::mpi)
+        //   - PETSc         : SAMURAI_WITH_PETSC
+#if defined(WITH_STATS) && defined(NLOHMANN_JSON_VERSION_MAJOR)
+        deps.push_back({"nlohmann_json", format_triplet(NLOHMANN_JSON_VERSION_MAJOR, NLOHMANN_JSON_VERSION_MINOR, NLOHMANN_JSON_VERSION_PATCH)});
 #endif
-#if defined(SAMURAI_WITH_MPI) && defined(BOOST_VERSION)
-        deps.push_back({"Boost", fmt::format("{}.{}.{}", BOOST_VERSION / 100000, (BOOST_VERSION / 100) % 1000, BOOST_VERSION % 100)});
+#if defined(SAMURAI_WITH_MPI) && defined(BOOST_VERSION) // encoded as major * 100000 + minor * 100 + patch
+        deps.push_back({"Boost", format_triplet(BOOST_VERSION / 100000, (BOOST_VERSION / 100) % 1000, BOOST_VERSION % 100)});
 #endif
 #if defined(SAMURAI_WITH_PETSC) && defined(PETSC_VERSION_MAJOR)
-        deps.push_back({"PETSc", fmt::format("{}.{}.{}", PETSC_VERSION_MAJOR, PETSC_VERSION_MINOR, PETSC_VERSION_SUBMINOR)});
+        deps.push_back({"PETSc", format_triplet(PETSC_VERSION_MAJOR, PETSC_VERSION_MINOR, PETSC_VERSION_SUBMINOR)});
 #endif
 #if defined(SAMURAI_WITH_MPI) && defined(MPI_VERSION)
         deps.push_back({"MPI (standard)", fmt::format("{}.{}", MPI_VERSION, MPI_SUBVERSION)});
@@ -157,50 +177,41 @@ namespace samurai
     }
 
     /// The build-time configuration (enabled features, selected containers, ...).
+    /// A feature reads "ON" when its compile-time macro is defined, "OFF" otherwise.
     inline std::vector<dependency_info> build_info()
     {
         std::vector<dependency_info> info;
-
-        const auto on_off = [](bool enabled)
-        {
-            return enabled ? "ON" : "OFF";
-        };
 
 #if defined(SAMURAI_FIELD_CONTAINER_EIGEN3)
         info.push_back({"field container", "eigen3"});
 #else
         info.push_back({"field container", "xtensor"});
 #endif
-
-        bool with_mpi = false;
 #ifdef SAMURAI_WITH_MPI
-        with_mpi = true;
+        info.push_back({"MPI", "ON"});
+#else
+        info.push_back({"MPI", "OFF"});
 #endif
-        info.push_back({"MPI", on_off(with_mpi)});
-
-        bool with_petsc = false;
 #ifdef SAMURAI_WITH_PETSC
-        with_petsc = true;
+        info.push_back({"PETSc", "ON"});
+#else
+        info.push_back({"PETSc", "OFF"});
 #endif
-        info.push_back({"PETSc", on_off(with_petsc)});
-
-        bool with_openmp = false;
 #ifdef SAMURAI_WITH_OPENMP
-        with_openmp = true;
+        info.push_back({"OpenMP", "ON"});
+#else
+        info.push_back({"OpenMP", "OFF"});
 #endif
-        info.push_back({"OpenMP", on_off(with_openmp)});
-
-        bool with_parmetis = false;
 #ifdef SAMURAI_WITH_PARMETIS
-        with_parmetis = true;
+        info.push_back({"ParMETIS", "ON"});
+#else
+        info.push_back({"ParMETIS", "OFF"});
 #endif
-        info.push_back({"ParMETIS", on_off(with_parmetis)});
-
-        bool with_ptscotch = false;
 #ifdef SAMURAI_WITH_PTSCOTCH
-        with_ptscotch = true;
+        info.push_back({"PT-Scotch", "ON"});
+#else
+        info.push_back({"PT-Scotch", "OFF"});
 #endif
-        info.push_back({"PT-Scotch", on_off(with_ptscotch)});
 
         return info;
     }

--- a/include/samurai/version.hpp
+++ b/include/samurai/version.hpp
@@ -161,7 +161,8 @@ namespace samurai
         //   - Boost / MPI   : SAMURAI_WITH_MPI   (serialization + boost::mpi)
         //   - PETSc         : SAMURAI_WITH_PETSC
 #if defined(WITH_STATS) && defined(NLOHMANN_JSON_VERSION_MAJOR)
-        deps.push_back({"nlohmann_json", format_triplet(NLOHMANN_JSON_VERSION_MAJOR, NLOHMANN_JSON_VERSION_MINOR, NLOHMANN_JSON_VERSION_PATCH)});
+        deps.push_back(
+            {"nlohmann_json", format_triplet(NLOHMANN_JSON_VERSION_MAJOR, NLOHMANN_JSON_VERSION_MINOR, NLOHMANN_JSON_VERSION_PATCH)});
 #endif
 #if defined(SAMURAI_WITH_MPI) && defined(BOOST_VERSION) // encoded as major * 100000 + minor * 100 + patch
         deps.push_back({"Boost", format_triplet(BOOST_VERSION / 100000, (BOOST_VERSION / 100) % 1000, BOOST_VERSION % 100)});

--- a/include/samurai/version.hpp
+++ b/include/samurai/version.hpp
@@ -139,8 +139,8 @@ namespace samurai
         // option is enabled, so the list mirrors what this build actually uses
         // (and not merely what happens to be installed in the environment).
 #if (defined(SAMURAI_WITH_PARMETIS) || defined(SAMURAI_WITH_PTSCOTCH)) && defined(NLOHMANN_JSON_VERSION_MAJOR)
-        deps.push_back(
-            {"nlohmann_json", fmt::format("{}.{}.{}", NLOHMANN_JSON_VERSION_MAJOR, NLOHMANN_JSON_VERSION_MINOR, NLOHMANN_JSON_VERSION_PATCH)});
+        deps.push_back({"nlohmann_json",
+                        fmt::format("{}.{}.{}", NLOHMANN_JSON_VERSION_MAJOR, NLOHMANN_JSON_VERSION_MINOR, NLOHMANN_JSON_VERSION_PATCH)});
 #endif
 #if defined(SAMURAI_WITH_MPI) && defined(BOOST_VERSION)
         deps.push_back({"Boost", fmt::format("{}.{}.{}", BOOST_VERSION / 100000, (BOOST_VERSION / 100) % 1000, BOOST_VERSION % 100)});

--- a/include/samurai/version.hpp
+++ b/include/samurai/version.hpp
@@ -102,6 +102,17 @@ namespace samurai
         return detail::format_triplet(SAMURAI_VERSION_MAJOR, SAMURAI_VERSION_MINOR, SAMURAI_VERSION_PATCH);
     }
 
+    /// The short SHA of the current commit, or an empty string on a tagged
+    /// release (or when git was unavailable at configure time). Injected by CMake.
+    inline std::string git_sha()
+    {
+#ifdef SAMURAI_GIT_SHA
+        return SAMURAI_GIT_SHA;
+#else
+        return {};
+#endif
+    }
+
     /// The compiler used to build the current translation unit, e.g. "Clang 18.1.0".
     inline std::string compiler_info()
     {
@@ -238,7 +249,9 @@ namespace samurai
 
         const auto title = disable_color ? fmt::text_style() : fmt::emphasis::bold;
 
-        os << fmt::format(title, "samurai {}\n", version());
+        const auto sha    = git_sha();
+        const auto tagged = sha.empty() ? std::string{} : fmt::format(" ({})", sha);
+        os << fmt::format(title, "samurai {}{}\n", version(), tagged);
         os << "\n";
         os << fmt::format(title, "Dependencies\n");
         // cppcheck-suppress knownEmptyContainer  // the dependency macros are defined by external headers, invisible to cppcheck

--- a/include/samurai/version.hpp
+++ b/include/samurai/version.hpp
@@ -5,6 +5,7 @@
 #include <algorithm>
 #include <cstddef>
 #include <iostream>
+#include <numeric>
 #include <ostream>
 #include <string>
 #include <vector>
@@ -211,21 +212,24 @@ namespace samurai
         const auto build = build_info();
 
         // Column width computed from the widest label so the two colons align.
-        std::size_t width = std::string("samurai").size();
-        for (const auto& d : deps)
+        const auto widest = [](std::size_t w, const std::vector<dependency_info>& items)
         {
-            width = std::max(width, d.name.size());
-        }
-        for (const auto& b : build)
-        {
-            width = std::max(width, b.name.size());
-        }
+            return std::accumulate(items.begin(),
+                                   items.end(),
+                                   w,
+                                   [](std::size_t acc, const dependency_info& it)
+                                   {
+                                       return std::max(acc, it.name.size());
+                                   });
+        };
+        std::size_t width = widest(widest(std::string("samurai").size(), deps), build);
 
         const auto title = disable_color ? fmt::text_style() : fmt::emphasis::bold;
 
         os << fmt::format(title, "samurai {}\n", version());
         os << "\n";
         os << fmt::format(title, "Dependencies\n");
+        // cppcheck-suppress knownEmptyContainer  // the dependency macros are defined by external headers, invisible to cppcheck
         for (const auto& d : deps)
         {
             os << fmt::format("  {:<{}} : {}\n", d.name, width, d.version);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -40,6 +40,7 @@ set(SAMURAI_TESTS
     test_subset.cpp
     test_timers.cpp
     test_utils.cpp
+    test_version.cpp
 )
 
 if(rapidcheck_FOUND)

--- a/tests/test_version.cpp
+++ b/tests/test_version.cpp
@@ -1,0 +1,74 @@
+#include <algorithm>
+#include <regex>
+#include <sstream>
+
+#include <gtest/gtest.h>
+
+#include <samurai/version.hpp>
+
+namespace samurai
+{
+    TEST(version, format)
+    {
+        // version() must always be a "major.minor.patch" triplet.
+        EXPECT_TRUE(std::regex_match(version(), std::regex(R"(\d+\.\d+\.\d+)")));
+    }
+
+    TEST(version, dependencies)
+    {
+        const auto deps = dependencies_info();
+
+        // fmt is a mandatory dependency, so it is always reported...
+        const auto has = [&](std::string_view name)
+        {
+            return std::any_of(deps.begin(),
+                               deps.end(),
+                               [&](const dependency_info& d)
+                               {
+                                   return d.name == name;
+                               });
+        };
+        EXPECT_TRUE(has("fmt"));
+
+        // ...and every reported version is a non-empty string.
+        for (const auto& d : deps)
+        {
+            EXPECT_FALSE(d.version.empty()) << "empty version for " << d.name;
+        }
+    }
+
+    TEST(version, build)
+    {
+        const auto build = build_info();
+
+        const auto value_of = [&](std::string_view name) -> std::string
+        {
+            const auto it = std::find_if(build.begin(),
+                                         build.end(),
+                                         [&](const dependency_info& b)
+                                         {
+                                             return b.name == name;
+                                         });
+            return it == build.end() ? std::string{} : it->version;
+        };
+
+        // The MPI feature must reflect the compile-time configuration.
+#ifdef SAMURAI_WITH_MPI
+        EXPECT_EQ(value_of("MPI"), "ON");
+#else
+        EXPECT_EQ(value_of("MPI"), "OFF");
+#endif
+    }
+
+    TEST(version, print)
+    {
+        std::ostringstream os;
+        print_info(os);
+        const auto out = os.str();
+
+        EXPECT_NE(out.find("samurai"), std::string::npos);
+        EXPECT_NE(out.find(version()), std::string::npos);
+        EXPECT_NE(out.find("Dependencies"), std::string::npos);
+        EXPECT_NE(out.find("Build configuration"), std::string::npos);
+    }
+}

--- a/tests/test_version.cpp
+++ b/tests/test_version.cpp
@@ -60,6 +60,16 @@ namespace samurai
 #endif
     }
 
+    TEST(version, git_sha)
+    {
+        const auto sha = git_sha();
+        // Empty on a tagged release, otherwise a lowercase hex short SHA.
+        if (!sha.empty())
+        {
+            EXPECT_TRUE(std::regex_match(sha, std::regex("[0-9a-f]+")));
+        }
+    }
+
     TEST(version, print)
     {
         std::ostringstream os;
@@ -70,5 +80,11 @@ namespace samurai
         EXPECT_NE(out.find(version()), std::string::npos);
         EXPECT_NE(out.find("Dependencies"), std::string::npos);
         EXPECT_NE(out.find("Build configuration"), std::string::npos);
+
+        // When built off a tag, the commit SHA must appear next to the version.
+        if (const auto sha = git_sha(); !sha.empty())
+        {
+            EXPECT_NE(out.find(sha), std::string::npos);
+        }
     }
 }


### PR DESCRIPTION
## Description
This PR introduces a public version/build reporting facility for samurai, exposing the library version, compile-time detected dependency versions, and build-configuration flags, along with a `--info` CLI flag and accompanying tests.

**Changes:**

- Add `samurai::version()`, `dependencies_info()`, `build_info()`, and `print_info()` in a new public header.
- Add a `--info` CLI flag that prints version/dependency/build information and exits.
- Add a new GoogleTest suite validating version formatting and info reporting.

## Code of Conduct
By submitting this PR, you agree to follow our [Code of Conduct](https://github.com/hpc-maths/samurai/blob/master/docs/CODE_OF_CONDUCT.md)
- [x] I agree to follow this project's Code of Conduct
