### PR TITLE
feat: hdf5/xdmf metadata provided by the user

### DIFF
--- a/include/samurai/io/hdf5.hpp
+++ b/include/samurai/io/hdf5.hpp
@@ -5,6 +5,7 @@
 
 #include <algorithm>
 #include <array>
+#include <functional>
 #include <string>
 #include <type_traits>
 
@@ -35,6 +36,7 @@ namespace mpi = boost::mpi;
 #include "../interval.hpp"
 #include "../timers.hpp"
 #include "../utils.hpp"
+#include "metadata.hpp"
 #include "util.hpp"
 
 namespace samurai
@@ -153,6 +155,10 @@ namespace samurai
 
         bool by_level   = false;
         bool by_mesh_id = false;
+
+        // User callback to inject arbitrary metadata (time, simulation
+        // parameters, ...) into the HDF5 file and the XDMF document.
+        std::function<void(MetadataWriter&)> metadata = {};
     };
 
     template <class Config>
@@ -167,6 +173,10 @@ namespace samurai
         }
 
         bool by_mesh_id;
+
+        // User callback to inject arbitrary metadata (time, simulation
+        // parameters, ...) into the HDF5 file and the XDMF document.
+        std::function<void(MetadataWriter&)> metadata = {};
     };
 
     template <class D>
@@ -197,6 +207,7 @@ namespace samurai
       protected:
 
         pugi::xml_node& domain();
+        HighFive::File& file();
 
         template <class Submesh>
         void save_on_mesh(pugi::xml_node& grid_parent, const std::string& prefix, const Submesh& submesh, const std::string& mesh_name);
@@ -263,6 +274,7 @@ namespace samurai
 
         const mesh_t& mesh() const;
         const options_t& options() const;
+        void write_metadata();
 
       private:
 
@@ -352,6 +364,16 @@ namespace samurai
     SAMURAI_INLINE auto SaveBase<D, Mesh, T...>::options() const -> const options_t&
     {
         return m_options;
+    }
+
+    template <class D, class Mesh, class... T>
+    SAMURAI_INLINE void SaveBase<D, Mesh, T...>::write_metadata()
+    {
+        if (m_options.metadata)
+        {
+            MetadataWriter writer(this->file(), this->domain());
+            m_options.metadata(writer);
+        }
     }
 
     template <class D, class Mesh, class... T>
@@ -489,6 +511,7 @@ namespace samurai
                 this->save_on_mesh(this->domain(), prefix, mesh, "mesh");
             }
         }
+        this->write_metadata();
     }
 
     template <class D, class Mesh, class... T>
@@ -564,6 +587,7 @@ namespace samurai
             std::string prefix = fmt::format("/mesh");
             this->save_on_mesh(this->domain(), prefix, mesh, "mesh");
         }
+        this->write_metadata();
     }
 
 #ifdef SAMURAI_WITH_MPI
@@ -643,6 +667,12 @@ namespace samurai
     SAMURAI_INLINE pugi::xml_node& Hdf5<D>::domain()
     {
         return m_domain;
+    }
+
+    template <class D>
+    SAMURAI_INLINE HighFive::File& Hdf5<D>::file()
+    {
+        return h5_file;
     }
 
     template <class D>

--- a/include/samurai/io/hdf5.hpp
+++ b/include/samurai/io/hdf5.hpp
@@ -156,8 +156,9 @@ namespace samurai
         bool by_level   = false;
         bool by_mesh_id = false;
 
-        // User callback to inject arbitrary metadata (time, simulation
-        // parameters, ...) into the HDF5 file and the XDMF document.
+        // User callback to inject arbitrary metadata (time, simulation parameters, ...)
+        // into the HDF5 file and the XDMF document. Under MPI (comm size > 1),
+        // it must be executed collectively on all ranks.
         std::function<void(MetadataWriter&)> metadata = {};
     };
 

--- a/include/samurai/io/metadata.hpp
+++ b/include/samurai/io/metadata.hpp
@@ -1,0 +1,122 @@
+// Copyright 2018-2025 the samurai's authors
+// SPDX-License-Identifier:  BSD-3-Clause
+
+#pragma once
+
+#include <string>
+
+#include <highfive/H5Easy.hpp>
+#include <pugixml.hpp>
+
+namespace samurai
+{
+    /**
+     * Facade used to inject user-defined metadata into the HDF5 file and, when
+     * available, the XDMF document produced by samurai::save / samurai::dump.
+     *
+     * The XDMF node is optional: when it is null (e.g. a checkpoint written with
+     * samurai::dump, which has no XDMF), the XDMF-related operations become
+     * no-ops and only the HDF5 file is written. A single class therefore serves
+     * both the visualization path (save, with XDMF) and the restart path (dump,
+     * HDF5 only).
+     */
+    class MetadataWriter
+    {
+      public:
+
+        /// Constructor for the HDF5-only case (no XDMF document).
+        explicit MetadataWriter(HighFive::File& file)
+            : m_file(file)
+        {
+        }
+
+        /// Constructor for the visualization case (HDF5 + XDMF <Domain> node).
+        MetadataWriter(HighFive::File& file, const pugi::xml_node& domain)
+            : m_file(file)
+            , m_domain(domain)
+        {
+        }
+
+        /// Write (or overwrite) an arbitrary attribute on the root group of the
+        /// HDF5 file. Works for scalars, std::string and std::vector<T>.
+        template <class T>
+        MetadataWriter& attribute(const std::string& name, const T& value)
+        {
+            if (m_file.hasAttribute(name))
+            {
+                m_file.getAttribute(name).write(value);
+            }
+            else
+            {
+                m_file.createAttribute(name, value);
+            }
+            return *this;
+        }
+
+        /// Store the simulation time as the HDF5 attribute "time" and, when an
+        /// XDMF document is attached, add a <Time> node to every top-level grid
+        /// (so that ParaView/VisIt expose a time cursor).
+        MetadataWriter& time(double t)
+        {
+            attribute("time", t);
+            for (pugi::xml_node grid : m_domain.children("Grid"))
+            {
+                auto time_node                      = grid.prepend_child("Time");
+                time_node.append_attribute("Value") = t;
+            }
+            return *this;
+        }
+
+        /// Add a human-readable <Information> node under the XDMF <Domain>.
+        /// No-op when no XDMF document is attached.
+        MetadataWriter& information(const std::string& name, const std::string& value)
+        {
+            auto info                      = m_domain.append_child("Information");
+            info.append_attribute("Name")  = name.c_str();
+            info.append_attribute("Value") = value.c_str();
+            return *this;
+        }
+
+      private:
+
+        HighFive::File& m_file; // NOLINT(cppcoreguidelines-avoid-const-or-ref-data-members)
+        pugi::xml_node m_domain{};
+    };
+
+    /**
+     * Facade used to read user-defined metadata back from an HDF5 file produced
+     * by samurai::save / samurai::dump.
+     */
+    class MetadataReader
+    {
+      public:
+
+        explicit MetadataReader(const HighFive::File& file)
+            : m_file(file)
+        {
+        }
+
+        /// Whether an attribute with the given name exists on the root group.
+        bool has(const std::string& name) const
+        {
+            return m_file.hasAttribute(name);
+        }
+
+        /// Read an attribute from the root group of the HDF5 file.
+        template <class T>
+        T attribute(const std::string& name) const
+        {
+            return m_file.getAttribute(name).read<T>();
+        }
+
+        /// Convenience accessor for the simulation time.
+        double time() const
+        {
+            return attribute<double>("time");
+        }
+
+      private:
+
+        const HighFive::File& m_file; // NOLINT(cppcoreguidelines-avoid-const-or-ref-data-members)
+    };
+}

--- a/include/samurai/io/restart.hpp
+++ b/include/samurai/io/restart.hpp
@@ -204,7 +204,7 @@ namespace samurai
     // simulation parameters, ...) into the checkpoint file. The callback is a
     // template parameter invoked in place: no std::function, no allocation.
     template <class Callback, class Mesh, class... Fields>
-        requires mesh_like<Mesh> && std::invocable<Callback&, MetadataWriter&>
+        requires mesh_like<Mesh> && std::invocable<Callback&&, MetadataWriter&>
     void dump(const fs::path& path, const std::string& filename, Callback&& metadata, const Mesh& mesh, const Fields&... fields)
     {
         HighFive::FileAccessProps fapl;
@@ -215,6 +215,7 @@ namespace samurai
         HighFive::File file(fmt::format("{}.h5", (path / filename).string()), HighFive::File::Overwrite, fapl);
         dump(file, mesh, fields...);
         MetadataWriter writer(file); // no XDMF for a checkpoint: HDF5 only
+        // NOTE: Under MPI, this callback must be executed collectively on all ranks.
         std::forward<Callback>(metadata)(writer);
     }
 
@@ -467,7 +468,7 @@ namespace samurai
     // Same as above, with a user callback to read back arbitrary metadata
     // (time, simulation parameters, ...) previously written by dump.
     template <class Callback, class Mesh, class... Fields>
-        requires mesh_like<Mesh> && std::invocable<Callback&, MetadataReader&>
+        requires mesh_like<Mesh> && std::invocable<Callback&&, MetadataReader&>
     void load(const fs::path& path, const std::string& filename, Callback&& metadata, Mesh& mesh, Fields&... fields)
     {
         HighFive::FileAccessProps fapl;
@@ -478,6 +479,7 @@ namespace samurai
         HighFive::File file(fmt::format("{}.h5", (path / filename).string()), HighFive::File::ReadOnly, fapl);
         load(file, mesh, fields...);
         MetadataReader reader(file);
+        // NOTE: Under MPI, this callback must be executed collectively on all ranks.
         std::forward<Callback>(metadata)(reader);
     }
 

--- a/include/samurai/io/restart.hpp
+++ b/include/samurai/io/restart.hpp
@@ -3,7 +3,9 @@
 
 #pragma once
 
+#include <concepts>
 #include <filesystem>
+#include <utility>
 namespace fs = std::filesystem;
 
 #include <highfive/H5Easy.hpp>
@@ -21,6 +23,7 @@ namespace mpi = boost::mpi;
 #include "../level_cell_array.hpp"
 #include "../mesh.hpp"
 #include "../uniform_mesh.hpp"
+#include "metadata.hpp"
 #include "util.hpp"
 
 namespace HighFive
@@ -185,6 +188,7 @@ namespace samurai
     }
 
     template <class Mesh, class... Fields>
+        requires mesh_like<Mesh>
     void dump(const fs::path& path, const std::string& filename, const Mesh& mesh, const Fields&... fields)
     {
         HighFive::FileAccessProps fapl;
@@ -196,11 +200,36 @@ namespace samurai
         dump(file, mesh, fields...);
     }
 
+    // Same as above, with a user callback to write arbitrary metadata (time,
+    // simulation parameters, ...) into the checkpoint file. The callback is a
+    // template parameter invoked in place: no std::function, no allocation.
+    template <class Callback, class Mesh, class... Fields>
+        requires mesh_like<Mesh> && std::invocable<Callback&, MetadataWriter&>
+    void dump(const fs::path& path, const std::string& filename, Callback&& metadata, const Mesh& mesh, const Fields&... fields)
+    {
+        HighFive::FileAccessProps fapl;
+#ifdef SAMURAI_WITH_MPI
+        fapl.add(HighFive::MPIOFileAccess{MPI_COMM_WORLD, MPI_INFO_NULL});
+        fapl.add(HighFive::MPIOCollectiveMetadata{});
+#endif
+        HighFive::File file(fmt::format("{}.h5", (path / filename).string()), HighFive::File::Overwrite, fapl);
+        dump(file, mesh, fields...);
+        MetadataWriter writer(file); // no XDMF for a checkpoint: HDF5 only
+        std::forward<Callback>(metadata)(writer);
+    }
+
     template <class Mesh, class... Fields>
         requires mesh_like<Mesh>
     void dump(const std::string& filename, const Mesh& mesh, const Fields&... fields)
     {
         dump(fs::current_path(), filename, mesh, fields...);
+    }
+
+    template <class Callback, class Mesh, class... Fields>
+        requires mesh_like<Mesh> && std::invocable<Callback&, MetadataWriter&>
+    void dump(const std::string& filename, Callback&& metadata, const Mesh& mesh, const Fields&... fields)
+    {
+        dump(fs::current_path(), filename, std::forward<Callback>(metadata), mesh, fields...);
     }
 
     template <class T>
@@ -423,6 +452,7 @@ namespace samurai
     }
 
     template <class Mesh, class... Fields>
+        requires mesh_like<Mesh>
     void load(const fs::path& path, const std::string& filename, Mesh& mesh, Fields&... fields)
     {
         HighFive::FileAccessProps fapl;
@@ -434,10 +464,34 @@ namespace samurai
         load(file, mesh, fields...);
     }
 
+    // Same as above, with a user callback to read back arbitrary metadata
+    // (time, simulation parameters, ...) previously written by dump.
+    template <class Callback, class Mesh, class... Fields>
+        requires mesh_like<Mesh> && std::invocable<Callback&, MetadataReader&>
+    void load(const fs::path& path, const std::string& filename, Callback&& metadata, Mesh& mesh, Fields&... fields)
+    {
+        HighFive::FileAccessProps fapl;
+#ifdef SAMURAI_WITH_MPI
+        fapl.add(HighFive::MPIOFileAccess{MPI_COMM_WORLD, MPI_INFO_NULL});
+        fapl.add(HighFive::MPIOCollectiveMetadata{});
+#endif
+        HighFive::File file(fmt::format("{}.h5", (path / filename).string()), HighFive::File::ReadOnly, fapl);
+        load(file, mesh, fields...);
+        MetadataReader reader(file);
+        std::forward<Callback>(metadata)(reader);
+    }
+
     template <class Mesh, class... Fields>
         requires mesh_like<Mesh>
     void load(const std::string& filename, Mesh& mesh, Fields&... fields)
     {
         load(fs::current_path(), filename, mesh, fields...);
+    }
+
+    template <class Callback, class Mesh, class... Fields>
+        requires mesh_like<Mesh> && std::invocable<Callback&, MetadataReader&>
+    void load(const std::string& filename, Callback&& metadata, Mesh& mesh, Fields&... fields)
+    {
+        load(fs::current_path(), filename, std::forward<Callback>(metadata), mesh, fields...);
     }
 }

--- a/tests/test_hdf5.cpp
+++ b/tests/test_hdf5.cpp
@@ -133,4 +133,81 @@ namespace samurai
         args::save_debug_fields = true;
         test_save(mesh);
     }
+
+    TYPED_TEST(hdf5_test, metadata)
+    {
+        static constexpr std::size_t dim = TypeParam::value;
+
+        xt::xtensor_fixed<double, xt::xshape<dim>> min_corner;
+        xt::xtensor_fixed<double, xt::xshape<dim>> max_corner;
+        min_corner.fill(-1);
+        max_corner.fill(1);
+        Box<double, dim> box(min_corner, max_corner);
+        auto mesh_cfg = mesh_config<dim>().min_level(4).max_level(4);
+        auto mesh     = mra::make_mesh(box, mesh_cfg);
+        auto u        = make_scalar_field<double>("u", mesh);
+        u.fill(1.);
+
+        const double time = 1.5;
+        const double Re   = 100.;
+
+        Hdf5Options<decltype(mesh)> options;
+        options.metadata = [&](MetadataWriter& w)
+        {
+            w.time(time).attribute("Re", Re).information("scheme", "WENO5");
+        };
+        save("test", "test_metadata", options, mesh, u);
+
+        // The metadata callback is optional: saving without it must still work
+        // and produce no <Time> node.
+        save("test", "test_no_metadata", mesh, u);
+
+#ifndef SAMURAI_WITH_MPI
+        // --- HDF5 attributes ---
+        {
+            HighFive::File file("test/test_metadata.h5", HighFive::File::ReadOnly);
+            ASSERT_TRUE(file.hasAttribute("time"));
+            ASSERT_TRUE(file.hasAttribute("Re"));
+            EXPECT_DOUBLE_EQ(file.getAttribute("time").read<double>(), time);
+            EXPECT_DOUBLE_EQ(file.getAttribute("Re").read<double>(), Re);
+        }
+
+        // --- XDMF <Time> in every top-level grid + <Information> ---
+        {
+            pugi::xml_document doc;
+            ASSERT_TRUE(doc.load_file("test/test_metadata.xdmf"));
+            auto domain        = doc.child("Xdmf").child("Domain");
+            std::size_t n_grid = 0;
+            std::size_t n_time = 0;
+            for (pugi::xml_node grid : domain.children("Grid"))
+            {
+                ++n_grid;
+                auto time_node = grid.child("Time");
+                if (time_node)
+                {
+                    ++n_time;
+                    EXPECT_DOUBLE_EQ(time_node.attribute("Value").as_double(), time);
+                }
+            }
+            EXPECT_GT(n_grid, 0u);
+            EXPECT_EQ(n_grid, n_time); // a <Time> node in every top-level grid
+            EXPECT_STREQ(domain.child("Information").attribute("Name").value(), "scheme");
+            EXPECT_STREQ(domain.child("Information").attribute("Value").value(), "WENO5");
+        }
+
+        // --- no metadata -> no attribute, no <Time> ---
+        {
+            HighFive::File file("test/test_no_metadata.h5", HighFive::File::ReadOnly);
+            EXPECT_FALSE(file.hasAttribute("time"));
+
+            pugi::xml_document doc;
+            ASSERT_TRUE(doc.load_file("test/test_no_metadata.xdmf"));
+            auto domain = doc.child("Xdmf").child("Domain");
+            for (pugi::xml_node grid : domain.children("Grid"))
+            {
+                EXPECT_TRUE(grid.child("Time").empty());
+            }
+        }
+#endif
+    }
 }

--- a/tests/test_restart.cpp
+++ b/tests/test_restart.cpp
@@ -142,13 +142,14 @@ namespace samurai
         const double Re   = 100.;
         const int iter    = 42;
 
-        dump("mesh",
-             [&](MetadataWriter& w)
-             {
-                 w.time(time).attribute("Re", Re).attribute("iteration", iter);
-             },
-             mesh,
-             u);
+        dump(
+            "mesh",
+            [&](MetadataWriter& w)
+            {
+                w.time(time).attribute("Re", Re).attribute("iteration", iter);
+            },
+            mesh,
+            u);
 
         auto mesh2 = create_mesh<2>(10);
         auto u2    = make_scalar_field<double>("u", mesh2);
@@ -158,17 +159,18 @@ namespace samurai
         int iter_read    = 0;
         bool has_time    = false;
         bool has_missing = true;
-        load("mesh",
-             [&](MetadataReader& r)
-             {
-                 has_time    = r.has("time");
-                 has_missing = r.has("does_not_exist");
-                 time_read   = r.time();
-                 Re_read     = r.attribute<double>("Re");
-                 iter_read   = r.attribute<int>("iteration");
-             },
-             mesh2,
-             u2);
+        load(
+            "mesh",
+            [&](MetadataReader& r)
+            {
+                has_time    = r.has("time");
+                has_missing = r.has("does_not_exist");
+                time_read   = r.time();
+                Re_read     = r.attribute<double>("Re");
+                iter_read   = r.attribute<int>("iteration");
+            },
+            mesh2,
+            u2);
 
         EXPECT_TRUE(u == u2); // fields still round-trip alongside the metadata
         EXPECT_TRUE(has_time);
@@ -182,23 +184,25 @@ namespace samurai
     {
         auto mesh         = create_mesh<2>(1);
         const double time = 2.5;
-        dump(fs::current_path(),
-             "mesh_meta",
-             [&](MetadataWriter& w)
-             {
-                 w.time(time);
-             },
-             mesh);
+        dump(
+            fs::current_path(),
+            "mesh_meta",
+            [&](MetadataWriter& w)
+            {
+                w.time(time);
+            },
+            mesh);
 
         decltype(mesh) mesh2;
         double time_read = 0.;
-        load(fs::current_path(),
-             "mesh_meta",
-             [&](MetadataReader& r)
-             {
-                 time_read = r.time();
-             },
-             mesh2);
+        load(
+            fs::current_path(),
+            "mesh_meta",
+            [&](MetadataReader& r)
+            {
+                time_read = r.time();
+            },
+            mesh2);
 
         EXPECT_TRUE(mesh == mesh2);
         EXPECT_DOUBLE_EQ(time_read, time);

--- a/tests/test_restart.cpp
+++ b/tests/test_restart.cpp
@@ -131,4 +131,76 @@ namespace samurai
         EXPECT_TRUE(u == u2);
         EXPECT_TRUE(v == v2);
     }
+
+    TEST(restart, restart_metadata)
+    {
+        auto mesh = create_mesh<2>(1);
+        auto u    = make_scalar_field<double>("u", mesh);
+        u.fill(1.);
+
+        const double time = 1.5;
+        const double Re   = 100.;
+        const int iter    = 42;
+
+        dump("mesh",
+             [&](MetadataWriter& w)
+             {
+                 w.time(time).attribute("Re", Re).attribute("iteration", iter);
+             },
+             mesh,
+             u);
+
+        auto mesh2 = create_mesh<2>(10);
+        auto u2    = make_scalar_field<double>("u", mesh2);
+
+        double time_read = 0.;
+        double Re_read   = 0.;
+        int iter_read    = 0;
+        bool has_time    = false;
+        bool has_missing = true;
+        load("mesh",
+             [&](MetadataReader& r)
+             {
+                 has_time    = r.has("time");
+                 has_missing = r.has("does_not_exist");
+                 time_read   = r.time();
+                 Re_read     = r.attribute<double>("Re");
+                 iter_read   = r.attribute<int>("iteration");
+             },
+             mesh2,
+             u2);
+
+        EXPECT_TRUE(u == u2); // fields still round-trip alongside the metadata
+        EXPECT_TRUE(has_time);
+        EXPECT_FALSE(has_missing);
+        EXPECT_DOUBLE_EQ(time_read, time);
+        EXPECT_DOUBLE_EQ(Re_read, Re);
+        EXPECT_EQ(iter_read, iter);
+    }
+
+    TEST(restart, restart_metadata_with_path)
+    {
+        auto mesh         = create_mesh<2>(1);
+        const double time = 2.5;
+        dump(fs::current_path(),
+             "mesh_meta",
+             [&](MetadataWriter& w)
+             {
+                 w.time(time);
+             },
+             mesh);
+
+        decltype(mesh) mesh2;
+        double time_read = 0.;
+        load(fs::current_path(),
+             "mesh_meta",
+             [&](MetadataReader& r)
+             {
+                 time_read = r.time();
+             },
+             mesh2);
+
+        EXPECT_TRUE(mesh == mesh2);
+        EXPECT_DOUBLE_EQ(time_read, time);
+    }
 }


### PR DESCRIPTION
## Description
This PR adds an API for user-provided metadata when writing/reading HDF5-based outputs, covering both visualization output (save → HDF5 + XDMF) and restart checkpoints (dump/load → HDF5 only).

**Changes:**

- Introduces MetadataWriter/MetadataReader facades to write/read root HDF5 attributes and (optionally) XDMF metadata nodes.
- Extends restart I/O (dump/load) with callback overloads to persist arbitrary metadata alongside mesh/fields.
- Extends HDF5 save options with an optional metadata callback and adds tests validating HDF5 attributes and XDMF <Time>/<Information> behavior.

## How has this been tested?
see `test_hdf5.cpp` and `test_restart.cpp` in the tests directory.

## Code of Conduct
By submitting this PR, you agree to follow our [Code of Conduct](https://github.com/hpc-maths/samurai/blob/master/docs/CODE_OF_CONDUCT.md)
- [x] I agree to follow this project's Code of Conduct
