### PR TITLE
feat: paraview reader

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -202,6 +202,13 @@ jobs:
                   cd build
                   ./tests/test_samurai_lib
 
+            - name: Generate ParaView reader reference files
+              shell: bash -l {0}
+              run: |
+                  export LD_LIBRARY_PATH="$CONDA_PREFIX/lib:$LD_LIBRARY_PATH"
+                  mkdir -p tests/reference/paraview
+                  ./build/tests/generate_paraview_reference tests/reference/paraview
+
             - name: Test with pytest
               shell: bash -l {0}
               run: |
@@ -277,6 +284,7 @@ jobs:
                   cmake --build build --target finite-volume-heat
                   cmake --build build --target finite-volume-lid-driven-cavity
                   cmake --build build --target finite-volume-burgers-os-2d-mpi
+                  cmake --build build --target generate_paraview_reference
 
             - name: MPI test finite-volume-advection-2d
               shell: micromamba-shell {0}
@@ -430,6 +438,19 @@ jobs:
                   cd tests
                   SAMURAI_MPI_BUILD_DIR="${GITHUB_WORKSPACE}/build" python -m pytest test_load_balancing.py -v
 
+            - name: Generate ParaView reader reference files
+              shell: micromamba-shell {0}
+              run: |
+                  mkdir -p tests/reference/paraview
+                  mpiexec -n 1 ./build/tests/generate_paraview_reference tests/reference/paraview
+                  mpiexec -n 2 ./build/tests/generate_paraview_reference tests/reference/paraview --mpi
+
+            - name: ParaView reader tests (pytest)
+              shell: micromamba-shell {0}
+              run: |
+                  cd tests
+                  pytest test_paraview_reader.py -v
+
             - name: ccache statistics
               shell: micromamba-shell {0}
               if: always()
@@ -496,6 +517,12 @@ jobs:
               shell: bash -l {0}
               if: always()
               run: ccache --show-stats --verbose
+
+            - name: Generate ParaView reader reference files
+              shell: bash -l {0}
+              run: |
+                  mkdir -p tests/reference/paraview
+                  ./build/tests/generate_paraview_reference tests/reference/paraview
 
             - name: Run tests
               shell: bash -l {0}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -78,6 +78,13 @@ else()
     target_link_libraries(test_samurai_lib samurai gtest_main gtest)
 endif()
 
+# Standalone tool (no gtest): regenerates the small samurai files consumed by
+# test_paraview_reader.py. Not tracked in git (they are gitignored .h5 files),
+# so CI must build and run this before running that test.
+add_executable(generate_paraview_reference ${CMAKE_CURRENT_SOURCE_DIR}/../tools/paraview/tests/generate_reference.cpp)
+target_include_directories(generate_paraview_reference PRIVATE ${SAMURAI_INCLUDE_DIR})
+target_link_libraries(generate_paraview_reference samurai)
+
 if(WITH_MPI)
     add_subdirectory(mpi)
 endif()

--- a/tests/test_paraview_reader.py
+++ b/tests/test_paraview_reader.py
@@ -71,6 +71,24 @@ def test_extra_arrays_optional():
     assert "u" in block["fields"]
 
 
+def test_load_from_subgroup(tmp_path):
+    # A file may hold the samurai layout under a subgroup; load(group=...) must
+    # reconstruct it identically to a root-level file.
+    ref = os.path.join(_REF_DIR, "ref_2d.h5")
+    nested = tmp_path / "multigrid.h5"
+    with h5py.File(ref, "r") as src, h5py.File(nested, "w") as dst:
+        grid = dst.create_group("grids/g0")
+        for key in ("mesh", "fields", "n_process"):
+            src.copy(key, grid)
+
+    root_block = load(ref)[0]
+    nested_block = load(str(nested), group="grids/g0")[0]
+    np.testing.assert_array_equal(nested_block["center"], root_block["center"])
+    np.testing.assert_array_equal(
+        nested_block["fields"]["u"], root_block["fields"]["u"]
+    )
+
+
 def test_load_rejects_save_file(tmp_path):
     # A save() file (explicit points/connectivity, no /mesh/dim) must raise a
     # clear error rather than a raw KeyError.

--- a/tests/test_paraview_reader.py
+++ b/tests/test_paraview_reader.py
@@ -1,0 +1,135 @@
+# Copyright 2018-2025 the samurai's authors
+# SPDX-License-Identifier:  BSD-3-Clause
+"""
+Validate the samurai ParaView reader (tools/paraview/samurai_load.py) against small
+reference files produced by tools/paraview/tests/generate_reference.cpp.
+
+The reference field is the analytic oracle ``u(center) = sum_d center[d]*10**d``.
+Checking ``u == u(reconstructed center)`` for every cell validates, at once, the
+geometry reconstruction and the (offset-driven) ``for_each_cell`` traversal order
+on which the flat field buffer relies.
+"""
+
+import os
+import sys
+
+import numpy as np
+import pytest
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_PLUGIN_DIR = os.path.join(_HERE, "..", "tools", "paraview")
+sys.path.insert(0, _PLUGIN_DIR)
+_REF_DIR = os.path.join(_HERE, "reference", "paraview")
+
+h5py = pytest.importorskip("h5py")
+from samurai_load import load, discover_series  # noqa: E402
+
+
+def analytic(centers, dim):
+    weights = 10.0 ** np.arange(dim)
+    return centers[:, :dim] @ weights
+
+
+@pytest.mark.parametrize("name,dim", [("ref_1d", 1), ("ref_2d", 2), ("ref_3d", 3)])
+def test_sequential_reconstruction(name, dim):
+    blocks = load(os.path.join(_REF_DIR, f"{name}.h5"))
+    assert len(blocks) == 1
+    block = blocks[0]
+
+    n_cells = block["center"].shape[0]
+    assert n_cells > 0
+    assert block["dim"] == dim
+    assert block["connectivity"].shape == (n_cells, 1 << dim)
+    assert block["points"].shape == (n_cells * (1 << dim), 3)
+    assert np.isfinite(block["points"]).all()
+
+    u = block["fields"]["u"][:, 0]
+    assert u.shape[0] == n_cells
+    np.testing.assert_allclose(u, analytic(block["center"], dim), atol=1e-9)
+
+
+def test_mpi_reconstruction():
+    blocks = load(os.path.join(_REF_DIR, "ref_2d_mpi.h5"))
+    assert len(blocks) >= 2  # generated with mpirun -n 2
+
+    centers = np.concatenate([b["center"] for b in blocks])
+    u = np.concatenate([b["fields"]["u"][:, 0] for b in blocks])
+
+    # Every cell carries the analytic value of its own center.
+    np.testing.assert_allclose(u, analytic(centers, 2), atol=1e-9)
+
+    # Ranks partition the mesh: no cell is shared or missing.
+    keys = {tuple(np.round(c, 9)) for c in centers}
+    assert len(keys) == centers.shape[0]
+
+
+def test_extra_arrays_optional():
+    blocks = load(os.path.join(_REF_DIR, "ref_2d.h5"), extra_arrays=False)
+    block = blocks[0]
+    assert "level" not in block
+    assert "center" not in block
+    assert "u" in block["fields"]
+
+
+def test_load_rejects_save_file(tmp_path):
+    # A save() file (explicit points/connectivity, no /mesh/dim) must raise a
+    # clear error rather than a raw KeyError.
+    path = tmp_path / "explicit.h5"
+    with h5py.File(path, "w") as f:
+        grp = f.create_group("mesh")
+        grp.create_dataset("points", data=np.zeros((4, 3)))
+        grp.create_dataset("connectivity", data=np.zeros((1, 4), dtype=np.int64))
+    with pytest.raises(ValueError, match="save"):
+        load(str(path))
+
+
+def test_load_rejects_non_samurai_file(tmp_path):
+    path = tmp_path / "empty.h5"
+    with h5py.File(path, "w"):
+        pass
+    with pytest.raises(ValueError, match="not a samurai dump"):
+        load(str(path))
+
+
+def test_discover_series(tmp_path):
+    # A numbered series: opening ANY one file must expose all time steps.
+    for n in (0, 1, 2, 10):
+        (tmp_path / f"sol_ite_{n}.h5").write_bytes(b"")
+    (tmp_path / "other.h5").write_bytes(b"")  # unrelated, must be ignored
+
+    files, times = discover_series(str(tmp_path / "sol_ite_1.h5"))
+    assert times == [0.0, 1.0, 2.0, 10.0]  # natural order: 2 before 10
+    assert [os.path.basename(f) for f in files] == [
+        "sol_ite_0.h5", "sol_ite_1.h5", "sol_ite_2.h5", "sol_ite_10.h5"
+    ]
+
+
+def test_discover_series_single_file(tmp_path):
+    (tmp_path / "snapshot.h5").write_bytes(b"")
+    files, times = discover_series(str(tmp_path / "snapshot.h5"))
+    assert times == [0.0]
+    assert len(files) == 1
+
+
+def test_discover_series_uses_time_attribute(tmp_path):
+    # When every file stores the "time" root attribute, it is used as the time
+    # axis instead of the iteration index.
+    physical_times = [0.0, 0.05, 0.1]
+    for n, t in enumerate(physical_times):
+        with h5py.File(tmp_path / f"sol_ite_{n}.h5", "w") as f:
+            f.attrs["time"] = t
+    files, times = discover_series(str(tmp_path / "sol_ite_0.h5"))
+    assert [os.path.basename(f) for f in files] == [
+        "sol_ite_0.h5", "sol_ite_1.h5", "sol_ite_2.h5"
+    ]
+    assert times == physical_times
+
+
+def test_discover_series_falls_back_without_time(tmp_path):
+    # If any file lacks the attribute, fall back to the iteration numbers.
+    with h5py.File(tmp_path / "sol_ite_0.h5", "w") as f:
+        f.attrs["time"] = 0.0
+    with h5py.File(tmp_path / "sol_ite_1.h5", "w") as f:
+        pass  # no time attribute
+    files, times = discover_series(str(tmp_path / "sol_ite_0.h5"))
+    assert times == [0.0, 1.0]

--- a/tests/test_paraview_reader.py
+++ b/tests/test_paraview_reader.py
@@ -49,7 +49,12 @@ def test_sequential_reconstruction(name, dim):
 
 
 def test_mpi_reconstruction():
-    blocks = load(os.path.join(_REF_DIR, "ref_2d_mpi.h5"))
+    ref = os.path.join(_REF_DIR, "ref_2d_mpi.h5")
+    if not os.path.exists(ref):
+        # Only produced by generate_paraview_reference on an MPI-enabled build
+        # (see .github/workflows/ci.yml, job linux-mpi-mamba).
+        pytest.skip("ref_2d_mpi.h5 not generated (requires an MPI-enabled build)")
+    blocks = load(ref)
     assert len(blocks) >= 2  # generated with mpirun -n 2
 
     centers = np.concatenate([b["center"] for b in blocks])

--- a/tools/paraview/README.md
+++ b/tools/paraview/README.md
@@ -1,0 +1,132 @@
+# ParaView reader for samurai files
+
+Samurai writes its state as a **compressed HDF5 file** that stores only its
+internal interval representation of the mesh (via `samurai::dump`; this is
+becoming samurai's standard format, read back with `samurai::load`). The file is
+compact but not directly viewable, because no explicit geometry is stored.
+
+This plugin lets ParaView open such a file directly: it rebuilds the
+finite-element view (points, quadrilaterals in 2D / hexahedra in 3D, cell data)
+on the fly. It replaces the old explicit-mesh export (points + connectivity +
+`.xdmf`), which is being retired.
+
+## Files
+
+| File | Role |
+|------|------|
+| `samurai_load.py` | Pure `numpy` + `h5py` reconstruction of a samurai file. No ParaView dependency; unit-testable. Exposes `load()`, `discover_series()`, `read_time()`. |
+| `SamuraiReader.py` | ParaView reader (`@smproxy.reader`) wrapping `samurai_load`. |
+| `tests/generate_reference.cpp` | Regenerates the small reference files used by the tests. |
+
+## Requirements
+
+The reader needs **`h5py`** (and `numpy`, always bundled) in ParaView's Python.
+
+Check inside ParaView's Python shell (*View > Python Shell*):
+
+```python
+import h5py  # must succeed
+```
+
+If it fails, install it into ParaView's interpreter. Recent ParaView binaries
+ship a `pip`:
+
+```bash
+# adjust to your ParaView install
+/path/to/ParaView.app/Contents/bin/pvpython -m pip install h5py
+```
+
+## Usage
+
+1. *Tools > Manage Plugins... > Load New...* and select `SamuraiReader.py`
+   (optionally tick *Auto Load*).
+2. *File > Open* and choose a samurai `.h5` file (e.g. `mysolution.h5` produced
+   by `samurai::dump`). The reader is registered for the `.h5` extension.
+3. Apply. Color by any field.
+
+Options in the *Properties* panel:
+
+- **Expose mesh arrays** (on by default): also attach `level`, `indices` and
+  `center` as cell arrays. They are computed for free during reconstruction and
+  are handy to filter/color by AMR level (equivalent to `--save-debug-fields`).
+
+### Time series / animations
+
+To animate a simulation, write one file per output step with a numbered suffix,
+e.g. `sol_ite_0.h5`, `sol_ite_1.h5`, ... (this is what the `--nfiles` option of
+the demos produces via the `_ite_{n}` suffix).
+
+Then simply **open any one file of the series** (e.g. `sol_ite_0.h5`). The reader
+auto-discovers the sibling files on disk (same prefix, trailing number) and
+exposes one time step per file — it does **not** rely on ParaView's file-series
+grouping. The usual VCR / time controls then step or play through them, and
+*File > Save Animation* exports a movie.
+
+Files are ordered naturally (`_2` before `_10`). The **time value** shown by
+ParaView is the physical simulation time when the file stores it — i.e. the
+`"time"` HDF5 root attribute written by samurai's `MetadataWriter`
+(`include/samurai/io/metadata.hpp`, `.time(t)`). If any file of the series lacks
+it, the reader falls back to the trailing iteration number. A file with no
+trailing number is a single snapshot (one time step).
+
+To record the physical time, pass a metadata callback to `samurai::dump`:
+
+```cpp
+samurai::dump(path, fmt::format("sol_ite_{}", n),
+              [&](samurai::MetadataWriter& m) { m.time(t); },
+              mesh, u);
+```
+
+### MPI files
+
+A file written by an MPI run stores one slice per rank. The reader reconstructs
+each rank independently and returns a `vtkPartitionedDataSet` with one partition
+per rank.
+
+## How it works
+
+A samurai file stores, per level and per direction, the compressed intervals
+(`m_cells`) and offsets (`m_offsets`) plus `dim`, `min/max_level`,
+`origin_point` and `scaling_factor`. No geometry is stored. The reader:
+
+1. rebuilds the integer cell indices `(i, j, k)` by reproducing the
+   `for_each_cell` traversal (the offset-driven interval iterator of
+   `LevelCellArray`) — this is essential because field values are stored as a
+   flat buffer in exactly that order, with no explicit indexing;
+2. computes the geometry with `length = scaling_factor / 2**level`,
+   `corner = origin_point + length * indices`, and the unit-cell vertex offsets
+   of samurai's `get_element`;
+3. attaches each field as **cell data**.
+
+## Tests
+
+`tests/test_paraview_reader.py` (run from the repository test suite) reconstructs
+the reference files in `tests/reference/paraview/` and checks that every cell
+carries the analytic value `u = sum_d center[d]*10**d` of its own center —
+validating geometry **and** traversal order simultaneously — plus the MPI
+partition and time-series invariants.
+
+### Regenerating the reference files
+
+They are produced by `tests/generate_reference.cpp`, compiled against the
+samurai headers. Example (adapt the toolchain to your environment):
+
+```bash
+mpic++ -DSAMURAI_WITH_MPI -DSAMURAI_ENABLE_INLINE \
+  -DSAMURAI_FIELD_CONTAINER_XTENSOR -DSAMURAI_FLUX_CONTAINER_XTENSOR \
+  -DSAMURAI_STATIC_MAT_CONTAINER_XTENSOR -DFMT_SHARED \
+  -I../../../include -std=c++20 \
+  tests/generate_reference.cpp -o generate_reference \
+  -lhdf5 -lpugixml -lfmt -lboost_mpi -lboost_serialization
+
+./generate_reference ../../../tests/reference/paraview            # ref_1d/2d/3d.h5
+mpirun -n 2 ./generate_reference ../../../tests/reference/paraview --mpi  # ref_2d_mpi.h5
+```
+
+## Current limitations
+
+- A samurai file only contains the leaf cells (`mesh_id_t::cells`). Other
+  submeshes (ghosts, `by_mesh_id`) are not reconstructible from it. The `level`
+  cell array lets you filter by AMR level instead.
+- Points are emitted per cell (no deduplication). This is correct for
+  visualization; deduplication is a possible future memory optimization.

--- a/tools/paraview/README.md
+++ b/tools/paraview/README.md
@@ -20,7 +20,9 @@ on the fly. It replaces the old explicit-mesh export (points + connectivity +
 
 ## Requirements
 
-The reader needs **`h5py`** (and `numpy`, always bundled) in ParaView's Python.
+- **ParaView 5.10+ / VTK 9** — the reader uses `vtkCellArray.SetData(offsets,
+  connectivity)` and `vtkPartitionedDataSet`.
+- **`h5py`** (and `numpy`, always bundled) in ParaView's Python.
 
 Check inside ParaView's Python shell (*View > Python Shell*):
 
@@ -122,6 +124,27 @@ mpic++ -DSAMURAI_WITH_MPI -DSAMURAI_ENABLE_INLINE \
 ./generate_reference ../../../tests/reference/paraview            # ref_1d/2d/3d.h5
 mpirun -n 2 ./generate_reference ../../../tests/reference/paraview --mpi  # ref_2d_mpi.h5
 ```
+
+## Troubleshooting
+
+- **The reader does not appear / a wrong reader opens the file.** `.h5` is a
+  generic extension shared by many tools, so ParaView may pick another reader.
+  Use *File > Open*, then in the dialog choose **"Samurai reader"** explicitly
+  (or *Open With...*). The reader validates the file structure and raises a clear
+  error on non-samurai `.h5` files (e.g. a `save()` file), rather than crashing.
+- **Changes to the plugin are not picked up.** ParaView caches imported Python
+  modules for the whole session. After editing `SamuraiReader.py` /
+  `samurai_load.py`, **fully quit and relaunch ParaView** — reloading the plugin
+  is not enough.
+- **`import h5py` fails in the Python shell.** Install it into ParaView's
+  interpreter (see Requirements).
+
+## Multiple grids in one file
+
+`samurai_load.load(filename, group=...)` can read a samurai layout stored under a
+subgroup, e.g. `load("multi.h5", group="grids/g0")`. This is the extension point
+for files that hold several grids side by side; the default (`group=None`) reads
+the file root.
 
 ## Current limitations
 

--- a/tools/paraview/README.md
+++ b/tools/paraview/README.md
@@ -12,11 +12,11 @@ on the fly. It replaces the old explicit-mesh export (points + connectivity +
 
 ## Files
 
-| File | Role |
-|------|------|
-| `samurai_load.py` | Pure `numpy` + `h5py` reconstruction of a samurai file. No ParaView dependency; unit-testable. Exposes `load()`, `discover_series()`, `read_time()`. |
-| `SamuraiReader.py` | ParaView reader (`@smproxy.reader`) wrapping `samurai_load`. |
-| `tests/generate_reference.cpp` | Regenerates the small reference files used by the tests. |
+| File                           | Role                                                                                                                                                 |
+| ------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `samurai_load.py`              | Pure `numpy` + `h5py` reconstruction of a samurai file. No ParaView dependency; unit-testable. Exposes `load()`, `discover_series()`, `read_time()`. |
+| `SamuraiReader.py`             | ParaView reader (`@smproxy.reader`) wrapping `samurai_load`.                                                                                         |
+| `tests/generate_reference.cpp` | Regenerates the small reference files used by the tests.                                                                                             |
 
 ## Requirements
 
@@ -110,8 +110,15 @@ partition and time-series invariants.
 
 ### Regenerating the reference files
 
-They are produced by `tests/generate_reference.cpp`, compiled against the
-samurai headers. Example (adapt the toolchain to your environment):
+CI (re)builds and runs the
+`generate_paraview_reference` CMake target (see `.github/workflows/ci.yml`,
+jobs `linux-mamba`/`macos-mamba` for `ref_1d/2d/3d.h5`, and `linux-mpi-mamba`
+for `ref_2d_mpi.h5`) before running the pytest suite, so they never go stale.
+
+To regenerate them locally, build that target (requires `-DBUILD_TESTS=ON`)
+and run the resulting `generate_paraview_reference` executable — or compile
+`tests/generate_reference.cpp` by hand against the samurai headers. Example
+(adapt the toolchain to your environment):
 
 ```bash
 mpic++ -DSAMURAI_WITH_MPI -DSAMURAI_ENABLE_INLINE \

--- a/tools/paraview/SamuraiReader.py
+++ b/tools/paraview/SamuraiReader.py
@@ -1,0 +1,181 @@
+# Copyright 2018-2025 the samurai's authors
+# SPDX-License-Identifier:  BSD-3-Clause
+"""
+ParaView reader for samurai data files (compressed HDF5).
+
+Load it through ParaView's *Tools > Manage Plugins... > Load New...* and pick
+this file.  A samurai data file only stores the compressed interval representation of
+the mesh; the finite-element view (quadrilaterals in 2D, hexahedra in 3D) is
+rebuilt on the fly by :mod:`samurai_load`.  With an MPI file, one partition is
+produced per rank.
+
+Time series / animation: open **any single file** of a numbered series (e.g.
+``sol_ite_0.h5``, ``sol_ite_1.h5``, ...).  The reader auto-discovers the sibling
+files on disk, so it does not rely on ParaView's file-series grouping: every file
+becomes one time step and the time controls animate through them.
+
+Requires ``h5py`` in ParaView's Python (see README.md).
+"""
+
+import os
+import sys
+
+import numpy as np
+
+# Make ``samurai_load`` importable regardless of ParaView's working directory.
+_HERE = os.path.dirname(os.path.abspath(__file__))
+if _HERE not in sys.path:
+    sys.path.insert(0, _HERE)
+
+from samurai_load import load, discover_series  # noqa: E402
+
+from paraview.util.vtkAlgorithm import (  # noqa: E402
+    VTKPythonAlgorithmBase,
+    smproxy,
+    smproperty,
+    smdomain,
+    smhint,
+)
+from vtkmodules.vtkCommonDataModel import vtkPartitionedDataSet, vtkUnstructuredGrid  # noqa: E402
+from vtkmodules.vtkCommonDataModel import vtkDataObject  # noqa: E402
+from vtkmodules.vtkCommonCore import vtkPoints  # noqa: E402
+from vtkmodules.vtkCommonExecutionModel import vtkStreamingDemandDrivenPipeline  # noqa: E402
+from vtkmodules.util.numpy_support import numpy_to_vtk, numpy_to_vtkIdTypeArray  # noqa: E402
+
+
+def _build_unstructured_grid(block):
+    """Turn a :func:`samurai_load.load` block into a ``vtkUnstructuredGrid``."""
+    points = np.ascontiguousarray(block["points"], dtype=np.float64)
+    connectivity = block["connectivity"]
+    n_cells, n_vertices = connectivity.shape
+
+    ug = vtkUnstructuredGrid()
+
+    vtk_points = vtkPoints()
+    vtk_points.SetData(numpy_to_vtk(points, deep=1))
+    ug.SetPoints(vtk_points)
+
+    if n_cells > 0:
+        # vtkCellArray (VTK 9) = offsets + flat connectivity.
+        offsets = np.arange(0, (n_cells + 1) * n_vertices, n_vertices, dtype=np.int64)
+        conn = np.ascontiguousarray(connectivity.ravel(), dtype=np.int64)
+
+        from vtkmodules.vtkCommonDataModel import vtkCellArray
+
+        cell_array = vtkCellArray()
+        cell_array.SetData(
+            numpy_to_vtkIdTypeArray(offsets, deep=1),
+            numpy_to_vtkIdTypeArray(conn, deep=1),
+        )
+        cell_types = np.full(n_cells, block["vtk_cell_type"], dtype=np.uint8)
+        ug.SetCells(numpy_to_vtk(cell_types, deep=1, array_type=3), cell_array)  # 3 = VTK_UNSIGNED_CHAR
+
+    cell_data = ug.GetCellData()
+
+    def add_array(name, values, active_scalar=False):
+        arr = numpy_to_vtk(np.ascontiguousarray(values), deep=1)
+        arr.SetName(name)
+        cell_data.AddArray(arr)
+        if active_scalar and values.ndim == 1:
+            cell_data.SetActiveScalars(name)
+
+    first = True
+    for name, values in block["fields"].items():
+        v = values[:, 0] if values.shape[1] == 1 else values
+        add_array(name, v, active_scalar=first)
+        first = False
+
+    for extra in ("level", "indices", "center"):
+        if extra in block:
+            add_array(extra, block[extra])
+
+    return ug
+
+
+@smproxy.reader(
+    name="SamuraiReader",
+    label="Samurai reader",
+    extensions="h5",
+    file_description="Samurai data (HDF5)",
+)
+class SamuraiReader(VTKPythonAlgorithmBase):
+    def __init__(self):
+        super().__init__(nInputPorts=0, nOutputPorts=1, outputType="vtkPartitionedDataSet")
+        self._filename = None
+        self._extra_arrays = True
+        self._files = []
+        self._times = []
+
+    # -- File name: open any one file; the numbered series is auto-discovered. --
+    @smproperty.stringvector(name="FileName")
+    @smdomain.filelist()
+    @smhint.filechooser(extensions="h5", file_description="Samurai data (HDF5)")
+    def SetFileName(self, name):
+        if name != self._filename:
+            self._filename = name
+            self.Modified()
+
+    # Exposes the time controls in the GUI and populates the animation.
+    @smproperty.doublevector(
+        name="TimestepValues",
+        information_only="1",
+        si_class="vtkSITimeStepsProperty",
+    )
+    def GetTimestepValues(self):
+        if not self._filename:
+            return None
+        _, times = discover_series(self._filename)
+        return times
+
+    @smproperty.intvector(name="ExposeMeshArrays", default_values=1)
+    @smdomain.xml('<BooleanDomain name="bool"/>')
+    def SetExposeMeshArrays(self, value):
+        value = bool(value)
+        if value != self._extra_arrays:
+            self._extra_arrays = value
+            self.Modified()
+
+    # -- Pipeline ---------------------------------------------------------------
+    def RequestInformation(self, request, inInfoVec, outInfoVec):
+        if not self._filename:
+            return 1
+
+        self._files, self._times = discover_series(self._filename)
+
+        info = outInfoVec.GetInformationObject(0)
+        info.Remove(vtkStreamingDemandDrivenPipeline.TIME_STEPS())
+        info.Remove(vtkStreamingDemandDrivenPipeline.TIME_RANGE())
+        for t in self._times:
+            info.Append(vtkStreamingDemandDrivenPipeline.TIME_STEPS(), t)
+        info.Append(vtkStreamingDemandDrivenPipeline.TIME_RANGE(), self._times[0])
+        info.Append(vtkStreamingDemandDrivenPipeline.TIME_RANGE(), self._times[-1])
+        return 1
+
+    def _requested_index(self, info):
+        if not self._times:
+            return 0
+        if info.Has(vtkStreamingDemandDrivenPipeline.UPDATE_TIME_STEP()):
+            t = info.Get(vtkStreamingDemandDrivenPipeline.UPDATE_TIME_STEP())
+            # nearest advertised time
+            return min(range(len(self._times)), key=lambda i: abs(self._times[i] - t))
+        return 0
+
+    def RequestData(self, request, inInfoVec, outInfoVec):
+        if not self._filename:
+            raise RuntimeError("No file name set for SamuraiReader")
+
+        if not self._files:
+            self._files, self._times = discover_series(self._filename)
+
+        info = outInfoVec.GetInformationObject(0)
+        index = self._requested_index(info)
+        filename = self._files[index]
+
+        blocks = load(filename, extra_arrays=self._extra_arrays)
+        output = vtkPartitionedDataSet.GetData(outInfoVec, 0)
+        output.SetNumberOfPartitions(len(blocks))
+        for p, block in enumerate(blocks):
+            output.SetPartition(p, _build_unstructured_grid(block))
+
+        output.GetInformation().Set(vtkDataObject.DATA_TIME_STEP(), float(self._times[index]))
+        return 1

--- a/tools/paraview/SamuraiReader.py
+++ b/tools/paraview/SamuraiReader.py
@@ -41,6 +41,7 @@ from vtkmodules.vtkCommonDataModel import vtkDataObject  # noqa: E402
 from vtkmodules.vtkCommonCore import vtkPoints  # noqa: E402
 from vtkmodules.vtkCommonExecutionModel import vtkStreamingDemandDrivenPipeline  # noqa: E402
 from vtkmodules.util.numpy_support import numpy_to_vtk, numpy_to_vtkIdTypeArray  # noqa: E402
+from vtkmodules.util.vtkConstants import VTK_UNSIGNED_CHAR  # noqa: E402
 
 
 def _build_unstructured_grid(block):
@@ -68,7 +69,7 @@ def _build_unstructured_grid(block):
             numpy_to_vtkIdTypeArray(conn, deep=1),
         )
         cell_types = np.full(n_cells, block["vtk_cell_type"], dtype=np.uint8)
-        ug.SetCells(numpy_to_vtk(cell_types, deep=1, array_type=3), cell_array)  # 3 = VTK_UNSIGNED_CHAR
+        ug.SetCells(numpy_to_vtk(cell_types, deep=1, array_type=VTK_UNSIGNED_CHAR), cell_array)
 
     cell_data = ug.GetCellData()
 
@@ -79,6 +80,8 @@ def _build_unstructured_grid(block):
         if active_scalar and values.ndim == 1:
             cell_data.SetActiveScalars(name)
 
+    # The first field is set as the active scalar so ParaView colors by it by
+    # default; the user can always switch the coloring array afterwards.
     first = True
     for name, values in block["fields"].items():
         v = values[:, 0] if values.shape[1] == 1 else values
@@ -103,8 +106,7 @@ class SamuraiReader(VTKPythonAlgorithmBase):
         super().__init__(nInputPorts=0, nOutputPorts=1, outputType="vtkPartitionedDataSet")
         self._filename = None
         self._extra_arrays = True
-        self._files = []
-        self._times = []
+        self._series_cache = None  # (filename, files, times)
 
     # -- File name: open any one file; the numbered series is auto-discovered. --
     @smproperty.stringvector(name="FileName")
@@ -113,7 +115,22 @@ class SamuraiReader(VTKPythonAlgorithmBase):
     def SetFileName(self, name):
         if name != self._filename:
             self._filename = name
+            self._series_cache = None  # invalidate the discovered series
             self.Modified()
+
+    def _series(self):
+        """Discovered ``(files, times)`` for the current file, memoized.
+
+        ``GetTimestepValues`` is polled often by the GUI and ``discover_series``
+        lists the directory and opens every sibling file, so the result is cached
+        until the file name changes.
+        """
+        if not self._filename:
+            return [], []
+        if self._series_cache is None or self._series_cache[0] != self._filename:
+            files, times = discover_series(self._filename)
+            self._series_cache = (self._filename, files, times)
+        return self._series_cache[1], self._series_cache[2]
 
     # Exposes the time controls in the GUI and populates the animation.
     @smproperty.doublevector(
@@ -122,10 +139,8 @@ class SamuraiReader(VTKPythonAlgorithmBase):
         si_class="vtkSITimeStepsProperty",
     )
     def GetTimestepValues(self):
-        if not self._filename:
-            return None
-        _, times = discover_series(self._filename)
-        return times
+        _, times = self._series()
+        return times or None
 
     @smproperty.intvector(name="ExposeMeshArrays", default_values=1)
     @smdomain.xml('<BooleanDomain name="bool"/>')
@@ -137,39 +152,36 @@ class SamuraiReader(VTKPythonAlgorithmBase):
 
     # -- Pipeline ---------------------------------------------------------------
     def RequestInformation(self, request, inInfoVec, outInfoVec):
-        if not self._filename:
+        _, times = self._series()
+        if not times:
             return 1
-
-        self._files, self._times = discover_series(self._filename)
 
         info = outInfoVec.GetInformationObject(0)
         info.Remove(vtkStreamingDemandDrivenPipeline.TIME_STEPS())
         info.Remove(vtkStreamingDemandDrivenPipeline.TIME_RANGE())
-        for t in self._times:
+        for t in times:
             info.Append(vtkStreamingDemandDrivenPipeline.TIME_STEPS(), t)
-        info.Append(vtkStreamingDemandDrivenPipeline.TIME_RANGE(), self._times[0])
-        info.Append(vtkStreamingDemandDrivenPipeline.TIME_RANGE(), self._times[-1])
+        info.Append(vtkStreamingDemandDrivenPipeline.TIME_RANGE(), times[0])
+        info.Append(vtkStreamingDemandDrivenPipeline.TIME_RANGE(), times[-1])
         return 1
 
-    def _requested_index(self, info):
-        if not self._times:
+    def _requested_index(self, info, times):
+        if not times:
             return 0
         if info.Has(vtkStreamingDemandDrivenPipeline.UPDATE_TIME_STEP()):
             t = info.Get(vtkStreamingDemandDrivenPipeline.UPDATE_TIME_STEP())
             # nearest advertised time
-            return min(range(len(self._times)), key=lambda i: abs(self._times[i] - t))
+            return min(range(len(times)), key=lambda i: abs(times[i] - t))
         return 0
 
     def RequestData(self, request, inInfoVec, outInfoVec):
         if not self._filename:
             raise RuntimeError("No file name set for SamuraiReader")
 
-        if not self._files:
-            self._files, self._times = discover_series(self._filename)
-
+        files, times = self._series()
         info = outInfoVec.GetInformationObject(0)
-        index = self._requested_index(info)
-        filename = self._files[index]
+        index = self._requested_index(info, times)
+        filename = files[index]
 
         blocks = load(filename, extra_arrays=self._extra_arrays)
         output = vtkPartitionedDataSet.GetData(outInfoVec, 0)
@@ -177,5 +189,5 @@ class SamuraiReader(VTKPythonAlgorithmBase):
         for p, block in enumerate(blocks):
             output.SetPartition(p, _build_unstructured_grid(block))
 
-        output.GetInformation().Set(vtkDataObject.DATA_TIME_STEP(), float(self._times[index]))
+        output.GetInformation().Set(vtkDataObject.DATA_TIME_STEP(), float(times[index]))
         return 1

--- a/tools/paraview/samurai_load.py
+++ b/tools/paraview/samurai_load.py
@@ -1,0 +1,367 @@
+# Copyright 2018-2025 the samurai's authors
+# SPDX-License-Identifier:  BSD-3-Clause
+"""
+Reconstruction of a samurai data file as an explicit finite-element
+mesh (points + connectivity + cell data).
+
+This module only depends on ``numpy`` and ``h5py`` so that it can be unit-tested
+without ParaView.  The ParaView reader (``SamuraiReader.py``) is a thin wrapper
+that turns the blocks returned here into VTK datasets.
+
+Samurai never stores the cell geometry.  A data file only contains, per level and per
+direction, the compressed interval representation of the mesh
+(``m_cells`` / ``m_offsets``, see ``include/samurai/level_cell_array.hpp``) plus
+``dim``, ``min_level``/``max_level``, ``origin_point`` and ``scaling_factor``.
+The geometry is rebuilt on the fly:
+
+    length = scaling_factor / 2**level
+    corner = origin_point + length * (i, j, k)        # cell.hpp:corner()
+    vertex = corner + length * unit_offset            # hdf5.hpp:get_element
+
+Field values carry **no stored indexing**: their order is exactly the traversal
+order of ``for_each_cell`` (levels min->max, then the interval/offset iterator of
+each level).  Correctness therefore hinges on reproducing that traversal, which
+is what :func:`_enumerate_level` does.
+"""
+
+import os
+import re
+
+import numpy as np
+import h5py
+
+# VTK cell type ids (avoid importing vtk here to keep the module dependency-free)
+VTK_LINE = 3
+VTK_QUAD = 9
+VTK_HEXAHEDRON = 12
+
+# Unit-cell vertex offsets, matching samurai's ``get_element`` (hdf5.hpp:61-80).
+# The ordering is already the one expected by VTK_LINE / VTK_QUAD / VTK_HEXAHEDRON.
+_UNIT_ELEMENT = {
+    1: np.array([[0.0], [1.0]]),
+    2: np.array([[0, 0], [1, 0], [1, 1], [0, 1]], dtype=float),
+    3: np.array(
+        [
+            [0, 0, 0], [1, 0, 0], [1, 1, 0], [0, 1, 0],
+            [0, 0, 1], [1, 0, 1], [1, 1, 1], [0, 1, 1],
+        ],
+        dtype=float,
+    ),
+}
+_VTK_CELL_TYPE = {1: VTK_LINE, 2: VTK_QUAD, 3: VTK_HEXAHEDRON}
+
+
+def read_time(filename):
+    """Return the simulation time stored in a samurai file, or ``None`` if absent.
+
+    ``samurai::dump`` combined with the ``MetadataWriter`` (see
+    ``include/samurai/io/metadata.hpp``) stores the time as the HDF5 root
+    attribute ``"time"``.
+    """
+    if not filename.endswith(".h5"):
+        filename = filename + ".h5"
+    try:
+        with h5py.File(filename, "r") as f:
+            if "time" in f.attrs:
+                return float(f.attrs["time"])
+    except OSError:
+        pass
+    return None
+
+
+def discover_series(filename):
+    """Return ``(files, times)`` for the numbered series containing ``filename``.
+
+    A file written per output step is named with a trailing integer before
+    ``.h5`` (e.g. ``sol_ite_0.h5``, ``sol_ite_1.h5``, ...).  Given any one of
+    them, this globs the siblings that share the same prefix so that opening a
+    single file exposes the whole animation.  If ``filename`` has no trailing
+    number, the series is just that one file.
+
+    Files are ordered by their trailing integer (natural order).  ``times`` are
+    the simulation times read from the ``"time"`` HDF5 attribute when **every**
+    file exposes it; otherwise they fall back to the trailing integers.
+    """
+    filename = os.path.abspath(filename)
+    if not filename.endswith(".h5"):
+        filename = filename + ".h5"
+    directory = os.path.dirname(filename)
+    base = os.path.basename(filename)[:-3]  # strip ".h5"
+
+    match = re.match(r"^(.*?)(\d+)$", base)
+    if match is None:
+        files = [filename]
+        iterations = [0]
+    else:
+        prefix = match.group(1)
+        pattern = re.compile(r"^" + re.escape(prefix) + r"(\d+)\.h5$")
+        try:
+            entries = os.listdir(directory or ".")
+        except OSError:
+            entries = []
+        found = []
+        for name in entries:
+            m = pattern.match(name)
+            if m is not None:
+                found.append((int(m.group(1)), os.path.join(directory, name)))
+        if not found:
+            files = [filename]
+            iterations = [0]
+        else:
+            found.sort()
+            files = [p for _, p in found]
+            iterations = [n for n, _ in found]
+
+    # Prefer the stored simulation time when available for every file.
+    times = [read_time(f) for f in files]
+    if any(t is None for t in times):
+        times = [float(n) for n in iterations]
+    return files, times
+
+
+def _slice_partitioned(group, rank):
+    """Return the ``rank``-th slice of a samurai partitioned dataset.
+
+    A partitioned dataset is a group holding ``data`` (the concatenated buffer of
+    every MPI rank) and ``partition`` (cumulative per-rank sizes, length
+    ``n_process + 1``); see ``dump(file, name, std::vector<T>)`` in
+    ``restart.hpp``.  Empty datasets are not written at all, hence the ``None``
+    handling by the caller.
+    """
+    partition = group["partition"][()]
+    begin = int(partition[rank])
+    end = int(partition[rank + 1])
+    return group["data"][begin:end]
+
+
+def _enumerate_level(cells, offsets, dim):
+    """Enumerate integer cell indices of a single level, in ``for_each_cell`` order.
+
+    ``cells[d]`` is the structured ``Interval`` array of ``m_cells[d]`` (fields
+    ``start``, ``end``, ``step``, ``index``).  ``offsets[d]`` (``d >= 1``) is
+    ``m_offsets[d-1]``: for an interval ``iv`` of direction ``d`` and a coordinate
+    ``c`` in ``[iv.start, iv.end)``, the attached intervals of direction ``d-1``
+    span ``offsets[d][iv.index + c] .. offsets[d][iv.index + c + 1]``.
+
+    Returns an ``(n_cells, dim)`` int array of the ``(i[, j[, k]])`` indices.
+    """
+    x_iv = cells[0]
+    if x_iv is None or len(x_iv) == 0:
+        return np.zeros((0, dim), dtype=np.int64)
+
+    x_start = x_iv["start"].astype(np.int64)
+    x_end = x_iv["end"].astype(np.int64)
+
+    def expand_rows(rows):
+        """rows: list of (xi_begin, xi_end, extra_indices).  Vectorized x-expansion."""
+        i_parts = []
+        extra_parts = [] if rows and len(rows[0][2]) else None
+        for xb, xe, extra in rows:
+            for xi in range(xb, xe):
+                rng = np.arange(x_start[xi], x_end[xi], dtype=np.int64)
+                i_parts.append(rng)
+                if extra_parts is not None:
+                    extra_parts.append(np.tile(extra, (rng.size, 1)))
+        if not i_parts:
+            return np.zeros((0, dim), dtype=np.int64)
+        i_col = np.concatenate(i_parts).reshape(-1, 1)
+        if extra_parts is None:
+            return i_col
+        return np.hstack([i_col, np.concatenate(extra_parts)])
+
+    if dim == 1:
+        return expand_rows([(0, len(x_iv), np.array([], dtype=np.int64))])
+
+    if dim == 2:
+        off0 = offsets[1].astype(np.int64)  # m_offsets[0]: y -> x-interval range
+        y_iv = cells[1]
+        rows = []
+        for yiv in y_iv:
+            base = np.int64(yiv["index"])
+            for y in range(int(yiv["start"]), int(yiv["end"])):
+                xb = off0[base + y]
+                xe = off0[base + y + 1]
+                rows.append((xb, xe, np.array([y], dtype=np.int64)))
+        return expand_rows(rows)
+
+    if dim == 3:
+        off0 = offsets[1].astype(np.int64)  # m_offsets[0]: y -> x-interval range
+        off1 = offsets[2].astype(np.int64)  # m_offsets[1]: z -> y-interval range
+        y_iv = cells[1]
+        z_iv = cells[2]
+        rows = []
+        for ziv in z_iv:
+            zbase = np.int64(ziv["index"])
+            for z in range(int(ziv["start"]), int(ziv["end"])):
+                yb = off1[zbase + z]
+                ye = off1[zbase + z + 1]
+                for yi in range(yb, ye):
+                    yiv = y_iv[yi]
+                    ybase = np.int64(yiv["index"])
+                    for y in range(int(yiv["start"]), int(yiv["end"])):
+                        xb = off0[ybase + y]
+                        xe = off0[ybase + y + 1]
+                        rows.append((xb, xe, np.array([y, z], dtype=np.int64)))
+        return expand_rows(rows)
+
+    raise ValueError(f"unsupported dimension {dim}")
+
+
+def _read_rank_indices(mesh, dim, min_level, max_level, rank):
+    """Rebuild the ``(indices, levels)`` of every cell owned by ``rank``.
+
+    Cells are concatenated level by level (min->max), matching the order in which
+    fields were flattened by ``extract_data_as_vector``.
+    """
+    all_indices = []
+    all_levels = []
+    for level in range(min_level, max_level + 1):
+        level_group = mesh.get(f"level/{level}")
+        if level_group is None:
+            continue
+        cells = {}
+        offsets = {}
+        empty = False
+        for d in range(dim):
+            iv_group = level_group.get(f"dim/{d}/intervals")
+            if iv_group is None:
+                empty = True
+                break
+            cells[d] = _slice_partitioned(iv_group, rank)
+            if d >= 1:
+                off_group = level_group.get(f"dim/{d}/offsets")
+                offsets[d] = _slice_partitioned(off_group, rank)
+        if empty or cells[0] is None or len(cells[0]) == 0:
+            continue
+        idx = _enumerate_level(cells, offsets, dim)
+        if idx.shape[0] == 0:
+            continue
+        all_indices.append(idx)
+        all_levels.append(np.full(idx.shape[0], level, dtype=np.int64))
+
+    if not all_indices:
+        return np.zeros((0, dim), dtype=np.int64), np.zeros((0,), dtype=np.int64)
+    return np.concatenate(all_indices), np.concatenate(all_levels)
+
+
+def _build_geometry(indices, levels, origin_point, scaling_factor, dim):
+    """Build ``(points, connectivity, centers)`` for the given cells.
+
+    Points are emitted per cell (no deduplication): simple and correct.  Points
+    are always 3D (zero padding for ``dim < 3``) as expected by VTK.
+    """
+    n_cells = indices.shape[0]
+    n_vertices = 1 << dim
+    unit = _UNIT_ELEMENT[dim]  # (n_vertices, dim)
+
+    length = (scaling_factor / (2.0 ** levels)).reshape(-1, 1)  # (n_cells, 1)
+    origin = np.asarray(origin_point, dtype=float).reshape(1, dim)
+
+    corner = origin + length * indices  # (n_cells, dim)
+    centers3 = np.zeros((n_cells, 3), dtype=float)
+    centers3[:, :dim] = corner + 0.5 * length
+
+    # vertices[c, k, :] = corner[c] + length[c] * unit[k]
+    verts = corner[:, None, :] + length[:, None, :] * unit[None, :, :]  # (n_cells, nv, dim)
+    points = np.zeros((n_cells * n_vertices, 3), dtype=float)
+    points[:, :dim] = verts.reshape(-1, dim)
+
+    connectivity = np.arange(n_cells * n_vertices, dtype=np.int64).reshape(n_cells, n_vertices)
+    return points, connectivity, centers3
+
+
+def load(filename, extra_arrays=True):
+    """Read a samurai ``.h5`` file and reconstruct the finite-element mesh.
+
+    Parameters
+    ----------
+    filename : str
+        Path to the samurai file (with or without the ``.h5`` extension).
+    extra_arrays : bool
+        Also expose ``level``, ``indices`` and ``center`` as cell arrays
+        (computed for free during reconstruction).
+
+    Returns
+    -------
+    list of dict
+        One block per MPI rank.  Each block has ``dim``, ``vtk_cell_type``,
+        ``points`` (N, 3), ``connectivity`` (n_cells, 2**dim), ``fields`` (a
+        ``{name: (n_cells, n_comp) array}`` mapping) and, if requested, the extra
+        cell arrays.
+    """
+    if not filename.endswith(".h5"):
+        filename = filename + ".h5"
+
+    with h5py.File(filename, "r") as f:
+        if "mesh/dim" not in f:
+            # Give an actionable message instead of a raw KeyError on 'dim'.
+            looks_like_save = ("mesh" in f) and any(
+                key in f["mesh"] for key in ("points", "connectivity")
+            )
+            if not looks_like_save and "mesh" in f:
+                # multi-rank save() nests points/connectivity under rank groups
+                looks_like_save = any(
+                    isinstance(f["mesh"][k], h5py.Group)
+                    and ("points" in f["mesh"][k] or "connectivity" in f["mesh"][k])
+                    for k in f["mesh"].keys()
+                )
+            if looks_like_save:
+                raise ValueError(
+                    f"'{filename}' looks like a samurai save() file (explicit "
+                    "points/connectivity mesh), which this reader does not handle. "
+                    "Open the compressed dump/restart file instead."
+                )
+            raise ValueError(
+                f"'{filename}' is not a samurai dump file: '/mesh/dim' is missing."
+            )
+
+        mesh = f["mesh"]
+        dim = int(f["mesh/dim"][()])
+        min_level = int(f["mesh/min_level"][()])
+        max_level = int(f["mesh/max_level"][()])
+        origin_point = np.asarray(f["mesh/origin_point"][()], dtype=float).reshape(-1)[:dim]
+        scaling_factor = float(f["mesh/scaling_factor"][()])
+        n_process = int(f["n_process"][()]) if "n_process" in f else 1
+
+        # Field metadata (n_comp) and partitioned data groups.
+        field_meta = {}
+        if "fields" in f:
+            for name in f["fields"].keys():
+                n_comp = int(f[f"fields/{name}/n_comp"][()])
+                field_meta[name] = n_comp
+
+        blocks = []
+        for rank in range(n_process):
+            indices, levels = _read_rank_indices(mesh, dim, min_level, max_level, rank)
+            n_cells = indices.shape[0]
+            points, connectivity, centers = _build_geometry(
+                indices, levels, origin_point, scaling_factor, dim
+            )
+
+            fields = {}
+            for name, n_comp in field_meta.items():
+                data_group = f[f"fields/{name}/data"]
+                flat = _slice_partitioned(data_group, rank)
+                values = np.asarray(flat).reshape(-1, n_comp)
+                if values.shape[0] != n_cells:
+                    raise ValueError(
+                        f"field '{name}' rank {rank}: {values.shape[0]} values for "
+                        f"{n_cells} reconstructed cells"
+                    )
+                fields[name] = values
+
+            block = {
+                "dim": dim,
+                "rank": rank,
+                "vtk_cell_type": _VTK_CELL_TYPE[dim],
+                "points": points,
+                "connectivity": connectivity,
+                "fields": fields,
+            }
+            if extra_arrays:
+                block["level"] = levels.astype(np.int32)
+                block["indices"] = indices.astype(np.int32)
+                block["center"] = centers
+            blocks.append(block)
+
+    return blocks

--- a/tools/paraview/samurai_load.py
+++ b/tools/paraview/samurai_load.py
@@ -270,13 +270,43 @@ def _build_geometry(indices, levels, origin_point, scaling_factor, dim):
     return points, connectivity, centers3
 
 
-def load(filename, extra_arrays=True):
+def _validate_samurai_group(root, filename):
+    """Raise a clear error if ``root`` is not a samurai mesh group."""
+    if "mesh/dim" in root:
+        return
+    # Give an actionable message instead of a raw KeyError on 'dim'.
+    looks_like_save = ("mesh" in root) and any(
+        key in root["mesh"] for key in ("points", "connectivity")
+    )
+    if not looks_like_save and "mesh" in root:
+        # multi-rank save() nests points/connectivity under rank groups
+        looks_like_save = any(
+            isinstance(root["mesh"][k], h5py.Group)
+            and ("points" in root["mesh"][k] or "connectivity" in root["mesh"][k])
+            for k in root["mesh"].keys()
+        )
+    if looks_like_save:
+        raise ValueError(
+            f"'{filename}' looks like a samurai save() file (explicit "
+            "points/connectivity mesh), which this reader does not handle. "
+            "Open the compressed dump/restart file instead."
+        )
+    raise ValueError(
+        f"'{filename}' is not a samurai dump file: '/mesh/dim' is missing."
+    )
+
+
+def load(filename, group=None, extra_arrays=True):
     """Read a samurai ``.h5`` file and reconstruct the finite-element mesh.
 
     Parameters
     ----------
     filename : str
         Path to the samurai file (with or without the ``.h5`` extension).
+    group : str, optional
+        HDF5 group under which the samurai layout (``mesh``, ``fields``,
+        ``n_process``) lives. Defaults to the file root. Pass e.g.
+        ``"grids/my_grid"`` for files that hold several grids side by side.
     extra_arrays : bool
         Also expose ``level``, ``indices`` and ``center`` as cell arrays
         (computed for free during reconstruction).
@@ -293,41 +323,22 @@ def load(filename, extra_arrays=True):
         filename = filename + ".h5"
 
     with h5py.File(filename, "r") as f:
-        if "mesh/dim" not in f:
-            # Give an actionable message instead of a raw KeyError on 'dim'.
-            looks_like_save = ("mesh" in f) and any(
-                key in f["mesh"] for key in ("points", "connectivity")
-            )
-            if not looks_like_save and "mesh" in f:
-                # multi-rank save() nests points/connectivity under rank groups
-                looks_like_save = any(
-                    isinstance(f["mesh"][k], h5py.Group)
-                    and ("points" in f["mesh"][k] or "connectivity" in f["mesh"][k])
-                    for k in f["mesh"].keys()
-                )
-            if looks_like_save:
-                raise ValueError(
-                    f"'{filename}' looks like a samurai save() file (explicit "
-                    "points/connectivity mesh), which this reader does not handle. "
-                    "Open the compressed dump/restart file instead."
-                )
-            raise ValueError(
-                f"'{filename}' is not a samurai dump file: '/mesh/dim' is missing."
-            )
+        root = f[group] if group else f
+        _validate_samurai_group(root, filename)
 
-        mesh = f["mesh"]
-        dim = int(f["mesh/dim"][()])
-        min_level = int(f["mesh/min_level"][()])
-        max_level = int(f["mesh/max_level"][()])
-        origin_point = np.asarray(f["mesh/origin_point"][()], dtype=float).reshape(-1)[:dim]
-        scaling_factor = float(f["mesh/scaling_factor"][()])
-        n_process = int(f["n_process"][()]) if "n_process" in f else 1
+        mesh = root["mesh"]
+        dim = int(root["mesh/dim"][()])
+        min_level = int(root["mesh/min_level"][()])
+        max_level = int(root["mesh/max_level"][()])
+        origin_point = np.asarray(root["mesh/origin_point"][()], dtype=float).reshape(-1)[:dim]
+        scaling_factor = float(root["mesh/scaling_factor"][()])
+        n_process = int(root["n_process"][()]) if "n_process" in root else 1
 
         # Field metadata (n_comp) and partitioned data groups.
         field_meta = {}
-        if "fields" in f:
-            for name in f["fields"].keys():
-                n_comp = int(f[f"fields/{name}/n_comp"][()])
+        if "fields" in root:
+            for name in root["fields"].keys():
+                n_comp = int(root[f"fields/{name}/n_comp"][()])
                 field_meta[name] = n_comp
 
         blocks = []
@@ -340,7 +351,7 @@ def load(filename, extra_arrays=True):
 
             fields = {}
             for name, n_comp in field_meta.items():
-                data_group = f[f"fields/{name}/data"]
+                data_group = root[f"fields/{name}/data"]
                 flat = _slice_partitioned(data_group, rank)
                 values = np.asarray(flat).reshape(-1, n_comp)
                 if values.shape[0] != n_cells:

--- a/tools/paraview/tests/generate_reference.cpp
+++ b/tools/paraview/tests/generate_reference.cpp
@@ -1,0 +1,122 @@
+// Copyright 2018-2025 the samurai's authors
+// SPDX-License-Identifier:  BSD-3-Clause
+//
+// Generates the small reference samurai files consumed by test_paraview_reader.py.
+// The field `u` is set to the analytic oracle
+//
+//     u(center) = sum_d center[d] * 10^d
+//
+// so that the Python reconstruction can verify value <-> geometry <-> ordering
+// without any tolerance ambiguity.  Regenerate with (see tools/paraview/README.md):
+//
+//   <mpicxx> -DSAMURAI_WITH_MPI ... generate_reference.cpp -o generate_reference
+//   ./generate_reference                    # writes ref_1d/2d/3d.h5
+//   mpirun -n 2 ./generate_reference --mpi  # writes ref_2d_mpi.h5
+//
+// The output directory is the first CLI argument (default: current directory).
+#include <cmath>
+#include <string>
+
+#include <samurai/algorithm.hpp>
+#include <samurai/box.hpp>
+#include <samurai/field.hpp>
+#include <samurai/io/restart.hpp>
+#include <samurai/mr/adapt.hpp>
+#include <samurai/mr/mesh.hpp>
+#include <samurai/samurai.hpp>
+
+template <class Coord>
+double analytic(const Coord& c, std::size_t dim)
+{
+    double v = 0., w = 1.;
+    for (std::size_t d = 0; d < dim; ++d)
+    {
+        v += w * c[d];
+        w *= 10.;
+    }
+    return v;
+}
+
+template <std::size_t dim>
+auto make_graded_mesh_and_field(std::size_t max_level, double eps, double sharpness)
+{
+    using Box = samurai::Box<double, dim>;
+    typename Box::point_t lo, hi;
+    lo.fill(0.);
+    hi.fill(1.);
+    Box box(lo, hi);
+
+    auto config = samurai::mesh_config<dim>().min_level(2).max_level(max_level).disable_minimal_ghost_width();
+    auto mesh   = samurai::mra::make_mesh(box, config);
+    auto u      = samurai::make_scalar_field<double>("u", mesh);
+
+    samurai::for_each_cell(mesh,
+                           [&](auto cell)
+                           {
+                               auto c    = cell.center();
+                               double r2 = 0.;
+                               for (std::size_t d = 0; d < dim; ++d)
+                               {
+                                   r2 += (c[d] - 0.5) * (c[d] - 0.5);
+                               }
+                               u[cell] = std::exp(-sharpness * r2);
+                           });
+
+    auto adapt = samurai::make_MRAdapt(u);
+    adapt(samurai::mra_config().epsilon(eps));
+
+    samurai::for_each_cell(mesh,
+                           [&](auto cell)
+                           {
+                               u[cell] = analytic(cell.center(), dim);
+                           });
+    return std::make_pair(std::move(mesh), std::move(u));
+}
+
+int main(int argc, char* argv[])
+{
+    samurai::initialize(argc, argv);
+
+    std::string dir = ".";
+    bool mpi        = false;
+    for (int i = 1; i < argc; ++i)
+    {
+        std::string a = argv[i];
+        if (a == "--mpi")
+        {
+            mpi = true;
+        }
+        else if (a[0] != '-')
+        {
+            dir = a;
+        }
+    }
+    auto path = [&](const std::string& f)
+    {
+        return dir + "/" + f;
+    };
+
+    if (mpi)
+    {
+        auto [mesh, u] = make_graded_mesh_and_field<2>(5, 1e-3, 200.);
+        samurai::dump(path("ref_2d_mpi"), mesh, u);
+    }
+    else
+    {
+        {
+            auto [mesh, u] = make_graded_mesh_and_field<1>(5, 1e-3, 200.);
+            samurai::dump(path("ref_1d"), mesh, u);
+        }
+        {
+            auto [mesh, u] = make_graded_mesh_and_field<2>(4, 1e-2, 100.);
+            samurai::dump(path("ref_2d"), mesh, u);
+        }
+        {
+            auto [mesh, u] = make_graded_mesh_and_field<3>(3, 1e-2, 30.);
+            samurai::dump(path("ref_3d"), mesh, u);
+        }
+    }
+
+    samurai::finalize();
+    return 0;
+}


### PR DESCRIPTION
## Description
Adds a ParaView Python reader plugin to open samurai “dump/restart” compressed HDF5 outputs directly in ParaView by reconstructing explicit geometry (points/connectivity) and exposing fields as cell data. It also introduces a reference-file generator plus pytest coverage, and wires CI to regenerate the reference .h5 files before running the new tests.

**Changes:**

- Implement `tools/paraview/samurai_load.py` (numpy+h5py) to reconstruct mesh geometry/traversal and discover time series.
- Add ParaView plugin entrypoint `tools/paraview/SamuraiReader.py` plus end-user documentation in `tools/paraview/README.md`.
- Add reference-file generator + pytest suite + CI steps to generate those references in builds (incl. MPI case).

## How has this been tested?
see `tests/test_paraview_reader.py`

## Code of Conduct
By submitting this PR, you agree to follow our [Code of Conduct](https://github.com/hpc-maths/samurai/blob/master/docs/CODE_OF_CONDUCT.md)
- [x] I agree to follow this project's Code of Conduct
