### PR TITLE
feat: yt reader

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -209,6 +209,13 @@ jobs:
                   mkdir -p tests/reference/paraview
                   ./build/tests/generate_paraview_reference tests/reference/paraview
 
+            - name: Generate yt reader reference files
+              shell: bash -l {0}
+              run: |
+                  export LD_LIBRARY_PATH="$CONDA_PREFIX/lib:$LD_LIBRARY_PATH"
+                  mkdir -p tests/reference/yt
+                  ./build/tests/generate_yt_reference tests/reference/yt
+
             - name: Test with pytest
               shell: bash -l {0}
               run: |
@@ -285,6 +292,7 @@ jobs:
                   cmake --build build --target finite-volume-lid-driven-cavity
                   cmake --build build --target finite-volume-burgers-os-2d-mpi
                   cmake --build build --target generate_paraview_reference
+                  cmake --build build --target generate_yt_reference
 
             - name: MPI test finite-volume-advection-2d
               shell: micromamba-shell {0}
@@ -451,6 +459,19 @@ jobs:
                   cd tests
                   pytest test_paraview_reader.py -v
 
+            - name: Generate yt reader reference files
+              shell: micromamba-shell {0}
+              run: |
+                  mkdir -p tests/reference/yt
+                  mpiexec -n 1 ./build/tests/generate_yt_reference tests/reference/yt
+                  mpiexec -n 2 ./build/tests/generate_yt_reference tests/reference/yt --mpi
+
+            - name: yt reader tests (pytest)
+              shell: micromamba-shell {0}
+              run: |
+                  cd tests
+                  pytest test_yt_reader.py -v
+
             - name: ccache statistics
               shell: micromamba-shell {0}
               if: always()
@@ -523,6 +544,12 @@ jobs:
               run: |
                   mkdir -p tests/reference/paraview
                   ./build/tests/generate_paraview_reference tests/reference/paraview
+
+            - name: Generate yt reader reference files
+              shell: bash -l {0}
+              run: |
+                  mkdir -p tests/reference/yt
+                  ./build/tests/generate_yt_reference tests/reference/yt
 
             - name: Run tests
               shell: bash -l {0}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -78,12 +78,16 @@ else()
     target_link_libraries(test_samurai_lib samurai gtest_main gtest)
 endif()
 
-# Standalone tool (no gtest): regenerates the small samurai files consumed by
-# test_paraview_reader.py. Not tracked in git (they are gitignored .h5 files),
-# so CI must build and run this before running that test.
+# Standalone tools (no gtest): regenerate the small samurai files consumed by
+# test_paraview_reader.py / test_yt_reader.py. Not tracked in git (they are
+# gitignored .h5 files), so CI must build and run these before running those tests.
 add_executable(generate_paraview_reference ${CMAKE_CURRENT_SOURCE_DIR}/../tools/paraview/tests/generate_reference.cpp)
 target_include_directories(generate_paraview_reference PRIVATE ${SAMURAI_INCLUDE_DIR})
 target_link_libraries(generate_paraview_reference samurai)
+
+add_executable(generate_yt_reference ${CMAKE_CURRENT_SOURCE_DIR}/../tools/yt/tests/generate_reference.cpp)
+target_include_directories(generate_yt_reference PRIVATE ${SAMURAI_INCLUDE_DIR})
+target_link_libraries(generate_yt_reference samurai)
 
 if(WITH_MPI)
     add_subdirectory(mpi)

--- a/tests/test_paraview_reader.py
+++ b/tests/test_paraview_reader.py
@@ -10,19 +10,32 @@ geometry reconstruction and the (offset-driven) ``for_each_cell`` traversal orde
 on which the flat field buffer relies.
 """
 
+import importlib.util
 import os
-import sys
 
 import numpy as np
 import pytest
 
 _HERE = os.path.dirname(os.path.abspath(__file__))
 _PLUGIN_DIR = os.path.join(_HERE, "..", "tools", "paraview")
-sys.path.insert(0, _PLUGIN_DIR)
 _REF_DIR = os.path.join(_HERE, "reference", "paraview")
 
 h5py = pytest.importorskip("h5py")
-from samurai_load import load, discover_series  # noqa: E402
+
+
+def _load_module(name, path):
+    # tools/paraview and tools/yt each ship a module named "samurai_load.py";
+    # loading both under that same name in one pytest session would make the
+    # second import silently reuse the first module (via sys.modules), so each
+    # plugin's module is loaded here under its own unique name instead.
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+_samurai_load = _load_module("paraview_samurai_load", os.path.join(_PLUGIN_DIR, "samurai_load.py"))
+load, discover_series = _samurai_load.load, _samurai_load.discover_series
 
 
 def analytic(centers, dim):

--- a/tests/test_yt_reader.py
+++ b/tests/test_yt_reader.py
@@ -1,0 +1,195 @@
+# Copyright 2018-2025 the samurai's authors
+# SPDX-License-Identifier:  BSD-3-Clause
+"""
+Validate the samurai yt loader (tools/yt/) against small reference files produced
+by tools/yt/tests/generate_reference.cpp.
+
+The reference field is the analytic oracle ``u(center) = sum_d center[d]*10**d``.
+Checking ``u == u(reconstructed center)`` for every cell validates, at once, the
+geometry reconstruction and the (offset-driven) ``for_each_cell`` traversal order
+on which the flat field buffer relies -- first at the patch level (pure numpy /
+h5py, no yt) and then end-to-end through a loaded yt dataset.
+"""
+
+import os
+import sys
+
+import numpy as np
+import pytest
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_PLUGIN_DIR = os.path.join(_HERE, "..", "tools", "yt")
+sys.path.insert(0, _PLUGIN_DIR)
+_REF_DIR = os.path.join(_HERE, "reference", "yt")
+
+h5py = pytest.importorskip("h5py")
+from samurai_load import discover_series, read_amr_grids, read_cells  # noqa: E402
+
+
+def analytic(centers, dim):
+    weights = 10.0 ** np.arange(dim)
+    return centers[:, :dim] @ weights
+
+
+# --------------------------------------------------------------------------- #
+# Pure reconstruction (numpy + h5py, no yt)                                    #
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize("name,dim", [("ref_1d", 1), ("ref_2d", 2), ("ref_3d", 3)])
+def test_cell_reconstruction(name, dim):
+    # Every leaf must carry the analytic value of its own center: validates the
+    # geometry and the for_each_cell traversal order at once.
+    centers, levels, fields, meta = read_cells(os.path.join(_REF_DIR, f"{name}.h5"))
+    assert meta["dim"] == dim
+    n_cells = centers.shape[0]
+    assert n_cells > 0
+    assert levels.shape == (n_cells,)
+    np.testing.assert_allclose(fields["u"], analytic(centers, dim), atol=1e-9)
+
+
+@pytest.mark.parametrize("name,dim", [("ref_1d", 1), ("ref_2d", 2), ("ref_3d", 3)])
+def test_amr_grid_structure(name, dim):
+    grids, meta = read_amr_grids(os.path.join(_REF_DIR, f"{name}.h5"))
+    assert len(grids) >= 1
+    dd = meta["domain_dimensions"]
+    assert dd[dim:].tolist() == [1] * (3 - dim)  # unused dims collapse to one cell
+    assert (dd[:dim] > 0).all()
+
+    # The root grid tiles the domain at level 0; refined grids sit above it.
+    root = grids[0]
+    assert root["level"] == 0
+    np.testing.assert_array_equal(root["dimensions"], dd)
+    child_dims = [2 if d < dim else 1 for d in range(3)]
+    for grid in grids[1:]:
+        assert grid["level"] >= 1
+        assert grid["dimensions"].tolist() == child_dims
+        assert grid["u"].shape == tuple(child_dims)
+
+
+def test_uniform_mesh_root_grid():
+    # A uniform min_level mesh: every cell is a leaf on the root grid, so the
+    # reconstruction must be a single level-0 grid full of real (non-masked)
+    # values -- the one path the graded meshes never exercise.
+    grids, meta = read_amr_grids(os.path.join(_REF_DIR, "ref_uniform.h5"))
+    assert len(grids) == 1
+    assert grids[0]["level"] == 0
+
+    centers, levels, fields, _ = read_cells(os.path.join(_REF_DIR, "ref_uniform.h5"))
+    assert set(levels.tolist()) == {meta["min_level"]}
+    np.testing.assert_allclose(fields["u"], analytic(centers, 2), atol=1e-9)
+
+
+def test_mpi_reconstruction():
+    ref = os.path.join(_REF_DIR, "ref_2d_mpi.h5")
+    if not os.path.exists(ref):
+        pytest.skip("ref_2d_mpi.h5 not generated (requires an MPI-enabled build)")
+    centers, _, fields, _ = read_cells(ref)
+    np.testing.assert_allclose(fields["u"], analytic(centers, 2), atol=1e-9)
+
+    # Ranks partition the mesh: every cell appears exactly once.
+    keys = {tuple(np.round(c, 9)) for c in centers}
+    assert len(keys) == centers.shape[0]
+
+
+def test_load_from_subgroup(tmp_path):
+    # A file may hold the samurai layout under a subgroup; read_cells(group=...)
+    # must reconstruct it identically to a root-level file.
+    ref = os.path.join(_REF_DIR, "ref_2d.h5")
+    nested = tmp_path / "multigrid.h5"
+    with h5py.File(ref, "r") as src, h5py.File(nested, "w") as dst:
+        grid = dst.create_group("grids/g0")
+        for key in ("mesh", "fields", "n_process"):
+            src.copy(key, grid)
+
+    root_centers, _, root_fields, _ = read_cells(ref)
+    nested_centers, _, nested_fields, _ = read_cells(str(nested), group="grids/g0")
+    np.testing.assert_array_equal(nested_centers, root_centers)
+    np.testing.assert_array_equal(nested_fields["u"], root_fields["u"])
+
+
+def test_rejects_save_file(tmp_path):
+    path = tmp_path / "explicit.h5"
+    with h5py.File(path, "w") as f:
+        grp = f.create_group("mesh")
+        grp.create_dataset("points", data=np.zeros((4, 3)))
+        grp.create_dataset("connectivity", data=np.zeros((1, 4), dtype=np.int64))
+    with pytest.raises(ValueError, match="save"):
+        read_cells(str(path))
+
+
+def test_rejects_non_samurai_file(tmp_path):
+    path = tmp_path / "empty.h5"
+    with h5py.File(path, "w"):
+        pass
+    with pytest.raises(ValueError, match="not a samurai dump"):
+        read_cells(str(path))
+
+
+def test_discover_series(tmp_path):
+    for n in (0, 1, 2, 10):
+        (tmp_path / f"sol_ite_{n}.h5").write_bytes(b"")
+    (tmp_path / "other.h5").write_bytes(b"")  # unrelated, must be ignored
+
+    files, times = discover_series(str(tmp_path / "sol_ite_1.h5"))
+    assert times == [0.0, 1.0, 2.0, 10.0]  # natural order: 2 before 10
+    assert [os.path.basename(f) for f in files] == [
+        "sol_ite_0.h5", "sol_ite_1.h5", "sol_ite_2.h5", "sol_ite_10.h5"
+    ]
+
+
+def test_discover_series_uses_time_attribute(tmp_path):
+    physical_times = [0.0, 0.05, 0.1]
+    for n, t in enumerate(physical_times):
+        with h5py.File(tmp_path / f"sol_ite_{n}.h5", "w") as f:
+            f.attrs["time"] = t
+    _, times = discover_series(str(tmp_path / "sol_ite_0.h5"))
+    assert times == physical_times
+
+
+# --------------------------------------------------------------------------- #
+# End-to-end through yt                                                        #
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize(
+    "name,dim", [("ref_1d", 1), ("ref_2d", 2), ("ref_3d", 3), ("ref_uniform", 2)]
+)
+def test_yt_dataset(name, dim):
+    pytest.importorskip("yt")
+    from samurai_yt import load_samurai
+
+    ds = load_samurai(os.path.join(_REF_DIR, f"{name}.h5"))
+    assert int(ds.dimensionality) == dim
+
+    ad = ds.all_data()
+    coords = ["x", "y", "z"]
+    centers = np.stack(
+        [np.asarray(ad["index", coords[d]]) for d in range(dim)], axis=1
+    )
+    u = np.asarray(ad["stream", "u"])
+    assert u.shape[0] > 0
+    # Reconstructed leaves carry the analytic value of their own centers: this
+    # cross-checks geometry and traversal order end-to-end through yt.
+    np.testing.assert_allclose(u, analytic(centers, dim), atol=1e-9)
+
+
+def test_yt_time():
+    yt = pytest.importorskip("yt")
+    from samurai_yt import load_samurai
+
+    ref = os.path.join(_REF_DIR, "ref_2d.h5")
+    ds = load_samurai(ref)
+    with h5py.File(ref, "r") as f:
+        expected = float(f.attrs["time"]) if "time" in f.attrs else 0.0
+    assert float(ds.current_time) == pytest.approx(expected)
+
+
+def test_yt_fields_are_linear_by_default():
+    # PDE fields must default to a linear scale: yt otherwise guesses a log
+    # scale and turns tiny over/undershoots into visual noise (issue seen on
+    # the advection demo).
+    pytest.importorskip("yt")
+    from samurai_yt import load_samurai
+
+    ds = load_samurai(os.path.join(_REF_DIR, "ref_2d.h5"))
+    assert ds.field_info["stream", "u"].take_log is False
+
+    ds_log = load_samurai(os.path.join(_REF_DIR, "ref_2d.h5"), take_log=True)
+    assert ds_log.field_info["stream", "u"].take_log is True

--- a/tests/test_yt_reader.py
+++ b/tests/test_yt_reader.py
@@ -1,14 +1,15 @@
 # Copyright 2018-2025 the samurai's authors
 # SPDX-License-Identifier:  BSD-3-Clause
 """
-Validate the samurai yt loader (tools/yt/) against small reference files produced
-by tools/yt/tests/generate_reference.cpp.
+Validate the samurai yt loader (tools/yt/) against small reference files.
 
-The reference field is the analytic oracle ``u(center) = sum_d center[d]*10**d``.
-Checking ``u == u(reconstructed center)`` for every cell validates, at once, the
-geometry reconstruction and the (offset-driven) ``for_each_cell`` traversal order
-on which the flat field buffer relies -- first at the patch level (pure numpy /
-h5py, no yt) and then end-to-end through a loaded yt dataset.
+The reference files are produced by tools/yt/tests/generate_reference.cpp.
+The reference field is the analytic oracle ``u(center) = sum_d
+center[d]*10**d``. Checking ``u == u(reconstructed center)`` for every cell
+validates, at once, the geometry reconstruction and the (offset-driven)
+``for_each_cell`` traversal order on which the flat field buffer relies --
+first at the patch level (pure numpy / h5py, no yt) and then end-to-end
+through a loaded yt dataset.
 """
 
 import os
@@ -171,7 +172,7 @@ def test_yt_dataset(name, dim):
 
 
 def test_yt_time():
-    yt = pytest.importorskip("yt")
+    pytest.importorskip("yt")
     from samurai_yt import load_samurai
 
     ref = os.path.join(_REF_DIR, "ref_2d.h5")

--- a/tools/yt/README.md
+++ b/tools/yt/README.md
@@ -1,0 +1,178 @@
+# yt loader for samurai files
+
+Samurai writes its state as a **compressed HDF5 file** that stores only its
+internal interval representation of the mesh (via `samurai::dump`; this is
+becoming samurai's standard format, read back with `samurai::load`). The file is
+compact but not directly usable, because no explicit geometry is stored.
+
+This loader opens such a file directly in [yt](https://yt-project.org): it
+rebuilds the adaptive mesh on the fly and hands it to yt as an AMR dataset, so
+the full yt toolbox (slices, projections, profiles, volume rendering, derived
+fields) works on samurai data.
+
+## Files
+
+| File                           | Role                                                                                                                                        |
+| ------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| `samurai_load.py`              | Pure `numpy` + `h5py` reconstruction of a samurai file. No yt dependency; unit-testable. Exposes `read_cells()`, `read_amr_grids()`, `discover_series()`, `read_time()`. |
+| `samurai_yt.py`                | Thin yt wrapper. Exposes `load_samurai()` and `load_samurai_series()`.                                                                       |
+| `tests/generate_reference.cpp` | Regenerates the small reference files used by the tests.                                                                                     |
+
+## Requirements
+
+- **yt 4.x** and **`h5py`** (with `numpy`) in the same Python environment.
+
+```bash
+python -m pip install yt h5py
+```
+
+## Usage
+
+```python
+import yt
+import samurai_yt
+
+ds = samurai_yt.load_samurai("solution.h5")   # a samurai::dump file
+
+# Anything yt can do on an AMR dataset now works:
+yt.SlicePlot(ds, "z", ("stream", "u")).save()
+print(ds.all_data().quantities.extrema(("stream", "u")))
+```
+
+Fields are exposed under the `"stream"` field type: a scalar field `u` becomes
+`("stream", "u")`; a vector field `v` with `n` components becomes
+`("stream", "v_0")`, ..., `("stream", "v_<n-1>")`.
+
+Fields default to a **linear** color scale, which is the sensible default for the
+PDE solutions samurai produces: otherwise yt guesses a log scale from the value
+range and turns tiny numerical over/undershoots (and any negative value) into
+misleading visual noise. Pass `take_log=True` to `load_samurai` to restore yt's
+log scale, or set it per plot with `plot.set_log(("stream", "u"), True)`.
+
+If `samurai_yt` is not on the Python path, add the plugin directory first:
+
+```python
+import sys; sys.path.insert(0, "/path/to/samurai/tools/yt")
+```
+
+### Showing the mesh
+
+Overlay the samurai mesh on a slice with `annotate_cell_edges`:
+
+```python
+p = yt.SlicePlot(ds, "z", ("stream", "u"))
+p.annotate_cell_edges()
+p.zoom(8)                        # zoom in: cells get tiny in refined regions
+p.save()
+```
+
+You can also color directly by refinement level with the built-in field
+`("index", "grid_level")`:
+
+```python
+yt.SlicePlot(ds, "z", ("index", "grid_level")).save()
+```
+
+**Prefer `annotate_cell_edges` over `annotate_grids` here.** `annotate_grids`
+draws the boundary of each yt *grid object*, not of each cell -- and the
+unrefined background is a single grid object covering the whole domain (see
+"How it works" below), so `annotate_grids` shows no lines at all there, which
+can look like cells are missing. It isn't a bug: `annotate_cell_edges` on the
+same dataset shows every cell, including the coarse background.
+
+### Time series / animations
+
+Write one file per output step with a numbered suffix, e.g. `sol_ite_0.h5`,
+`sol_ite_1.h5`, ... (this is what the `--nfiles` option of the demos produces via
+the `_ite_{n}` suffix). Then load the whole series from **any one file**:
+
+```python
+series = samurai_yt.load_samurai_series("sol_ite_0.h5")
+for ds in series:
+    yt.SlicePlot(ds, "z", ("stream", "u")).save(f"frame_{ds.current_time}")
+```
+
+The siblings sharing the same prefix are discovered on disk (natural order, `_2`
+before `_10`). Each dataset's `current_time` is the **physical** simulation time
+when the file stores it — i.e. the `"time"` HDF5 root attribute written by
+samurai's `MetadataWriter` (`include/samurai/io/metadata.hpp`, `.time(t)`) — and
+falls back to the iteration number otherwise. To record the physical time, pass a
+metadata callback to `samurai::dump`:
+
+```cpp
+samurai::dump(path, fmt::format("sol_ite_{}", n),
+              [&](samurai::MetadataWriter& m) { m.time(t); },
+              mesh, u);
+```
+
+### MPI files
+
+A file written by an MPI run stores one slice per rank. The loader reads every
+rank and merges them into a single AMR hierarchy, so an MPI run and a sequential
+run produce the same dataset.
+
+### Raw cell data (without yt)
+
+`samurai_load.read_cells()` returns the leaf cells as plain numpy arrays
+(`centers`, `levels`, `fields`) with no yt dependency — handy for quick analysis
+or testing.
+
+## How it works
+
+Samurai is **cell-based** (octree) AMR: any cell may be a leaf, and a refined
+cell splits into `2**dim` children. yt's `load_amr_grids` expects **block** AMR
+(Enzo style), where every grid begins on a cell edge of its *parent* level. A
+lone fine cell on an odd index (the second child of its parent) does not, so
+cells cannot be handed to yt one by one.
+
+The loader therefore rebuilds the octree as block-aligned grids:
+
+1. it reproduces the `for_each_cell` traversal (the offset-driven interval
+   iterator of `LevelCellArray`) to recover each leaf's integer index and value —
+   essential because field values are stored as a flat buffer in exactly that
+   order, with no explicit indexing;
+2. it emits one root grid covering the whole domain at `min_level` (yt level 0),
+   then one `2**dim`-cell grid per refined cell, whose left edge is the parent
+   cell edge — exactly what yt's alignment check wants. Grid edges are computed
+   with yt's own `linspace` arithmetic so they match that check bit for bit.
+
+Cells covered by a finer grid are masked by yt, so a coarse cell's placeholder
+value is never selected — only the leaves survive, each with its own value.
+
+## Tests
+
+`tests/test_yt_reader.py` (run from the repository test suite) reconstructs the
+reference files in `tests/reference/yt/` and checks that every cell carries the
+analytic value `u = sum_d center[d]*10**d` of its own center — validating
+geometry **and** traversal order simultaneously — both at the cell level (no yt)
+and end-to-end through a loaded yt dataset, plus the MPI and uniform-mesh cases.
+
+### Regenerating the reference files
+
+Build the `generate_yt_reference` CMake target (requires `-DBUILD_TESTS=ON`) and
+run it — or compile `tests/generate_reference.cpp` by hand against the samurai
+headers. Example (adapt the toolchain to your environment):
+
+```bash
+mpic++ -DSAMURAI_WITH_MPI -DSAMURAI_ENABLE_INLINE \
+  -DSAMURAI_FIELD_CONTAINER_XTENSOR -DSAMURAI_FLUX_CONTAINER_XTENSOR \
+  -DSAMURAI_STATIC_MAT_CONTAINER_XTENSOR -DFMT_SHARED \
+  -I../../../include -std=c++20 \
+  tests/generate_reference.cpp -o generate_reference \
+  -lhdf5 -lpugixml -lfmt -lboost_mpi -lboost_serialization
+
+./generate_reference ../../../tests/reference/yt             # ref_1d/2d/3d/uniform.h5
+mpirun -n 2 ./generate_reference ../../../tests/reference/yt --mpi  # ref_2d_mpi.h5
+```
+
+`.h5` files are git-ignored globally, so the reference fixtures must be added
+with `git add -f`.
+
+## Current limitations
+
+- A samurai file only contains the leaf cells (`mesh_id_t::cells`). Other
+  submeshes (ghosts, `by_mesh_id`) are not reconstructible from it.
+- The root grid is dense at `min_level`: a very large `min_level` makes it heavy.
+  Typical samurai meshes use a small `min_level`, so this is rarely an issue.
+- The domain is assumed rectangular (the common case). A hole in the coarse
+  covering would read back as an empty region rather than an error.

--- a/tools/yt/README.md
+++ b/tools/yt/README.md
@@ -12,11 +12,13 @@ fields) works on samurai data.
 
 ## Files
 
-| File                           | Role                                                                                                                                        |
-| ------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------- |
-| `samurai_load.py`              | Pure `numpy` + `h5py` reconstruction of a samurai file. No yt dependency; unit-testable. Exposes `read_cells()`, `read_amr_grids()`, `discover_series()`, `read_time()`. |
-| `samurai_yt.py`                | Thin yt wrapper. Exposes `load_samurai()` and `load_samurai_series()`.                                                                       |
-| `tests/generate_reference.cpp` | Regenerates the small reference files used by the tests.                                                                                     |
+- `samurai_load.py` — pure `numpy` + `h5py` reconstruction of a samurai file.
+  No yt dependency; unit-testable. Exposes `read_cells()`, `read_amr_grids()`,
+  `discover_series()`, `read_time()`.
+- `samurai_yt.py` — thin yt wrapper. Exposes `load_samurai()` and
+  `load_samurai_series()`.
+- `tests/generate_reference.cpp` — regenerates the small reference files used
+  by the tests.
 
 ## Requirements
 
@@ -43,11 +45,12 @@ Fields are exposed under the `"stream"` field type: a scalar field `u` becomes
 `("stream", "u")`; a vector field `v` with `n` components becomes
 `("stream", "v_0")`, ..., `("stream", "v_<n-1>")`.
 
-Fields default to a **linear** color scale, which is the sensible default for the
-PDE solutions samurai produces: otherwise yt guesses a log scale from the value
-range and turns tiny numerical over/undershoots (and any negative value) into
-misleading visual noise. Pass `take_log=True` to `load_samurai` to restore yt's
-log scale, or set it per plot with `plot.set_log(("stream", "u"), True)`.
+Fields default to a **linear** color scale, which is the sensible default for
+the PDE solutions samurai produces: otherwise yt guesses a log scale from the
+value range and turns tiny numerical over/undershoots (and any negative
+value) into misleading visual noise. Pass `take_log=True` to `load_samurai`
+to restore yt's log scale, or set it per plot with
+`plot.set_log(("stream", "u"), True)`.
 
 If `samurai_yt` is not on the Python path, add the plugin directory first:
 
@@ -83,8 +86,8 @@ same dataset shows every cell, including the coarse background.
 ### Time series / animations
 
 Write one file per output step with a numbered suffix, e.g. `sol_ite_0.h5`,
-`sol_ite_1.h5`, ... (this is what the `--nfiles` option of the demos produces via
-the `_ite_{n}` suffix). Then load the whole series from **any one file**:
+`sol_ite_1.h5`, ... (this is what the `--nfiles` option of the demos produces
+via the `_ite_{n}` suffix). Then load the whole series from **any one file**:
 
 ```python
 series = samurai_yt.load_samurai_series("sol_ite_0.h5")
@@ -92,12 +95,13 @@ for ds in series:
     yt.SlicePlot(ds, "z", ("stream", "u")).save(f"frame_{ds.current_time}")
 ```
 
-The siblings sharing the same prefix are discovered on disk (natural order, `_2`
-before `_10`). Each dataset's `current_time` is the **physical** simulation time
-when the file stores it — i.e. the `"time"` HDF5 root attribute written by
-samurai's `MetadataWriter` (`include/samurai/io/metadata.hpp`, `.time(t)`) — and
-falls back to the iteration number otherwise. To record the physical time, pass a
-metadata callback to `samurai::dump`:
+The siblings sharing the same prefix are discovered on disk (natural order,
+`_2` before `_10`). Each dataset's `current_time` is the **physical**
+simulation time when the file stores it — i.e. the `"time"` HDF5 root
+attribute written by samurai's `MetadataWriter`
+(`include/samurai/io/metadata.hpp`, `.time(t)`) — and falls back to the
+iteration number otherwise. To record the physical time, pass a metadata
+callback to `samurai::dump`:
 
 ```cpp
 samurai::dump(path, fmt::format("sol_ite_{}", n),
@@ -114,8 +118,8 @@ run produce the same dataset.
 ### Raw cell data (without yt)
 
 `samurai_load.read_cells()` returns the leaf cells as plain numpy arrays
-(`centers`, `levels`, `fields`) with no yt dependency — handy for quick analysis
-or testing.
+(`centers`, `levels`, `fields`) with no yt dependency — handy for quick
+analysis or testing.
 
 ## How it works
 
@@ -128,30 +132,32 @@ cells cannot be handed to yt one by one.
 The loader therefore rebuilds the octree as block-aligned grids:
 
 1. it reproduces the `for_each_cell` traversal (the offset-driven interval
-   iterator of `LevelCellArray`) to recover each leaf's integer index and value —
-   essential because field values are stored as a flat buffer in exactly that
-   order, with no explicit indexing;
-2. it emits one root grid covering the whole domain at `min_level` (yt level 0),
-   then one `2**dim`-cell grid per refined cell, whose left edge is the parent
-   cell edge — exactly what yt's alignment check wants. Grid edges are computed
-   with yt's own `linspace` arithmetic so they match that check bit for bit.
+   iterator of `LevelCellArray`) to recover each leaf's integer index and
+   value — essential because field values are stored as a flat buffer in
+   exactly that order, with no explicit indexing;
+2. it emits one root grid covering the whole domain at `min_level` (yt level
+   0), then one `2**dim`-cell grid per refined cell, whose left edge is the
+   parent cell edge — exactly what yt's alignment check wants. Grid edges are
+   computed with yt's own `linspace` arithmetic so they match that check bit
+   for bit.
 
 Cells covered by a finer grid are masked by yt, so a coarse cell's placeholder
 value is never selected — only the leaves survive, each with its own value.
 
 ## Tests
 
-`tests/test_yt_reader.py` (run from the repository test suite) reconstructs the
-reference files in `tests/reference/yt/` and checks that every cell carries the
-analytic value `u = sum_d center[d]*10**d` of its own center — validating
-geometry **and** traversal order simultaneously — both at the cell level (no yt)
-and end-to-end through a loaded yt dataset, plus the MPI and uniform-mesh cases.
+`tests/test_yt_reader.py` (run from the repository test suite) reconstructs
+the reference files in `tests/reference/yt/` and checks that every cell
+carries the analytic value `u = sum_d center[d]*10**d` of its own center —
+validating geometry **and** traversal order simultaneously — both at the cell
+level (no yt) and end-to-end through a loaded yt dataset, plus the MPI and
+uniform-mesh cases.
 
 ### Regenerating the reference files
 
-Build the `generate_yt_reference` CMake target (requires `-DBUILD_TESTS=ON`) and
-run it — or compile `tests/generate_reference.cpp` by hand against the samurai
-headers. Example (adapt the toolchain to your environment):
+Build the `generate_yt_reference` CMake target (requires `-DBUILD_TESTS=ON`)
+and run it — or compile `tests/generate_reference.cpp` by hand against the
+samurai headers. Example (adapt the toolchain to your environment):
 
 ```bash
 mpic++ -DSAMURAI_WITH_MPI -DSAMURAI_ENABLE_INLINE \
@@ -161,8 +167,10 @@ mpic++ -DSAMURAI_WITH_MPI -DSAMURAI_ENABLE_INLINE \
   tests/generate_reference.cpp -o generate_reference \
   -lhdf5 -lpugixml -lfmt -lboost_mpi -lboost_serialization
 
-./generate_reference ../../../tests/reference/yt             # ref_1d/2d/3d/uniform.h5
-mpirun -n 2 ./generate_reference ../../../tests/reference/yt --mpi  # ref_2d_mpi.h5
+# writes ref_1d/2d/3d/uniform.h5
+./generate_reference ../../../tests/reference/yt
+# writes ref_2d_mpi.h5
+mpirun -n 2 ./generate_reference ../../../tests/reference/yt --mpi
 ```
 
 `.h5` files are git-ignored globally, so the reference fixtures must be added
@@ -172,7 +180,8 @@ with `git add -f`.
 
 - A samurai file only contains the leaf cells (`mesh_id_t::cells`). Other
   submeshes (ghosts, `by_mesh_id`) are not reconstructible from it.
-- The root grid is dense at `min_level`: a very large `min_level` makes it heavy.
+- The root grid is dense at `min_level`: a very large `min_level` makes it
+  heavy.
   Typical samurai meshes use a small `min_level`, so this is rarely an issue.
 - The domain is assumed rectangular (the common case). A hole in the coarse
   covering would read back as an empty region rather than an error.

--- a/tools/yt/samurai_load.py
+++ b/tools/yt/samurai_load.py
@@ -1,0 +1,461 @@
+# Copyright 2018-2025 the samurai's authors
+# SPDX-License-Identifier:  BSD-3-Clause
+"""
+Reconstruction of a samurai data file as a list of AMR grids, ready to be handed
+to ``yt.load_amr_grids``.
+
+This module only depends on ``numpy`` and ``h5py`` so that it can be unit-tested
+without yt.  The yt loader (``samurai_yt.py``) is a thin wrapper that turns the
+grids returned here into a ``StreamDataset``.
+
+Samurai never stores the cell geometry.  A data file only contains, per level and
+per direction, the compressed interval representation of the mesh (``m_cells`` /
+``m_offsets``, see ``include/samurai/level_cell_array.hpp``) plus ``dim``,
+``min_level``/``max_level``, ``origin_point`` and ``scaling_factor``.  Field
+values carry no stored indexing: their order is exactly the traversal order of
+``for_each_cell`` (levels min->max, then the offset-driven interval iterator of
+each level).
+
+Mapping samurai to yt
+---------------------
+Samurai is *cell-based* (octree) AMR: any cell can be a leaf, and a refined cell
+splits into ``2**dim`` children.  yt's :func:`yt.load_amr_grids` expects
+*block* AMR (Enzo style): every grid must start on a cell edge of its **parent**
+level.  A lone fine cell sitting on an odd index (the second child of its parent)
+does not, so cells cannot be handed to yt one by one.
+
+We therefore rebuild the octree as block-aligned grids:
+
+* one root grid covering the whole domain at ``min_level`` (yt level 0);
+* for every refined (internal) cell, one ``2**dim``-cell grid holding its
+  children, whose left edge is the parent cell edge -- exactly what yt wants.
+
+Cells covered by a finer grid are masked by yt, so a coarse cell's placeholder
+value is never selected; only leaves survive, each with its own value.  Grid
+edges are computed with yt's own ``linspace`` formula so they match the internal
+alignment check (bug #1295) bit for bit.
+"""
+
+import os
+import re
+
+import numpy as np
+import h5py
+
+
+def read_time(filename):
+    """Return the simulation time stored in a samurai file, or ``None`` if absent.
+
+    ``samurai::dump`` combined with the ``MetadataWriter`` (see
+    ``include/samurai/io/metadata.hpp``) stores the time as the HDF5 root
+    attribute ``"time"``.
+    """
+    if not filename.endswith(".h5"):
+        filename = filename + ".h5"
+    try:
+        with h5py.File(filename, "r") as f:
+            if "time" in f.attrs:
+                return float(f.attrs["time"])
+    except OSError:
+        pass
+    return None
+
+
+def discover_series(filename):
+    """Return ``(files, times)`` for the numbered series containing ``filename``.
+
+    A file written per output step is named with a trailing integer before
+    ``.h5`` (e.g. ``sol_ite_0.h5``, ``sol_ite_1.h5``, ...).  Given any one of
+    them, this globs the siblings that share the same prefix so that opening a
+    single file exposes the whole animation.  If ``filename`` has no trailing
+    number, the series is just that one file.
+
+    Files are ordered by their trailing integer (natural order).  ``times`` are
+    the simulation times read from the ``"time"`` HDF5 attribute when **every**
+    file exposes it; otherwise they fall back to the trailing integers.
+    """
+    filename = os.path.abspath(filename)
+    if not filename.endswith(".h5"):
+        filename = filename + ".h5"
+    directory = os.path.dirname(filename)
+    base = os.path.basename(filename)[:-3]  # strip ".h5"
+
+    match = re.match(r"^(.*?)(\d+)$", base)
+    if match is None:
+        files = [filename]
+        iterations = [0]
+    else:
+        prefix = match.group(1)
+        pattern = re.compile(r"^" + re.escape(prefix) + r"(\d+)\.h5$")
+        try:
+            entries = os.listdir(directory or ".")
+        except OSError:
+            entries = []
+        found = []
+        for name in entries:
+            m = pattern.match(name)
+            if m is not None:
+                found.append((int(m.group(1)), os.path.join(directory, name)))
+        if not found:
+            files = [filename]
+            iterations = [0]
+        else:
+            found.sort()
+            files = [p for _, p in found]
+            iterations = [n for n, _ in found]
+
+    # Prefer the stored simulation time when available for every file.
+    times = [read_time(f) for f in files]
+    if any(t is None for t in times):
+        times = [float(n) for n in iterations]
+    return files, times
+
+
+def _slice_partitioned(group, rank):
+    """Return the ``rank``-th slice of a samurai partitioned dataset.
+
+    A partitioned dataset is a group holding ``data`` (the concatenated buffer of
+    every MPI rank) and ``partition`` (cumulative per-rank sizes, length
+    ``n_process + 1``); see ``dump(file, name, std::vector<T>)`` in
+    ``restart.hpp``.
+    """
+    partition = group["partition"][()]
+    begin = int(partition[rank])
+    end = int(partition[rank + 1])
+    return group["data"][begin:end]
+
+
+def _enumerate_intervals(cells, offsets, dim):
+    """Yield the mesh intervals of one level in ``for_each_cell`` order.
+
+    Each yielded tuple ``(x_start, x_end, y, z)`` is one x-run of contiguous
+    cells (``y``/``z`` default to ``0`` in the unused dimensions).  ``cells[d]``
+    is the structured ``Interval`` array of ``m_cells[d]`` (fields ``start``,
+    ``end``, ``step``, ``index``).  ``offsets[d]`` (``d >= 1``) is ``m_offsets[d-1]``:
+    for an interval ``iv`` of direction ``d`` and a coordinate ``c`` in
+    ``[iv.start, iv.end)``, the attached intervals of direction ``d-1`` span
+    ``offsets[d][iv.index + c] .. offsets[d][iv.index + c + 1]``.
+
+    Yielding in this exact order is what keeps the flat field buffer aligned with
+    the reconstructed patches.
+    """
+    x_iv = cells[0]
+    if x_iv is None or len(x_iv) == 0:
+        return
+    x_start = x_iv["start"].astype(np.int64)
+    x_end = x_iv["end"].astype(np.int64)
+
+    if dim == 1:
+        for xi in range(len(x_iv)):
+            yield int(x_start[xi]), int(x_end[xi]), 0, 0
+        return
+
+    if dim == 2:
+        off0 = offsets[1].astype(np.int64)  # m_offsets[0]: y -> x-interval range
+        for yiv in cells[1]:
+            base = int(yiv["index"])
+            for y in range(int(yiv["start"]), int(yiv["end"])):
+                for xi in range(off0[base + y], off0[base + y + 1]):
+                    yield int(x_start[xi]), int(x_end[xi]), y, 0
+        return
+
+    if dim == 3:
+        off0 = offsets[1].astype(np.int64)  # m_offsets[0]: y -> x-interval range
+        off1 = offsets[2].astype(np.int64)  # m_offsets[1]: z -> y-interval range
+        y_iv = cells[1]
+        for ziv in cells[2]:
+            zbase = int(ziv["index"])
+            for z in range(int(ziv["start"]), int(ziv["end"])):
+                for yi in range(off1[zbase + z], off1[zbase + z + 1]):
+                    yiv = y_iv[yi]
+                    ybase = int(yiv["index"])
+                    for y in range(int(yiv["start"]), int(yiv["end"])):
+                        for xi in range(off0[ybase + y], off0[ybase + y + 1]):
+                            yield int(x_start[xi]), int(x_end[xi]), y, z
+        return
+
+    raise ValueError(f"unsupported dimension {dim}")
+
+
+def _read_leaves(root, fields, dim, min_level, max_level, n_process):
+    """Read every leaf cell as ``(keys, levels, values)``.
+
+    ``keys`` is an ``(n_cells, 3)`` int array of ``(i, j, k)`` indices at each
+    cell's own level (unused dimensions are ``0``); ``levels`` its per-cell level;
+    ``values`` a ``{field: (n_cells, n_comp)}`` mapping.  Ranks are read in turn
+    and concatenated, so the flat field buffers stay aligned with the cells.
+    """
+    mesh = root["mesh"]
+    key_parts, level_parts = [], []
+    value_parts = {name: [] for name in fields}
+
+    for rank in range(n_process):
+        rank_keys, rank_levels = [], []
+        for level in range(min_level, max_level + 1):
+            level_group = mesh.get(f"level/{level}")
+            if level_group is None:
+                continue
+            cells, offsets, empty = {}, {}, False
+            for d in range(dim):
+                iv_group = level_group.get(f"dim/{d}/intervals")
+                if iv_group is None:
+                    empty = True
+                    break
+                cells[d] = _slice_partitioned(iv_group, rank)
+                if d >= 1:
+                    offsets[d] = _slice_partitioned(level_group.get(f"dim/{d}/offsets"), rank)
+            if empty or cells[0] is None or len(cells[0]) == 0:
+                continue
+            for x0, x1, y, z in _enumerate_intervals(cells, offsets, dim):
+                xs = np.arange(x0, x1, dtype=np.int64)
+                block = np.zeros((xs.size, 3), dtype=np.int64)
+                block[:, 0], block[:, 1], block[:, 2] = xs, y, z
+                rank_keys.append(block)
+                rank_levels.append(np.full(xs.size, level, dtype=np.int64))
+
+        if not rank_keys:
+            continue
+        rank_keys = np.concatenate(rank_keys)
+        key_parts.append(rank_keys)
+        level_parts.append(np.concatenate(rank_levels))
+        for name, n_comp in fields.items():
+            buf = np.asarray(_slice_partitioned(root[f"fields/{name}/data"], rank))
+            value_parts[name].append(buf.reshape(rank_keys.shape[0], n_comp))
+
+    if not key_parts:
+        return (
+            np.zeros((0, 3), dtype=np.int64),
+            np.zeros(0, dtype=np.int64),
+            {name: np.zeros((0, n_comp)) for name, n_comp in fields.items()},
+        )
+    keys = np.concatenate(key_parts)
+    levels = np.concatenate(level_parts)
+    values = {name: np.concatenate(parts) for name, parts in value_parts.items()}
+    return keys, levels, values
+
+
+def _validate_samurai_group(root, filename):
+    """Raise a clear error if ``root`` is not a samurai mesh group."""
+    if "mesh/dim" in root:
+        return
+    # Detect a save() file (explicit points/connectivity) for an actionable message.
+    looks_like_save = "mesh" in root and (
+        any(k in root["mesh"] for k in ("points", "connectivity"))
+        or any(
+            isinstance(root["mesh"][k], h5py.Group)
+            and ("points" in root["mesh"][k] or "connectivity" in root["mesh"][k])
+            for k in root["mesh"].keys()
+        )
+    )
+    if looks_like_save:
+        raise ValueError(
+            f"'{filename}' looks like a samurai save() file (explicit "
+            "points/connectivity mesh), which this loader does not handle. "
+            "Open the compressed dump/restart file instead."
+        )
+    raise ValueError(f"'{filename}' is not a samurai dump file: '/mesh/dim' is missing.")
+
+
+def _read_file(filename, group):
+    """Open a samurai file and return its metadata plus the leaf cells."""
+    if not filename.endswith(".h5"):
+        filename = filename + ".h5"
+    with h5py.File(filename, "r") as f:
+        root = f[group] if group else f
+        _validate_samurai_group(root, filename)
+
+        dim = int(root["mesh/dim"][()])
+        origin = np.zeros(3, dtype=np.float64)
+        origin[:dim] = np.asarray(root["mesh/origin_point"][()], dtype=np.float64).reshape(-1)[:dim]
+        meta = {
+            "dim": dim,
+            "min_level": int(root["mesh/min_level"][()]),
+            "max_level": int(root["mesh/max_level"][()]),
+            "origin": origin,
+            "scaling": float(root["mesh/scaling_factor"][()]),
+            "time": read_time(filename),
+        }
+        n_process = int(root["n_process"][()]) if "n_process" in root else 1
+        field_comp = {}
+        if "fields" in root:
+            for name in root["fields"].keys():
+                field_comp[name] = int(root[f"fields/{name}/n_comp"][()])
+
+        keys, levels, values = _read_leaves(
+            root, field_comp, dim, meta["min_level"], meta["max_level"], n_process
+        )
+    meta["field_comp"] = field_comp
+    return meta, keys, levels, values
+
+
+def read_cells(filename, group=None):
+    """Return the samurai leaf cells -- pure ``numpy``/``h5py``, no yt.
+
+    Returns ``(centers, levels, fields, meta)`` where ``centers`` is an
+    ``(n_cells, 3)`` array of physical cell centers (unused dimensions padded with
+    the origin), ``levels`` the per-cell level, ``fields`` a ``{name: (n_cells,)}``
+    mapping (vector fields split into ``name_<c>``) and ``meta`` carries ``dim``,
+    ``min_level``, ``max_level`` and ``time``.  This is the raw cell data, without
+    the AMR-grid rebuild that yt needs.
+    """
+    meta, keys, levels, values = _read_file(filename, group)
+    dim = meta["dim"]
+
+    length = (meta["scaling"] / 2.0 ** levels).reshape(-1, 1)  # (n_cells, 1)
+    centers = np.tile(meta["origin"], (keys.shape[0], 1))
+    centers[:, :dim] = meta["origin"][:dim] + (keys[:, :dim] + 0.5) * length
+
+    fields = {}
+    for name, n_comp in meta["field_comp"].items():
+        if n_comp == 1:
+            fields[name] = values[name][:, 0]
+        else:
+            for c in range(n_comp):
+                fields[f"{name}_{c}"] = values[name][:, c]
+    return centers, levels, fields, meta
+
+
+def _internal_nodes(keys, levels, min_level):
+    """Return the set of refined cells ``(level, i, j, k)`` (ancestors of leaves).
+
+    Walking up from every leaf marks each ancestor once; a cell is either a leaf
+    or internal, never both, so this is exactly the set of cells that must be
+    handed to yt as a refined ``2**dim``-cell grid.
+    """
+    internal = set()
+    for row in range(keys.shape[0]):
+        level = int(levels[row])
+        i, j, k = int(keys[row, 0]), int(keys[row, 1]), int(keys[row, 2])
+        while level > min_level:
+            level -= 1
+            i, j, k = i >> 1, j >> 1, k >> 1  # arithmetic shift == samurai's parent
+            node = (level, i, j, k)
+            if node in internal:
+                break
+            internal.add(node)
+    return internal
+
+
+def read_amr_grids(filename, group=None):
+    """Read a samurai ``.h5`` file and reconstruct it as block-aligned AMR grids.
+
+    Parameters
+    ----------
+    filename : str
+        Path to the samurai file (with or without the ``.h5`` extension).
+    group : str, optional
+        HDF5 group under which the samurai layout (``mesh``, ``fields``,
+        ``n_process``) lives.  Defaults to the file root; pass e.g.
+        ``"grids/my_grid"`` for a file holding several grids side by side.
+
+    Returns
+    -------
+    grids : list of dict
+        yt grids (see :func:`yt.load_amr_grids`): a root grid covering the domain
+        at ``min_level`` plus one ``2**dim``-cell grid per refined cell.  Each
+        dict carries ``left_edge``, ``right_edge``, ``dimensions``, ``level``
+        (0 == ``min_level``) and one array per scalar field (vector fields are
+        split into ``name_<c>`` components).
+    meta : dict
+        ``dim``, ``domain_dimensions`` (3 ints), ``bbox`` (3x2 floats),
+        ``min_level``, ``max_level``, ``time`` (or ``None``) and ``fields`` (the
+        list of yt field names).
+    """
+    meta, keys, levels, values = _read_file(filename, group)
+    dim = meta["dim"]
+    min_level = meta["min_level"]
+    origin = meta["origin"]
+    scaling = meta["scaling"]
+
+    # Split vector fields into scalar components (one yt field each).
+    fields = {}
+    for name, n_comp in meta["field_comp"].items():
+        if n_comp == 1:
+            fields[name] = values[name][:, 0]
+        else:
+            for c in range(n_comp):
+                fields[f"{name}_{c}"] = values[name][:, c]
+
+    n_cells = keys.shape[0]
+    # Leaf value lookup: (level, i, j, k) -> row.  Cells absent from it are
+    # refined; their placeholder value is masked by the covering finer grid.
+    leaf_row = {
+        (int(levels[r]), int(keys[r, 0]), int(keys[r, 1]), int(keys[r, 2])): r
+        for r in range(n_cells)
+    }
+
+    def fill(name, level, i0, j0, k0, dims):
+        """Field array of shape ``dims`` for the cell block anchored at ``(i0,j0,k0)``."""
+        col = fields[name]
+        out = np.zeros(dims, dtype=col.dtype)
+        for a in range(dims[0]):
+            for b in range(dims[1]):
+                for c in range(dims[2]):
+                    r = leaf_row.get((level, i0 + a, j0 + b, k0 + c))
+                    if r is not None:
+                        out[a, b, c] = col[r]
+        return out
+
+    dx0 = scaling / 2.0**min_level  # coarsest cell size; yt level 0 == min_level
+
+    # Domain box, exactly a whole number of coarsest cells (every cell nests in
+    # the min_level grid, so these bounds are the samurai domain box).
+    idx_lo = np.zeros(3, dtype=np.int64)
+    idx_hi = np.ones(3, dtype=np.int64)  # unused dims span a single coarse cell
+    for d in range(dim):
+        coarse = keys[:, d] >> (levels - min_level)  # index projected to min_level
+        idx_lo[d] = coarse.min()
+        idx_hi[d] = coarse.max() + 1
+    domain_dimensions = (idx_hi - idx_lo).astype(np.int64)
+
+    domain_left = origin.copy()
+    domain_right = origin.copy()
+    domain_left[:dim] = origin[:dim] + idx_lo[:dim] * dx0
+    domain_right[:dim] = origin[:dim] + idx_hi[:dim] * dx0
+    domain_right[dim:] = origin[dim:] + dx0
+    bbox = np.stack([domain_left, domain_right], axis=1)
+
+    child_dims = tuple(2 if d < dim else 1 for d in range(3))
+
+    grids = []
+    # Root grid: the whole domain at the coarsest level.
+    root_grid = {
+        "left_edge": domain_left,
+        "right_edge": domain_right,
+        "dimensions": domain_dimensions.copy(),
+        "level": 0,
+    }
+    for name in fields:
+        root_grid[name] = fill(
+            name, min_level, idx_lo[0], idx_lo[1], idx_lo[2], tuple(domain_dimensions)
+        )
+    grids.append(root_grid)
+
+    # One 2**dim-cell grid per refined cell, its left edge on the parent cell edge.
+    for level, i, j, k in sorted(_internal_nodes(keys, levels, min_level)):
+        lvl = level - min_level + 1  # yt level of the children
+        left = domain_left.copy()
+        right = domain_right.copy()
+        for d, idx in enumerate((i, j, k)):
+            if d >= dim:
+                continue
+            # yt requires the edge to lie on a parent-level cell edge; reproduce
+            # its own linspace arithmetic so the values match bit for bit.
+            n_parent = int(domain_dimensions[d]) * (1 << (lvl - 1))
+            m = idx - (int(idx_lo[d]) << (level - min_level))
+            step = (domain_right[d] - domain_left[d]) / n_parent
+            left[d] = domain_left[d] + m * step
+            right[d] = domain_left[d] + (m + 1) * step
+        grid = {
+            "left_edge": left,
+            "right_edge": right,
+            "dimensions": np.array(child_dims, dtype=np.int64),
+            "level": lvl,
+        }
+        for name in fields:
+            grid[name] = fill(name, level + 1, 2 * i, 2 * j, 2 * k, child_dims)
+        grids.append(grid)
+
+    meta.update(domain_dimensions=domain_dimensions, bbox=bbox, fields=sorted(fields))
+    del meta["field_comp"], meta["origin"], meta["scaling"]
+    return grids, meta

--- a/tools/yt/samurai_load.py
+++ b/tools/yt/samurai_load.py
@@ -1,12 +1,12 @@
 # Copyright 2018-2025 the samurai's authors
 # SPDX-License-Identifier:  BSD-3-Clause
 """
-Reconstruction of a samurai data file as a list of AMR grids, ready to be handed
-to ``yt.load_amr_grids``.
+Reconstruction of a samurai data file as a list of AMR grids.
 
-This module only depends on ``numpy`` and ``h5py`` so that it can be unit-tested
-without yt.  The yt loader (``samurai_yt.py``) is a thin wrapper that turns the
-grids returned here into a ``StreamDataset``.
+The result is ready to be handed to ``yt.load_amr_grids``. This module only
+depends on ``numpy`` and ``h5py`` so that it can be unit-tested without yt.
+The yt loader (``samurai_yt.py``) is a thin wrapper that turns the grids
+returned here into a ``StreamDataset``.
 
 Samurai never stores the cell geometry.  A data file only contains, per level and
 per direction, the compressed interval representation of the mesh (``m_cells`` /
@@ -265,8 +265,9 @@ def _read_file(filename, group):
         _validate_samurai_group(root, filename)
 
         dim = int(root["mesh/dim"][()])
+        origin_point = np.asarray(root["mesh/origin_point"][()], dtype=np.float64)
         origin = np.zeros(3, dtype=np.float64)
-        origin[:dim] = np.asarray(root["mesh/origin_point"][()], dtype=np.float64).reshape(-1)[:dim]
+        origin[:dim] = origin_point.reshape(-1)[:dim]
         meta = {
             "dim": dim,
             "min_level": int(root["mesh/min_level"][()]),
@@ -358,8 +359,9 @@ def read_amr_grids(filename, group=None):
         split into ``name_<c>`` components).
     meta : dict
         ``dim``, ``domain_dimensions`` (3 ints), ``bbox`` (3x2 floats),
-        ``min_level``, ``max_level``, ``time`` (or ``None``) and ``fields`` (the
-        list of yt field names).
+        ``min_level``, ``max_level``, ``time`` (or ``None``) and ``fields``
+        (the list of yt field names).
+
     """
     meta, keys, levels, values = _read_file(filename, group)
     dim = meta["dim"]

--- a/tools/yt/samurai_yt.py
+++ b/tools/yt/samurai_yt.py
@@ -1,0 +1,94 @@
+# Copyright 2018-2025 the samurai's authors
+# SPDX-License-Identifier:  BSD-3-Clause
+"""
+Load a samurai data file (compressed HDF5) into `yt <https://yt-project.org>`_.
+
+Samurai writes its state as a compact HDF5 file that stores only its internal
+interval representation of the mesh (via ``samurai::dump``, read back with
+``samurai::load``); no explicit geometry is stored.  Because that interval
+representation *is* a patch-AMR description -- one contiguous x-run of cells per
+patch -- it maps directly onto :func:`yt.load_amr_grids`, so the full yt toolbox
+(slices, projections, profiles, volume rendering) works on samurai data.
+
+Example
+-------
+>>> import samurai_yt
+>>> ds = samurai_yt.load_samurai("solution.h5")
+>>> yt.SlicePlot(ds, "z", ("stream", "u")).save()
+
+The heavy lifting (reading the file, rebuilding the patches) lives in
+:mod:`samurai_load`, which depends only on ``numpy`` and ``h5py`` and is
+unit-testable without yt.
+"""
+
+import os
+import sys
+
+# Make ``samurai_load`` importable regardless of the caller's working directory.
+_HERE = os.path.dirname(os.path.abspath(__file__))
+if _HERE not in sys.path:
+    sys.path.insert(0, _HERE)
+
+from samurai_load import discover_series, read_amr_grids  # noqa: E402
+
+
+def load_samurai(filename, group=None, length_unit=1.0, take_log=False, **kwargs):
+    """Load a single samurai ``.h5`` file as a yt ``StreamDataset``.
+
+    Parameters
+    ----------
+    filename : str
+        Path to the samurai file (with or without the ``.h5`` extension).
+    group : str, optional
+        HDF5 group under which the samurai layout lives (see
+        :func:`samurai_load.read_amr_grids`).  Defaults to the file root.
+    length_unit : float or str, optional
+        Physical length of one code-length unit (default ``1.0``).  Samurai
+        coordinates are used as ``code_length``.
+    take_log : bool or None, optional
+        Whether the fields should be shown on a log scale.  Defaults to ``False``
+        (linear), which is the sensible default for the PDE solutions samurai
+        produces -- otherwise yt guesses a log scale from the value range and
+        turns small over/undershoots (and any negative value) into visual noise.
+        Pass ``None`` to keep yt's own guess.
+    **kwargs
+        Forwarded to :func:`yt.load_amr_grids` (e.g. ``periodicity``,
+        ``unit_system``).
+
+    Returns
+    -------
+    yt.frontends.stream.data_structures.StreamDataset
+        Scalar fields are exposed as ``("stream", name)``; each component of a
+        vector field ``v`` is exposed as ``("stream", "v_<c>")``.
+    """
+    import yt
+
+    grids, meta = read_amr_grids(filename, group=group)
+    kwargs.setdefault("periodicity", (False, False, False))
+    ds = yt.load_amr_grids(
+        grids,
+        meta["domain_dimensions"],
+        length_unit=length_unit,
+        bbox=meta["bbox"],
+        sim_time=meta["time"] or 0.0,
+        **kwargs,
+    )
+    if take_log is not None:
+        for name in meta["fields"]:
+            ds.field_info["stream", name].take_log = take_log
+    return ds
+
+
+def load_samurai_series(filename, **kwargs):
+    """Load a numbered samurai series as a time-ordered list of datasets.
+
+    Given any one file of a series (e.g. ``sol_ite_0.h5``), the siblings sharing
+    the same prefix are discovered on disk (see
+    :func:`samurai_load.discover_series`) and loaded in natural order.  Each
+    dataset's ``current_time`` is the physical time stored in the file (or its
+    iteration index as a fallback).
+
+    Extra keyword arguments are forwarded to :func:`load_samurai`.
+    """
+    files, _ = discover_series(filename)
+    return [load_samurai(f, **kwargs) for f in files]

--- a/tools/yt/samurai_yt.py
+++ b/tools/yt/samurai_yt.py
@@ -10,8 +10,8 @@ representation *is* a patch-AMR description -- one contiguous x-run of cells per
 patch -- it maps directly onto :func:`yt.load_amr_grids`, so the full yt toolbox
 (slices, projections, profiles, volume rendering) works on samurai data.
 
-Example
--------
+Examples
+--------
 >>> import samurai_yt
 >>> ds = samurai_yt.load_samurai("solution.h5")
 >>> yt.SlicePlot(ds, "z", ("stream", "u")).save()

--- a/tools/yt/tests/generate_reference.cpp
+++ b/tools/yt/tests/generate_reference.cpp
@@ -1,0 +1,149 @@
+// Copyright 2018-2025 the samurai's authors
+// SPDX-License-Identifier:  BSD-3-Clause
+//
+// Generates the small reference samurai files consumed by test_yt_reader.py.
+// The field `u` is set to the analytic oracle
+//
+//     u(center) = sum_d center[d] * 10^d
+//
+// so that the yt reconstruction can verify value <-> geometry <-> ordering
+// without any tolerance ambiguity.  Regenerate with (see tools/yt/README.md):
+//
+//   <mpicxx> -DSAMURAI_WITH_MPI ... generate_reference.cpp -o generate_reference
+//   ./generate_reference                    # writes ref_1d/2d/3d.h5
+//   mpirun -n 2 ./generate_reference --mpi  # writes ref_2d_mpi.h5
+//
+// The output directory is the first CLI argument (default: current directory).
+#include <cmath>
+#include <string>
+
+#include <samurai/algorithm.hpp>
+#include <samurai/box.hpp>
+#include <samurai/field.hpp>
+#include <samurai/io/restart.hpp>
+#include <samurai/mr/adapt.hpp>
+#include <samurai/mr/mesh.hpp>
+#include <samurai/samurai.hpp>
+
+template <class Coord>
+double analytic(const Coord& c, std::size_t dim)
+{
+    double v = 0., w = 1.;
+    for (std::size_t d = 0; d < dim; ++d)
+    {
+        v += w * c[d];
+        w *= 10.;
+    }
+    return v;
+}
+
+template <std::size_t dim>
+auto make_graded_mesh_and_field(std::size_t max_level, double eps, double sharpness)
+{
+    using Box = samurai::Box<double, dim>;
+    typename Box::point_t lo, hi;
+    lo.fill(0.);
+    hi.fill(1.);
+    Box box(lo, hi);
+
+    auto config = samurai::mesh_config<dim>().min_level(2).max_level(max_level).disable_minimal_ghost_width();
+    auto mesh   = samurai::mra::make_mesh(box, config);
+    auto u      = samurai::make_scalar_field<double>("u", mesh);
+
+    samurai::for_each_cell(mesh,
+                           [&](auto cell)
+                           {
+                               auto c    = cell.center();
+                               double r2 = 0.;
+                               for (std::size_t d = 0; d < dim; ++d)
+                               {
+                                   r2 += (c[d] - 0.5) * (c[d] - 0.5);
+                               }
+                               u[cell] = std::exp(-sharpness * r2);
+                           });
+
+    auto adapt = samurai::make_MRAdapt(u);
+    adapt(samurai::mra_config().epsilon(eps));
+
+    samurai::for_each_cell(mesh,
+                           [&](auto cell)
+                           {
+                               u[cell] = analytic(cell.center(), dim);
+                           });
+    return std::make_pair(std::move(mesh), std::move(u));
+}
+
+// A uniform mesh at a single level: every cell is a leaf at the coarsest level,
+// exercising the root grid (real values, no refinement) on the reader side.
+template <std::size_t dim>
+auto make_uniform_mesh_and_field(std::size_t level)
+{
+    using Box = samurai::Box<double, dim>;
+    typename Box::point_t lo, hi;
+    lo.fill(0.);
+    hi.fill(1.);
+    Box box(lo, hi);
+
+    auto config = samurai::mesh_config<dim>().min_level(level).max_level(level).disable_minimal_ghost_width();
+    auto mesh   = samurai::mra::make_mesh(box, config);
+    auto u      = samurai::make_scalar_field<double>("u", mesh);
+
+    samurai::for_each_cell(mesh,
+                           [&](auto cell)
+                           {
+                               u[cell] = analytic(cell.center(), dim);
+                           });
+    return std::make_pair(std::move(mesh), std::move(u));
+}
+
+int main(int argc, char* argv[])
+{
+    samurai::initialize(argc, argv);
+
+    std::string dir = ".";
+    bool mpi        = false;
+    for (int i = 1; i < argc; ++i)
+    {
+        std::string a = argv[i];
+        if (a == "--mpi")
+        {
+            mpi = true;
+        }
+        else if (a[0] != '-')
+        {
+            dir = a;
+        }
+    }
+    auto path = [&](const std::string& f)
+    {
+        return dir + "/" + f;
+    };
+
+    if (mpi)
+    {
+        auto [mesh, u] = make_graded_mesh_and_field<2>(5, 1e-3, 200.);
+        samurai::dump(path("ref_2d_mpi"), mesh, u);
+    }
+    else
+    {
+        {
+            auto [mesh, u] = make_graded_mesh_and_field<1>(5, 1e-3, 200.);
+            samurai::dump(path("ref_1d"), mesh, u);
+        }
+        {
+            auto [mesh, u] = make_graded_mesh_and_field<2>(4, 1e-2, 100.);
+            samurai::dump(path("ref_2d"), mesh, u);
+        }
+        {
+            auto [mesh, u] = make_graded_mesh_and_field<3>(3, 1e-2, 30.);
+            samurai::dump(path("ref_3d"), mesh, u);
+        }
+        {
+            auto [mesh, u] = make_uniform_mesh_and_field<2>(2);
+            samurai::dump(path("ref_uniform"), mesh, u);
+        }
+    }
+
+    samurai::finalize();
+    return 0;
+}


### PR DESCRIPTION
## Description
Adds a yt Project (https://yt-project.org) loader plugin to open samurai "dump/restart" compressed HDF5 outputs directly in yt, on the same model as the ParaView reader (#460). It also fixes a module-name collision between the two plugins' `samurai_load.py` files, wires CI to generate/test both plugins side by side.

**Changes:**

- Implement `tools/yt/samurai_load.py` (numpy+h5py) to reconstruct the intervals as block-aligned AMR grids, plus `read_cells()` for raw leaf data without yt.
- Add yt wrapper `tools/yt/samurai_yt.py` (`load_samurai()`, `load_samurai_series()`) plus end-user documentation in `tools/yt/README.md`.
- Add reference-file generator + pytest suite + CI steps to generate those references in builds (incl. MPI case), alongside the existing ParaView ones.
- Fix a samurai_load module-name collision between `tools/paraview` and `tools/yt` when both test suites are collected in the same pytest session.

## How has this been tested?
see `tests/test_yt_reader.py` also validated interactively against a real `advection_2d` dump in yt 4.4.2 (SlicePlot, annotate_cell_edges, projections).

## Code of Conduct
By submitting this PR, you agree to follow our [Code of Conduct](https://github.com/hpc-maths/samurai/blob/master/docs/CODE_OF_CONDUCT.md)
- [x] I agree to follow this project's Code of Conduct
