### PR TITLE
refactor: remove SOA storage for vector fields

### DIFF
--- a/demos/FiniteVolume/burgers.cpp
+++ b/demos/FiniteVolume/burgers.cpp
@@ -18,7 +18,7 @@ auto exact_solution(xt::xtensor_fixed<double, xt::xshape<dim>> coords, double t)
     const double b  = 0;
     const double& x = coords(0);
     auto value      = (a * x + b) / (a * t + 1);
-    return samurai::CollapsArray<double, n_comp, false>(value);
+    return samurai::CollapsArray<double, n_comp>(value);
 }
 
 template <class Field>

--- a/demos/FiniteVolume/stokes_2d.cpp
+++ b/demos/FiniteVolume/stokes_2d.cpp
@@ -95,7 +95,6 @@ int main(int argc, char* argv[])
 
     constexpr std::size_t dim = 2;
 
-    static constexpr bool is_soa                                     = false;
     static constexpr samurai::petsc::BlockAssemblyType assembly_type = samurai::petsc::BlockAssemblyType::NestedMatrices;
 
     //----------------//
@@ -153,7 +152,7 @@ int main(int argc, char* argv[])
         //       p = pressure
 
         // Unknowns
-        auto velocity = samurai::make_vector_field<dim, is_soa>("velocity", mesh);
+        auto velocity = samurai::make_vector_field<dim>("velocity", mesh);
         auto pressure = samurai::make_scalar_field<double>("pressure", mesh);
 
         using VelocityField = decltype(velocity);
@@ -167,7 +166,7 @@ int main(int argc, char* argv[])
                                                     const auto& y = coord[1];
                                                     double v_x    = 1 / (pi * pi) * sin(pi * (x + y));
                                                     double v_y    = -v_x;
-                                                    return samurai::Array<double, dim, is_soa>{v_x, v_y};
+                                                    return samurai::Array<double, dim>{v_x, v_y};
                                                 });
 
         samurai::make_bc<samurai::Neumann<1>>(pressure,
@@ -193,7 +192,7 @@ int main(int argc, char* argv[])
         // clang-format on
 
         // Right-hand side
-        auto f    = samurai::make_vector_field<dim, is_soa>("f",
+        auto f    = samurai::make_vector_field<dim>("f",
                                                          mesh,
                                                          [](const auto& coord)
                                                          {
@@ -201,7 +200,7 @@ int main(int argc, char* argv[])
                                                              const auto& y = coord[1];
                                                              double f_x    = 2 * sin(pi * (x + y)) + (1 / pi) * cos(pi * (x + y));
                                                              double f_y    = -2 * sin(pi * (x + y)) + (1 / pi) * cos(pi * (x + y));
-                                                             return samurai::Array<double, dim, is_soa>{f_x, f_y};
+                                                             return samurai::Array<double, dim>{f_x, f_y};
                                                          });
         auto zero = samurai::make_scalar_field<double>("zero", mesh);
         zero.fill(0);
@@ -224,7 +223,7 @@ int main(int argc, char* argv[])
                                     const auto& y = coord[1];
                                     auto v_x      = 1 / (pi * pi) * sin(pi * (x + y));
                                     auto v_y      = -v_x;
-                                    return samurai::Array<double, dim, is_soa>{v_x, v_y};
+                                    return samurai::Array<double, dim>{v_x, v_y};
                                 });
         std::cout.precision(2);
         std::cout << "L2-error on the velocity: " << std::scientific << error << std::endl;
@@ -235,7 +234,7 @@ int main(int argc, char* argv[])
         samurai::save(path, filename, mesh, velocity);
         samurai::save(path, "pressure", mesh, pressure);
 
-        auto exact_velocity = samurai::make_vector_field<dim, is_soa>("exact_velocity",
+        auto exact_velocity = samurai::make_vector_field<dim>("exact_velocity",
                                                                       mesh,
                                                                       [](const auto& coord)
                                                                       {
@@ -243,11 +242,11 @@ int main(int argc, char* argv[])
                                                                           const auto& y = coord[1];
                                                                           auto v_x      = 1 / (pi * pi) * sin(pi * (x + y));
                                                                           auto v_y      = -v_x;
-                                                                          return samurai::Array<double, dim, is_soa>{v_x, v_y};
+                                                                          return samurai::Array<double, dim>{v_x, v_y};
                                                                       });
         samurai::save(path, "exact_velocity", mesh, exact_velocity);
 
-        /*auto err = samurai::make_vector_field<dim, is_soa>("error", mesh);
+        /*auto err = samurai::make_vector_field<dim>("error", mesh);
         for_each_cell(err.mesh(), [&](const auto& cell)
             {
                 err[cell] = exact_velocity[cell] - velocity[cell];
@@ -293,7 +292,7 @@ int main(int argc, char* argv[])
                        - pi * sin(t) * sin(t) * sin(pi * x) * sin(pi * y);
             double f_y = -(cos(t) + 8 * diff_coeff * pi * pi * sin(t)) * cos(2 * pi * x) * sin(2 * pi * y)
                        + pi * sin(t) * sin(t) * cos(pi * x) * cos(pi * y);
-            return samurai::Array<double, dim, is_soa>{f_x, f_y};
+            return samurai::Array<double, dim>{f_x, f_y};
         };
 
         // Exact solution
@@ -303,7 +302,7 @@ int main(int argc, char* argv[])
             const auto& y = coord[1];
             double v_x    = std::sin(t) * std::sin(2 * pi * x) * std::cos(2 * pi * y);
             double v_y    = -std::sin(t) * std::cos(2 * pi * x) * std::sin(2 * pi * y);
-            return samurai::Array<double, dim, is_soa>{v_x, v_y};
+            return samurai::Array<double, dim>{v_x, v_y};
         };
         auto exact_normal_grad_pressure = [&](double t, const auto& coord)
         {
@@ -314,15 +313,15 @@ int main(int argc, char* argv[])
         };
 
         // Unknowns
-        auto velocity     = samurai::make_vector_field<dim, is_soa>("velocity", mesh);
-        auto velocity_np1 = samurai::make_vector_field<dim, is_soa>("velocity_np1", mesh);
+        auto velocity     = samurai::make_vector_field<dim>("velocity", mesh);
+        auto velocity_np1 = samurai::make_vector_field<dim>("velocity_np1", mesh);
         auto pressure_np1 = samurai::make_scalar_field<double>("pressure_np1", mesh);
 
         using VelocityField = decltype(velocity);
         using PressureField = decltype(pressure_np1);
 
         // Right-hand side
-        auto rhs  = samurai::make_vector_field<dim, is_soa>("rhs", mesh);
+        auto rhs  = samurai::make_vector_field<dim>("rhs", mesh);
         auto zero = samurai::make_scalar_field<double>("zero", mesh);
 
         // Boundary conditions
@@ -446,7 +445,7 @@ int main(int argc, char* argv[])
             // Solve the linear equation
             //                [I + dt*Diff] v_np1 + dt*p_np1 = v_n + dt*f
             //                         -Div v_np1            = 0
-            auto f = samurai::make_vector_field<dim, is_soa>("f",
+            auto f = samurai::make_vector_field<dim>("f",
                                                              mesh,
                                                              [&](const auto& coord)
                                                              {

--- a/demos/multigrid/main.cpp
+++ b/demos/multigrid/main.cpp
@@ -125,9 +125,8 @@ int main(int argc, char* argv[])
 
     constexpr std::size_t dim     = 2;
     constexpr unsigned int n_comp = 1;
-    constexpr bool is_soa         = false;
     using Mesh                    = decltype(create_uniform_mesh<dim>(1));
-    using Field                   = samurai::VectorField<Mesh, double, n_comp, is_soa>;
+    using Field                   = samurai::VectorField<Mesh, double, n_comp>;
 
     //----------------//
     //   Parameters   //
@@ -208,8 +207,8 @@ int main(int argc, char* argv[])
     // Create problem //
     //----------------//
 
-    auto source   = samurai::make_vector_field<double, n_comp, is_soa>("source", mesh, test_case->source());
-    auto solution = samurai::make_vector_field<double, n_comp, is_soa>("solution", mesh);
+    auto source   = samurai::make_vector_field<double, n_comp>("source", mesh, test_case->source());
+    auto solution = samurai::make_vector_field<double, n_comp>("solution", mesh);
     solution.fill(0);
 
     // Boundary conditions
@@ -270,7 +269,7 @@ int main(int argc, char* argv[])
     std::cout << "Elapsed time: " << total_timer.Elapsed() << std::endl;
     std::cout << std::endl;
 
-    /*auto right_fluxes = samurai::make_vector_field<double, n_comp, is_soa>("fluxes", mesh);
+    /*auto right_fluxes = samurai::make_vector_field<double, n_comp>("fluxes", mesh);
     samurai::DirectionVector<dim> right = {1, 0};
     samurai::Stencil<2, dim> comput_stencil = {{0, 0}, {1, 0}};
     samurai::for_each_interface(mesh, right, comput_stencil,

--- a/docs/source/reference/finite_volume_schemes.rst
+++ b/docs/source/reference/finite_volume_schemes.rst
@@ -524,7 +524,7 @@ In the configuration, the number of components of the output field is set to the
     auto u = samurai::make_scalar_field<double>("u", mesh);
 
     using input_field_t                       = decltype(u);
-    using output_field_t = VectorField<typename input_field_t::mesh_t, typename input_field_t::value_type, dim, detail::is_soa_v<input_field_t>>;
+    using output_field_t = VectorField<typename input_field_t::mesh_t, typename input_field_t::value_type, dim>;
 
     using cfg = samurai::FluxConfig<samurai::SchemeType::LinearHomogeneous,
                                     2,              // stencil_size

--- a/include/samurai/algorithm/utils.hpp
+++ b/include/samurai/algorithm/utils.hpp
@@ -95,18 +95,6 @@ namespace samurai
                         d_data[off_d + ii] = s_data[off_s + ii];
                     }
                 }
-                else if constexpr (detail::is_soa_v<Dest>) // SoA: data()[comp * nb_cells + cell]
-                {
-                    const std::size_t nb_d = static_cast<std::size_t>(dest.array().shape()[1]);
-                    const std::size_t nb_s = static_cast<std::size_t>(src.array().shape()[1]);
-                    for (std::size_t ii = 0; ii < n; ++ii)
-                    {
-                        for (std::size_t c = 0; c < nc; ++c)
-                        {
-                            d_data[c * nb_d + off_d + ii] = s_data[c * nb_s + off_s + ii];
-                        }
-                    }
-                }
                 else // AoS (cell-major): data()[cell * n_comp + comp]
                 {
                     for (std::size_t ii = 0; ii < n; ++ii)

--- a/include/samurai/bc/bc.hpp
+++ b/include/samurai/bc/bc.hpp
@@ -81,7 +81,7 @@ namespace samurai
     template <class Config>
     class UniformMesh;
 
-    template <class mesh_t, class value_t, std::size_t size, bool SOA>
+    template <class mesh_t, class value_t, std::size_t size>
     class VectorField;
 
     template <class mesh_t, class value_t>
@@ -94,7 +94,7 @@ namespace samurai
     struct BcValue
     {
         static constexpr std::size_t dim = Field::dim;
-        using value_t     = CollapsArray<typename Field::value_type, Field::n_comp, detail::is_soa_v<Field>, Field::is_scalar>;
+        using value_t     = CollapsArray<typename Field::value_type, Field::n_comp, Field::is_scalar>;
         using coords_t    = xt::xtensor_fixed<double, xt::xshape<dim>>;
         using direction_t = DirectionVector<dim>;
         using cell_t      = typename Field::cell_t;

--- a/include/samurai/field/concepts.hpp
+++ b/include/samurai/field/concepts.hpp
@@ -11,7 +11,7 @@ namespace samurai
 {
     template <class mesh_t, class value_t>
     class ScalarField;
-    template <class mesh_t, class value_t, std::size_t n_comp, bool SOA>
+    template <class mesh_t, class value_t, std::size_t n_comp>
     class VectorField;
 
     template <class T>
@@ -20,8 +20,8 @@ namespace samurai
     template <class mesh_t, class value_t>
     constexpr bool field_like_helper<ScalarField<mesh_t, value_t>> = true;
 
-    template <class mesh_t, class value_t, std::size_t n_comp, bool SOA>
-    constexpr bool field_like_helper<VectorField<mesh_t, value_t, n_comp, SOA>> = true;
+    template <class mesh_t, class value_t, std::size_t n_comp>
+    constexpr bool field_like_helper<VectorField<mesh_t, value_t, n_comp>> = true;
 
     template <class T>
     concept field_like = field_like_helper<std::remove_cvref_t<T>>;

--- a/include/samurai/field/scalar_field.hpp
+++ b/include/samurai/field/scalar_field.hpp
@@ -32,7 +32,7 @@ namespace samurai
             using interval_value_t              = typename interval_t::value_t;
             using cell_t                        = typename mesh_t::cell_t;
             using data_type                     = field_data_storage_t<value_t, 1>;
-            using local_data_type               = local_field_data_t<value_t, 1, false, true>;
+            using local_data_type               = local_field_data_t<value_t, 1, true>;
             using size_type                     = typename data_type::size_type;
             static constexpr auto static_layout = data_type::static_layout;
         };

--- a/include/samurai/field/vector_field.hpp
+++ b/include/samurai/field/vector_field.hpp
@@ -18,15 +18,15 @@
 
 namespace samurai
 {
-    template <class mesh_t, class value_t, std::size_t n_comp, bool SOA>
+    template <class mesh_t, class value_t, std::size_t n_comp>
     class VectorField;
 
     namespace detail
     {
         // VectorField specialization ---------------------------------------------
 
-        template <class mesh_t_, class value_t, std::size_t n_comp, bool SOA>
-        struct inner_field_types<VectorField<mesh_t_, value_t, n_comp, SOA>>
+        template <class mesh_t_, class value_t, std::size_t n_comp>
+        struct inner_field_types<VectorField<mesh_t_, value_t, n_comp>>
         {
             using mesh_t                     = mesh_t_;
             static constexpr std::size_t dim = mesh_t::dim;
@@ -35,18 +35,18 @@ namespace samurai
             using index_t                    = typename interval_t::index_t;
             using interval_value_t           = typename interval_t::value_t;
             using cell_t                     = typename mesh_t::cell_t;
-            using data_type                  = field_data_storage_t<value_t, n_comp, SOA, false>;
-            using local_data_type            = local_field_data_t<value_t, n_comp, SOA, false>;
+            using data_type                  = field_data_storage_t<value_t, n_comp, false>;
+            using local_data_type            = local_field_data_t<value_t, n_comp, false>;
             using size_type                  = typename data_type::size_type;
 
             static constexpr auto static_layout = data_type::static_layout;
         };
 
-        template <class mesh_t, class value_t, std::size_t n_comp, bool SOA>
-        struct field_data_access<VectorField<mesh_t, value_t, n_comp, SOA>>
-            : public field_data_access_base<VectorField<mesh_t, value_t, n_comp, SOA>>
+        template <class mesh_t, class value_t, std::size_t n_comp>
+        struct field_data_access<VectorField<mesh_t, value_t, n_comp>>
+            : public field_data_access_base<VectorField<mesh_t, value_t, n_comp>>
         {
-            using base_type = field_data_access_base<VectorField<mesh_t, value_t, n_comp, SOA>>;
+            using base_type = field_data_access_base<VectorField<mesh_t, value_t, n_comp>>;
 
             using data_type  = typename base_type::data_type;
             using size_type  = typename data_type::size_type;
@@ -134,15 +134,15 @@ namespace samurai
     // class VectorField
     // ------------------------------------------------------------------------
 
-    template <class mesh_t_, class value_t, std::size_t n_comp_, bool SOA>
-    class VectorField : public field_expression<VectorField<mesh_t_, value_t, n_comp_, SOA>>,
+    template <class mesh_t_, class value_t, std::size_t n_comp_>
+    class VectorField : public field_expression<VectorField<mesh_t_, value_t, n_comp_>>,
                         public inner_mesh_type<mesh_t_>,
-                        public detail::field_data_access<VectorField<mesh_t_, value_t, n_comp_, SOA>>,
-                        public detail::FieldBase<VectorField<mesh_t_, value_t, n_comp_, SOA>>
+                        public detail::field_data_access<VectorField<mesh_t_, value_t, n_comp_>>,
+                        public detail::FieldBase<VectorField<mesh_t_, value_t, n_comp_>>
     {
       public:
 
-        using self_type  = VectorField<mesh_t_, value_t, n_comp_, SOA>;
+        using self_type  = VectorField<mesh_t_, value_t, n_comp_>;
         using mesh_t     = mesh_t_;
         using value_type = value_t;
 
@@ -151,7 +151,6 @@ namespace samurai
         using size_type        = typename data_access_type::size_type;
 
         static constexpr size_type n_comp = n_comp_;
-        static constexpr bool is_soa      = SOA;
         static constexpr bool is_scalar   = false;
 
         VectorField() = default;
@@ -174,41 +173,41 @@ namespace samurai
 
     // VectorField constructors -----------------------------------------------
 
-    template <class mesh_t, class value_t, std::size_t n_comp_, bool SOA>
-    SAMURAI_INLINE VectorField<mesh_t, value_t, n_comp_, SOA>::VectorField(std::string name, mesh_t& mesh)
+    template <class mesh_t, class value_t, std::size_t n_comp_>
+    SAMURAI_INLINE VectorField<mesh_t, value_t, n_comp_>::VectorField(std::string name, mesh_t& mesh)
         : inner_mesh_t(mesh)
     {
         this->m_name = std::move(name);
         this->resize();
     }
 
-    template <class mesh_t, class value_t, std::size_t n_comp_, bool SOA>
+    template <class mesh_t, class value_t, std::size_t n_comp_>
     template <class E>
-    SAMURAI_INLINE VectorField<mesh_t, value_t, n_comp_, SOA>::VectorField(const field_expression<E>& e)
+    SAMURAI_INLINE VectorField<mesh_t, value_t, n_comp_>::VectorField(const field_expression<E>& e)
         : inner_mesh_t(detail::extract_mesh(e.derived_cast()))
     {
         this->resize();
         *this = e;
     }
 
-    template <class mesh_t, class value_t, std::size_t n_comp_, bool SOA>
-    SAMURAI_INLINE VectorField<mesh_t, value_t, n_comp_, SOA>::VectorField(const VectorField& field)
+    template <class mesh_t, class value_t, std::size_t n_comp_>
+    SAMURAI_INLINE VectorField<mesh_t, value_t, n_comp_>::VectorField(const VectorField& field)
     {
         this->assign_from(field);
     }
 
     // VectorField operators --------------------------------------------------
 
-    template <class mesh_t, class value_t, std::size_t n_comp_, bool SOA>
-    SAMURAI_INLINE auto VectorField<mesh_t, value_t, n_comp_, SOA>::operator=(const VectorField& field) -> VectorField&
+    template <class mesh_t, class value_t, std::size_t n_comp_>
+    SAMURAI_INLINE auto VectorField<mesh_t, value_t, n_comp_>::operator=(const VectorField& field) -> VectorField&
     {
         this->assign_from(field);
         return *this;
     }
 
-    template <class mesh_t, class value_t, std::size_t n_comp_, bool SOA>
+    template <class mesh_t, class value_t, std::size_t n_comp_>
     template <class E>
-    SAMURAI_INLINE auto VectorField<mesh_t, value_t, n_comp_, SOA>::operator=(const field_expression<E>& e) -> VectorField&
+    SAMURAI_INLINE auto VectorField<mesh_t, value_t, n_comp_>::operator=(const field_expression<E>& e) -> VectorField&
     {
         this->assign_expression(e);
         return *this;
@@ -218,10 +217,10 @@ namespace samurai
 
     namespace detail
     {
-        template <class value_t, std::size_t n_comp, bool SOA, class mesh_t>
+        template <class value_t, std::size_t n_comp, class mesh_t>
         auto make_vector_field_with_nan_init(const std::string& name, mesh_t& mesh)
         {
-            VectorField<mesh_t, value_t, n_comp, SOA> field(name, mesh);
+            VectorField<mesh_t, value_t, n_comp> field(name, mesh);
 #ifdef SAMURAI_CHECK_NAN
             if constexpr (std::is_floating_point_v<value_t>)
             {
@@ -232,28 +231,28 @@ namespace samurai
         }
     }
 
-    // Overloads with explicit value_t, n_comp, SOA
-    template <class value_t, std::size_t n_comp, bool SOA = false, class mesh_t>
+    // Overloads with explicit value_t, n_comp
+    template <class value_t, std::size_t n_comp, class mesh_t>
         requires mesh_like<mesh_t>
     auto make_vector_field(const std::string& name, mesh_t& mesh)
     {
-        return detail::make_vector_field_with_nan_init<value_t, n_comp, SOA>(name, mesh);
+        return detail::make_vector_field_with_nan_init<value_t, n_comp>(name, mesh);
     }
 
-    template <class value_t, std::size_t n_comp, bool SOA = false, class mesh_t>
+    template <class value_t, std::size_t n_comp, class mesh_t>
         requires mesh_like<mesh_t>
     auto make_vector_field(const std::string& name, mesh_t& mesh, value_t init_value)
     {
-        auto field = detail::make_vector_field_with_nan_init<value_t, n_comp, SOA>(name, mesh);
+        auto field = detail::make_vector_field_with_nan_init<value_t, n_comp>(name, mesh);
         field.fill(init_value);
         return field;
     }
 
-    template <class value_t, std::size_t n_comp, bool SOA = false, class mesh_t, class Func, std::size_t polynomial_degree>
+    template <class value_t, std::size_t n_comp, class mesh_t, class Func, std::size_t polynomial_degree>
         requires mesh_like<mesh_t>
     auto make_vector_field(const std::string& name, mesh_t& mesh, Func&& f, const GaussLegendre<polynomial_degree>& gl)
     {
-        auto field = detail::make_vector_field_with_nan_init<value_t, n_comp, SOA>(name, mesh);
+        auto field = detail::make_vector_field_with_nan_init<value_t, n_comp>(name, mesh);
         field.fill(0);
 
         for_each_cell(mesh,
@@ -264,11 +263,11 @@ namespace samurai
         return field;
     }
 
-    template <class value_t, std::size_t n_comp, bool SOA = false, class mesh_t, class Func>
+    template <class value_t, std::size_t n_comp, class mesh_t, class Func>
         requires mesh_like<mesh_t> && std::is_invocable_v<Func, typename Cell<mesh_t::dim, typename mesh_t::interval_t>::coords_t>
     auto make_vector_field(const std::string& name, mesh_t& mesh, Func&& f)
     {
-        auto field = detail::make_vector_field_with_nan_init<value_t, n_comp, SOA>(name, mesh);
+        auto field = detail::make_vector_field_with_nan_init<value_t, n_comp>(name, mesh);
         field.fill(0);
 
         for_each_cell(mesh,
@@ -279,32 +278,32 @@ namespace samurai
         return field;
     }
 
-    // Overloads with default value_t = double (allows make_vector_field<2, false>)
-    template <std::size_t n_comp, bool SOA = false, class mesh_t>
+    // Overloads with default value_t = double (allows make_vector_field<2>)
+    template <std::size_t n_comp, class mesh_t>
         requires mesh_like<mesh_t>
     auto make_vector_field(const std::string& name, mesh_t& mesh)
     {
-        return make_vector_field<double, n_comp, SOA>(name, mesh);
+        return make_vector_field<double, n_comp>(name, mesh);
     }
 
-    template <std::size_t n_comp, bool SOA = false, class mesh_t>
+    template <std::size_t n_comp, class mesh_t>
         requires mesh_like<mesh_t>
     auto make_vector_field(const std::string& name, mesh_t& mesh, double init_value)
     {
-        return make_vector_field<double, n_comp, SOA>(name, mesh, init_value);
+        return make_vector_field<double, n_comp>(name, mesh, init_value);
     }
 
-    template <std::size_t n_comp, bool SOA = false, class mesh_t, class Func, std::size_t polynomial_degree>
+    template <std::size_t n_comp, class mesh_t, class Func, std::size_t polynomial_degree>
         requires mesh_like<mesh_t>
     auto make_vector_field(const std::string& name, mesh_t& mesh, Func&& f, const GaussLegendre<polynomial_degree>& gl)
     {
-        return make_vector_field<double, n_comp, SOA>(name, mesh, std::forward<Func>(f), gl);
+        return make_vector_field<double, n_comp>(name, mesh, std::forward<Func>(f), gl);
     }
 
-    template <std::size_t n_comp, bool SOA = false, class mesh_t, class Func>
+    template <std::size_t n_comp, class mesh_t, class Func>
         requires mesh_like<mesh_t> && std::is_invocable_v<Func, typename Cell<mesh_t::dim, typename mesh_t::interval_t>::coords_t>
     auto make_vector_field(const std::string& name, mesh_t& mesh, Func&& f)
     {
-        return make_vector_field<double, n_comp, SOA>(name, mesh, std::forward<Func>(f));
+        return make_vector_field<double, n_comp>(name, mesh, std::forward<Func>(f));
     }
 } // namespace samurai

--- a/include/samurai/mr/adapt.hpp
+++ b/include/samurai/mr/adapt.hpp
@@ -89,7 +89,7 @@ namespace samurai
             using mesh_t   = typename TField::mesh_t;
             using detail_t = std::conditional_t<TField::is_scalar,
                                                 ScalarField<mesh_t, typename TField::value_type>,
-                                                VectorField<mesh_t, typename TField::value_type, TField::n_comp, detail::is_soa_v<TField>>>;
+                                                VectorField<mesh_t, typename TField::value_type, TField::n_comp>>;
         };
     }
 

--- a/include/samurai/mr/operators.hpp
+++ b/include/samurai/mr/operators.hpp
@@ -291,21 +291,10 @@ namespace samurai
                         for (std::size_t nc = 0; nc < T2::n_comp; ++nc)
                         {
                             double d1, d2, d3, d4;
-                            if constexpr (T2::is_soa)
-                            {
-                                std::size_t size = field.mesh().nb_cells();
-                                d1               = data[(ind1 + i_f) + nc * size];
-                                d2               = data[(ind1 + i_f + 1) + nc * size];
-                                d3               = data[(ind2 + i_f) + nc * size];
-                                d4               = data[(ind2 + i_f + 1) + nc * size];
-                            }
-                            else
-                            {
-                                d1 = data[(ind1 + i_f) * T2::n_comp + nc];
-                                d2 = data[(ind1 + i_f + 1) * T2::n_comp + nc];
-                                d3 = data[(ind2 + i_f) * T2::n_comp + nc];
-                                d4 = data[(ind2 + i_f + 1) * T2::n_comp + nc];
-                            }
+                            d1 = data[(ind1 + i_f) * T2::n_comp + nc];
+                            d2 = data[(ind1 + i_f + 1) * T2::n_comp + nc];
+                            d3 = data[(ind2 + i_f) * T2::n_comp + nc];
+                            d4 = data[(ind2 + i_f + 1) * T2::n_comp + nc];
 
                             for (std::size_t kj = 0; kj < interp_size; ++kj)
                             {
@@ -442,29 +431,14 @@ namespace samurai
                         for (std::size_t nc = 0; nc < T2::n_comp; ++nc)
                         {
                             double d1, d2, d3, d4, d5, d6, d7, d8;
-                            if constexpr (T2::is_soa)
-                            {
-                                std::size_t size = field.mesh().nb_cells();
-                                d1               = data[(ind1 + i_f) + nc * size];
-                                d2               = data[(ind1 + i_f + 1) + nc * size];
-                                d3               = data[(ind2 + i_f) + nc * size];
-                                d4               = data[(ind2 + i_f + 1) + nc * size];
-                                d5               = data[(ind3 + i_f) + nc * size];
-                                d6               = data[(ind3 + i_f + 1) + nc * size];
-                                d7               = data[(ind4 + i_f) + nc * size];
-                                d8               = data[(ind4 + i_f + 1) + nc * size];
-                            }
-                            else
-                            {
-                                d1 = data[(ind1 + i_f) * T2::n_comp + nc];
-                                d2 = data[(ind1 + i_f + 1) * T2::n_comp + nc];
-                                d3 = data[(ind2 + i_f) * T2::n_comp + nc];
-                                d4 = data[(ind2 + i_f + 1) * T2::n_comp + nc];
-                                d5 = data[(ind3 + i_f) * T2::n_comp + nc];
-                                d6 = data[(ind3 + i_f + 1) * T2::n_comp + nc];
-                                d7 = data[(ind4 + i_f) * T2::n_comp + nc];
-                                d8 = data[(ind4 + i_f + 1) * T2::n_comp + nc];
-                            }
+                            d1 = data[(ind1 + i_f) * T2::n_comp + nc];
+                            d2 = data[(ind1 + i_f + 1) * T2::n_comp + nc];
+                            d3 = data[(ind2 + i_f) * T2::n_comp + nc];
+                            d4 = data[(ind2 + i_f + 1) * T2::n_comp + nc];
+                            d5 = data[(ind3 + i_f) * T2::n_comp + nc];
+                            d6 = data[(ind3 + i_f + 1) * T2::n_comp + nc];
+                            d7 = data[(ind4 + i_f) * T2::n_comp + nc];
+                            d8 = data[(ind4 + i_f + 1) * T2::n_comp + nc];
 
                             for (std::size_t kk = 0; kk < interp_size; ++kk)
                             {
@@ -540,7 +514,6 @@ namespace samurai
 
             static constexpr std::size_t dim    = Field::dim;
             static constexpr std::size_t n_comp = Field::n_comp;
-            static constexpr bool is_soa        = detail::is_soa_v<Field>;
             static constexpr bool is_scalar     = false;
 
             using interval_t    = typename Field::interval_t;

--- a/include/samurai/numeric/gauss_legendre.hpp
+++ b/include/samurai/numeric/gauss_legendre.hpp
@@ -40,7 +40,7 @@ namespace samurai
             }
             else
             {
-                Array<double, func_result_size, false> sum;
+                Array<double, func_result_size> sum;
                 sum.fill(0);
                 compute_quadrature_sum(cell, sum, f);
                 return eval(pow(half_h, dim) * sum);

--- a/include/samurai/petsc/block_assembly.hpp
+++ b/include/samurai/petsc/block_assembly.hpp
@@ -1258,8 +1258,8 @@ namespace samurai
          * monolithicAssembly.create_matrix(monolithicA);
          * monolithicAssembly.assemble_matrix(monolithicA);
          * Vec mono_x                = monolithicAssembly.create_applicable_vector(x); // copy
-         * auto result_velocity_mono = samurai::make_field<dim, is_soa>("result_velocity", mesh);
-         * auto result_pressure_mono = samurai::make_field<1, is_soa>("result_pressure", mesh);
+         * auto result_velocity_mono = samurai::make_field<dim>("result_velocity", mesh);
+         * auto result_pressure_mono = samurai::make_field<1>("result_pressure", mesh);
          * auto result_mono          = stokes.tie_rhs(result_velocity_mono, result_pressure_mono);
          * Vec mono_result           = monolithicAssembly.create_rhs_vector(result_mono); // copy
          * MatMult(monolithicA, mono_x, mono_result);
@@ -1271,8 +1271,8 @@ namespace samurai
          * nestedAssembly.create_matrix(nestedA);
          * nestedAssembly.assemble_matrix(nestedA);
          * Vec nest_x                = nestedAssembly.create_applicable_vector(x);
-         * auto result_velocity_nest = samurai::make_field<dim, is_soa>("result_velocity", mesh);
-         * auto result_pressure_nest = samurai::make_field<1, is_soa>("result_pressure", mesh);
+         * auto result_velocity_nest = samurai::make_field<dim>("result_velocity", mesh);
+         * auto result_pressure_nest = samurai::make_field<1>("result_pressure", mesh);
          * auto result_nest          = stokes.tie_rhs(result_velocity_nest, result_pressure_nest);
          * Vec nest_result           = nestedAssembly.create_rhs_vector(result_nest);
          * MatMult(nestedA, nest_x, nest_result);

--- a/include/samurai/petsc/fv/cell_based_scheme_assembly.hpp
+++ b/include/samurai/petsc/fv/cell_based_scheme_assembly.hpp
@@ -55,10 +55,6 @@ namespace samurai
                 {
                     return cell_local_index;
                 }
-                else if constexpr (detail::is_soa_v<field_t>)
-                {
-                    return field_j * stencil_size + cell_local_index;
-                }
                 else
                 {
                     return cell_local_index * input_n_comp + field_j;
@@ -70,10 +66,6 @@ namespace samurai
                 if constexpr (output_n_comp == 1)
                 {
                     return cell_local_index;
-                }
-                else if constexpr (detail::is_soa_v<field_t>)
-                {
-                    return field_i * stencil_size + cell_local_index;
                 }
                 else
                 {
@@ -132,72 +124,15 @@ namespace samurai
                     return;
                 }
 
-                StencilCoeffs<cfg_t> coeffs;
-
-                // If LinearHomogeneous, take only the non-zero coefficients into account.
-                // Not sure if this optimization really makes a difference though...
-                if constexpr (cfg_t::scheme_type == SchemeType::LinearHomogeneous && detail::is_soa_v<field_t>)
-                {
-                    for (unsigned int field_i = 0; field_i < output_n_comp; ++field_i)
-                    {
-                        scheme().coefficients(coeffs, cell_length(1., 0));
-                        PetscInt scheme_nnz_i = 0;
-                        for (unsigned int field_j = 0; field_j < input_n_comp; ++field_j)
-                        {
-                            if constexpr (cfg_t::contiguous_indices_start > 0)
-                            {
-                                for (unsigned int c = 0; c < cfg_t::contiguous_indices_start; ++c)
-                                {
-                                    double coeff = scheme().cell_coeff(coeffs, c, field_i, field_j);
-                                    if (coeff != 0)
-                                    {
-                                        scheme_nnz_i++;
-                                    }
-                                }
-                            }
-                            if constexpr (cfg_t::contiguous_indices_size > 0)
-                            {
-                                for (unsigned int c = 0; c < cfg_t::contiguous_indices_size; ++c)
-                                {
-                                    double coeff = scheme().cell_coeff(coeffs, c, field_i, field_j);
-                                    if (coeff != 0)
-                                    {
-                                        scheme_nnz_i += cfg_t::contiguous_indices_size;
-                                        break;
-                                    }
-                                }
-                            }
-                            if constexpr (cfg_t::contiguous_indices_start + cfg_t::contiguous_indices_size < cfg_t::stencil_size)
-                            {
-                                for (unsigned int c = cfg_t::contiguous_indices_start + cfg_t::contiguous_indices_size; c < stencil_size; ++c)
-                                {
-                                    double coeff = scheme().cell_coeff(coeffs, c, field_i, field_j);
-                                    if (coeff != 0)
-                                    {
-                                        scheme_nnz_i++;
-                                    }
-                                }
-                            }
-                        }
-                        for_each_cell(mesh(),
-                                      [&](auto& cell)
-                                      {
-                                          d_nnz[static_cast<std::size_t>(this->local_row_index(cell, field_i))] += scheme_nnz_i;
-                                      });
-                    }
-                }
-                else
-                {
-                    PetscInt scheme_nnz_i = stencil_size * input_n_comp;
-                    for_each_cell(mesh(),
-                                  [&](auto& cell)
+                PetscInt scheme_nnz_i = stencil_size * input_n_comp;
+                for_each_cell(mesh(),
+                              [&](auto& cell)
+                              {
+                                  for (unsigned int field_i = 0; field_i < output_n_comp; ++field_i)
                                   {
-                                      for (unsigned int field_i = 0; field_i < output_n_comp; ++field_i)
-                                      {
-                                          d_nnz[static_cast<std::size_t>(this->local_row_index(cell, field_i))] += scheme_nnz_i;
-                                      }
-                                  });
-                }
+                                      d_nnz[static_cast<std::size_t>(this->local_row_index(cell, field_i))] += scheme_nnz_i;
+                                  }
+                              });
             }
 #endif
 
@@ -262,9 +197,9 @@ namespace samurai
                         //     field_j (Grad_y) |  |  |  |-1| 1|
 
                         // Coefficient insertion
-                        if constexpr (field_t::is_scalar || detail::is_soa_v<field_t>)
+                        if constexpr (field_t::is_scalar)
                         {
-                            // In SOA, the indices are ordered in field_i for
+                            // The indices are ordered in field_i for
                             // all cells, then field_j for all cells:
                             //
                             // - Diffusion example:

--- a/include/samurai/petsc/utils.hpp
+++ b/include/samurai/petsc/utils.hpp
@@ -233,8 +233,6 @@ namespace samurai
         template <class Field>
         Vec create_petsc_vector_from(Field& f, const typename Field::cell_t& cell)
         {
-            static_assert(Field::is_scalar || !detail::is_soa_v<Field>);
-
             Vec v;
             auto vec_size        = static_cast<PetscInt>(Field::n_comp);
             auto cell_data_index = Field::n_comp * static_cast<std::size_t>(cell.index);

--- a/include/samurai/reconstruction.hpp
+++ b/include/samurai/reconstruction.hpp
@@ -531,7 +531,7 @@ namespace samurai
             }
             else
             {
-                return make_vector_field<typename Field::value_type, Field::n_comp, detail::is_soa_v<Field>>(name, mesh);
+                return make_vector_field<typename Field::value_type, Field::n_comp>(name, mesh);
             }
         };
 
@@ -542,7 +542,7 @@ namespace samurai
         reconstruct_mesh.update_index();
 
         auto m = holder(reconstruct_mesh);
-        // auto reconstruct_field = make_field<typename Field::value_type, Field::n_comp, detail::is_soa_v<Field>>(field.name(), m);
+        // auto reconstruct_field = make_field<typename Field::value_type, Field::n_comp>(field.name(), m);
         auto reconstruct_field = make_field_like(field.name(), m);
         reconstruct_field.fill(0.);
 
@@ -789,14 +789,7 @@ namespace samurai
             }
             else
             {
-                if constexpr (Field::is_soa)
-                {
-                    return xt::view(f(level, indices...), xt::all(), 0);
-                }
-                else
-                {
-                    return xt::view(f(level, indices...), 0);
-                }
+                return xt::view(f(level, indices...), 0);
             }
         };
 
@@ -852,24 +845,16 @@ namespace samurai
                         {
                             auto i_dst = static_cast<size_type>(((i.start + ii) >> static_cast<value_t>(shift))
                                                                 - (i.start >> static_cast<value_t>(shift)));
-                            if constexpr (detail::is_soa_v<Field_src> && !Field_src::is_scalar)
-                            {
-                                view(dst, placeholders::all(), i_dst) += view(src, placeholders::all(), static_cast<size_type>(ii))
-                                                                       / (1 << shift * dim);
-                            }
-                            else
-                            {
 #if defined(SAMURAI_FIELD_CONTAINER_EIGEN3)
-                                static_assert(detail::is_soa_v<Field_src> && !Field_src::is_scalar,
-                                              "transfer() is not implemented with Eigen for scalar fields and vectorial fields in AOS.");
+                            static_assert(sizeof(Field_src) == 0,
+                                          "transfer() is not implemented with Eigen for scalar and vectorial fields.");
                             // In the lid-driven-cavity demo, the following line of code does not compile with Eigen.
 #else
-                                static_assert(Field_src::static_layout == layout_type::row_major,
-                                              "transfer() is not implemented when the xtensor within a field is col-major.");
+                            static_assert(Field_src::static_layout == layout_type::row_major,
+                                          "transfer() is not implemented when the xtensor within a field is col-major.");
                             // In the lid-driven-cavity demo, the following line of code crashes at execution in col_major.
 #endif
-                                view(dst, i_dst) += view(src, static_cast<size_type>(ii)) / (1 << shift * dim);
-                            }
+                            view(dst, i_dst) += view(src, static_cast<size_type>(ii)) / (1 << shift * dim);
                         }
                     });
             }

--- a/include/samurai/schemes/fv/FV_scheme.hpp
+++ b/include/samurai/schemes/fv/FV_scheme.hpp
@@ -108,7 +108,7 @@ namespace samurai
 
         // using output_field_t = std::conditional_t<input_field_t::is_scalar && output_n_comp == 1,
         //                                           ScalarField<mesh_t, field_value_type>,
-        //                                           VectorField<mesh_t, field_value_type, output_n_comp, detail::is_soa_v<input_field_t>>>;
+        //                                           VectorField<mesh_t, field_value_type, output_n_comp>>;
 
         using dirichlet_t = DirichletImpl<nb_bdry_ghosts, field_t>;
         using neumann_t   = NeumannImpl<nb_bdry_ghosts, field_t>;

--- a/include/samurai/schemes/fv/cell_based/algebraic_operators.hpp
+++ b/include/samurai/schemes/fv/cell_based/algebraic_operators.hpp
@@ -167,7 +167,7 @@ namespace samurai
                 StencilCoeffs<lin_cfg> coeffs;
                 auto h = cell.length;
                 lin_scheme.coefficients(coeffs, h);
-                value += mat_vec<detail::is_soa_v<input_field_t>, can_collapse>(coeffs, field[cell]);
+                value += mat_vec<can_collapse>(coeffs, field[cell]);
             };
 
             addition_scheme.local_scheme_function() = nullptr;
@@ -180,7 +180,7 @@ namespace samurai
                     StencilCoeffs<lin_cfg> coeffs;
                     auto h = cell.length;
                     lin_scheme.coefficients(coeffs, h);
-                    value += mat_vec<detail::is_soa_v<input_field_t>, can_collapse>(coeffs, field[cell]);
+                    value += mat_vec<can_collapse>(coeffs, field[cell]);
                 };
             }
 

--- a/include/samurai/schemes/fv/cell_based/cell_based_scheme_definition.hpp
+++ b/include/samurai/schemes/fv/cell_based/cell_based_scheme_definition.hpp
@@ -82,7 +82,6 @@ namespace samurai
     template <class cfg>
     using SchemeValue = CollapsArray<typename cfg::output_field_t::value_type,
                                      cfg::output_field_t::n_comp,
-                                     detail::is_soa_v<typename cfg::output_field_t>,
                                      cfg::output_field_t::is_scalar>;
 
     /**

--- a/include/samurai/schemes/fv/operators/convection_lin.hpp
+++ b/include/samurai/schemes/fv/operators/convection_lin.hpp
@@ -86,7 +86,6 @@ namespace samurai
     auto make_convection_weno5(const VelocityVector<Field::dim>& velocity)
     {
         static constexpr std::size_t dim          = Field::dim;
-        static constexpr bool is_soa              = detail::is_soa_v<Field>;
         static constexpr std::size_t stencil_size = 6;
         using input_field_t                       = Field;
         using output_field_t                      = Field;
@@ -110,14 +109,14 @@ namespace samurai
                     weno5[d].cons_flux_function =
                         [&velocity](FluxValue<cfg>& flux, const StencilData<cfg>& /*data*/, const StencilValues<cfg>& u)
                     {
-                        Array<FluxValue<cfg>, 5, is_soa> f({u[0], u[1], u[2], u[3], u[4]});
+                        Array<FluxValue<cfg>, 5> f({u[0], u[1], u[2], u[3], u[4]});
                         f *= velocity(d);
                         compute_weno5_flux(flux, f);
                     };
                     weno5[d].cons_jacobian_function =
                         [&velocity](StencilJacobian<cfg>& jac, const StencilData<cfg>& /*data*/, const StencilValues<cfg>& u)
                     {
-                        Array<FluxValue<cfg>, 5, is_soa> f({u[0], u[1], u[2], u[3], u[4]});
+                        Array<FluxValue<cfg>, 5> f({u[0], u[1], u[2], u[3], u[4]});
                         f *= velocity(d);
 
                         std::array<decltype(&jac[0]), 5> jacobians({&jac[0], &jac[1], &jac[2], &jac[3], &jac[4]});
@@ -138,14 +137,14 @@ namespace samurai
                     weno5[d].cons_flux_function =
                         [&velocity](FluxValue<cfg>& flux, const StencilData<cfg>& /*data*/, const StencilValues<cfg>& u)
                     {
-                        Array<FluxValue<cfg>, 5, is_soa> f({u[5], u[4], u[3], u[2], u[1]});
+                        Array<FluxValue<cfg>, 5> f({u[5], u[4], u[3], u[2], u[1]});
                         f *= velocity(d);
                         compute_weno5_flux(flux, f);
                     };
                     weno5[d].cons_jacobian_function =
                         [&velocity](StencilJacobian<cfg>& jac, const StencilData<cfg>& /*data*/, const StencilValues<cfg>& u)
                     {
-                        Array<FluxValue<cfg>, 5, is_soa> f({u[5], u[4], u[3], u[2], u[1]});
+                        Array<FluxValue<cfg>, 5> f({u[5], u[4], u[3], u[2], u[1]});
                         f *= velocity(d);
 
                         std::array<decltype(&jac[0]), 5> jacobians({&jac[5], &jac[4], &jac[3], &jac[2], &jac[1]});
@@ -254,7 +253,6 @@ namespace samurai
     auto make_convection_weno5(VelocityField& velocity_field)
     {
         static constexpr std::size_t dim = Field::dim;
-        static constexpr bool is_soa     = detail::is_soa_v<Field>;
 
         static constexpr std::size_t stencil_size = 6;
         using input_field_t                       = Field;
@@ -285,13 +283,13 @@ namespace samurai
 
                     if (v >= 0)
                     {
-                        Array<FluxValue<cfg>, 5, is_soa> f({u[0], u[1], u[2], u[3], u[4]});
+                        Array<FluxValue<cfg>, 5> f({u[0], u[1], u[2], u[3], u[4]});
                         f *= v;
                         compute_weno5_flux(flux, f);
                     }
                     else
                     {
-                        Array<FluxValue<cfg>, 5, is_soa> f({u[5], u[4], u[3], u[2], u[1]});
+                        Array<FluxValue<cfg>, 5> f({u[5], u[4], u[3], u[2], u[1]});
                         f *= v;
                         compute_weno5_flux(flux, f);
                     }

--- a/include/samurai/schemes/fv/operators/gradient.hpp
+++ b/include/samurai/schemes/fv/operators/gradient.hpp
@@ -13,7 +13,7 @@ namespace samurai
 
         static constexpr std::size_t stencil_size = 2;
         using input_field_t                       = Field;
-        using output_field_t = VectorField<typename Field::mesh_t, typename Field::value_type, dim, detail::is_soa_v<input_field_t>>;
+        using output_field_t = VectorField<typename Field::mesh_t, typename Field::value_type, dim>;
 
         using cfg = FluxConfig<SchemeType::LinearHomogeneous, stencil_size, output_field_t, input_field_t>;
 

--- a/include/samurai/storage/collapsable_linear_algebra.hpp
+++ b/include/samurai/storage/collapsable_linear_algebra.hpp
@@ -100,18 +100,18 @@ namespace samurai
         // return e;
     }
 
-    template <bool SOA, bool can_collapse, class value_type, std::enable_if_t<std::is_floating_point_v<value_type>, bool> = true>
+    template <bool can_collapse, class value_type, std::enable_if_t<std::is_floating_point_v<value_type>, bool> = true>
     auto mat_vec(value_type A, value_type x)
     {
         return A * x;
     }
 
-    template <bool SOA, bool can_collapse, class value_type, std::size_t rows, std::size_t cols, class vector_type>
+    template <bool can_collapse, class value_type, std::size_t rows, std::size_t cols, class vector_type>
     auto mat_vec(const Matrix<value_type, rows, cols>& A, const vector_type& x)
     {
         // 'vector_type' can be an xt::view or a CollapsArray
 
-        CollapsArray<value_type, rows, SOA, can_collapse> res = zeros<CollapsMatrix<value_type, rows, cols, can_collapse>>();
+        CollapsArray<value_type, rows, can_collapse> res = zeros<CollapsMatrix<value_type, rows, cols, can_collapse>>();
         if constexpr (rows == 1 && cols == 1 && can_collapse)
         {
             res = A * x;

--- a/include/samurai/storage/containers_config.hpp
+++ b/include/samurai/storage/containers_config.hpp
@@ -32,20 +32,20 @@ namespace samurai
 
 #if defined(SAMURAI_FIELD_CONTAINER_EIGEN3)
 
-    template <class value_type, std::size_t size = 1, bool SOA = false, bool can_collapse = true>
-    using field_data_storage_t = eigen_container<value_type, size, SOA, can_collapse>;
+    template <class value_type, std::size_t size = 1, bool can_collapse = true>
+    using field_data_storage_t = eigen_container<value_type, size>;
 
-    template <class value_type, std::size_t size, bool SOA = false, bool can_collapse = true>
-    using local_field_data_t = eigen_collapsable_static_array<value_type, size, SOA, can_collapse>;
+    template <class value_type, std::size_t size, bool can_collapse = true>
+    using local_field_data_t = eigen_collapsable_static_array<value_type, size, can_collapse>;
 
     template <class T>
     using default_view_t = Eigen::IndexedView<T, Eigen::internal::ArithmeticSequenceRange<16777215, -1, 16777215>, Eigen::internal::SingleRange<0>>;
 #else // SAMURAI_FIELD_CONTAINER_XTENSOR
 
-    template <class value_type, std::size_t size = 1, bool SOA = false, bool can_collapse = true>
-    using field_data_storage_t = xtensor_container<value_type, size, SOA, can_collapse>;
+    template <class value_type, std::size_t size = 1, bool can_collapse = true>
+    using field_data_storage_t = xtensor_container<value_type, size, can_collapse>;
 
-    template <class value_type, std::size_t size, bool SOA = false, bool can_collapse = true>
+    template <class value_type, std::size_t size, bool can_collapse = true>
     using local_field_data_t = xtensor_collapsable_static_array<value_type, size, can_collapse>;
 
     template <class T>
@@ -56,15 +56,15 @@ namespace samurai
     // Static array //
     //--------------//
 
-    template <class value_type, std::size_t size, bool SOA = false>
+    template <class value_type, std::size_t size>
 #if defined(SAMURAI_FIELD_CONTAINER_EIGEN3)
-    using Array = eigen_static_array<value_type, size, SOA>;
+    using Array = eigen_static_array<value_type, size>;
 #else // SAMURAI_FIELD_CONTAINER_XTENSOR
     using Array = xtensor_static_array<value_type, size>;
 #endif
 
-    template <class value_type, std::size_t size, bool SOA = false, bool can_collapse = true>
-    using CollapsArray = CollapsableArray<Array<value_type, size, SOA>, value_type, size, can_collapse>;
+    template <class value_type, std::size_t size, bool can_collapse = true>
+    using CollapsArray = CollapsableArray<Array<value_type, size>, value_type, size, can_collapse>;
 
     //----------------//
     // Flux container //

--- a/include/samurai/storage/eigen/eigen.hpp
+++ b/include/samurai/storage/eigen/eigen.hpp
@@ -21,37 +21,31 @@ namespace samurai
 
     namespace detail
     {
-        template <class value_t, std::size_t size, bool SOA, class = void>
+        template <class value_t, std::size_t size, class = void>
         struct eigen_type;
 
-        template <class value_t, bool SOA>
-        struct eigen_type<value_t, 1, SOA>
+        template <class value_t>
+        struct eigen_type<value_t, 1>
         {
             using type = Eigen::Array<value_t, Eigen::Dynamic, 1>;
         };
 
         template <class value_t, std::size_t size>
-        struct eigen_type<value_t, size, true, std::enable_if_t<(size > 1)>>
-        {
-            using type = Eigen::Array<value_t, size, Eigen::Dynamic, Eigen::RowMajor>;
-        };
-
-        template <class value_t, std::size_t size>
-        struct eigen_type<value_t, size, false, std::enable_if_t<(size > 1)>>
+        struct eigen_type<value_t, size, std::enable_if_t<(size > 1)>>
         {
             using type = Eigen::Array<value_t, Eigen::Dynamic, size, Eigen::ColMajor>;
         };
 
-        template <class value_t, std::size_t size, bool SOA>
-        using eigen_type_t = typename eigen_type<value_t, size, SOA>::type;
+        template <class value_t, std::size_t size>
+        using eigen_type_t = typename eigen_type<value_t, size>::type;
 
     }
 
-    template <class value_t, std::size_t size, bool SOA>
+    template <class value_t, std::size_t size>
     struct eigen_container
     {
         static constexpr layout_type static_layout = SAMURAI_DEFAULT_LAYOUT; // cppcheck-suppress unusedStructMember
-        using container_t                          = detail::eigen_type_t<value_t, size, SOA>;
+        using container_t                          = detail::eigen_type_t<value_t, size>;
         using size_type                            = Eigen::Index;
 
         eigen_container() = default;
@@ -80,14 +74,7 @@ namespace samurai
             }
             else
             {
-                if constexpr (SOA)
-                {
-                    m_data.resize(size, dynamic_size);
-                }
-                else
-                {
-                    m_data.resize(dynamic_size, size);
-                }
+                m_data.resize(dynamic_size, size);
             }
         }
 
@@ -96,118 +83,67 @@ namespace samurai
         container_t m_data;
     };
 
-    template <class value_t, bool SOA>
-    auto view(eigen_container<value_t, 1, SOA>& container, const range_t<Eigen::Index>& range)
+    template <class value_t>
+    auto view(eigen_container<value_t, 1>& container, const range_t<Eigen::Index>& range)
     {
         return container.data()(Eigen::seq(range.start, range.end - 1, range.step));
     }
 
     template <class value_t, std::size_t size, typename = std::enable_if_t<(size > 1)>>
-    auto view(eigen_container<value_t, size, true>& container, const range_t<Eigen::Index>& range)
-    {
-        return container.data()(Eigen::placeholders::all, Eigen::seq(range.start, range.end - 1, range.step));
-    }
-
-    template <class value_t, std::size_t size, typename = std::enable_if_t<(size > 1)>>
-    auto view(eigen_container<value_t, size, false>& container, const range_t<Eigen::Index>& range)
+    auto view(eigen_container<value_t, size>& container, const range_t<Eigen::Index>& range)
     {
         return container.data()(Eigen::seq(range.start, range.end - 1, range.step), Eigen::placeholders::all);
     }
 
     template <class value_t, std::size_t size>
-    auto view(eigen_container<value_t, size, true>& container, const range_t<std::size_t>& range_item, const range_t<Eigen::Index>& range)
-    {
-        return container.data()(Eigen::seq(range_item.start, range_item.end - 1, range_item.step),
-                                Eigen::seq(range.start, range.end - 1, range.step));
-    }
-
-    template <class value_t, std::size_t size>
-    auto view(eigen_container<value_t, size, false>& container, const range_t<std::size_t>& range_item, const range_t<Eigen::Index>& range)
+    auto view(eigen_container<value_t, size>& container, const range_t<std::size_t>& range_item, const range_t<Eigen::Index>& range)
     {
         return container.data()(Eigen::seq(range.start, range.end - 1, range.step),
                                 Eigen::seq(range_item.start, range_item.end - 1, range_item.step));
     }
 
     template <class value_t, std::size_t size>
-    auto view(eigen_container<value_t, size, true>& container, std::size_t item, const range_t<Eigen::Index>& range)
-    {
-        return container.data()(item, Eigen::seq(range.start, range.end - 1, range.step));
-    }
-
-    template <class value_t, std::size_t size>
-    auto view(eigen_container<value_t, size, false>& container, std::size_t item, const range_t<Eigen::Index>& range)
+    auto view(eigen_container<value_t, size>& container, std::size_t item, const range_t<Eigen::Index>& range)
     {
         return container.data()(Eigen::seq(range.start, range.end - 1, range.step), item);
     }
 
-    template <class value_t, bool SOA>
-    auto view(const eigen_container<value_t, 1, SOA>& container, const range_t<Eigen::Index>& range)
+    template <class value_t>
+    auto view(const eigen_container<value_t, 1>& container, const range_t<Eigen::Index>& range)
     {
         return container.data()(Eigen::seq(range.start, range.end - 1, range.step));
     }
 
     template <class value_t, std::size_t size, typename = std::enable_if_t<(size > 1)>>
-    auto view(const eigen_container<value_t, size, true>& container, const range_t<Eigen::Index>& range)
-    {
-        return container.data()(Eigen::placeholders::all, Eigen::seq(range.start, range.end - 1, range.step));
-    }
-
-    template <class value_t, std::size_t size, typename = std::enable_if_t<(size > 1)>>
-    auto view(const eigen_container<value_t, size, false>& container, const range_t<Eigen::Index>& range)
+    auto view(const eigen_container<value_t, size>& container, const range_t<Eigen::Index>& range)
     {
         return container.data()(Eigen::seq(range.start, range.end - 1, range.step), Eigen::placeholders::all);
     }
 
     template <class value_t, std::size_t size>
     auto
-    view(const eigen_container<value_t, size, true>& container, const range_t<std::size_t>& range_item, const range_t<Eigen::Index>& range)
-    {
-        return container.data()(Eigen::seq(range_item.start, range_item.end - 1, range_item.step),
-                                Eigen::seq(range.start, range.end - 1, range.step));
-    }
-
-    template <class value_t, std::size_t size>
-    auto
-    view(const eigen_container<value_t, size, false>& container, const range_t<std::size_t>& range_item, const range_t<Eigen::Index>& range)
+    view(const eigen_container<value_t, size>& container, const range_t<std::size_t>& range_item, const range_t<Eigen::Index>& range)
     {
         return container.data()(Eigen::seq(range.start, range.end - 1, range.step),
                                 Eigen::seq(range_item.start, range_item.end - 1, range_item.step));
     }
 
     template <class value_t, std::size_t size>
-    auto view(const eigen_container<value_t, size, true>& container, std::size_t item, const range_t<Eigen::Index>& range)
-    {
-        return container.data()(item, Eigen::seq(range.start, range.end - 1, range.step));
-    }
-
-    template <class value_t, std::size_t size>
-    auto view(const eigen_container<value_t, size, false>& container, std::size_t item, const range_t<Eigen::Index>& range)
+    auto view(const eigen_container<value_t, size>& container, std::size_t item, const range_t<Eigen::Index>& range)
     {
         return container.data()(Eigen::seq(range.start, range.end - 1, range.step), item);
     }
 
     template <class value_t, std::size_t size>
-    auto view(const eigen_container<value_t, size, false>& container, Eigen::Index index)
+    auto view(const eigen_container<value_t, size>& container, Eigen::Index index)
     {
         return container.data()(index, Eigen::placeholders::all);
     }
 
     template <class value_t, std::size_t size>
-    auto view(eigen_container<value_t, size, false>& container, Eigen::Index index)
+    auto view(eigen_container<value_t, size>& container, Eigen::Index index)
     {
         return container.data()(index, Eigen::placeholders::all);
-    }
-
-    template <class value_t, std::size_t size>
-    auto view(const eigen_container<value_t, size, true>& container, Eigen::Index index)
-    {
-        return container.data()(Eigen::placeholders::all, index);
-    }
-
-    template <class value_t, std::size_t size>
-    auto view(eigen_container<value_t, size, true>& container, Eigen::Index index)
-    {
-        return container.data()(Eigen::placeholders::all, index);
     }
 
     template <class D>

--- a/include/samurai/storage/eigen/eigen_static.hpp
+++ b/include/samurai/storage/eigen/eigen_static.hpp
@@ -14,24 +14,18 @@ namespace samurai
 
     namespace detail
     {
-        template <class value_type, std::size_t size, bool SOA>
+        template <class value_type, std::size_t size>
         struct eigen_static_array
         {
             using type = Eigen::Array<value_type, 1, size>;
         };
 
         template <class value_type, std::size_t size>
-        struct eigen_static_array<value_type, size, true>
-        {
-            using type = Eigen::Array<value_type, size, 1>;
-        };
-
-        template <class value_type, std::size_t size, bool SOA>
-        using eigen_static_array_t = typename eigen_static_array<value_type, size, SOA>::type;
+        using eigen_static_array_t = typename eigen_static_array<value_type, size>::type;
 
     }
-    template <class value_type, std::size_t size, bool SOA>
-    using eigen_static_array = detail::eigen_static_array_t<value_type, size, SOA>;
+    template <class value_type, std::size_t size>
+    using eigen_static_array = detail::eigen_static_array_t<value_type, size>;
 
     // using eigen_static_array = Eigen::Matrix<value_type, 1, size>;
     // using eigen_static_array = Eigen::Array<value_type, size, 1>;
@@ -41,8 +35,8 @@ namespace samurai
     template <class value_type, std::size_t rows, std::size_t cols>
     using eigen_static_matrix = Eigen::Matrix<value_type, rows, cols>;
 
-    template <class value_type, std::size_t size, bool SOA, bool can_collapse>
-    using eigen_collapsable_static_array = CollapsableArray<eigen_static_array<value_type, size, SOA>, value_type, size, can_collapse>;
+    template <class value_type, std::size_t size, bool can_collapse>
+    using eigen_collapsable_static_array = CollapsableArray<eigen_static_array<value_type, size>, value_type, size, can_collapse>;
 
     template <class value_type, std::size_t rows, std::size_t cols>
     using eigen_collapsable_static_matrix = CollapsableMatrix<eigen_static_matrix<value_type, rows, cols>, value_type, rows, cols>;
@@ -65,8 +59,8 @@ namespace samurai
     // Functions //
     //-----------//
 
-    template <class value_type, std::size_t size, bool SOA>
-    void fill(eigen_static_array<value_type, size, SOA>& array, value_type value)
+    template <class value_type, std::size_t size>
+    void fill(eigen_static_array<value_type, size>& array, value_type value)
     {
         array.fill(value);
     }

--- a/include/samurai/storage/utils.hpp
+++ b/include/samurai/storage/utils.hpp
@@ -9,30 +9,24 @@ namespace samurai
 {
     namespace detail
     {
-        template <std::size_t size, bool SOA, bool can_collapse, layout_type L>
+        template <std::size_t size, bool can_collapse, layout_type L>
         struct static_size_first : std::false_type
         {
         };
 
         template <std::size_t size, bool can_collapse>
             requires(size > 1)
-        struct static_size_first<size, true, can_collapse, layout_type::row_major> : std::true_type
+        struct static_size_first<size, can_collapse, layout_type::column_major> : std::true_type
         {
         };
 
-        template <std::size_t size, bool can_collapse>
-            requires(size > 1)
-        struct static_size_first<size, false, can_collapse, layout_type::column_major> : std::true_type
+        template <layout_type L>
+        struct static_size_first<1, false, L> : std::true_type
         {
         };
 
-        template <bool SOA, layout_type L>
-        struct static_size_first<1, SOA, false, L> : std::true_type
-        {
-        };
-
-        template <std::size_t size, bool SOA, bool can_collapse, layout_type L>
-        static constexpr bool static_size_first_v = static_size_first<size, SOA, can_collapse, L>::value;
+        template <std::size_t size, bool can_collapse, layout_type L>
+        static constexpr bool static_size_first_v = static_size_first<size, can_collapse, L>::value;
     }
 
     template <class T>

--- a/include/samurai/storage/xtensor/xtensor.hpp
+++ b/include/samurai/storage/xtensor/xtensor.hpp
@@ -39,7 +39,7 @@ namespace samurai
         static constexpr ::xt::layout_type xtensor_layout_v = xtensor_layout<L>::value;
     }
 
-    template <class value_t, std::size_t size, bool SOA = false, bool can_collapse = true>
+    template <class value_t, std::size_t size, bool can_collapse = true>
     struct xtensor_container
     {
         static constexpr layout_type static_layout = SAMURAI_DEFAULT_LAYOUT;
@@ -72,7 +72,7 @@ namespace samurai
             }
             else
             {
-                if constexpr (detail::static_size_first_v<size, SOA, can_collapse, static_layout>)
+                if constexpr (detail::static_size_first_v<size, can_collapse, static_layout>)
                 {
                     m_data.resize({size, dynamic_size});
                 }
@@ -92,11 +92,11 @@ namespace samurai
     // VIEW: CONST IMPLEMENTATION //
     ////////////////////////////////
 
-    template <class value_t, std::size_t size, bool SOA, bool can_collapse>
-    auto view(const xtensor_container<value_t, size, SOA, can_collapse>& container, const range_t<long long>& range)
+    template <class value_t, std::size_t size, bool can_collapse>
+    auto view(const xtensor_container<value_t, size, can_collapse>& container, const range_t<long long>& range)
     {
-        static constexpr layout_type static_layout = xtensor_container<value_t, size, SOA, can_collapse>::static_layout;
-        if constexpr (detail::static_size_first_v<size, SOA, can_collapse, static_layout>)
+        static constexpr layout_type static_layout = xtensor_container<value_t, size, can_collapse>::static_layout;
+        if constexpr (detail::static_size_first_v<size, can_collapse, static_layout>)
         {
             return xt::view(container.data(), xt::all(), xt::range(range.start, range.end, range.step));
         }
@@ -106,14 +106,14 @@ namespace samurai
         }
     }
 
-    template <class value_t, std::size_t size, bool SOA, bool can_collapse>
-    auto view(const xtensor_container<value_t, size, SOA, can_collapse>& container,
+    template <class value_t, std::size_t size, bool can_collapse>
+    auto view(const xtensor_container<value_t, size, can_collapse>& container,
               const range_t<std::size_t>& range_item,
               const range_t<long long>& range)
     {
         static_assert(size > 1, "size must be greater than 1");
-        static constexpr layout_type static_layout = xtensor_container<value_t, size, SOA, can_collapse>::static_layout;
-        if constexpr (detail::static_size_first_v<size, SOA, can_collapse, static_layout>)
+        static constexpr layout_type static_layout = xtensor_container<value_t, size, can_collapse>::static_layout;
+        if constexpr (detail::static_size_first_v<size, can_collapse, static_layout>)
         {
             return xt::view(container.data(),
                             xt::range(range_item.start, range_item.end, range_item.step),
@@ -127,12 +127,12 @@ namespace samurai
         }
     }
 
-    template <class value_t, std::size_t size, bool SOA, bool can_collapse>
-    auto view(const xtensor_container<value_t, size, SOA, can_collapse>& container, std::size_t item, const range_t<long long>& range)
+    template <class value_t, std::size_t size, bool can_collapse>
+    auto view(const xtensor_container<value_t, size, can_collapse>& container, std::size_t item, const range_t<long long>& range)
     {
         static_assert(size > 1, "size must be greater than 1");
-        static constexpr layout_type static_layout = xtensor_container<value_t, size, SOA, can_collapse>::static_layout;
-        if constexpr (detail::static_size_first_v<size, SOA, can_collapse, static_layout>)
+        static constexpr layout_type static_layout = xtensor_container<value_t, size, can_collapse>::static_layout;
+        if constexpr (detail::static_size_first_v<size, can_collapse, static_layout>)
         {
             return xt::view(container.data(), item, xt::range(range.start, range.end, range.step));
         }
@@ -142,12 +142,12 @@ namespace samurai
         }
     }
 
-    template <class value_t, std::size_t size, bool SOA, bool can_collapse>
-    auto view(const xtensor_container<value_t, size, SOA, can_collapse>& container, std::size_t index)
+    template <class value_t, std::size_t size, bool can_collapse>
+    auto view(const xtensor_container<value_t, size, can_collapse>& container, std::size_t index)
     {
-        static constexpr layout_type static_layout = xtensor_container<value_t, size, SOA, can_collapse>::static_layout;
+        static constexpr layout_type static_layout = xtensor_container<value_t, size, can_collapse>::static_layout;
 
-        if constexpr (detail::static_size_first_v<size, SOA, can_collapse, static_layout>)
+        if constexpr (detail::static_size_first_v<size, can_collapse, static_layout>)
         {
             return xt::view(container.data(), xt::all(), index);
         }
@@ -161,11 +161,11 @@ namespace samurai
     // VIEW: NON CONST IMPLEMENTATION //
     ////////////////////////////////////
 
-    template <class value_t, std::size_t size, bool SOA, bool can_collapse>
-    auto view(xtensor_container<value_t, size, SOA, can_collapse>& container, const range_t<long long>& range)
+    template <class value_t, std::size_t size, bool can_collapse>
+    auto view(xtensor_container<value_t, size, can_collapse>& container, const range_t<long long>& range)
     {
-        static constexpr layout_type static_layout = xtensor_container<value_t, size, SOA, can_collapse>::static_layout;
-        if constexpr (detail::static_size_first_v<size, SOA, can_collapse, static_layout>)
+        static constexpr layout_type static_layout = xtensor_container<value_t, size, can_collapse>::static_layout;
+        if constexpr (detail::static_size_first_v<size, can_collapse, static_layout>)
         {
             return xt::view(container.data(), xt::all(), xt::range(range.start, range.end, range.step));
         }
@@ -175,14 +175,14 @@ namespace samurai
         }
     }
 
-    template <class value_t, std::size_t size, bool SOA, bool can_collapse>
-    auto view(xtensor_container<value_t, size, SOA, can_collapse>& container,
+    template <class value_t, std::size_t size, bool can_collapse>
+    auto view(xtensor_container<value_t, size, can_collapse>& container,
               const range_t<std::size_t>& range_item,
               const range_t<long long>& range)
     {
         static_assert(size > 1, "size must be greater than 1");
-        static constexpr layout_type static_layout = xtensor_container<value_t, size, SOA, can_collapse>::static_layout;
-        if constexpr (detail::static_size_first_v<size, SOA, can_collapse, static_layout>)
+        static constexpr layout_type static_layout = xtensor_container<value_t, size, can_collapse>::static_layout;
+        if constexpr (detail::static_size_first_v<size, can_collapse, static_layout>)
         {
             return xt::view(container.data(),
                             xt::range(range_item.start, range_item.end, range_item.step),
@@ -196,12 +196,12 @@ namespace samurai
         }
     }
 
-    template <class value_t, std::size_t size, bool SOA, bool can_collapse>
-    auto view(xtensor_container<value_t, size, SOA, can_collapse>& container, std::size_t item, const range_t<long long>& range)
+    template <class value_t, std::size_t size, bool can_collapse>
+    auto view(xtensor_container<value_t, size, can_collapse>& container, std::size_t item, const range_t<long long>& range)
     {
         static_assert(size > 1, "size must be greater than 1");
-        static constexpr layout_type static_layout = xtensor_container<value_t, size, SOA, can_collapse>::static_layout;
-        if constexpr (detail::static_size_first_v<size, SOA, can_collapse, static_layout>)
+        static constexpr layout_type static_layout = xtensor_container<value_t, size, can_collapse>::static_layout;
+        if constexpr (detail::static_size_first_v<size, can_collapse, static_layout>)
         {
             return xt::view(container.data(), item, xt::range(range.start, range.end, range.step));
         }
@@ -211,11 +211,11 @@ namespace samurai
         }
     }
 
-    template <class value_t, std::size_t size, bool SOA, bool can_collapse>
-    auto view(xtensor_container<value_t, size, SOA, can_collapse>& container, std::size_t index)
+    template <class value_t, std::size_t size, bool can_collapse>
+    auto view(xtensor_container<value_t, size, can_collapse>& container, std::size_t index)
     {
-        static constexpr layout_type static_layout = xtensor_container<value_t, size, SOA, can_collapse>::static_layout;
-        if constexpr (detail::static_size_first_v<size, SOA, can_collapse, static_layout>)
+        static constexpr layout_type static_layout = xtensor_container<value_t, size, can_collapse>::static_layout;
+        if constexpr (detail::static_size_first_v<size, can_collapse, static_layout>)
         {
             return xt::view(container.data(), xt::all(), index);
         }

--- a/include/samurai/utils.hpp
+++ b/include/samurai/utils.hpp
@@ -104,7 +104,7 @@ namespace samurai
     template <template <std::size_t dim, class T> class OP, class... CT>
     class field_operator_function;
 
-    template <class mesh_t, class value_t, std::size_t n_comp, bool SOA = false>
+    template <class mesh_t, class value_t, std::size_t n_comp>
     class VectorField;
 
     template <class mesh_t, class value_t>
@@ -321,30 +321,6 @@ namespace samurai
         }
 
         /**
-         * @brief test if template parameter is SOA of AOS Field (false by default like VectorField)
-         *
-         * @tparam T type to test
-         */
-        template <class T>
-        struct is_soa : std::false_type
-        {
-        };
-
-        // specialization for VectorField
-        template <class Mesh, class value_t, std::size_t n_comp, bool SOA>
-        struct is_soa<VectorField<Mesh, value_t, n_comp, SOA>> : std::bool_constant<SOA>
-        {
-        };
-
-        /**
-         * @brief helper to get value of is_soa
-         *
-         * @tparam T type to test
-         */
-        template <class T>
-        constexpr bool is_soa_v = is_soa<std::decay_t<T>>::value;
-
-        /**
          * @brief test if template parameter is a samurai field (ScalarField or VectorField)
          *
          * @tparam T type to test
@@ -355,8 +331,8 @@ namespace samurai
         };
 
         // specialization for VectorField
-        template <class Mesh, class value_t, std::size_t n_comp, bool SOA>
-        struct is_field_type<VectorField<Mesh, value_t, n_comp, SOA>> : std::true_type
+        template <class Mesh, class value_t, std::size_t n_comp>
+        struct is_field_type<VectorField<Mesh, value_t, n_comp>> : std::true_type
         {
         };
 
@@ -524,25 +500,6 @@ namespace samurai
         shift[d] = (max_indices[d] - min_indices[d]) >> delta_l;
         return shift;
     }
-
-    // template <class Field>
-    // SAMURAI_INLINE auto&
-    // field_value(typename Field::value_type* data, const typename Field::index_t& cell_index, [[maybe_unused]] std::size_t field_i)
-    // {
-    //     if constexpr (Field::is_scalar)
-    //     {
-    //         return *data[cell_index];
-    //     }
-    //     else if constexpr (detail::is_soa_v<Field>)
-    //     {
-    //         static_assert(Field::is_scalar || !detail::is_soa_v<Field>, "field_value() is not implemented for SOA fields");
-    //         return *data[field_i /*  *n_cells */ + cell_index];
-    //     }
-    //     else
-    //     {
-    //         return *data[cell_index * Field::n_comp + field_i];
-    //     }
-    // }
 
     //------------------------------//
     // Greater Common Divisor (GCD) //

--- a/tests/mpi/test_lb_flux.cpp
+++ b/tests/mpi/test_lb_flux.cpp
@@ -189,7 +189,7 @@ namespace
             u,
             [](const auto&, const auto&, const auto& coords)
             {
-                return samurai::CollapsArray<double, n_comp, false>({curved(coords[0], coords[1], 0), curved(coords[0], coords[1], 1)});
+                return samurai::CollapsArray<double, n_comp>({curved(coords[0], coords[1], 0), curved(coords[0], coords[1], 1)});
             });
 
         auto balancer = lb::make_load_balancer(lb::LoadBalanceConfig{}, strategy);
@@ -221,7 +221,7 @@ namespace
             u,
             [](const auto&, const auto&, const auto& coords)
             {
-                return samurai::CollapsArray<double, n_comp, false>({curved(coords[0], coords[1], 0), curved(coords[0], coords[1], 1)});
+                return samurai::CollapsArray<double, n_comp>({curved(coords[0], coords[1], 0), curved(coords[0], coords[1], 1)});
             });
         auto balancer = lb::make_load_balancer(lb::LoadBalanceConfig{}, strategy);
         balancer.load_balance(lb::weight::uniform(), u);

--- a/tests/test_adapt.cpp
+++ b/tests/test_adapt.cpp
@@ -35,7 +35,7 @@ namespace samurai
         auto mesh_cfg = mesh_config<dim>().min_level(2).max_level(4);
         auto mesh     = mra::make_mesh(box_t{xt::zeros<double>({dim}), xt::ones<double>({dim})}, mesh_cfg);
         auto u_1      = make_scalar_field<double>("u_1", mesh);
-        auto u_2      = make_vector_field<double, 3, true>("u_2", mesh);
+        auto u_2      = make_vector_field<double, 3>("u_2", mesh);
         auto u_3      = make_vector_field<double, 2>("u_3", mesh);
 
         auto adapt      = make_MRAdapt(u_1, u_2, u_3);

--- a/tests/test_bc.cpp
+++ b/tests/test_bc.cpp
@@ -50,7 +50,7 @@ namespace samurai
         auto u                           = make_vector_field<double, 4>("u", mesh);
 
         make_bc<Dirichlet<1>>(u, 1., 2., 3., 4.);
-        samurai::Array<double, 4, false> expected({1, 2, 3, 4});
+        samurai::Array<double, 4> expected({1, 2, 3, 4});
         EXPECT_TRUE(compare(u.get_bc()[0]->constant_value(), expected));
     }
 

--- a/tests/test_field.cpp
+++ b/tests/test_field.cpp
@@ -114,16 +114,16 @@ namespace samurai
                       });
 
         auto it = field.begin();
-        EXPECT_TRUE(compare(*it, samurai::Array<std::size_t, 2, true>{0, 1}));
+        EXPECT_TRUE(compare(*it, samurai::Array<std::size_t, 2>{0, 1}));
         it += 2;
-        EXPECT_TRUE(compare(*it, samurai::Array<std::size_t, 4, true>{4, 5, 6, 7}));
+        EXPECT_TRUE(compare(*it, samurai::Array<std::size_t, 4>{4, 5, 6, 7}));
         ++it;
         EXPECT_EQ(it, field.end());
 
         auto itr = field.rbegin();
-        EXPECT_TRUE(compare(*itr, samurai::Array<std::size_t, 4, true>{4, 5, 6, 7}));
+        EXPECT_TRUE(compare(*itr, samurai::Array<std::size_t, 4>{4, 5, 6, 7}));
         itr += 2;
-        EXPECT_TRUE(compare(*itr, samurai::Array<std::size_t, 2, true>{0, 1}));
+        EXPECT_TRUE(compare(*itr, samurai::Array<std::size_t, 2>{0, 1}));
         ++itr;
         EXPECT_EQ(itr, field.rend());
     }


### PR DESCRIPTION
Keep only the AOS (array-of-structs) storage layout and remove the bool SOA template parameter from VectorField, make_vector_field, the storage containers (xtensor/eigen), Array/CollapsArray, mat_vec and the detail::is_soa trait, collapsing all is_soa branches onto AOS.

 <!-- Thank you for your contribution to samurai! -->

<!-- Please check the following before submitting your PR -->
- [ ] I have installed [pre-commit](https://pre-commit.com/) locally and use it to validate my commits.
- [ ] The PR title follows the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) convention.
      Available tags: 'build', 'chore', 'ci', 'docs', 'feat', 'fix', 'perf', 'refactor', 'revert', 'style', 'test'
- [ ] This new PR is documented.
- [ ] This new PR is tested.

## Description
<!-- A clear and concise description of what you have done in this PR. -->

## Related issue
<!-- List the issues solved by this PR, if any. -->

## How has this been tested?
<!-- Give the list of files used to test this new implementation. -->

## Code of Conduct
By submitting this PR, you agree to follow our [Code of Conduct](https://github.com/hpc-maths/samurai/blob/master/docs/CODE_OF_CONDUCT.md)
- [ ] I agree to follow this project's Code of Conduct
