### PR TITLE
refactor: cleanups

### DIFF
--- a/include/samurai/bc/apply_field_bc.hpp
+++ b/include/samurai/bc/apply_field_bc.hpp
@@ -7,6 +7,8 @@
 #include "../field/concepts.hpp"
 #include "polynomial_extrapolation.hpp"
 
+#include <stdexcept>
+
 namespace samurai
 {
     template <class Field, class Subset, std::size_t stencil_size, class Vector>
@@ -44,8 +46,7 @@ namespace samurai
         }
         else
         {
-            std::cerr << "Unknown BC type" << std::endl;
-            exit(EXIT_FAILURE);
+            throw std::runtime_error("Unknown BC type");
         }
     }
 

--- a/include/samurai/bc/apply_field_bc.hpp
+++ b/include/samurai/bc/apply_field_bc.hpp
@@ -10,7 +10,7 @@
 namespace samurai
 {
     template <class Field, class Subset, std::size_t stencil_size, class Vector>
-    void __apply_bc_on_subset(Bc<Field>& bc,
+    void apply_bc_on_subset(Bc<Field>& bc,
                               Field& field,
                               Subset& subset,
                               const StencilAnalyzer<stencil_size, Field::dim>& stencil,
@@ -92,7 +92,7 @@ namespace samurai
                     auto bdry_cells = intersection(mesh[mesh_id_t::cells][level], region_lca[d]).on(level);
                     if (level >= mesh.min_level()) // otherwise there is no cells
                     {
-                        __apply_bc_on_subset(bc, field, bdry_cells, stencil_analyzer, direction);
+                        apply_bc_on_subset(bc, field, bdry_cells, stencil_analyzer, direction);
                     }
                 }
             }
@@ -121,7 +121,7 @@ namespace samurai
      * @param bdry_cells subset corresponding to boundary cells where to apply the extrapolation on (center of the BC stencil)
      */
     template <std::size_t stencil_size, class Field, class Subset>
-    void __apply_extrapolation_bc__cells(Bc<Field>& bc,
+    void apply_extrapolation_bc_cells(Bc<Field>& bc,
                                          std::size_t level,
                                          Field& field,
                                          const DirectionVector<Field::dim>& direction,
@@ -140,14 +140,14 @@ namespace samurai
         {
             auto cells = intersection(mesh[mesh_id_t::cells][level], bdry_cells).on(level);
 
-            __apply_bc_on_subset(bc, field, cells, stencil_analyzer, direction);
+            apply_bc_on_subset(bc, field, cells, stencil_analyzer, direction);
         }
         else
         {
             auto translated_outer_nghbr = translate(mesh[mesh_id_t::reference][level], -(stencil_size / 2) * direction); // can be removed?
             auto cells                  = intersection(translated_outer_nghbr, mesh[mesh_id_t::cells][level], bdry_cells).on(level);
 
-            __apply_bc_on_subset(bc, field, cells, stencil_analyzer, direction);
+            apply_bc_on_subset(bc, field, cells, stencil_analyzer, direction);
         }
     }
 
@@ -212,7 +212,7 @@ namespace samurai
      * @param subset subset corresponding to inner ghosts where to apply the extrapolation on (center of the BC stencil)
      */
     template <std::size_t stencil_size, class Field, class Subset>
-    void __apply_extrapolation_bc__ghosts(Bc<Field>& bc,
+    void apply_extrapolation_bc_ghosts(Bc<Field>& bc,
                                           std::size_t level,
                                           Field& field,
                                           const DirectionVector<Field::dim>& direction,
@@ -231,7 +231,7 @@ namespace samurai
         auto inner_cells_and_ghosts           = intersection(potential_inner_cells_and_ghosts, mesh.get_union()[level]).on(level);
         // auto inner_cells_and_ghosts        = intersection(potential_inner_cells_and_ghosts, mesh[mesh_id_t::cells][level + 1]).on(level);
         auto inner_ghosts_with_outer_nghbr = difference(inner_cells_and_ghosts, mesh[mesh_id_t::cells][level]).on(level);
-        __apply_bc_on_subset(bc, field, inner_ghosts_with_outer_nghbr, stencil_analyzer, direction);
+        apply_bc_on_subset(bc, field, inner_ghosts_with_outer_nghbr, stencil_analyzer, direction);
     }
 
     template <class Field>
@@ -345,7 +345,7 @@ namespace samurai
                         {
                             PolynomialExtrapolation<Field, stencil_size> bc(domain, ConstantBc<Field>(), true);
                             auto corner = self(corner_lca).on(level);
-                            __apply_extrapolation_bc__cells<stencil_size>(bc, level, field, direction, corner);
+                            apply_extrapolation_bc_cells<stencil_size>(bc, level, field, direction, corner);
                         }
                     }
                 });
@@ -403,7 +403,7 @@ namespace samurai
         }
 
         // Restrict the corner to the cells that actually exist at this level. This is the same
-        // condition as in Step 1, where __apply_extrapolation_bc__cells() intersects the corner
+        // condition as in Step 1, where apply_extrapolation_bc_cells() intersects the corner
         // with mesh[cells][level] before applying the extrapolation.
         //
         // Why this restriction is necessary: on an adapted mesh, the domain corner is not
@@ -529,7 +529,7 @@ namespace samurai
                             PolynomialExtrapolation<Field, stencil_size> bc(domain, ConstantBc<Field>(), true);
 
                             auto boundary_cells = domain_boundary(field.mesh(), level, direction);
-                            __apply_extrapolation_bc__cells<stencil_size>(bc, level, field, direction, boundary_cells);
+                            apply_extrapolation_bc_cells<stencil_size>(bc, level, field, direction, boundary_cells);
                         }
                     }
                 });
@@ -557,7 +557,7 @@ namespace samurai
 
                             auto domain2         = self(field.mesh().domain()).on(level);
                             auto boundary_ghosts = difference(domain2, translate(domain2, -direction));
-                            __apply_extrapolation_bc__ghosts<stencil_size>(bc, level, field, direction, boundary_ghosts);
+                            apply_extrapolation_bc_ghosts<stencil_size>(bc, level, field, direction, boundary_ghosts);
                         }
                     }
                 });

--- a/include/samurai/bc/apply_field_bc.hpp
+++ b/include/samurai/bc/apply_field_bc.hpp
@@ -13,10 +13,10 @@ namespace samurai
 {
     template <class Field, class Subset, std::size_t stencil_size, class Vector>
     void apply_bc_on_subset(Bc<Field>& bc,
-                              Field& field,
-                              Subset& subset,
-                              const StencilAnalyzer<stencil_size, Field::dim>& stencil,
-                              const Vector& direction)
+                            Field& field,
+                            Subset& subset,
+                            const StencilAnalyzer<stencil_size, Field::dim>& stencil,
+                            const Vector& direction)
     {
         auto bc_function = bc.get_apply_function(std::integral_constant<std::size_t, stencil_size>(), direction);
         if (bc.get_value_type() == BCVType::constant)
@@ -122,11 +122,8 @@ namespace samurai
      * @param bdry_cells subset corresponding to boundary cells where to apply the extrapolation on (center of the BC stencil)
      */
     template <std::size_t stencil_size, class Field, class Subset>
-    void apply_extrapolation_bc_cells(Bc<Field>& bc,
-                                         std::size_t level,
-                                         Field& field,
-                                         const DirectionVector<Field::dim>& direction,
-                                         Subset& bdry_cells)
+    void
+    apply_extrapolation_bc_cells(Bc<Field>& bc, std::size_t level, Field& field, const DirectionVector<Field::dim>& direction, Subset& bdry_cells)
     {
         using mesh_id_t = typename Field::mesh_t::mesh_id_t;
 
@@ -214,10 +211,10 @@ namespace samurai
      */
     template <std::size_t stencil_size, class Field, class Subset>
     void apply_extrapolation_bc_ghosts(Bc<Field>& bc,
-                                          std::size_t level,
-                                          Field& field,
-                                          const DirectionVector<Field::dim>& direction,
-                                          Subset& inner_ghosts_location)
+                                       std::size_t level,
+                                       Field& field,
+                                       const DirectionVector<Field::dim>& direction,
+                                       Subset& inner_ghosts_location)
     {
         using mesh_id_t = typename Field::mesh_t::mesh_id_t;
 

--- a/include/samurai/bc/bc.hpp
+++ b/include/samurai/bc/bc.hpp
@@ -623,7 +623,6 @@ namespace samurai
         bcvalue_impl p_bcvalue;
         const lca_t& m_domain; // NOLINT(cppcoreguidelines-avoid-const-or-ref-data-members)
         region_t m_region;
-        // xt::xtensor<typename Field::value_type, detail::return_type<typename Field::value_type, n_comp>::dim> m_value;
     };
 
     ///////////////////

--- a/include/samurai/field/field_base.hpp
+++ b/include/samurai/field/field_base.hpp
@@ -12,6 +12,8 @@
 
 #include <fmt/format.h>
 
+#include <stdexcept>
+
 #include "../algorithm.hpp"
 #include "../bc/bc.hpp"
 #include "../field_expression.hpp"
@@ -303,11 +305,13 @@ namespace samurai
         {
             if (bc.stencil_size() > this->derived_cast().mesh().cfg().max_stencil_size())
             {
-                std::cerr << "The stencil size required by this boundary condition (" << bc.stencil_size()
-                          << ") is larger than the max_stencil_size parameter of the mesh ("
-                          << this->derived_cast().mesh().cfg().max_stencil_size() << ").\nYou can set it with mesh_config.max_stencil_radius("
-                          << bc.stencil_size() / 2 << ") or mesh_config.max_stencil_size(" << bc.stencil_size() << ")." << std::endl;
-                exit(EXIT_FAILURE);
+                throw std::invalid_argument(
+                    fmt::format("The stencil size required by this boundary condition ({}) is larger than the max_stencil_size parameter of "
+                                "the mesh ({}).\nYou can set it with mesh_config.max_stencil_radius({}) or mesh_config.max_stencil_size({}).",
+                                bc.stencil_size(),
+                                this->derived_cast().mesh().cfg().max_stencil_size(),
+                                bc.stencil_size() / 2,
+                                bc.stencil_size()));
             }
             p_bc.push_back(bc.clone());
             return p_bc.back().get();

--- a/include/samurai/field/field_base.hpp
+++ b/include/samurai/field/field_base.hpp
@@ -305,13 +305,13 @@ namespace samurai
         {
             if (bc.stencil_size() > this->derived_cast().mesh().cfg().max_stencil_size())
             {
-                throw std::invalid_argument(
-                    fmt::format("The stencil size required by this boundary condition ({}) is larger than the max_stencil_size parameter of "
-                                "the mesh ({}).\nYou can set it with mesh_config.max_stencil_radius({}) or mesh_config.max_stencil_size({}).",
-                                bc.stencil_size(),
-                                this->derived_cast().mesh().cfg().max_stencil_size(),
-                                bc.stencil_size() / 2,
-                                bc.stencil_size()));
+                throw std::invalid_argument(fmt::format(
+                    "The stencil size required by this boundary condition ({}) is larger than the max_stencil_size parameter of "
+                    "the mesh ({}).\nYou can set it with mesh_config.max_stencil_radius({}) or mesh_config.max_stencil_size({}).",
+                    bc.stencil_size(),
+                    this->derived_cast().mesh().cfg().max_stencil_size(),
+                    bc.stencil_size() / 2,
+                    bc.stencil_size()));
             }
             p_bc.push_back(bc.clone());
             return p_bc.back().get();

--- a/include/samurai/mesh.hpp
+++ b/include/samurai/mesh.hpp
@@ -11,6 +11,8 @@
 
 #include <fmt/format.h>
 
+#include <stdexcept>
+
 #include "cell_array.hpp"
 #include "cell_list.hpp"
 #include "domain_builder.hpp"
@@ -349,13 +351,11 @@ namespace samurai
                             return b;
                         }))
         {
-            std::cerr << "Periodicity is not implemented with DomainBuilder." << std::endl;
-            exit(EXIT_FAILURE);
+            throw std::runtime_error("Periodicity is not implemented with DomainBuilder.");
         }
 
 #ifdef SAMURAI_WITH_MPI
-        std::cerr << "MPI is not implemented with DomainBuilder." << std::endl;
-        std::exit(EXIT_FAILURE);
+        throw std::runtime_error("MPI is not implemented with DomainBuilder.");
 #else
         double scaling_factor_ = m_config.scaling_factor();
         compute_scaling_factor(domain_builder, scaling_factor_);

--- a/include/samurai/mesh_config.hpp
+++ b/include/samurai/mesh_config.hpp
@@ -8,6 +8,7 @@
 #include "samurai_config.hpp"
 
 #include <array>
+#include <stdexcept>
 
 namespace samurai
 {
@@ -380,8 +381,7 @@ namespace samurai
                 }
                 if (m_max_level < m_min_level)
                 {
-                    std::cerr << "Max level must be greater than min level." << std::endl;
-                    exit(EXIT_FAILURE);
+                    throw std::invalid_argument("Max level must be greater than min level.");
                 }
             }
 

--- a/include/samurai/petsc/block_assembly.hpp
+++ b/include/samurai/petsc/block_assembly.hpp
@@ -164,8 +164,8 @@ namespace samurai
                                 {
                                     throw std::runtime_error(
                                         fmt::format("Assembly failure: incompatible number of rows of block ({}, {}): {} (expected {})",
-                                                    row,
-                                                    col,
+                                                    static_cast<std::size_t>(row),
+                                                    static_cast<std::size_t>(col),
                                                     op.owned_matrix_rows(),
                                                     block_owned_rows));
                                 }
@@ -205,8 +205,8 @@ namespace samurai
                                 {
                                     throw std::runtime_error(
                                         fmt::format("Assembly failure: incompatible number of columns of block ({}, {}): {} (expected {})",
-                                                    row,
-                                                    col,
+                                                    static_cast<std::size_t>(row),
+                                                    static_cast<std::size_t>(col),
                                                     op.owned_matrix_cols(),
                                                     block_owned_cols));
                                 }
@@ -248,8 +248,8 @@ namespace samurai
                                                  throw std::invalid_argument(
                                                      fmt::format("unknown {} is not compatible with the scheme ({}, {}) (named '{}')",
                                                                  i,
-                                                                 row,
-                                                                 col,
+                                                                 static_cast<std::size_t>(row),
+                                                                 static_cast<std::size_t>(col),
                                                                  op.name()));
                                              }
                                          }
@@ -319,8 +319,8 @@ namespace samurai
                             throw std::runtime_error(
                                 fmt::format("Function 'create_vector()' is ambiguous in this context, because the block ({}, {}) is not "
                                             "square. Use 'create_applicable_vector()' or 'create_rhs_vector()' instead.",
-                                            row,
-                                            col));
+                                            static_cast<std::size_t>(row),
+                                            static_cast<std::size_t>(col)));
                         }
                     });
             }

--- a/include/samurai/petsc/block_assembly.hpp
+++ b/include/samurai/petsc/block_assembly.hpp
@@ -5,6 +5,9 @@
 #include "utils.hpp"
 #include "zero_block_assembly.hpp"
 
+#include <fmt/format.h>
+#include <stdexcept>
+
 namespace samurai
 {
     namespace petsc
@@ -159,9 +162,12 @@ namespace samurai
                                 }
                                 else if (op.owned_matrix_rows() != block_owned_rows)
                                 {
-                                    std::cerr << "Assembly failure: incompatible number of rows of block (" << row << ", " << col
-                                              << "): " << op.owned_matrix_rows() << " (expected " << block_owned_rows << ")" << std::endl;
-                                    exit(EXIT_FAILURE);
+                                    throw std::runtime_error(
+                                        fmt::format("Assembly failure: incompatible number of rows of block ({}, {}): {} (expected {})",
+                                                    row,
+                                                    col,
+                                                    op.owned_matrix_rows(),
+                                                    block_owned_rows));
                                 }
                             }
                         });
@@ -197,9 +203,12 @@ namespace samurai
                                 }
                                 else if (op.owned_matrix_cols() != block_owned_cols)
                                 {
-                                    std::cerr << "Assembly failure: incompatible number of columns of block (" << row << ", " << col
-                                              << "): " << op.owned_matrix_cols() << " (expected " << block_owned_cols << ")" << std::endl;
-                                    exit(EXIT_FAILURE);
+                                    throw std::runtime_error(
+                                        fmt::format("Assembly failure: incompatible number of columns of block ({}, {}): {} (expected {})",
+                                                    row,
+                                                    col,
+                                                    op.owned_matrix_cols(),
+                                                    block_owned_cols));
                                 }
                             }
                         });
@@ -236,10 +245,12 @@ namespace samurai
                                              }
                                              else
                                              {
-                                                 std::cerr << "unknown " << i << " is not compatible with the scheme (" << row << ", "
-                                                           << col << ") (named '" << op.name() << "')" << std::endl;
-                                                 assert(false);
-                                                 exit(EXIT_FAILURE);
+                                                 throw std::invalid_argument(
+                                                     fmt::format("unknown {} is not compatible with the scheme ({}, {}) (named '{}')",
+                                                                 i,
+                                                                 row,
+                                                                 col,
+                                                                 op.name()));
                                              }
                                          }
                                      }
@@ -305,9 +316,11 @@ namespace samurai
                     {
                         if (row == col && op.owned_matrix_rows() != op.owned_matrix_cols())
                         {
-                            std::cerr << "Function 'create_vector()' is ambiguous in this context, because the block (" << row << ", " << col
-                                      << ") is not square. Use 'create_applicable_vector()' or 'create_rhs_vector()' instead." << std::endl;
-                            exit(EXIT_FAILURE);
+                            throw std::runtime_error(
+                                fmt::format("Function 'create_vector()' is ambiguous in this context, because the block ({}, {}) is not "
+                                            "square. Use 'create_applicable_vector()' or 'create_rhs_vector()' instead.",
+                                            row,
+                                            col));
                         }
                     });
             }

--- a/include/samurai/petsc/compute_cell_ownership.hpp
+++ b/include/samurai/petsc/compute_cell_ownership.hpp
@@ -4,6 +4,8 @@
 #include "../field.hpp"
 #include "../io/hdf5.hpp"
 
+#include <stdexcept>
+
 namespace samurai
 {
     namespace petsc
@@ -527,7 +529,7 @@ namespace samurai
                 std::cerr << fmt::format(
                     "[{}] This usually happens when low level ghosts are shared between subdomains that are not in each other's direct neighbourhood. To solve this issue, try increasing the min level.\n",
                     rank);
-                exit(EXIT_FAILURE);
+                throw std::runtime_error(fmt::format("[{}] Cell ownership mismatch detected. See 'owner_mismatch.xdmf' for details.", rank));
             }
 
             //--------------------------//

--- a/include/samurai/petsc/fv/FV_scheme_assembly.hpp
+++ b/include/samurai/petsc/fv/FV_scheme_assembly.hpp
@@ -4,6 +4,9 @@
 #include "../../numeric/prediction.hpp"
 #include "../../schemes/fv/FV_scheme.hpp"
 #include "../../schemes/fv/scheme_operators.hpp"
+
+#include <fmt/format.h>
+#include <stdexcept>
 #include "../compute_cell_ownership.hpp"
 #include "../global_numbering.hpp"
 #include "../matrix_assembly.hpp"
@@ -163,9 +166,8 @@ namespace samurai
             {
                 if (!m_unknown)
                 {
-                    std::cerr << "Undefined unknown for operator " << scheme().name() << ". Assembly initialization failed!" << std::endl;
-                    assert(false);
-                    exit(EXIT_FAILURE);
+                    throw std::runtime_error(
+                        fmt::format("Undefined unknown for operator {}. Assembly initialization failed!", scheme().name()));
                 }
 
                 mesh().cell_ownership().is_computed = false;
@@ -920,8 +922,7 @@ namespace samurai
 #ifdef SAMURAI_WITH_MPI
                     if (mpi::communicator().size() > 1)
                     {
-                        std::cerr << "Periodic boundary conditions are not supported with MPI." << std::endl;
-                        exit(EXIT_FAILURE);
+                        throw std::runtime_error("Periodic boundary conditions are not supported with MPI.");
                     }
 #endif
                     assemble_periodic_bc(A);
@@ -1122,11 +1123,13 @@ namespace samurai
                                                       INSERT_VALUES);
                         if (error)
                         {
-                            std::cerr << scheme().name() << ": failure to insert diagonal coefficient at ("
-                                      << m_block_row_shift + static_cast<PetscInt>(i) << ", " << m_block_col_shift + static_cast<PetscInt>(i)
-                                      << "), i.e. (" << i << ", " << i << ") in the block." << std::endl;
-                            assert(false);
-                            exit(EXIT_FAILURE);
+                            throw std::runtime_error(
+                                fmt::format("{}: failure to insert diagonal coefficient at ({}, {}), i.e. ({}, {}) in the block.",
+                                            scheme().name(),
+                                            m_block_row_shift + static_cast<PetscInt>(i),
+                                            m_block_col_shift + static_cast<PetscInt>(i),
+                                            i,
+                                            i));
                         }
                         // m_is_row_empty[i] = false;
                     }
@@ -1305,10 +1308,11 @@ namespace samurai
                                                                   current_insert_mode());
                                     if (error)
                                     {
-                                        std::cerr << scheme().name() << ": failure to insert projection coefficient at (" << ghost_index
-                                                  << ", " << local_col_index(children[i], field_i) << ")." << std::endl;
-                                        assert(false);
-                                        exit(EXIT_FAILURE);
+                                        throw std::runtime_error(
+                                            fmt::format("{}: failure to insert projection coefficient at ({}, {}).",
+                                                        scheme().name(),
+                                                        ghost_index,
+                                                        local_col_index(children[i], field_i)));
                                     }
                                 }
                                 set_is_row_not_empty(ghost_index);

--- a/include/samurai/petsc/fv/FV_scheme_assembly.hpp
+++ b/include/samurai/petsc/fv/FV_scheme_assembly.hpp
@@ -5,11 +5,11 @@
 #include "../../schemes/fv/FV_scheme.hpp"
 #include "../../schemes/fv/scheme_operators.hpp"
 
-#include <fmt/format.h>
-#include <stdexcept>
 #include "../compute_cell_ownership.hpp"
 #include "../global_numbering.hpp"
 #include "../matrix_assembly.hpp"
+#include <fmt/format.h>
+#include <stdexcept>
 
 namespace samurai
 {
@@ -1308,11 +1308,10 @@ namespace samurai
                                                                   current_insert_mode());
                                     if (error)
                                     {
-                                        throw std::runtime_error(
-                                            fmt::format("{}: failure to insert projection coefficient at ({}, {}).",
-                                                        scheme().name(),
-                                                        ghost_index,
-                                                        local_col_index(children[i], field_i)));
+                                        throw std::runtime_error(fmt::format("{}: failure to insert projection coefficient at ({}, {}).",
+                                                                             scheme().name(),
+                                                                             ghost_index,
+                                                                             local_col_index(children[i], field_i)));
                                     }
                                 }
                                 set_is_row_not_empty(ghost_index);

--- a/include/samurai/petsc/linear_block_solver.hpp
+++ b/include/samurai/petsc/linear_block_solver.hpp
@@ -65,7 +65,7 @@ namespace samurai
                 {
                     if (m_A == nullptr)
                     {
-                        throw std::runtime_error("The matrix must be assemble before calling set_pc_fieldsplit().");
+                        throw std::runtime_error("The matrix must be assembled before calling set_pc_fieldsplit().");
                     }
                     IS IS_fields[cols];
                     MatNestGetISs(m_A, IS_fields, NULL);

--- a/include/samurai/petsc/linear_block_solver.hpp
+++ b/include/samurai/petsc/linear_block_solver.hpp
@@ -3,6 +3,8 @@
 #include "block_assembly.hpp"
 #include "linear_solver.hpp"
 
+#include <stdexcept>
+
 namespace samurai
 {
     namespace petsc
@@ -63,8 +65,7 @@ namespace samurai
                 {
                     if (m_A == nullptr)
                     {
-                        std::cerr << "The matrix must be assemble before calling set_pc_fieldsplit()." << std::endl;
-                        exit(EXIT_FAILURE);
+                        throw std::runtime_error("The matrix must be assemble before calling set_pc_fieldsplit().");
                     }
                     IS IS_fields[cols];
                     MatNestGetISs(m_A, IS_fields, NULL);
@@ -127,9 +128,7 @@ namespace samurai
                     // PetscErrorCode err = KSPSetUp(m_ksp); // PETSc fails at KSPSolve() for some reason.
                     if (err != PETSC_SUCCESS)
                     {
-                        std::cerr << "The setup of the solver failed!" << std::endl;
-                        assert(false && "Failed solver setup");
-                        exit(EXIT_FAILURE);
+                        throw std::runtime_error("The setup of the solver failed!");
                     }
                     times::timers.stop("solver setup");
 

--- a/include/samurai/petsc/linear_solver.hpp
+++ b/include/samurai/petsc/linear_solver.hpp
@@ -8,9 +8,8 @@
 #include "multigrid/petsc/GeometricMultigrid.hpp"
 #else
 #include "utils.hpp"
-
-#include <stdexcept>
 #endif
+#include <stdexcept>
 
 namespace samurai
 {

--- a/include/samurai/petsc/linear_solver.hpp
+++ b/include/samurai/petsc/linear_solver.hpp
@@ -8,6 +8,8 @@
 #include "multigrid/petsc/GeometricMultigrid.hpp"
 #else
 #include "utils.hpp"
+
+#include <stdexcept>
 #endif
 
 namespace samurai
@@ -126,10 +128,8 @@ namespace samurai
             {
                 if (assembly().undefined_unknown())
                 {
-                    std::cerr << "Undefined unknown(s) for this linear system. Please set the unknowns using the instruction '[solver].set_unknown(u);' or '[solver].set_unknowns(u1, u2...);'."
-                              << std::endl;
-                    assert(false && "Undefined unknown(s)");
-                    exit(EXIT_FAILURE);
+                    throw std::runtime_error("Undefined unknown(s) for this linear system. Please set the unknowns using the instruction "
+                                             "'[solver].set_unknown(u);' or '[solver].set_unknowns(u1, u2...);'.");
                 }
 
                 if (m_reuse_allocated_matrix)
@@ -177,9 +177,7 @@ namespace samurai
 
                 if (err != PETSC_SUCCESS)
                 {
-                    std::cerr << "The setup of the solver failed!" << std::endl;
-                    assert(false && "Failed solver setup");
-                    exit(EXIT_FAILURE);
+                    throw std::runtime_error("The setup of the solver failed!");
                 }
 
                 if (after_setup)
@@ -237,12 +235,7 @@ namespace samurai
                     using namespace std::string_literals;
                     const char* reason_text;
                     KSPGetConvergedReasonString(m_ksp, &reason_text);
-                    std::cerr << "Divergence of the solver ("s + reason_text + ")" << std::endl;
-                    // VecView(b, PETSC_VIEWER_STDOUT_(PETSC_COMM_SELF));
-                    // std::cout << std::endl;
-                    // assert(check_nan_or_inf(b));
-                    assert(false && "Divergence of the solver");
-                    exit(EXIT_FAILURE);
+                    throw std::runtime_error("Divergence of the solver ("s + reason_text + ")");
                 }
                 // VecView(x, PETSC_VIEWER_STDOUT_(PETSC_COMM_SELF)); std::cout << std::endl;
             }
@@ -337,11 +330,7 @@ namespace samurai
                 {
                     if constexpr (Mesh::dim > 2)
                     {
-                        std::cerr << "Samurai Multigrid is not implemented for "
-                                     "dim > 2."
-                                  << std::endl;
-                        assert(false);
-                        exit(EXIT_FAILURE);
+                        throw std::runtime_error("Samurai Multigrid is not implemented for dim > 2.");
                     }
                     _samurai_mg = GeometricMultigrid(assembly(), assembly().mesh());
                     _samurai_mg.apply_as_pc(m_ksp);
@@ -366,10 +355,8 @@ namespace samurai
 
                 if (assembly().undefined_unknown())
                 {
-                    std::cerr << "Undefined unknown for this linear system. Please set the unknown using the instruction '[solver].set_unknown(u);'."
-                              << std::endl;
-                    assert(false && "Undefined unknown");
-                    exit(EXIT_FAILURE);
+                    throw std::runtime_error(
+                        "Undefined unknown for this linear system. Please set the unknown using the instruction '[solver].set_unknown(u);'.");
                 }
                 if (!m_use_samurai_mg)
                 {

--- a/include/samurai/petsc/manual_assembly.hpp
+++ b/include/samurai/petsc/manual_assembly.hpp
@@ -3,6 +3,8 @@
 #include "matrix_assembly.hpp"
 #include "utils.hpp"
 
+#include <stdexcept>
+
 namespace samurai
 {
     namespace petsc
@@ -99,8 +101,7 @@ namespace samurai
 #ifdef SAMURAI_WITH_MPI
                     if (mpi::communicator().size() > 1)
                     {
-                        std::cerr << "This function is not implemented for MPI yet in ManualAssembly." << std::endl;
-                        exit(EXIT_FAILURE);
+                        throw std::runtime_error("This function is not implemented for MPI yet in ManualAssembly.");
                     }
 #endif
                     copy(field, x, this->block_col_shift());

--- a/include/samurai/petsc/matrix_assembly.hpp
+++ b/include/samurai/petsc/matrix_assembly.hpp
@@ -2,6 +2,9 @@
 #include "../timers.hpp"
 #include <petsc.h>
 
+#include <fmt/format.h>
+#include <stdexcept>
+
 namespace samurai
 {
     namespace petsc
@@ -384,8 +387,7 @@ namespace samurai
                         PetscErrorCode ierr = MatAssemblyEnd(A, MAT_FINAL_ASSEMBLY);
                         if (ierr != PETSC_SUCCESS)
                         {
-                            std::cerr << "Error during MatAssemblyEnd of matrix '" << name() << "'." << std::endl;
-                            exit(EXIT_FAILURE);
+                            throw std::runtime_error(fmt::format("Error during MatAssemblyEnd of matrix '{}'.", name()));
                         }
                     }
                 }

--- a/include/samurai/petsc/nonlinear_local_solvers.hpp
+++ b/include/samurai/petsc/nonlinear_local_solvers.hpp
@@ -5,6 +5,9 @@
 #include "utils.hpp"
 #include <petsc.h>
 
+#include <fmt/format.h>
+#include <stdexcept>
+
 namespace samurai
 {
     namespace petsc
@@ -66,17 +69,13 @@ namespace samurai
             {
                 if (!m_scheme.scheme_definition().local_scheme_function)
                 {
-                    std::cerr << "The scheme function 'local_scheme_function' of operator '" << scheme.name()
-                              << "' has not been implemented." << std::endl;
-                    assert(false && "Undefined 'local_scheme_function'");
-                    exit(EXIT_FAILURE);
+                    throw std::runtime_error(
+                        fmt::format("The scheme function 'local_scheme_function' of operator '{}' has not been implemented.", scheme.name()));
                 }
                 if (!m_scheme.scheme_definition().local_jacobian_function)
                 {
-                    std::cerr << "The function 'local_jacobian_function' of operator '" << scheme.name() << "' has not been implemented."
-                              << std::endl;
-                    assert(false && "Undefined 'local_jacobian_function'");
-                    exit(EXIT_FAILURE);
+                    throw std::runtime_error(
+                        fmt::format("The function 'local_jacobian_function' of operator '{}' has not been implemented.", scheme.name()));
                 }
 
 #ifdef ENABLE_PARALLEL_NONLINEAR_SOLVES
@@ -174,10 +173,8 @@ namespace samurai
 
                 if (!m_unknown)
                 {
-                    std::cerr << "Undefined unknown for this non-linear system. Please set the unknowns using the instruction '[solver].set_unknown(u);'."
-                              << std::endl;
-                    assert(false && "Undefined unknown");
-                    exit(EXIT_FAILURE);
+                    throw std::runtime_error("Undefined unknown for this non-linear system. Please set the unknowns using the instruction "
+                                             "'[solver].set_unknown(u);'.");
                 }
 
                 // Configure the solvers
@@ -350,12 +347,7 @@ namespace samurai
                     using namespace std::string_literals;
                     const char* reason_text;
                     SNESGetConvergedReasonString(snes, &reason_text);
-                    std::cerr << "Divergence of the non-linear solver ("s + reason_text + ")" << std::endl;
-                    // VecView(b, PETSC_VIEWER_STDOUT_(PETSC_COMM_SELF));
-                    // std::cout << std::endl;
-                    // assert(check_nan_or_inf(b));
-                    assert(false && "Divergence of the solver");
-                    exit(EXIT_FAILURE);
+                    throw std::runtime_error("Divergence of the non-linear solver ("s + reason_text + ")");
                 }
                 // VecView(x, PETSC_VIEWER_STDOUT_(PETSC_COMM_SELF)); std::cout << std::endl;
             }

--- a/include/samurai/petsc/nonlinear_solver.hpp
+++ b/include/samurai/petsc/nonlinear_solver.hpp
@@ -5,6 +5,8 @@
 #include "utils.hpp"
 #include <petsc.h>
 
+#include <stdexcept>
+
 namespace samurai
 {
     namespace petsc
@@ -159,10 +161,8 @@ namespace samurai
 
                 if (assembly().undefined_unknown())
                 {
-                    std::cerr << "Undefined unknown(s) for this non-linear system. Please set the unknowns using the instruction '[solver].set_unknown(u);' or '[solver].set_unknowns(u1, u2...);'."
-                              << std::endl;
-                    assert(false && "Undefined unknown(s)");
-                    exit(EXIT_FAILURE);
+                    throw std::runtime_error("Undefined unknown(s) for this non-linear system. Please set the unknowns using the instruction "
+                                             "'[solver].set_unknown(u);' or '[solver].set_unknowns(u1, u2...);'.");
                 }
 
                 // Non-linear function
@@ -352,12 +352,7 @@ namespace samurai
                     using namespace std::string_literals;
                     const char* reason_text;
                     SNESGetConvergedReasonString(m_snes, &reason_text);
-                    std::cerr << "Divergence of the non-linear solver ("s + reason_text + ")" << std::endl;
-                    // VecView(b, PETSC_VIEWER_STDOUT_(PETSC_COMM_WORLD));
-                    // std::cout << std::endl;
-                    // assert(check_nan_or_inf(b));
-                    assert(false && "Divergence of the solver");
-                    exit(EXIT_FAILURE);
+                    throw std::runtime_error("Divergence of the non-linear solver ("s + reason_text + ")");
                 }
                 // VecView(x, PETSC_VIEWER_STDOUT_(PETSC_COMM_WORLD)); std::cout << std::endl;
                 return reason_code;

--- a/include/samurai/petsc/zero_block_assembly.hpp
+++ b/include/samurai/petsc/zero_block_assembly.hpp
@@ -1,6 +1,9 @@
 #pragma once
 #include "matrix_assembly.hpp"
 
+#include <fmt/format.h>
+#include <stdexcept>
+
 namespace samurai
 {
     namespace petsc
@@ -31,8 +34,7 @@ namespace samurai
             {
                 if (value != 0)
                 {
-                    std::cerr << "Unimplemented Assembly(" << value << ")" << std::endl;
-                    exit(EXIT_FAILURE);
+                    throw std::runtime_error(fmt::format("Unimplemented Assembly({})", value));
                 }
                 this->set_name("0");
             }

--- a/include/samurai/reconstruction.hpp
+++ b/include/samurai/reconstruction.hpp
@@ -3,6 +3,8 @@
 #include <array>
 #include <fmt/format.h>
 #include <fmt/ranges.h>
+
+#include <stdexcept>
 #include <tuple>
 #include <unordered_map>
 
@@ -516,9 +518,8 @@ namespace samurai
 
         if (field.mesh().max_stencil_radius() < 2)
         {
-            std::cerr << "The reconstruction function requires at least 2 ghosts on the boundary.\nTo fix this issue, remove mesh_config.disable_minimal_ghost_width()."
-                      << std::endl;
-            exit(EXIT_FAILURE);
+            throw std::runtime_error("The reconstruction function requires at least 2 ghosts on the boundary.\nTo fix this issue, remove "
+                                     "mesh_config.disable_minimal_ghost_width().");
         }
 
         update_ghost_mr_if_needed(field);
@@ -811,9 +812,8 @@ namespace samurai
 
         if (field_src.mesh().max_stencil_radius() < 2)
         {
-            std::cerr << "The transfer function requires at least 2 ghosts on the boundary.\nTo fix this issue, remove mesh_config.disable_minimal_ghost_width()."
-                      << std::endl;
-            exit(EXIT_FAILURE);
+            throw std::runtime_error("The transfer function requires at least 2 ghosts on the boundary.\nTo fix this issue, remove "
+                                     "mesh_config.disable_minimal_ghost_width().");
         }
 
         update_ghost_mr_if_needed(field_src);

--- a/include/samurai/schemes/block_operator.hpp
+++ b/include/samurai/schemes/block_operator.hpp
@@ -225,8 +225,8 @@ namespace samurai
                         using op_field_t = typename operator_t::input_field_t;
                         if constexpr (!std::is_same_v<std::decay_t<decltype(u)>, op_field_t>)
                         {
-                            throw std::invalid_argument(fmt::format(
-                                "unknown {} is not compatible with the scheme ({}, {}) (named '{}')", col, row, col, op.name()));
+                            throw std::invalid_argument(
+                                fmt::format("unknown {} is not compatible with the scheme ({}, {}) (named '{}')", col, row, col, op.name()));
                         }
                     }
                 });

--- a/include/samurai/schemes/block_operator.hpp
+++ b/include/samurai/schemes/block_operator.hpp
@@ -1,6 +1,9 @@
 #pragma once
 #include "../utils.hpp"
 
+#include <fmt/format.h>
+#include <stdexcept>
+
 namespace samurai
 {
     // Concept to check if a type has cfg_t::scheme_type
@@ -222,10 +225,8 @@ namespace samurai
                         using op_field_t = typename operator_t::input_field_t;
                         if constexpr (!std::is_same_v<std::decay_t<decltype(u)>, op_field_t>)
                         {
-                            std::cerr << "unknown " << col << " is not compatible with the scheme (" << row << ", " << col << ") (named '"
-                                      << op.name() << "')" << std::endl;
-                            assert(false);
-                            exit(EXIT_FAILURE);
+                            throw std::invalid_argument(fmt::format(
+                                "unknown {} is not compatible with the scheme ({}, {}) (named '{}')", col, row, col, op.name()));
                         }
                     }
                 });

--- a/include/samurai/schemes/fv/FV_scheme.hpp
+++ b/include/samurai/schemes/fv/FV_scheme.hpp
@@ -141,8 +141,6 @@ namespace samurai
             m_name = name;
         }
 
-        virtual ~FVScheme() = default;
-
         DerivedScheme& derived_cast() & noexcept
         {
             return *static_cast<DerivedScheme*>(this);

--- a/include/samurai/schemes/fv/FV_scheme.hpp
+++ b/include/samurai/schemes/fv/FV_scheme.hpp
@@ -106,10 +106,6 @@ namespace samurai
         static constexpr std::size_t bdry_stencil_size        = bdry_cfg::stencil_size;
         static constexpr std::size_t nb_bdry_ghosts           = bdry_cfg::nb_ghosts;
 
-        // using output_field_t = std::conditional_t<input_field_t::is_scalar && output_n_comp == 1,
-        //                                           ScalarField<mesh_t, field_value_type>,
-        //                                           VectorField<mesh_t, field_value_type, output_n_comp>>;
-
         using dirichlet_t = DirichletImpl<nb_bdry_ghosts, field_t>;
         using neumann_t   = NeumannImpl<nb_bdry_ghosts, field_t>;
 
@@ -145,10 +141,7 @@ namespace samurai
             m_name = name;
         }
 
-        virtual ~FVScheme()
-        {
-            m_name += " (deleted)";
-        }
+        virtual ~FVScheme() = default;
 
         DerivedScheme& derived_cast() & noexcept
         {

--- a/include/samurai/schemes/fv/cell_based/cell_based_scheme__nonlin.hpp
+++ b/include/samurai/schemes/fv/cell_based/cell_based_scheme__nonlin.hpp
@@ -184,10 +184,9 @@ namespace samurai
         {
             if (!jacobian_function())
             {
-                throw std::runtime_error(
-                    fmt::format("The jacobian function of operator '{}' has not been implemented.\n"
-                                "Use option -snes_mf or -snes_fd for an automatic computation of the jacobian matrix.",
-                                this->name()));
+                throw std::runtime_error(fmt::format("The jacobian function of operator '{}' has not been implemented.\n"
+                                                     "Use option -snes_mf or -snes_fd for an automatic computation of the jacobian matrix.",
+                                                     this->name()));
             }
 
             StencilJacobian<cfg> coeffs;

--- a/include/samurai/schemes/fv/cell_based/cell_based_scheme__nonlin.hpp
+++ b/include/samurai/schemes/fv/cell_based/cell_based_scheme__nonlin.hpp
@@ -1,6 +1,9 @@
 #pragma once
 #include "cell_based_scheme.hpp"
 
+#include <fmt/format.h>
+#include <stdexcept>
+
 namespace samurai
 {
     template <class cfg, class bdry_cfg>
@@ -181,9 +184,10 @@ namespace samurai
         {
             if (!jacobian_function())
             {
-                std::cerr << "The jacobian function of operator '" << this->name() << "' has not been implemented." << std::endl;
-                std::cerr << "Use option -snes_mf or -snes_fd for an automatic computation of the jacobian matrix." << std::endl;
-                exit(EXIT_FAILURE);
+                throw std::runtime_error(
+                    fmt::format("The jacobian function of operator '{}' has not been implemented.\n"
+                                "Use option -snes_mf or -snes_fd for an automatic computation of the jacobian matrix.",
+                                this->name()));
             }
 
             StencilJacobian<cfg> coeffs;

--- a/include/samurai/schemes/fv/explicit_FV_scheme.hpp
+++ b/include/samurai/schemes/fv/explicit_FV_scheme.hpp
@@ -2,6 +2,9 @@
 #include "../explicit_scheme.hpp"
 #include "FV_scheme.hpp"
 
+#include <fmt/format.h>
+#include <stdexcept>
+
 namespace samurai
 {
     /**
@@ -80,11 +83,14 @@ namespace samurai
 
             if (scheme_stencil_size > mesh_stencil_size)
             {
-                std::cerr << "The stencil size required by the scheme '" << scheme().name() << "' (" << scheme_stencil_size
-                          << ") is larger than the max_stencil_size parameter of the mesh (" << mesh_stencil_size
-                          << ").\nYou can set it with mesh_config.max_stencil_radius(" << scheme_stencil_size / 2
-                          << ") or mesh_config.max_stencil_size(" << scheme_stencil_size << ")." << std::endl;
-                exit(EXIT_FAILURE);
+                throw std::invalid_argument(
+                    fmt::format("The stencil size required by the scheme '{}' ({}) is larger than the max_stencil_size parameter of the "
+                                "mesh ({}).\nYou can set it with mesh_config.max_stencil_radius({}) or mesh_config.max_stencil_size({}).",
+                                scheme().name(),
+                                scheme_stencil_size,
+                                mesh_stencil_size,
+                                scheme_stencil_size / 2,
+                                scheme_stencil_size));
             }
 
             for (std::size_t d = 0; d < dim; ++d)
@@ -95,9 +101,7 @@ namespace samurai
 
         virtual void apply(std::size_t /* d */, output_field_t& /* output_field */, input_field_t& /* input_field */)
         {
-            std::cerr << "The scheme '" << scheme().name() << "' cannot be applied by direction." << std::endl;
-            assert(false);
-            exit(EXIT_FAILURE);
+            throw std::runtime_error(fmt::format("The scheme '{}' cannot be applied by direction.", scheme().name()));
         }
     };
 }

--- a/include/samurai/schemes/fv/flux_based/flux_based_scheme__nonlin.hpp
+++ b/include/samurai/schemes/fv/flux_based/flux_based_scheme__nonlin.hpp
@@ -610,10 +610,9 @@ namespace samurai
 
                 if (!jacobian_function)
                 {
-                    throw std::runtime_error(
-                        fmt::format("The jacobian function of operator '{}' has not been implemented.\n"
-                                    "Use option -snes_mf or -snes_fd for an automatic computation of the jacobian matrix.",
-                                    this->name()));
+                    throw std::runtime_error(fmt::format("The jacobian function of operator '{}' has not been implemented.\n"
+                                                         "Use option -snes_mf or -snes_fd for an automatic computation of the jacobian matrix.",
+                                                         this->name()));
                 }
 
                 // Worker variables

--- a/include/samurai/schemes/fv/flux_based/flux_based_scheme__nonlin.hpp
+++ b/include/samurai/schemes/fv/flux_based/flux_based_scheme__nonlin.hpp
@@ -1,6 +1,9 @@
 #pragma once
 #include "flux_based_scheme.hpp"
 
+#include <fmt/format.h>
+#include <stdexcept>
+
 namespace samurai
 {
     namespace detail
@@ -607,9 +610,10 @@ namespace samurai
 
                 if (!jacobian_function)
                 {
-                    std::cerr << "The jacobian function of operator '" << this->name() << "' has not been implemented." << std::endl;
-                    std::cerr << "Use option -snes_mf or -snes_fd for an automatic computation of the jacobian matrix." << std::endl;
-                    exit(EXIT_FAILURE);
+                    throw std::runtime_error(
+                        fmt::format("The jacobian function of operator '{}' has not been implemented.\n"
+                                    "Use option -snes_mf or -snes_fd for an automatic computation of the jacobian matrix.",
+                                    this->name()));
                 }
 
                 // Worker variables

--- a/include/samurai/schemes/fv/operators/convection_nonlin.hpp
+++ b/include/samurai/schemes/fv/operators/convection_nonlin.hpp
@@ -2,6 +2,8 @@
 #include "flux_divergence.hpp"
 #include "weno_impl.hpp"
 
+#include <stdexcept>
+
 namespace samurai
 {
     /**
@@ -123,8 +125,7 @@ namespace samurai
                             }
                             else
                             {
-                                std::cerr << "Not implemented for dim > 2" << std::endl;
-                                std::exit(EXIT_FAILURE);
+                                throw std::runtime_error("Not implemented for dim > 2");
                             }
                         }
                         else
@@ -148,8 +149,7 @@ namespace samurai
                             }
                             else
                             {
-                                std::cerr << "Not implemented for dim > 2" << std::endl;
-                                std::exit(EXIT_FAILURE);
+                                throw std::runtime_error("Not implemented for dim > 2");
                             }
                         }
                     }


### PR DESCRIPTION
## Description
This PR refactors error handling across the Samurai public headers by replacing `std::cerr` + `exit()`/`assert()` failure paths with C++ exceptions, and performs a few small cleanups (commented-out code removal and helper renames).

**Changes:**

- Replace hard process termination (`exit(EXIT_FAILURE)`) with `std::runtime_error` / `std::invalid_argument` in FV schemes, PETSc solvers/assemblies, mesh/config, and BC utilities.
- Standardize several error messages using `fmt::format` and add the necessary `<stdexcept>` / `fmt` includes.
- Cleanup: remove commented-out dead code and rename BC helper functions away from reserved `__* identifiers`.

## Code of Conduct
By submitting this PR, you agree to follow our [Code of Conduct](https://github.com/hpc-maths/samurai/blob/master/docs/CODE_OF_CONDUCT.md)
- [x] I agree to follow this project's Code of Conduct
