### PR TITLE
feat: add static_dispatch

### DIFF
--- a/include/samurai/algorithm/graduation.hpp
+++ b/include/samurai/algorithm/graduation.hpp
@@ -18,6 +18,7 @@ namespace mpi = boost::mpi;
 #include "../cell_flag.hpp"
 #include "../concepts.hpp"
 #include "../mesh.hpp"
+#include "../static_dispatch.hpp"
 #include "../stencil.hpp"
 #include "../subset/node.hpp"
 #include "../subset/utils.hpp"
@@ -164,16 +165,16 @@ namespace samurai
 
             auto ghost_width = mesh.cfg().graduation_width();
             assert(ghost_width < 10 && "Graduation not implemented for ghost_width higher than 10");
-            // maximum ghost width is set to 9
-            static_for<1, 10>::apply(
-                [&](auto static_ghost_width_)
-                {
-                    static constexpr int static_ghost_width = static_cast<int>(static_ghost_width_());
-                    if (ghost_width == static_ghost_width)
-                    {
-                        subset_2.apply_op(tag_to_keep<static_ghost_width>(tag, CellFlag::refine));
-                    }
-                });
+            // maximum ghost width is set to 9; widths outside [1, 9] leave the tags untouched.
+            if (ghost_width >= 1 && ghost_width < 10)
+            {
+                dispatch_static<1, 9>(ghost_width,
+                                      [&](auto static_ghost_width_)
+                                      {
+                                          static constexpr int static_ghost_width = static_cast<int>(static_ghost_width_());
+                                          subset_2.apply_op(tag_to_keep<static_ghost_width>(tag, CellFlag::refine));
+                                      });
+            }
 
             /**
              *      K     C                          K     K

--- a/include/samurai/algorithm/graduation.hpp
+++ b/include/samurai/algorithm/graduation.hpp
@@ -172,8 +172,7 @@ namespace samurai
                 dispatch_static<1, 9>(ghost_width,
                                       [&](auto static_ghost_width_)
                                       {
-                                          static constexpr int static_ghost_width = static_cast<int>(static_ghost_width_());
-                                          subset_2.apply_op(tag_to_keep<static_ghost_width>(tag, CellFlag::refine));
+                                          subset_2.apply_op(tag_to_keep<static_cast<int>(static_ghost_width_())>(tag, CellFlag::refine));
                                       });
             }
 

--- a/include/samurai/algorithm/graduation.hpp
+++ b/include/samurai/algorithm/graduation.hpp
@@ -163,9 +163,11 @@ namespace samurai
             auto subset_2 = intersection(mesh[mesh_id_t::cells][level], mesh[mesh_id_t::cells][level]);
 
             auto ghost_width = mesh.cfg().graduation_width();
-            assert(ghost_width < 10 && "Graduation not implemented for ghost_width higher than 10");
-            // maximum ghost width is set to 9; widths outside [1, 9] leave the tags untouched.
-            if (ghost_width >= 1 && ghost_width < 10)
+            // A width of 0 means no graduation constraint. Any other width is dispatched to the
+            // matching tag_to_keep<N> instantiation; dispatch_static itself throws std::out_of_range
+            // if the width exceeds what is instantiated below (tag_to_keep has no inherent limit,
+            // this range is just how many candidates we compile in).
+            if (ghost_width > 0)
             {
                 dispatch_static<1, 9>(ghost_width,
                                       [&](auto static_ghost_width_)

--- a/include/samurai/algorithm/graduation.hpp
+++ b/include/samurai/algorithm/graduation.hpp
@@ -17,6 +17,7 @@ namespace mpi = boost::mpi;
 #include "../cell_flag.hpp"
 #include "../concepts.hpp"
 #include "../mesh.hpp"
+#include "../static_dispatch.hpp"
 #include "../stencil.hpp"
 #include "../subset/node.hpp"
 #include "../subset/utils.hpp"
@@ -163,16 +164,16 @@ namespace samurai
 
             auto ghost_width = mesh.cfg().graduation_width();
             assert(ghost_width < 10 && "Graduation not implemented for ghost_width higher than 10");
-            // maximum ghost width is set to 9
-            static_for<1, 10>::apply(
-                [&](auto static_ghost_width_)
-                {
-                    static constexpr int static_ghost_width = static_cast<int>(static_ghost_width_());
-                    if (ghost_width == static_ghost_width)
-                    {
-                        subset_2.apply_op(tag_to_keep<static_ghost_width>(tag, CellFlag::refine));
-                    }
-                });
+            // maximum ghost width is set to 9; widths outside [1, 9] leave the tags untouched.
+            if (ghost_width >= 1 && ghost_width < 10)
+            {
+                dispatch_static<1, 9>(ghost_width,
+                                      [&](auto static_ghost_width_)
+                                      {
+                                          static constexpr int static_ghost_width = static_cast<int>(static_ghost_width_());
+                                          subset_2.apply_op(tag_to_keep<static_ghost_width>(tag, CellFlag::refine));
+                                      });
+            }
 
             /**
              *      K     C                          K     K

--- a/include/samurai/bc/apply_field_bc.hpp
+++ b/include/samurai/bc/apply_field_bc.hpp
@@ -5,6 +5,7 @@
 
 #include "../boundary.hpp"
 #include "../field/concepts.hpp"
+#include "../static_dispatch.hpp"
 #include "polynomial_extrapolation.hpp"
 
 #include <stdexcept>
@@ -149,55 +150,38 @@ namespace samurai
         }
     }
 
+    template <std::size_t layers, class Mesh, std::size_t... Is>
+    auto translated_outer_neighbours_impl(const Mesh& mesh,
+                                          std::size_t level,
+                                          const DirectionVector<Mesh::dim>& direction,
+                                          std::index_sequence<Is...>)
+    {
+        using mesh_id_t = typename Mesh::mesh_id_t;
+
+        // One translated copy of the reference cells per ghost layer, at offsets
+        // -layers, -(layers - 1), ..., -1 (i.e. -(layers - Is) for Is = 0 .. layers-1).
+        if constexpr (sizeof...(Is) == 1)
+        {
+            // `intersection` requires at least two sets, so the single-layer case is returned as-is.
+            return translate(mesh[mesh_id_t::reference][level], -layers * direction);
+        }
+        else
+        {
+            return intersection(translate(mesh[mesh_id_t::reference][level], -(layers - Is) * direction)...);
+        }
+    }
+
     template <std::size_t layers, class Mesh>
     auto translated_outer_neighbours(const Mesh& mesh, std::size_t level, const DirectionVector<Mesh::dim>& direction)
     {
-        using mesh_id_t = typename Mesh::mesh_id_t;
-        static_assert(layers <= 5, "not implemented for layers > 10");
+        static_assert(layers >= 1, "at least one ghost layer is required");
 
         // Technically, if mesh.domain().is_box(), then we can only test that the furthest layer of ghosts exists
         // (i.e. the set return by the case stencil_size == 2 below).
         // On the other hand, if the domain has holes, we have to check that all the intermediary ghost layers exist.
         // Since we can't easily make the distinction in a static way, we always check that all the ghost layers exist.
 
-        if constexpr (layers == 1)
-        {
-            return translate(mesh[mesh_id_t::reference][level], -layers * direction);
-        }
-        else if constexpr (layers == 2)
-        {
-            // clang-format off
-            return intersection(translate(mesh[mesh_id_t::reference][level], -(layers    ) * direction),
-                                translate(mesh[mesh_id_t::reference][level], -(layers - 1) * direction));
-            // clang-format on
-        }
-        else if constexpr (layers == 3)
-        {
-            // clang-format off
-            return intersection(translate(mesh[mesh_id_t::reference][level], -(layers    ) * direction),
-                                translate(mesh[mesh_id_t::reference][level], -(layers - 1) * direction),
-                                translate(mesh[mesh_id_t::reference][level], -(layers - 2) * direction));
-            // clang-format on
-        }
-        else if constexpr (layers == 4)
-        {
-            // clang-format off
-            return intersection(translate(mesh[mesh_id_t::reference][level], -(layers    ) * direction),
-                                translate(mesh[mesh_id_t::reference][level], -(layers - 1) * direction),
-                                translate(mesh[mesh_id_t::reference][level], -(layers - 2) * direction),
-                                translate(mesh[mesh_id_t::reference][level], -(layers - 3) * direction));
-            // clang-format on
-        }
-        else if constexpr (layers == 5)
-        {
-            // clang-format off
-            return intersection(translate(mesh[mesh_id_t::reference][level], -(layers    ) * direction),
-                                translate(mesh[mesh_id_t::reference][level], -(layers - 1) * direction),
-                                translate(mesh[mesh_id_t::reference][level], -(layers - 2) * direction),
-                                translate(mesh[mesh_id_t::reference][level], -(layers - 3) * direction),
-                                translate(mesh[mesh_id_t::reference][level], -(layers - 4) * direction));
-            // clang-format on
-        }
+        return translated_outer_neighbours_impl<layers>(mesh, level, direction, std::make_index_sequence<layers>{});
     }
 
     /**
@@ -240,16 +224,14 @@ namespace samurai
 
         for (auto& bc : field.get_bc())
         {
-            static_for<1, max_stencil_size_implemented_BC + 1>::apply( // for (int i=1; i<=max_stencil_size_implemented; i++)
-                [&](auto integral_constant_i)
-                {
-                    static constexpr std::size_t i = decltype(integral_constant_i)::value;
-
-                    if (bc->stencil_size() == i)
-                    {
-                        apply_bc_impl<Field, i>(*bc.get(), level, direction, field);
-                    }
-                });
+            // Dispatch on the runtime stencil size (in [1, max_stencil_size_implemented_BC]) to the
+            // corresponding compile-time instantiation of apply_bc_impl.
+            dispatch_static<1, max_stencil_size_implemented_BC>(bc->stencil_size(),
+                                                                [&](auto integral_constant_i)
+                                                                {
+                                                                    static constexpr std::size_t i = decltype(integral_constant_i)::value;
+                                                                    apply_bc_impl<Field, i>(*bc.get(), level, direction, field);
+                                                                });
         }
     }
 
@@ -333,18 +315,16 @@ namespace samurai
         for (int ghost_layer = 1; ghost_layer <= ghost_width; ++ghost_layer)
         {
             int stencil_s = 2 * ghost_layer;
-            static_for<2, max_stencil_size_PE + 1>::apply(
+            dispatch_static<2, max_stencil_size_PE>(
+                static_cast<std::size_t>(stencil_s),
                 [&](auto stencil_size_)
                 {
                     static constexpr int stencil_size = static_cast<int>(stencil_size_());
-                    if constexpr (stencil_size % 2 == 0)
+                    if constexpr (stencil_size % 2 == 0) // (PolynomialExtrapolation is only implemented for even stencil_size)
                     {
-                        if (stencil_s == stencil_size)
-                        {
-                            PolynomialExtrapolation<Field, stencil_size> bc(domain, ConstantBc<Field>(), true);
-                            auto corner = self(corner_lca).on(level);
-                            apply_extrapolation_bc_cells<stencil_size>(bc, level, field, direction, corner);
-                        }
+                        PolynomialExtrapolation<Field, stencil_size> bc(domain, ConstantBc<Field>(), true);
+                        auto corner = self(corner_lca).on(level);
+                        apply_extrapolation_bc_cells<stencil_size>(bc, level, field, direction, corner);
                     }
                 });
         }
@@ -514,21 +494,19 @@ namespace samurai
         for (int ghost_layer = ghost_layers_filled_by_bc + 1; ghost_layer <= ghost_width; ++ghost_layer)
         {
             int stencil_s = 2 * ghost_layer;
-            static_for<2, max_stencil_size_implemented_PE + 1>::apply(
+            dispatch_static<2, max_stencil_size_implemented_PE>(
+                static_cast<std::size_t>(stencil_s),
                 [&](auto stencil_size_)
                 {
                     static constexpr int stencil_size = static_cast<int>(stencil_size_());
 
                     if constexpr (stencil_size % 2 == 0) // (because PolynomialExtrapolation is only implemented for even stencil_size)
                     {
-                        if (stencil_s == stencil_size)
-                        {
-                            auto& domain = detail::get_mesh(field.mesh());
-                            PolynomialExtrapolation<Field, stencil_size> bc(domain, ConstantBc<Field>(), true);
+                        auto& domain = detail::get_mesh(field.mesh());
+                        PolynomialExtrapolation<Field, stencil_size> bc(domain, ConstantBc<Field>(), true);
 
-                            auto boundary_cells = domain_boundary(field.mesh(), level, direction);
-                            apply_extrapolation_bc_cells<stencil_size>(bc, level, field, direction, boundary_cells);
-                        }
+                        auto boundary_cells = domain_boundary(field.mesh(), level, direction);
+                        apply_extrapolation_bc_cells<stencil_size>(bc, level, field, direction, boundary_cells);
                     }
                 });
         }
@@ -541,22 +519,20 @@ namespace samurai
         for (int ghost_layer = ghost_layers_filled_by_projection_bc + 1; ghost_layer <= ghost_width; ++ghost_layer)
         {
             int stencil_s = 2 * ghost_layer;
-            static_for<2, max_stencil_size_implemented_PE + 1>::apply(
+            dispatch_static<2, max_stencil_size_implemented_PE>(
+                static_cast<std::size_t>(stencil_s),
                 [&](auto stencil_size_)
                 {
                     static constexpr int stencil_size = static_cast<int>(stencil_size_());
 
                     if constexpr (stencil_size % 2 == 0) // (because PolynomialExtrapolation is only implemented for even stencil_size)
                     {
-                        if (stencil_s == stencil_size)
-                        {
-                            auto& domain = detail::get_mesh(field.mesh());
-                            PolynomialExtrapolation<Field, stencil_size> bc(domain, ConstantBc<Field>(), true);
+                        auto& domain = detail::get_mesh(field.mesh());
+                        PolynomialExtrapolation<Field, stencil_size> bc(domain, ConstantBc<Field>(), true);
 
-                            auto domain2         = self(field.mesh().domain()).on(level);
-                            auto boundary_ghosts = difference(domain2, translate(domain2, -direction));
-                            apply_extrapolation_bc_ghosts<stencil_size>(bc, level, field, direction, boundary_ghosts);
-                        }
+                        auto domain2         = self(field.mesh().domain()).on(level);
+                        auto boundary_ghosts = difference(domain2, translate(domain2, -direction));
+                        apply_extrapolation_bc_ghosts<stencil_size>(bc, level, field, direction, boundary_ghosts);
                     }
                 });
         }

--- a/include/samurai/bc/apply_field_bc.hpp
+++ b/include/samurai/bc/apply_field_bc.hpp
@@ -5,6 +5,7 @@
 
 #include "../boundary.hpp"
 #include "../field/concepts.hpp"
+#include "../static_dispatch.hpp"
 #include "polynomial_extrapolation.hpp"
 #include <algorithm>
 
@@ -290,55 +291,38 @@ namespace samurai
         }
     }
 
+    template <std::size_t layers, class Mesh, std::size_t... Is>
+    auto translated_outer_neighbours_impl(const Mesh& mesh,
+                                          std::size_t level,
+                                          const DirectionVector<Mesh::dim>& direction,
+                                          std::index_sequence<Is...>)
+    {
+        using mesh_id_t = typename Mesh::mesh_id_t;
+
+        // One translated copy of the reference cells per ghost layer, at offsets
+        // -layers, -(layers - 1), ..., -1 (i.e. -(layers - Is) for Is = 0 .. layers-1).
+        if constexpr (sizeof...(Is) == 1)
+        {
+            // `intersection` requires at least two sets, so the single-layer case is returned as-is.
+            return translate(mesh[mesh_id_t::reference][level], -layers * direction);
+        }
+        else
+        {
+            return intersection(translate(mesh[mesh_id_t::reference][level], -(layers - Is) * direction)...);
+        }
+    }
+
     template <std::size_t layers, class Mesh>
     auto translated_outer_neighbours(const Mesh& mesh, std::size_t level, const DirectionVector<Mesh::dim>& direction)
     {
-        using mesh_id_t = typename Mesh::mesh_id_t;
-        static_assert(layers <= 5, "not implemented for layers > 10");
+        static_assert(layers >= 1, "at least one ghost layer is required");
 
         // Technically, if mesh.domain().is_box(), then we can only test that the furthest layer of ghosts exists
         // (i.e. the set return by the case stencil_size == 2 below).
         // On the other hand, if the domain has holes, we have to check that all the intermediary ghost layers exist.
         // Since we can't easily make the distinction in a static way, we always check that all the ghost layers exist.
 
-        if constexpr (layers == 1)
-        {
-            return translate(mesh[mesh_id_t::reference][level], -layers * direction);
-        }
-        else if constexpr (layers == 2)
-        {
-            // clang-format off
-            return intersection(translate(mesh[mesh_id_t::reference][level], -(layers    ) * direction),
-                                translate(mesh[mesh_id_t::reference][level], -(layers - 1) * direction));
-            // clang-format on
-        }
-        else if constexpr (layers == 3)
-        {
-            // clang-format off
-            return intersection(translate(mesh[mesh_id_t::reference][level], -(layers    ) * direction),
-                                translate(mesh[mesh_id_t::reference][level], -(layers - 1) * direction),
-                                translate(mesh[mesh_id_t::reference][level], -(layers - 2) * direction));
-            // clang-format on
-        }
-        else if constexpr (layers == 4)
-        {
-            // clang-format off
-            return intersection(translate(mesh[mesh_id_t::reference][level], -(layers    ) * direction),
-                                translate(mesh[mesh_id_t::reference][level], -(layers - 1) * direction),
-                                translate(mesh[mesh_id_t::reference][level], -(layers - 2) * direction),
-                                translate(mesh[mesh_id_t::reference][level], -(layers - 3) * direction));
-            // clang-format on
-        }
-        else if constexpr (layers == 5)
-        {
-            // clang-format off
-            return intersection(translate(mesh[mesh_id_t::reference][level], -(layers    ) * direction),
-                                translate(mesh[mesh_id_t::reference][level], -(layers - 1) * direction),
-                                translate(mesh[mesh_id_t::reference][level], -(layers - 2) * direction),
-                                translate(mesh[mesh_id_t::reference][level], -(layers - 3) * direction),
-                                translate(mesh[mesh_id_t::reference][level], -(layers - 4) * direction));
-            // clang-format on
-        }
+        return translated_outer_neighbours_impl<layers>(mesh, level, direction, std::make_index_sequence<layers>{});
     }
 
     /**
@@ -381,16 +365,14 @@ namespace samurai
 
         for (auto& bc : field.get_bc())
         {
-            static_for<1, max_stencil_size_implemented_BC + 1>::apply( // for (int i=1; i<=max_stencil_size_implemented; i++)
-                [&](auto integral_constant_i)
-                {
-                    static constexpr std::size_t i = decltype(integral_constant_i)::value;
-
-                    if (bc->stencil_size() == i)
-                    {
-                        apply_bc_impl<Field, i>(*bc.get(), level, direction, field);
-                    }
-                });
+            // Dispatch on the runtime stencil size (in [1, max_stencil_size_implemented_BC]) to the
+            // corresponding compile-time instantiation of apply_bc_impl.
+            dispatch_static<1, max_stencil_size_implemented_BC>(bc->stencil_size(),
+                                                                [&](auto integral_constant_i)
+                                                                {
+                                                                    static constexpr std::size_t i = decltype(integral_constant_i)::value;
+                                                                    apply_bc_impl<Field, i>(*bc.get(), level, direction, field);
+                                                                });
         }
     }
 
@@ -474,18 +456,16 @@ namespace samurai
         for (int ghost_layer = 1; ghost_layer <= ghost_width; ++ghost_layer)
         {
             int stencil_s = 2 * ghost_layer;
-            static_for<2, max_stencil_size_PE + 1>::apply(
+            dispatch_static<2, max_stencil_size_PE>(
+                static_cast<std::size_t>(stencil_s),
                 [&](auto stencil_size_)
                 {
                     static constexpr int stencil_size = static_cast<int>(stencil_size_());
-                    if constexpr (stencil_size % 2 == 0)
+                    if constexpr (stencil_size % 2 == 0) // (PolynomialExtrapolation is only implemented for even stencil_size)
                     {
-                        if (stencil_s == stencil_size)
-                        {
-                            PolynomialExtrapolation<Field, stencil_size> bc(domain, ConstantBc<Field>(), true);
-                            auto corner = self(corner_lca).on(level);
-                            apply_extrapolation_bc_cells<stencil_size>(bc, level, field, direction, corner);
-                        }
+                        PolynomialExtrapolation<Field, stencil_size> bc(domain, ConstantBc<Field>(), true);
+                        auto corner = self(corner_lca).on(level);
+                        apply_extrapolation_bc_cells<stencil_size>(bc, level, field, direction, corner);
                     }
                 });
         }
@@ -655,21 +635,19 @@ namespace samurai
         for (int ghost_layer = ghost_layers_filled_by_bc + 1; ghost_layer <= ghost_width; ++ghost_layer)
         {
             int stencil_s = 2 * ghost_layer;
-            static_for<2, max_stencil_size_implemented_PE + 1>::apply(
+            dispatch_static<2, max_stencil_size_implemented_PE>(
+                static_cast<std::size_t>(stencil_s),
                 [&](auto stencil_size_)
                 {
                     static constexpr int stencil_size = static_cast<int>(stencil_size_());
 
                     if constexpr (stencil_size % 2 == 0) // (because PolynomialExtrapolation is only implemented for even stencil_size)
                     {
-                        if (stencil_s == stencil_size)
-                        {
-                            auto& domain = detail::get_mesh(field.mesh());
-                            PolynomialExtrapolation<Field, stencil_size> bc(domain, ConstantBc<Field>(), true);
+                        auto& domain = detail::get_mesh(field.mesh());
+                        PolynomialExtrapolation<Field, stencil_size> bc(domain, ConstantBc<Field>(), true);
 
-                            auto boundary_cells = domain_boundary(field.mesh(), level, direction);
-                            apply_extrapolation_bc_cells<stencil_size>(bc, level, field, direction, boundary_cells);
-                        }
+                        auto boundary_cells = domain_boundary(field.mesh(), level, direction);
+                        apply_extrapolation_bc_cells<stencil_size>(bc, level, field, direction, boundary_cells);
                     }
                 });
         }
@@ -682,22 +660,20 @@ namespace samurai
         for (int ghost_layer = ghost_layers_filled_by_projection_bc + 1; ghost_layer <= ghost_width; ++ghost_layer)
         {
             int stencil_s = 2 * ghost_layer;
-            static_for<2, max_stencil_size_implemented_PE + 1>::apply(
+            dispatch_static<2, max_stencil_size_implemented_PE>(
+                static_cast<std::size_t>(stencil_s),
                 [&](auto stencil_size_)
                 {
                     static constexpr int stencil_size = static_cast<int>(stencil_size_());
 
                     if constexpr (stencil_size % 2 == 0) // (because PolynomialExtrapolation is only implemented for even stencil_size)
                     {
-                        if (stencil_s == stencil_size)
-                        {
-                            auto& domain = detail::get_mesh(field.mesh());
-                            PolynomialExtrapolation<Field, stencil_size> bc(domain, ConstantBc<Field>(), true);
+                        auto& domain = detail::get_mesh(field.mesh());
+                        PolynomialExtrapolation<Field, stencil_size> bc(domain, ConstantBc<Field>(), true);
 
-                            auto domain2         = self(field.mesh().domain()).on(level);
-                            auto boundary_ghosts = difference(domain2, translate(domain2, -direction));
-                            apply_extrapolation_bc_ghosts<stencil_size>(bc, level, field, direction, boundary_ghosts);
-                        }
+                        auto domain2         = self(field.mesh().domain()).on(level);
+                        auto boundary_ghosts = difference(domain2, translate(domain2, -direction));
+                        apply_extrapolation_bc_ghosts<stencil_size>(bc, level, field, direction, boundary_ghosts);
                     }
                 });
         }

--- a/include/samurai/bc/apply_field_bc.hpp
+++ b/include/samurai/bc/apply_field_bc.hpp
@@ -444,6 +444,10 @@ namespace samurai
         }
 
         static constexpr std::size_t max_stencil_size_PE = PolynomialExtrapolation<Field, 2>::max_stencil_size_implemented_PE;
+        // PolynomialExtrapolation is only implemented for even stencil_size, so we dispatch directly on the
+        // ghost layer (stencil_size = 2 * ghost_layer) instead of on the stencil size, to avoid instantiating
+        // the unused odd-stencil_size candidates.
+        static constexpr std::size_t max_ghost_layers_PE = max_stencil_size_PE / 2;
 
         int ghost_width        = field.mesh().ghost_width();
         const auto& domain     = detail::get_mesh(field.mesh());
@@ -455,19 +459,14 @@ namespace samurai
         // Step 1: Fill the diagonal ghost cells layer by layer using stencil sizes 2, 4, ..., 2*ghost_width
         for (int ghost_layer = 1; ghost_layer <= ghost_width; ++ghost_layer)
         {
-            int stencil_s = 2 * ghost_layer;
-            dispatch_static<2, max_stencil_size_PE>(
-                static_cast<std::size_t>(stencil_s),
-                [&](auto stencil_size_)
-                {
-                    static constexpr int stencil_size = static_cast<int>(stencil_size_());
-                    if constexpr (stencil_size % 2 == 0) // (PolynomialExtrapolation is only implemented for even stencil_size)
-                    {
-                        PolynomialExtrapolation<Field, stencil_size> bc(domain, ConstantBc<Field>(), true);
-                        auto corner = self(corner_lca).on(level);
-                        apply_extrapolation_bc_cells<stencil_size>(bc, level, field, direction, corner);
-                    }
-                });
+            dispatch_static<1, max_ghost_layers_PE>(static_cast<std::size_t>(ghost_layer),
+                                                    [&](auto ghost_layer_)
+                                                    {
+                                                        static constexpr int stencil_size = 2 * static_cast<int>(ghost_layer_());
+                                                        PolynomialExtrapolation<Field, stencil_size> bc(domain, ConstantBc<Field>(), true);
+                                                        auto corner = self(corner_lca).on(level);
+                                                        apply_extrapolation_bc_cells<stencil_size>(bc, level, field, direction, corner);
+                                                    });
         }
 
         // Step 2: Fill off-diagonal ghost cells by copying the diagonal ghost value.
@@ -622,6 +621,10 @@ namespace samurai
     {
         int ghost_width                                              = field.mesh().ghost_width();
         static constexpr std::size_t max_stencil_size_implemented_PE = PolynomialExtrapolation<Field, 2>::max_stencil_size_implemented_PE;
+        // PolynomialExtrapolation is only implemented for even stencil_size, so we dispatch directly on the
+        // ghost layer (stencil_size = 2 * ghost_layer) instead of on the stencil size, to avoid instantiating
+        // the unused odd-stencil_size candidates.
+        static constexpr std::size_t max_ghost_layers_implemented_PE = max_stencil_size_implemented_PE / 2;
 
         // 1. We fill the ghosts that are further than those filled by the B.C. (where there are boundary cells)
 
@@ -634,21 +637,17 @@ namespace samurai
         // We populate the ghosts sequentially from the closest to the farthest.
         for (int ghost_layer = ghost_layers_filled_by_bc + 1; ghost_layer <= ghost_width; ++ghost_layer)
         {
-            int stencil_s = 2 * ghost_layer;
-            dispatch_static<2, max_stencil_size_implemented_PE>(
-                static_cast<std::size_t>(stencil_s),
-                [&](auto stencil_size_)
+            dispatch_static<1, max_ghost_layers_implemented_PE>(
+                static_cast<std::size_t>(ghost_layer),
+                [&](auto ghost_layer_)
                 {
-                    static constexpr int stencil_size = static_cast<int>(stencil_size_());
+                    static constexpr int stencil_size = 2 * static_cast<int>(ghost_layer_());
 
-                    if constexpr (stencil_size % 2 == 0) // (because PolynomialExtrapolation is only implemented for even stencil_size)
-                    {
-                        auto& domain = detail::get_mesh(field.mesh());
-                        PolynomialExtrapolation<Field, stencil_size> bc(domain, ConstantBc<Field>(), true);
+                    auto& domain = detail::get_mesh(field.mesh());
+                    PolynomialExtrapolation<Field, stencil_size> bc(domain, ConstantBc<Field>(), true);
 
-                        auto boundary_cells = domain_boundary(field.mesh(), level, direction);
-                        apply_extrapolation_bc_cells<stencil_size>(bc, level, field, direction, boundary_cells);
-                    }
+                    auto boundary_cells = domain_boundary(field.mesh(), level, direction);
+                    apply_extrapolation_bc_cells<stencil_size>(bc, level, field, direction, boundary_cells);
                 });
         }
 
@@ -659,22 +658,18 @@ namespace samurai
 
         for (int ghost_layer = ghost_layers_filled_by_projection_bc + 1; ghost_layer <= ghost_width; ++ghost_layer)
         {
-            int stencil_s = 2 * ghost_layer;
-            dispatch_static<2, max_stencil_size_implemented_PE>(
-                static_cast<std::size_t>(stencil_s),
-                [&](auto stencil_size_)
+            dispatch_static<1, max_ghost_layers_implemented_PE>(
+                static_cast<std::size_t>(ghost_layer),
+                [&](auto ghost_layer_)
                 {
-                    static constexpr int stencil_size = static_cast<int>(stencil_size_());
+                    static constexpr int stencil_size = 2 * static_cast<int>(ghost_layer_());
 
-                    if constexpr (stencil_size % 2 == 0) // (because PolynomialExtrapolation is only implemented for even stencil_size)
-                    {
-                        auto& domain = detail::get_mesh(field.mesh());
-                        PolynomialExtrapolation<Field, stencil_size> bc(domain, ConstantBc<Field>(), true);
+                    auto& domain = detail::get_mesh(field.mesh());
+                    PolynomialExtrapolation<Field, stencil_size> bc(domain, ConstantBc<Field>(), true);
 
-                        auto domain2         = self(field.mesh().domain()).on(level);
-                        auto boundary_ghosts = difference(domain2, translate(domain2, -direction));
-                        apply_extrapolation_bc_ghosts<stencil_size>(bc, level, field, direction, boundary_ghosts);
-                    }
+                    auto domain2         = self(field.mesh().domain()).on(level);
+                    auto boundary_ghosts = difference(domain2, translate(domain2, -direction));
+                    apply_extrapolation_bc_ghosts<stencil_size>(bc, level, field, direction, boundary_ghosts);
                 });
         }
     }

--- a/include/samurai/static_dispatch.hpp
+++ b/include/samurai/static_dispatch.hpp
@@ -22,8 +22,7 @@ namespace samurai
             {
                 // Fold over the candidates: the ternary short-circuits so `f` is
                 // invoked at most once (for the branch where `value == min + Is`).
-                const bool matched = ((value == min + Is ? (std::forward<F>(f)(std::integral_constant<std::size_t, min + Is>{}), true)
-                                                         : false)
+                const bool matched = ((value == min + Is ? (std::forward<F>(f)(std::integral_constant<std::size_t, min + Is>{}), true) : false)
                                       || ...);
                 if (!matched)
                 {

--- a/include/samurai/static_dispatch.hpp
+++ b/include/samurai/static_dispatch.hpp
@@ -1,0 +1,76 @@
+// Copyright 2018-2025 the samurai's authors
+// SPDX-License-Identifier:  BSD-3-Clause
+
+#pragma once
+
+#include <cstddef>
+#include <optional>
+#include <stdexcept>
+#include <type_traits>
+#include <utility>
+
+namespace samurai
+{
+    namespace detail
+    {
+        template <std::size_t min, class F, std::size_t... Is>
+        constexpr decltype(auto) dispatch_static_impl(std::size_t value, F&& f, std::index_sequence<Is...>)
+        {
+            using result_t = decltype(std::forward<F>(f)(std::integral_constant<std::size_t, min>{}));
+
+            if constexpr (std::is_void_v<result_t>)
+            {
+                // Fold over the candidates: the ternary short-circuits so `f` is
+                // invoked at most once (for the branch where `value == min + Is`).
+                const bool matched = ((value == min + Is ? (std::forward<F>(f)(std::integral_constant<std::size_t, min + Is>{}), true)
+                                                         : false)
+                                      || ...);
+                if (!matched)
+                {
+                    throw std::out_of_range("dispatch_static: value out of range");
+                }
+            }
+            else
+            {
+                static_assert(!std::is_reference_v<result_t>, "dispatch_static: the callable must return by value (or void)");
+
+                std::optional<result_t> result;
+                const bool matched = ((value == min + Is
+                                           ? (result.emplace(std::forward<F>(f)(std::integral_constant<std::size_t, min + Is>{})), true)
+                                           : false)
+                                      || ...);
+                if (!matched)
+                {
+                    throw std::out_of_range("dispatch_static: value out of range");
+                }
+                return static_cast<result_t>(std::move(*result));
+            }
+        }
+    }
+
+    /**
+     * Runtime -> compile-time dispatch.
+     *
+     * For a runtime @p value in the inclusive range [ @p min , @p max ], calls
+     *     f(std::integral_constant<std::size_t, value>{})
+     * so that the value becomes available as a compile-time constant inside the
+     * callable. The callable is instantiated for every candidate in the range
+     * but invoked exactly once, for the matching value.
+     *
+     * Throws std::out_of_range if @p value is outside [ @p min , @p max ].
+     *
+     * The return value of @p f (which must be the same type for every candidate)
+     * is forwarded to the caller; a `void`-returning callable is supported.
+     *
+     * @tparam min  lowest value handled (inclusive)
+     * @tparam max  highest value handled (inclusive)
+     * @param  value  the runtime value to dispatch on
+     * @param  f      callable taking a std::integral_constant<std::size_t, N>
+     */
+    template <std::size_t min, std::size_t max, class F>
+    constexpr decltype(auto) dispatch_static(std::size_t value, F&& f)
+    {
+        static_assert(min <= max, "dispatch_static requires min <= max");
+        return detail::dispatch_static_impl<min>(value, std::forward<F>(f), std::make_index_sequence<max - min + 1>{});
+    }
+}

--- a/include/samurai/static_dispatch.hpp
+++ b/include/samurai/static_dispatch.hpp
@@ -4,7 +4,6 @@
 #pragma once
 
 #include <cstddef>
-#include <optional>
 #include <stdexcept>
 #include <type_traits>
 #include <utility>
@@ -13,36 +12,31 @@ namespace samurai
 {
     namespace detail
     {
-        template <std::size_t min, class F, std::size_t... Is>
-        constexpr decltype(auto) dispatch_static_impl(std::size_t value, F&& f, std::index_sequence<Is...>)
+        // Recursive binary dispatch: each leaf (min == max) does `return f(...)` directly,
+        // so the selected branch's result is returned by value with guaranteed copy elision
+        // (no intermediate staging), for both void and non-void callables.
+        template <std::size_t min, std::size_t max, class F>
+        constexpr decltype(auto) dispatch_static_impl(std::size_t value, F&& f)
         {
-            using result_t = decltype(std::forward<F>(f)(std::integral_constant<std::size_t, min>{}));
-
-            if constexpr (std::is_void_v<result_t>)
+            if constexpr (min == max)
             {
-                // Fold over the candidates: the ternary short-circuits so `f` is
-                // invoked at most once (for the branch where `value == min + Is`).
-                const bool matched = ((value == min + Is ? (std::forward<F>(f)(std::integral_constant<std::size_t, min + Is>{}), true) : false)
-                                      || ...);
-                if (!matched)
+                if (value != min)
                 {
                     throw std::out_of_range("dispatch_static: value out of range");
                 }
+                return std::forward<F>(f)(std::integral_constant<std::size_t, min>{});
             }
             else
             {
-                static_assert(!std::is_reference_v<result_t>, "dispatch_static: the callable must return by value (or void)");
-
-                std::optional<result_t> result;
-                const bool matched = ((value == min + Is
-                                           ? (result.emplace(std::forward<F>(f)(std::integral_constant<std::size_t, min + Is>{})), true)
-                                           : false)
-                                      || ...);
-                if (!matched)
+                constexpr std::size_t mid = min + (max - min) / 2;
+                if (value <= mid)
                 {
-                    throw std::out_of_range("dispatch_static: value out of range");
+                    return dispatch_static_impl<min, mid>(value, std::forward<F>(f));
                 }
-                return static_cast<result_t>(std::move(*result));
+                else
+                {
+                    return dispatch_static_impl<mid + 1, max>(value, std::forward<F>(f));
+                }
             }
         }
     }
@@ -59,7 +53,8 @@ namespace samurai
      * Throws std::out_of_range if @p value is outside [ @p min , @p max ].
      *
      * The return value of @p f (which must be the same type for every candidate)
-     * is forwarded to the caller; a `void`-returning callable is supported.
+     * is forwarded to the caller by value, with guaranteed copy elision; a
+     * `void`-returning callable is supported.
      *
      * @tparam min  lowest value handled (inclusive)
      * @tparam max  highest value handled (inclusive)
@@ -70,6 +65,10 @@ namespace samurai
     constexpr decltype(auto) dispatch_static(std::size_t value, F&& f)
     {
         static_assert(min <= max, "dispatch_static requires min <= max");
-        return detail::dispatch_static_impl<min>(value, std::forward<F>(f), std::make_index_sequence<max - min + 1>{});
+
+        using result_t = decltype(std::forward<F>(f)(std::integral_constant<std::size_t, min>{}));
+        static_assert(!std::is_reference_v<result_t>, "dispatch_static: the callable must return by value (or void)");
+
+        return detail::dispatch_static_impl<min, max>(value, std::forward<F>(f));
     }
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -56,6 +56,7 @@ set(SAMURAI_TESTS
     test_restart.cpp
     test_scaling.cpp
     test_sfc_curves.cpp
+    test_static_dispatch.cpp
     test_stencil.cpp
     test_subdomain_bbox.cpp
     test_subset.cpp

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -59,6 +59,7 @@ set(SAMURAI_TESTS
     test_restart.cpp
     test_scaling.cpp
     test_sfc_curves.cpp
+    test_static_dispatch.cpp
     test_stencil.cpp
     test_subdomain_bbox.cpp
     test_subset.cpp

--- a/tests/test_graduation.cpp
+++ b/tests/test_graduation.cpp
@@ -1,10 +1,14 @@
 #include <algorithm>
+#include <stdexcept>
 
 #include <gtest/gtest.h>
 
 #include <samurai/algorithm/graduation.hpp>
+#include <samurai/box.hpp>
 #include <samurai/cell_array.hpp>
 #include <samurai/cell_list.hpp>
+#include <samurai/field.hpp>
+#include <samurai/mr/mesh.hpp>
 
 namespace samurai
 {
@@ -253,5 +257,39 @@ namespace samurai
                                                              std::vector<LevelCellArray<1>>{empty4, fine});
 
         EXPECT_TRUE(same_lca(4, all_local, split)) << "case-2 refinement must not depend on which rank owns the fine cell";
+    }
+
+    namespace
+    {
+        // samurai::graduation() (as opposed to make_graduation() above) reads the graduation width
+        // from mesh.cfg() and dispatches it through dispatch_static<1, 9>.
+        auto make_graduation_width_test_tag(std::size_t graduation_width)
+        {
+            static constexpr std::size_t dim = 1;
+            using box_t                      = Box<double, dim>;
+
+            auto mesh_cfg = mesh_config<dim>().min_level(1).max_level(3).graduation_width(graduation_width);
+            auto mesh     = mra::make_mesh(box_t{xt::zeros<double>({dim}), xt::ones<double>({dim})}, mesh_cfg);
+            auto tag      = make_scalar_field<int>("tag", mesh);
+            tag.fill(static_cast<int>(CellFlag::keep));
+            return tag;
+        }
+    }
+
+    // A graduation width of 0 means "no graduation constraint" and must not throw.
+    TEST(graduation, width_zero_is_a_noop)
+    {
+        auto tag = make_graduation_width_test_tag(0);
+        const xt::xtensor_fixed<int, xt::xshape<2, 1>> stencil{{1}, {-1}};
+        EXPECT_NO_THROW(samurai::graduation(tag, stencil));
+    }
+
+    // A width beyond what dispatch_static<1, 9> is instantiated for must fail loudly
+    // (std::out_of_range) instead of silently skipping the graduation step.
+    TEST(graduation, width_above_dispatch_range_throws)
+    {
+        auto tag = make_graduation_width_test_tag(15);
+        const xt::xtensor_fixed<int, xt::xshape<2, 1>> stencil{{1}, {-1}};
+        EXPECT_THROW(samurai::graduation(tag, stencil), std::out_of_range);
     }
 }

--- a/tests/test_static_dispatch.cpp
+++ b/tests/test_static_dispatch.cpp
@@ -1,0 +1,111 @@
+// Copyright 2018-2025 the samurai's authors
+// SPDX-License-Identifier:  BSD-3-Clause
+
+#include <array>
+#include <stdexcept>
+
+#include <gtest/gtest.h>
+
+#include <samurai/static_dispatch.hpp>
+
+namespace samurai
+{
+    // The callable receives the runtime value as a compile-time constant.
+    TEST(static_dispatch, maps_value_to_compile_time_constant)
+    {
+        for (std::size_t value = 1; value <= 4; ++value)
+        {
+            std::size_t seen = dispatch_static<1, 4>(value,
+                                                     [](auto ic)
+                                                     {
+                                                         static constexpr std::size_t N = decltype(ic)::value;
+                                                         return N;
+                                                     });
+            EXPECT_EQ(seen, value);
+        }
+    }
+
+    // Both bounds are inclusive.
+    TEST(static_dispatch, bounds_are_inclusive)
+    {
+        // Extra parentheses: the comma in the template argument list must not be
+        // parsed as a macro-argument separator.
+        EXPECT_NO_THROW((dispatch_static<2, 5>(2, [](auto) {})));
+        EXPECT_NO_THROW((dispatch_static<2, 5>(5, [](auto) {})));
+    }
+
+    // A value outside [min, max] throws.
+    TEST(static_dispatch, out_of_range_throws)
+    {
+        EXPECT_THROW((dispatch_static<2, 5>(1, [](auto) {})), std::out_of_range);
+        EXPECT_THROW((dispatch_static<2, 5>(6, [](auto) {})), std::out_of_range);
+        EXPECT_THROW((dispatch_static<2, 5>(0, [](auto) {})), std::out_of_range);
+    }
+
+    // The return value is forwarded to the caller.
+    TEST(static_dispatch, forwards_return_value)
+    {
+        auto squared = dispatch_static<1, 3>(3,
+                                             [](auto ic)
+                                             {
+                                                 static constexpr std::size_t N = decltype(ic)::value;
+                                                 return N * N;
+                                             });
+        EXPECT_EQ(squared, 9u);
+    }
+
+    // A void-returning callable is supported.
+    TEST(static_dispatch, supports_void_callable)
+    {
+        std::size_t captured = 0;
+        dispatch_static<0, 3>(2,
+                              [&](auto ic)
+                              {
+                                  captured = decltype(ic)::value;
+                              });
+        EXPECT_EQ(captured, 2u);
+    }
+
+    // The callable is invoked exactly once, only for the matching value.
+    TEST(static_dispatch, invoked_exactly_once)
+    {
+        int calls = 0;
+        dispatch_static<1, 6>(4,
+                              [&](auto)
+                              {
+                                  ++calls;
+                              });
+        EXPECT_EQ(calls, 1);
+    }
+
+    // A single-value range [N, N] is valid.
+    TEST(static_dispatch, single_value_range)
+    {
+        std::size_t seen = dispatch_static<7, 7>(7,
+                                                 [](auto ic)
+                                                 {
+                                                     return decltype(ic)::value;
+                                                 });
+        EXPECT_EQ(seen, 7u);
+        EXPECT_THROW((dispatch_static<7, 7>(8, [](auto) {})), std::out_of_range);
+    }
+
+    // The compile-time constant can drive a template parameter / array size.
+    TEST(static_dispatch, drives_template_parameter)
+    {
+        auto sum = dispatch_static<1, 4>(3,
+                                         [](auto ic)
+                                         {
+                                             static constexpr std::size_t N = decltype(ic)::value;
+                                             std::array<int, N> a{};
+                                             a.fill(2);
+                                             int s = 0;
+                                             for (auto v : a)
+                                             {
+                                                 s += v;
+                                             }
+                                             return s;
+                                         });
+        EXPECT_EQ(sum, 6); // 3 elements * 2
+    }
+}

--- a/tests/test_static_dispatch.cpp
+++ b/tests/test_static_dispatch.cpp
@@ -108,4 +108,32 @@ namespace samurai
                                          });
         EXPECT_EQ(sum, 6); // 3 elements * 2
     }
+
+    // The result is returned via guaranteed copy elision, without staging it in any
+    // intermediate storage: a callable may validly return a type with no copy or move
+    // constructor at all.
+    TEST(static_dispatch, supports_non_movable_return_type)
+    {
+        struct non_movable
+        {
+            int value;
+
+            explicit non_movable(int v)
+                : value(v)
+            {
+            }
+
+            non_movable(const non_movable&)            = delete;
+            non_movable& operator=(const non_movable&) = delete;
+            non_movable(non_movable&&)                 = delete;
+            non_movable& operator=(non_movable&&)      = delete;
+        };
+
+        auto result = dispatch_static<1, 4>(3,
+                                            [](auto ic)
+                                            {
+                                                return non_movable{static_cast<int>(decltype(ic)::value) * 10};
+                                            });
+        EXPECT_EQ(result.value, 30);
+    }
 }


### PR DESCRIPTION
## Description

Adds `dispatch_static<min, max>(value, f)`, which turns a runtime value into a
compile-time constant by calling `f(std::integral_constant<std::size_t, value>{})`,
and uses it to replace the `static_for` + `if` pattern repeated across the codebase.

`static_for` instantiates every candidate and relies on a runtime `if` inside the
lambda to pick one, which silently does nothing when no candidate matches.
`dispatch_static` selects the branch itself by recursive binary dispatch and throws
`std::out_of_range` when the value is outside the instantiated range.

Call sites converted:

- `graduation.hpp`: the graduation width dispatch. An out-of-range width used to be
  caught by an `assert` (so, not in release builds) and then silently skipped;
  it now throws. A width of `0`, which means "no graduation constraint", is
  handled explicitly.
- `apply_field_bc.hpp`: the boundary-condition stencil size dispatch, and the two
  polynomial-extrapolation loops. Since `PolynomialExtrapolation` is only
  implemented for even stencil sizes, these now dispatch on the ghost layer
  (`stencil_size = 2 * ghost_layer`) rather than on the stencil size, so the unused
  odd-size candidates are no longer instantiated.
- `apply_field_bc.hpp`: `translated_outer_neighbours` was a chain of `if constexpr`
  branches, one per layer count, hardcoded up to 5. It is now a single
  `index_sequence` pack expansion, with no upper bound.

The callable's result is returned by guaranteed copy elision (no intermediate
staging), so a callable returning an immovable type by value is supported;
`void` callables are supported too.

## How has this been tested?

- `tests/test_static_dispatch.cpp` (new, 9 tests): value-to-constant mapping,
  inclusive bounds, `std::out_of_range` outside the range, return-value forwarding,
  `void` callables, single invocation, single-value range, use as a template
  parameter, and a non-movable return type.
- `tests/test_graduation.cpp`: two tests covering the behaviour change, a width of
  `0` being a no-op and a width beyond the instantiated range throwing.
- The rest of the test suite covers the converted call sites: 440 tests pass.

## Code of Conduct
By submitting this PR, you agree to follow our [Code of Conduct](https://github.com/hpc-maths/samurai/blob/master/docs/CODE_OF_CONDUCT.md)
- [x] I agree to follow this project's Code of Conduct
