### PR TITLE
perf: improve interval insertion for list of intervals

### DIFF
--- a/include/samurai/list_of_intervals.hpp
+++ b/include/samurai/list_of_intervals.hpp
@@ -3,8 +3,12 @@
 
 #pragma once
 
+#include <algorithm>
+#include <cstddef>
 #include <forward_list>
 #include <iostream>
+#include <iterator>
+#include <utility>
 
 #include "interval.hpp"
 #include "samurai_config.hpp"
@@ -35,6 +39,13 @@ namespace samurai
     /** @class ListOfIntervals
      *  @brief Forward list of intervals.
      *
+     * The intervals are kept sorted and disjoint. An iterator on the last
+     * interval touched is cached and used as a starting hint for the next
+     * insertion. Intervals are almost always added in increasing order, so this
+     * turns the insertion into an O(1) operation instead of a traversal of the
+     * whole list from its beginning. The hint is only an optimization: it never
+     * changes the content of the list.
+     *
      * @tparam TValue  The coordinate type (must be signed).
      * @tparam TIndex  The index type (must be signed).
      */
@@ -50,30 +61,100 @@ namespace samurai
         using list_t::begin;
         using list_t::cbegin;
         using list_t::cend;
-        using list_t::clear;
         using list_t::empty;
         using list_t::end;
 
-        using list_t::erase_after;
         using const_iterator = typename list_t::const_iterator;
         using iterator       = typename list_t::iterator;
         using value_type     = typename list_t::value_type;
 
+        ListOfIntervals();
+        ListOfIntervals(const ListOfIntervals& other);
+        ListOfIntervals& operator=(const ListOfIntervals& other);
+        ListOfIntervals(ListOfIntervals&& other) noexcept;
+        ListOfIntervals& operator=(ListOfIntervals&& other) noexcept;
+        ~ListOfIntervals() = default;
+
         std::size_t size() const;
 
+        void clear();
         void add_point(value_t point);
         void add_interval(const interval_t& interval);
+
+      private:
+
+        /// Iterator on the last interval touched, or before_begin() if there is none.
+        iterator m_hint;
+
+        /// Merge into *it all the following intervals it now overlaps.
+        void merge_following(iterator it, value_t interval_end);
     };
 
     ////////////////////////////////////
     // ListOfIntervals implementation //
     ////////////////////////////////////
 
+    template <typename TValue, typename TIndex>
+    SAMURAI_INLINE ListOfIntervals<TValue, TIndex>::ListOfIntervals()
+        : m_hint{before_begin()}
+    {
+    }
+
+    // The hint is tied to the nodes of a given container, so it is never taken
+    // over on copy nor on move. Dropping it is harmless: it only costs one full
+    // traversal on the next insertion.
+
+    template <typename TValue, typename TIndex>
+    SAMURAI_INLINE ListOfIntervals<TValue, TIndex>::ListOfIntervals(const ListOfIntervals& other)
+        : list_t{other}
+        , m_hint{before_begin()}
+    {
+    }
+
+    template <typename TValue, typename TIndex>
+    SAMURAI_INLINE auto ListOfIntervals<TValue, TIndex>::operator=(const ListOfIntervals& other) -> ListOfIntervals&
+    {
+        if (this != &other)
+        {
+            list_t::operator=(other);
+            m_hint = before_begin();
+        }
+        return *this;
+    }
+
+    template <typename TValue, typename TIndex>
+    SAMURAI_INLINE ListOfIntervals<TValue, TIndex>::ListOfIntervals(ListOfIntervals&& other) noexcept
+        : list_t{std::move(static_cast<list_t&>(other))}
+        , m_hint{before_begin()}
+    {
+        other.m_hint = other.before_begin();
+    }
+
+    template <typename TValue, typename TIndex>
+    SAMURAI_INLINE auto ListOfIntervals<TValue, TIndex>::operator=(ListOfIntervals&& other) noexcept -> ListOfIntervals&
+    {
+        if (this != &other)
+        {
+            list_t::operator=(std::move(static_cast<list_t&>(other)));
+            m_hint       = before_begin();
+            other.m_hint = other.before_begin();
+        }
+        return *this;
+    }
+
     /// Number of intervals stored in the list.
     template <typename TValue, typename TIndex>
     SAMURAI_INLINE std::size_t ListOfIntervals<TValue, TIndex>::size() const
     {
         return static_cast<std::size_t>(std::distance(begin(), end()));
+    }
+
+    /// Remove all the intervals.
+    template <typename TValue, typename TIndex>
+    SAMURAI_INLINE void ListOfIntervals<TValue, TIndex>::clear()
+    {
+        list_t::clear();
+        m_hint = before_begin();
     }
 
     /// Add a point inside the list.
@@ -92,29 +173,54 @@ namespace samurai
             return;
         }
 
+        // The intervals stored in the list are sorted and disjoint, so an
+        // interval starting after the hinted one can only be inserted after it:
+        // the search is then started from the hint rather than from the
+        // beginning of the list. Without this, each insertion walks the whole
+        // list and filling a list of n intervals costs O(n^2).
+        auto search_from = before_begin();
+        if (m_hint != before_begin() && interval.start >= m_hint->start)
+        {
+            if (interval.start <= m_hint->end)
+            {
+                // overlaps or touches the hinted interval: extend it
+                m_hint->end = std::max(m_hint->end, interval.end);
+                merge_following(m_hint, interval.end);
+                return;
+            }
+            search_from = m_hint;
+        }
+
         auto predicate = [interval](const auto& value)
         {
             return interval.start <= value.end;
         };
-        auto it = detail::forward_find_if(before_begin(), end(), predicate);
+        auto it = detail::forward_find_if(search_from, end(), predicate);
 
         // if we are at the end just append the new interval or
         // if we are between two intervals, insert it
         if (it.second == end() || interval.end < it.second->start)
         {
-            this->insert_after(it.first, interval);
+            m_hint = this->insert_after(it.first, interval);
             return;
         }
 
         // else there is an overlap
         it.second->start = std::min(it.second->start, interval.start);
         it.second->end   = std::max(it.second->end, interval.end);
+        merge_following(it.second, interval.end);
+        m_hint = it.second;
+    }
 
-        auto it_end = std::next(it.second);
-        while (it_end != end() && interval.end >= it_end->start)
+    /// Merge into *it all the following intervals it now overlaps.
+    template <typename TValue, typename TIndex>
+    SAMURAI_INLINE void ListOfIntervals<TValue, TIndex>::merge_following(iterator it, value_t interval_end)
+    {
+        auto it_next = std::next(it);
+        while (it_next != end() && interval_end >= it_next->start)
         {
-            it.second->end = std::max(it_end->end, interval.end);
-            it_end         = erase_after(it.second);
+            it->end = std::max(it_next->end, interval_end);
+            it_next = this->erase_after(it);
         }
     }
 

--- a/tests/test_list_of_intervals.cpp
+++ b/tests/test_list_of_intervals.cpp
@@ -95,6 +95,120 @@ namespace samurai
         EXPECT_EQ(list.size(), 1u);
     }
 
+    // The following tests exercise the search hint cached on the last interval
+    // touched, which makes the insertion in increasing order O(1).
+
+    TEST(list_of_intervals, add_intervals_in_several_increasing_passes)
+    {
+        // Typical of the building of a cell list: a first pass fills the level
+        // from the refined cells of the level below, a second one restarts from
+        // the beginning with the cells already at that level.
+        ListOfIntervals<int, int> list;
+        for (int i = 0; i < 100; i += 4)
+        {
+            list.add_interval({i, i + 1});
+        }
+        for (int i = 2; i < 100; i += 4)
+        {
+            list.add_interval({i, i + 1});
+        }
+        // and a decreasing pass, to make sure the hint is never trusted blindly
+        for (int i = 96; i >= 0; i -= 4)
+        {
+            list.add_interval({i + 1, i + 2});
+        }
+
+        EXPECT_EQ(list.size(), 25u);
+        int expected_start = 0;
+        for (const auto& interval : list)
+        {
+            EXPECT_EQ(interval.start, expected_start);
+            EXPECT_EQ(interval.end, expected_start + 3);
+            expected_start += 4;
+        }
+    }
+
+    TEST(list_of_intervals, clear_then_add)
+    {
+        ListOfIntervals<int, int> list;
+        list.add_interval({-3, 3});
+        list.clear();
+        EXPECT_EQ(list.size(), 0u);
+
+        list.add_point(7);
+        list.add_point(9);
+        list.add_point(8);
+        xt::xarray<Interval<int, int>> expected{
+            {7, 10}
+        };
+        EXPECT_EQ(list, expected);
+    }
+
+    TEST(list_of_intervals, copy_then_add)
+    {
+        ListOfIntervals<int, int> list;
+        list.add_interval({-3, 3});
+
+        ListOfIntervals<int, int> copy_constructed(list);
+        copy_constructed.add_interval({10, 12});
+
+        ListOfIntervals<int, int> copy_assigned;
+        copy_assigned.add_interval({-100, -50});
+        copy_assigned = list;
+        copy_assigned.add_interval({10, 12});
+
+        xt::xarray<Interval<int, int>> expected{
+            {-3, 3 },
+            {10, 12}
+        };
+        EXPECT_EQ(copy_constructed, expected);
+        EXPECT_EQ(copy_assigned, expected);
+    }
+
+    TEST(list_of_intervals, move_then_add)
+    {
+        xt::xarray<Interval<int, int>> expected{
+            {-3, 3 },
+            {10, 12}
+        };
+
+        ListOfIntervals<int, int> list;
+        list.add_interval({-3, 3});
+        ListOfIntervals<int, int> move_constructed(std::move(list));
+        move_constructed.add_interval({10, 12});
+        EXPECT_EQ(move_constructed, expected);
+
+        ListOfIntervals<int, int> other;
+        other.add_interval({-3, 3});
+        ListOfIntervals<int, int> move_assigned;
+        move_assigned.add_interval({-100, -50});
+        move_assigned = std::move(other);
+        move_assigned.add_interval({10, 12});
+        EXPECT_EQ(move_assigned, expected);
+    }
+
+    TEST(list_of_intervals, add_interval_swallowing_the_last_one)
+    {
+        ListOfIntervals<int, int> list;
+        list.add_interval({-3, -1});
+        list.add_interval({2, 4});
+        list.add_interval({8, 10});
+
+        // swallows every interval, including the last one
+        list.add_interval({-5, 12});
+        xt::xarray<Interval<int, int>> expected{
+            {-5, 12}
+        };
+        EXPECT_EQ(list, expected);
+
+        // the cached iterator must still designate the merged interval
+        list.add_interval({12, 14});
+        xt::xarray<Interval<int, int>> expected_after{
+            {-5, 14}
+        };
+        EXPECT_EQ(list, expected_after);
+    }
+
     TEST(list_of_intervals, ostream)
     {
         ListOfIntervals<int, int> list;


### PR DESCRIPTION
## Description

`ListOfIntervals::add_interval` restarted its search from `before_begin()` on every call, so filling a list of `n` intervals was **O(n²)**. It is on the critical path of every mesh construction, and `update_field` hits it once per cell.

Intervals are almost always added in increasing order, so an iterator on the last interval touched is now cached and used as a **starting hint**. The stored intervals being sorted and disjoint, an interval starting at or after the hint can only be inserted at or after it, so the search safely skips everything before. Sorted insertion becomes O(1) amortised.

The hint is only an optimization, never a source of truth: it is dropped on copy and on move (it is tied to the nodes of a given container), the search falls back to `before_begin()` when the new interval starts earlier, and the content of the list is unchanged in every case.

Caching just the *last* interval would not have sufficed: a level is filled in several increasing passes (refined cells of the level below, then cells already at that level, restarting at the beginning of the domain), and only the first would have been accelerated.

Two side effects:

- `clear()` becomes a member so it can reset the hint - same signature and behaviour.
- `erase_after` is no longer re-exported: it was the only exposed operation able to destroy the hinted node, leaving a dangling iterator and silent UB. It had no user in the repository and `insert_after` was never exposed either. **This is the only potentially breaking change here**; it can come back as a wrapper that invalidates the hint if preferred.

### Measured impact

1D AMR film-flow solver, levels 15-16, ~39k cells for ~3600 intervals per level, 362 mesh reconstructions:

| timer | before | after |
| --- | --- | --- |
| `build new mesh` | 10.935 s (91.4 % of runtime) | **0.090 s (7.9 %)** |
| total runtime | 11.96 s | **1.14 s** |

## How has this been tested?

`tests/test_list_of_intervals.cpp`: 5 added for the paths the hint introduces - several increasing passes plus a decreasing one, `clear()`, copy/move then insertion, and an interval swallowing the hinted one then an append on the merged result.

## Code of Conduct
- [x] I agree to follow this project's Code of Conduct