### PR TITLE
fix: graduation

### DIFF
--- a/include/samurai/algorithm/graduation.hpp
+++ b/include/samurai/algorithm/graduation.hpp
@@ -424,33 +424,35 @@ namespace samurai
                     {
                         for (size_t level = max_level; level != min_level; --level)
                         {
-                            auto boundaryCells = difference(ca[level], translate(self(domain).on(level), -translation)).on(level);
-
-                            for (int i = 2; i <= n_contiguous_boundary_cells; i += 2)
+                            // The boundary cells that drive the inward refinement must be seen from EVERY mesh (this rank
+                            // and all its neighbours), otherwise the set of boundary cells - and hence the refinement -
+                            // depends on the MPI partition: a boundary cell owned by a neighbour would be invisible here.
+                            // We therefore refine ONLY this rank's own level-1 cells (out drives the local `ca`), but from
+                            // boundary cells taken from `ca` and from each neighbour mesh. In sequential runs mpi_meshes is
+                            // empty and this reduces to the original single-mesh behaviour.
+                            auto refine_from = [&](const auto& src)
                             {
-                                // Here, the set algebra doesn't work, so we put the translation in a LevelCellArray before computing
-                                // the intersection. When the problem is fixed, remove the two following lines and uncomment the line
-                                // below.
-                                LevelCellArray<dim, TInterval> translated_boundary(translate(boundaryCells, -i * translation));
-                                auto refine_impl = [&](const auto& ca_lm1)
+                                auto boundaryCells = difference(src[level], translate(self(domain).on(level), -translation)).on(level);
+                                for (int i = 2; i <= n_contiguous_boundary_cells; i += 2)
                                 {
-                                    auto refine_subset = intersection(translated_boundary, ca_lm1).on(level - 1);
-                                    // auto refine_subset = intersection(translate(boundaryCells, -i*translation), ca[level-1]).on(level-1);
-
+                                    // Here, the set algebra doesn't work, so we put the translation in a LevelCellArray before
+                                    // computing the intersection.
+                                    LevelCellArray<dim, TInterval> translated_boundary(translate(boundaryCells, -i * translation));
+                                    auto refine_subset = intersection(translated_boundary, ca[level - 1]).on(level - 1);
                                     refine_subset(
                                         [&](const auto& x_interval, const auto& yz)
                                         {
                                             out[level - 1].push_back(x_interval, yz);
                                         });
-                                };
-                                refine_impl(ca[level - 1]);
-#ifdef SAMURAI_WITH_MPI
-                                for (const auto& mpi_mesh : mpi_meshes)
-                                {
-                                    refine_impl(mpi_mesh[level - 1]);
                                 }
-#endif
+                            };
+                            refine_from(ca);
+#ifdef SAMURAI_WITH_MPI
+                            for (const auto& mpi_mesh : mpi_meshes)
+                            {
+                                refine_from(mpi_mesh);
                             }
+#endif
                         }
                     }
 
@@ -464,12 +466,14 @@ namespace samurai
                     {
                         for (size_t level = max_level - 1; level != min_level - 1; --level)
                         {
-                            auto boundaryCells = difference(ca[level], translate(self(domain).on(level), -translation));
-                            for (int i = 1; i != max_stencil_radius; ++i)
+                            // Same partition-independence concern as the level-1 case above: take the boundary cells from
+                            // `ca` and from every neighbour mesh, but refine only this rank's own level+1 cells.
+                            auto refine_from = [&](const auto& src)
                             {
-                                auto refine_impl = [&](const auto& ca_lp1)
+                                auto boundaryCells = difference(src[level], translate(self(domain).on(level), -translation));
+                                for (int i = 1; i != max_stencil_radius; ++i)
                                 {
-                                    auto refine_subset = translate(intersection(translate(boundaryCells, -i * translation), ca_lp1).on(level),
+                                    auto refine_subset = translate(intersection(translate(boundaryCells, -i * translation), ca[level + 1]).on(level),
                                                                    i * translation)
                                                              .on(level);
                                     refine_subset(
@@ -477,15 +481,15 @@ namespace samurai
                                         {
                                             out[level].push_back(x_interval, yz);
                                         });
-                                };
-                                refine_impl(ca[level + 1]);
-#ifdef SAMURAI_WITH_MPI
-                                for (const auto& mpi_mesh : mpi_meshes)
-                                {
-                                    refine_impl(mpi_mesh[level + 1]);
                                 }
-#endif
+                            };
+                            refine_from(ca);
+#ifdef SAMURAI_WITH_MPI
+                            for (const auto& mpi_mesh : mpi_meshes)
+                            {
+                                refine_from(mpi_mesh);
                             }
+#endif
                         }
                     }
                 }

--- a/include/samurai/algorithm/graduation.hpp
+++ b/include/samurai/algorithm/graduation.hpp
@@ -473,8 +473,9 @@ namespace samurai
                                 auto boundaryCells = difference(src[level], translate(self(domain).on(level), -translation));
                                 for (int i = 1; i != max_stencil_radius; ++i)
                                 {
-                                    auto refine_subset = translate(intersection(translate(boundaryCells, -i * translation), ca[level + 1]).on(level),
-                                                                   i * translation)
+                                    auto refine_subset = translate(
+                                                             intersection(translate(boundaryCells, -i * translation), ca[level + 1]).on(level),
+                                                             i * translation)
                                                              .on(level);
                                     refine_subset(
                                         [&](const auto& x_interval, const auto& yz)

--- a/tests/test_graduation.cpp
+++ b/tests/test_graduation.cpp
@@ -43,4 +43,68 @@ namespace samurai
         samurai::make_graduation(ca);
         EXPECT_TRUE(is_graduated(ca));
     }
+
+#ifdef SAMURAI_WITH_MPI
+    // Non-regression test for the partition-dependence bug fixed alongside this test:
+    // list_interval_to_refine_for_contiguous_boundary_cells (active only when
+    // max_stencil_radius > 1) used to look for physical-boundary cells in the local
+    // `ca` only, so a boundary cell owned by a neighbour rank was invisible and the
+    // refinement it must trigger on the neighbouring inner cells depended on the MPI
+    // partition. The fix takes boundary cells from `ca` AND from every mesh in
+    // `mpi_meshes`, while still refining only the local rank's own cells.
+    //
+    // Domain: x in [0, 16) at level 4. A single coarse cell (level 3, index 6, i.e.
+    // fine x in [12, 14)) sits close enough to the right physical boundary
+    // (x = 16) that it must be refined to level 4 for a scheme with
+    // max_stencil_radius = 3, regardless of which rank owns the level-4 boundary
+    // cells (fine x in [14, 16)) that trigger this refinement.
+    TEST(graduation, contiguous_boundary_partition_independent)
+    {
+        constexpr size_t dim         = 1;
+        constexpr int stencil_radius = 3;
+
+        using ca_type    = CellArray<dim>;
+        using interval_t = typename ca_type::interval_t;
+        using coord_type = typename ca_type::lca_type::coord_type;
+        using out_t      = std::array<ArrayOfIntervalAndPoint<interval_t, coord_type>, ca_type::max_size>;
+
+        CellList<dim> domain_cl;
+        domain_cl[4][{}].add_interval({0, 16});
+        LevelCellArray<dim> domain(domain_cl[4]);
+
+        const std::array<bool, dim> is_periodic{false};
+
+        // Scenario A: this rank owns everything, including the boundary cells.
+        CellList<dim> cl_local;
+        cl_local[4][{}].add_interval({14, 16});
+        cl_local[3][{}].add_interval({6, 7});
+        ca_type ca_all_local{cl_local};
+
+        out_t out_single_rank{};
+        std::vector<ca_type> no_neighbours;
+        list_interval_to_refine_for_contiguous_boundary_cells(stencil_radius, ca_all_local, domain, no_neighbours, is_periodic, out_single_rank);
+
+        // Scenario B: this rank owns only the interior coarse cell; a neighbour rank
+        // owns the boundary cells (as can happen after load balancing moves a
+        // subdomain boundary into an active region).
+        CellList<dim> cl_interior_only;
+        cl_interior_only[3][{}].add_interval({6, 7});
+        ca_type ca_without_boundary{cl_interior_only};
+
+        CellList<dim> cl_neighbour;
+        cl_neighbour[4][{}].add_interval({14, 16});
+        ca_type neighbour_ca{cl_neighbour};
+        std::vector<ca_type> mpi_meshes{neighbour_ca};
+
+        out_t out_split_rank{};
+        list_interval_to_refine_for_contiguous_boundary_cells(stencil_radius, ca_without_boundary, domain, mpi_meshes, is_periodic, out_split_rank);
+
+        // The coarse cell must be flagged for refinement in both cases, identically,
+        // whether the boundary cells that trigger it are local or owned by a
+        // neighbour.
+        ASSERT_EQ(out_single_rank[3].size(), 1u);
+        ASSERT_EQ(out_split_rank[3].size(), 1u);
+        EXPECT_EQ(out_single_rank[3].get_interval(0), out_split_rank[3].get_interval(0));
+    }
+#endif // SAMURAI_WITH_MPI
 }


### PR DESCRIPTION
## Description
`list_interval_to_refine_for_contiguous_boundary_cells` (active only when max_stencil_radius > 1) computed the set of physical-boundary cells that drive the inward refinement from the LOCAL cell array `ca` only. Under MPI, a boundary cell owned by a neighbour rank was therefore invisible to this rank, so the refinement it must trigger on the neighbouring inner cells depended on how the domain was partitioned.

Consequence: `make_graduation` could produce a different graduated mesh on N ranks than on 1 rank, even when the refine/coarsen tags were bit-identical. It surfaced after load balancing moved a subdomain boundary into an active region, breaking 1-vs-N reproducibility (the adapted mesh, and hence the whole solution, diverged from a round-off-free seed).

Fix: take the boundary cells from `ca` AND from every neighbour mesh (mpi_meshes), while still refining only this rank's own cells. Sequential runs are unchanged since mpi_meshes is then empty, so this reduces to the former single-mesh behaviour.

## Code of Conduct
By submitting this PR, you agree to follow our [Code of Conduct](https://github.com/hpc-maths/samurai/blob/master/docs/CODE_OF_CONDUCT.md)
- [x] I agree to follow this project's Code of Conduct
