### PR TITLE
perf: subset traverser

### DIFF
--- a/benchmark/benchmark_set.cpp
+++ b/benchmark/benchmark_set.cpp
@@ -24,6 +24,16 @@
 // slower on the end-to-end advection_2d run; the "adapted" tier exists so
 // that this class of regression is visible without having to rebuild and run
 // a full demo.
+//
+// BM_RefineFootprint_adapted<3> is also a codegen canary: the fully-inlined
+// 3D traversal is so register-tight that perturbing the Projection code was
+// measured to cost ~+30% executed instructions (spills) on the REFINE path
+// even when the perturbation is never executed. Measured triggers: adding a
+// member holding a std::vector to SetTraits<Projection>::Workspace, or
+// writing to a Workspace member from the COARSEN branch of
+// get_traverser_impl (a branch this benchmark never takes); noinline / cold
+// / preserve_most on the added code did not help. Re-run this benchmark
+// after any change to include/samurai/subset/, however innocuous.
 
 #include <cmath>
 #include <cstddef>

--- a/benchmark/benchmark_set.cpp
+++ b/benchmark/benchmark_set.cpp
@@ -210,9 +210,74 @@ static void BM_StencilTranslation_adapted(benchmark::State& state)
     state.counters["cells"] = static_cast<double>(mesh.nb_cells(mesh_id_t::cells));
 }
 
+// cells[l] refined onto max_level: the REFINE projection footprint of
+// reconstruction and transfer (reconstruction.hpp), where every coarse row is
+// fanned out on 2^(max_level - l) fine rows per dimension. Arg: 1/eps.
+template <std::size_t dim>
+static void BM_RefineFootprint_adapted(benchmark::State& state)
+{
+    const std::size_t max_level = (dim == 2) ? 11 : 8;
+    auto mesh                   = make_adapted_mesh<dim>(1. / static_cast<double>(state.range(0)), max_level);
+    using mesh_id_t             = typename std::decay_t<decltype(mesh)>::mesh_id_t;
+
+    const auto min_l = mesh[mesh_id_t::cells].min_level();
+    const auto max_l = mesh[mesh_id_t::cells].max_level();
+
+    for (auto _ : state)
+    {
+        std::size_t acc = 0;
+        for (std::size_t level = min_l; level < max_l; ++level)
+        {
+            auto subset = samurai::self(mesh[mesh_id_t::cells][level]).on(max_l);
+            subset(
+                [&](const auto& i, const auto&)
+                {
+                    acc += i.size();
+                });
+        }
+        benchmark::DoNotOptimize(acc);
+    }
+    state.counters["cells"] = static_cast<double>(mesh.nb_cells(mesh_id_t::cells));
+}
+
+// intersection(all_cells[l], cells[l]).on(max_level): the REFINE projection
+// of a composite set, the pattern of transfer() (reconstruction.hpp), where
+// every fine row used to redo the intersection merge of its coarse row.
+// Arg: 1/eps.
+template <std::size_t dim>
+static void BM_TransferFootprint_adapted(benchmark::State& state)
+{
+    const std::size_t max_level = (dim == 2) ? 11 : 8;
+    auto mesh                   = make_adapted_mesh<dim>(1. / static_cast<double>(state.range(0)), max_level);
+    using mesh_id_t             = typename std::decay_t<decltype(mesh)>::mesh_id_t;
+
+    const auto min_l = mesh[mesh_id_t::cells].min_level();
+    const auto max_l = mesh[mesh_id_t::cells].max_level();
+
+    for (auto _ : state)
+    {
+        std::size_t acc = 0;
+        for (std::size_t level = min_l; level < max_l; ++level)
+        {
+            auto subset = samurai::intersection(mesh[mesh_id_t::all_cells][level], mesh[mesh_id_t::cells][level]).on(max_l);
+            subset(
+                [&](const auto& i, const auto&)
+                {
+                    acc += i.size();
+                });
+        }
+        benchmark::DoNotOptimize(acc);
+    }
+    state.counters["cells"] = static_cast<double>(mesh.nb_cells(mesh_id_t::cells));
+}
+
 BENCHMARK(BM_ProjectionFootprint_adapted<2>)->Arg(1000)->Arg(100000);
 BENCHMARK(BM_ProjectionFootprint_adapted<3>)->Arg(1000)->Arg(100000);
 BENCHMARK(BM_StencilTranslation_adapted<2>)->Arg(1000)->Arg(100000);
 BENCHMARK(BM_StencilTranslation_adapted<3>)->Arg(1000)->Arg(100000);
+BENCHMARK(BM_RefineFootprint_adapted<2>)->Arg(1000)->Arg(100000);
+BENCHMARK(BM_RefineFootprint_adapted<3>)->Arg(1000)->Arg(100000);
+BENCHMARK(BM_TransferFootprint_adapted<2>)->Arg(1000)->Arg(100000);
+BENCHMARK(BM_TransferFootprint_adapted<3>)->Arg(1000)->Arg(100000);
 
 BENCHMARK_MAIN();

--- a/include/samurai/list_of_intervals.hpp
+++ b/include/samurai/list_of_intervals.hpp
@@ -9,6 +9,7 @@
 #include <iostream>
 #include <iterator>
 #include <utility>
+#include <vector>
 
 #include "interval.hpp"
 #include "samurai_config.hpp"
@@ -226,6 +227,164 @@ namespace samurai
 
     template <typename value_t, typename index_t>
     SAMURAI_INLINE std::ostream& operator<<(std::ostream& out, const ListOfIntervals<value_t, index_t>& interval_list)
+    {
+        for (const auto& interval : interval_list)
+        {
+            out << interval << " ";
+        }
+        return out;
+    }
+
+    ///////////////////////////////////////
+    // FlatListOfIntervals definition    //
+    ///////////////////////////////////////
+
+    /** @class FlatListOfIntervals
+     *  @brief Vector-backed sorted list of disjoint intervals.
+     *
+     * Scratch buffer used by the subset workspaces. Same semantics as
+     * ListOfIntervals (the buffer always holds the union of the added
+     * intervals, sorted and disjoint) but on contiguous storage: insertion
+     * uses a binary search plus a memmove of a handful of PODs instead of
+     * walking a node-based list, and clear() keeps the capacity, so a buffer
+     * reused across rows stops allocating after the first few insertions.
+     */
+    template <typename TValue, typename TIndex = default_config::index_t>
+    struct FlatListOfIntervals
+    {
+        using value_t    = TValue;
+        using index_t    = TIndex;
+        using interval_t = Interval<value_t, index_t>;
+
+        using storage_t      = std::vector<interval_t>;
+        using const_iterator = typename storage_t::const_iterator;
+        using iterator       = typename storage_t::iterator;
+        using value_type     = interval_t;
+
+        SAMURAI_INLINE void clear()
+        {
+            m_intervals.clear();
+            m_hint = 0;
+        }
+
+        SAMURAI_INLINE bool empty() const
+        {
+            return m_intervals.empty();
+        }
+
+        SAMURAI_INLINE std::size_t size() const
+        {
+            return m_intervals.size();
+        }
+
+        SAMURAI_INLINE void add_interval(const interval_t& interval)
+        {
+            if (!interval.is_valid())
+            {
+                return;
+            }
+
+            if (m_intervals.empty())
+            {
+                m_intervals.push_back(interval);
+                m_hint = 0;
+                return;
+            }
+
+            // Same hint strategy as ListOfIntervals: intervals are almost
+            // always added in increasing order, starting the search from the
+            // last interval touched makes the insertion amortized O(1).
+            std::size_t i = 0;
+            if (interval.start >= m_intervals[m_hint].start)
+            {
+                if (interval.start <= m_intervals[m_hint].end)
+                {
+                    // overlaps or touches the hinted interval: extend it
+                    if (interval.end > m_intervals[m_hint].end)
+                    {
+                        m_intervals[m_hint].end = interval.end;
+                        absorb_following(m_hint);
+                    }
+                    return;
+                }
+                i = m_hint + 1;
+            }
+
+            // first interval that ends at or after the new one starts
+            while (i != m_intervals.size() && m_intervals[i].end < interval.start)
+            {
+                ++i;
+            }
+
+            if (i == m_intervals.size())
+            {
+                m_intervals.push_back(interval);
+            }
+            else if (interval.end < m_intervals[i].start)
+            {
+                // disjoint: insert in place
+                m_intervals.insert(m_intervals.begin() + std::ptrdiff_t(i), interval);
+            }
+            else
+            {
+                // overlap: extend *it, then absorb the intervals it now covers
+                m_intervals[i].start = std::min(m_intervals[i].start, interval.start);
+                if (interval.end > m_intervals[i].end)
+                {
+                    m_intervals[i].end = interval.end;
+                    absorb_following(i);
+                }
+            }
+            m_hint = i;
+        }
+
+        SAMURAI_INLINE void add_point(value_t point)
+        {
+            add_interval({point, point + 1});
+        }
+
+        SAMURAI_INLINE const_iterator cbegin() const
+        {
+            return m_intervals.cbegin();
+        }
+
+        SAMURAI_INLINE const_iterator cend() const
+        {
+            return m_intervals.cend();
+        }
+
+        SAMURAI_INLINE const_iterator begin() const
+        {
+            return m_intervals.begin();
+        }
+
+        SAMURAI_INLINE const_iterator end() const
+        {
+            return m_intervals.end();
+        }
+
+      private:
+
+        /// Merge into m_intervals[i] all the following intervals it now overlaps.
+        void absorb_following(std::size_t i)
+        {
+            std::size_t j = i + 1;
+            while (j != m_intervals.size() && m_intervals[j].start <= m_intervals[i].end)
+            {
+                m_intervals[i].end = std::max(m_intervals[i].end, m_intervals[j].end);
+                ++j;
+            }
+            m_intervals.erase(m_intervals.begin() + std::ptrdiff_t(i) + 1, m_intervals.begin() + std::ptrdiff_t(j));
+        }
+
+        storage_t m_intervals;
+
+        /// Index of the last interval touched.
+        std::size_t m_hint = 0;
+    };
+
+    template <typename value_t, typename index_t>
+    SAMURAI_INLINE std::ostream& operator<<(std::ostream& out, const FlatListOfIntervals<value_t, index_t>& interval_list)
     {
         for (const auto& interval : interval_list)
         {

--- a/include/samurai/subset/expansion.hpp
+++ b/include/samurai/subset/expansion.hpp
@@ -26,7 +26,7 @@ namespace samurai
             using array_of_traversers_t = std::vector<child_traverser_t<d>>;
 
             template <std::size_t d>
-            using list_of_intervals_t = ListOfIntervals<typename child_traverser_t<d>::value_t>;
+            using list_of_intervals_t = FlatListOfIntervals<typename child_traverser_t<d>::value_t>;
 
             template <std::size_t d>
             using InnerType = std::conditional_t<d == Set::dim - 2, array_of_traversers_t<d>, list_of_intervals_t<d>>;

--- a/include/samurai/subset/projection.hpp
+++ b/include/samurai/subset/projection.hpp
@@ -27,7 +27,7 @@ namespace samurai
             using child_traverser_t = typename Set::template traverser_t<d>;
 
             template <std::size_t d>
-            using work_t = ListOfIntervals<typename child_traverser_t<d>::value_t>;
+            using work_t = FlatListOfIntervals<typename child_traverser_t<d>::value_t>;
 
             using Type = std::tuple<work_t<ds>...>;
         };
@@ -142,9 +142,7 @@ namespace samurai
                                                    workspace.tmp_child_workspace,
                                                    list_of_intervals);
 
-                    return traverser_t<d>(m_set.get_traverser(utils::pow2(index, m_shift), d_ic, workspace.child_workspace),
-                                          list_of_intervals.cbegin(),
-                                          list_of_intervals.cend());
+                    return traverser_t<d>(list_of_intervals.cbegin(), list_of_intervals.cend());
                 }
                 else
                 {

--- a/include/samurai/subset/traversers/loi_traverser.hpp
+++ b/include/samurai/subset/traversers/loi_traverser.hpp
@@ -9,6 +9,6 @@
 namespace samurai
 {
     template <typename TValue>
-    using LOITraverser = RangeTraverser<typename ListOfIntervals<TValue>::const_iterator>;
+    using LOITraverser = RangeTraverser<typename FlatListOfIntervals<TValue>::const_iterator>;
 
 } // namespace samurai

--- a/include/samurai/subset/traversers/projection_traverser.hpp
+++ b/include/samurai/subset/traversers/projection_traverser.hpp
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include <optional>
+
 #include "../../list_of_intervals.hpp"
 #include "set_traverser_base.hpp"
 
@@ -24,23 +26,22 @@ namespace samurai
     class ProjectionTraverser : public SetTraverserBase<ProjectionTraverser<SetTraverser>>
     {
         using Self                 = ProjectionTraverser<SetTraverser>;
-        using SetTraverserIterator = typename ListOfIntervals<typename SetTraverser::value_t>::const_iterator;
+        using SetTraverserIterator = typename FlatListOfIntervals<typename SetTraverser::value_t>::const_iterator;
 
       public:
 
         SAMURAI_SET_TRAVERSER_TYPEDEFS
 
         ProjectionTraverser(SetTraverser set_traverser, [[maybe_unused]] const ProjectionType projectionType, const std::size_t shift)
-            : m_set_traverser(set_traverser)
+            : m_set_traverser(std::move(set_traverser))
             , m_shift(shift)
             , m_projectionType(ProjectionType::REFINE)
         {
             assert(projectionType == m_projectionType);
         }
 
-        ProjectionTraverser(SetTraverser set_traverser, SetTraverserIterator first_interval, SetTraverserIterator bound_interval)
-            : m_set_traverser(set_traverser)
-            , m_shift(0)
+        ProjectionTraverser(SetTraverserIterator first_interval, SetTraverserIterator bound_interval)
+            : m_shift(0)
             , m_first_interval(first_interval)
             , m_bound_interval(bound_interval)
             , m_projectionType(ProjectionType::COARSEN)
@@ -55,7 +56,7 @@ namespace samurai
             }
             else
             {
-                return m_set_traverser.is_empty();
+                return m_set_traverser->is_empty();
             }
         }
 
@@ -67,21 +68,21 @@ namespace samurai
             }
             else
             {
-                m_set_traverser.next_interval();
+                m_set_traverser->next_interval();
             }
         }
 
         SAMURAI_INLINE current_interval_t current_interval_impl() const
         {
-            return (m_projectionType == ProjectionType::COARSEN) ? *m_first_interval : m_set_traverser.current_interval() << m_shift;
+            return (m_projectionType == ProjectionType::COARSEN) ? *m_first_interval : m_set_traverser->current_interval() << m_shift;
         }
 
       private:
 
-        SetTraverser m_set_traverser;          // only used when refining
-        std::size_t m_shift;                   // only used when refining
-        SetTraverserIterator m_first_interval; // only use when coarsening
-        SetTraverserIterator m_bound_interval; // only use when coarsening
+        std::optional<SetTraverser> m_set_traverser; // only engaged when refining
+        std::size_t m_shift;                         // only used when refining
+        SetTraverserIterator m_first_interval;       // only used when coarsening
+        SetTraverserIterator m_bound_interval;       // only used when coarsening
         ProjectionType m_projectionType;
     };
 

--- a/include/samurai/subset/utils.hpp
+++ b/include/samurai/subset/utils.hpp
@@ -216,7 +216,7 @@ namespace samurai
                                       UnaryFunc&& unaryFunc,
                                       typename Set::yz_index_t& index,
                                       typename Set::Workspace& child_workspace,
-                                      ListOfIntervals<typename Set::value_t>& list_of_intervals)
+                                      FlatListOfIntervals<typename Set::value_t>& list_of_intervals)
             {
                 using child_traverser_t        = typename Set::template traverser_t<d_cur>;
                 using child_interval_t         = typename child_traverser_t::interval_t;
@@ -265,7 +265,7 @@ namespace samurai
                               std::integral_constant<std::size_t, D> d,
                               UnaryFunc&& unaryFunc,
                               typename Set::Workspace& child_workspace,
-                              ListOfIntervals<typename Set::value_t>& list_of_intervals)
+                              FlatListOfIntervals<typename Set::value_t>& list_of_intervals)
         {
             using yz_index_t = typename Set::yz_index_t;
 


### PR DESCRIPTION
## Description
This PR improves the performance of the projection operator through two fixes:

- We introduce a new interval container based on a `std::vector`, which proves to be faster than `ListOfIntervals` in this specific case.
- We remove the storage of a `set_traverser` when in COARSEN configuration.

This is an initial attempt to reduce the time spent in this type of operator, where we need to rebuild a list of intervals.

## Code of Conduct
By submitting this PR, you agree to follow our [Code of Conduct](https://github.com/hpc-maths/samurai/blob/master/docs/CODE_OF_CONDUCT.md)
- [x] I agree to follow this project's Code of Conduct
