### PR TITLE
perf(mesh): detect the adaptation fixed point before constructing the new mesh

### DIFF
--- a/include/samurai/algorithm/update_fields.hpp
+++ b/include/samurai/algorithm/update_fields.hpp
@@ -134,6 +134,7 @@ namespace samurai
         using size_type                  = typename Tag::size_type;
         using mesh_id_t                  = typename Tag::mesh_t::mesh_id_t;
         using cl_type                    = typename Tag::mesh_t::cl_type;
+        using ca_type                    = typename Tag::mesh_t::ca_type;
 
         auto& mesh = tag.mesh();
 
@@ -180,18 +181,23 @@ namespace samurai
                               }
                           });
 
-        mesh_t new_mesh = {cl, mesh};
+        // Fixed-point detection BEFORE constructing the new mesh: the
+        // construction builds every derived mesh id and, with MPI, exchanges
+        // the full meshes with the neighbouring subdomains - all of it thrown
+        // away when the adaptation has converged.
+        ca_type new_cells{cl, false};
 
 #ifdef SAMURAI_WITH_MPI
         mpi::communicator world;
-        if (mpi::all_reduce(world, mesh == new_mesh, std::logical_and()))
+        if (mpi::all_reduce(world, same_cells(mesh, new_cells), std::logical_and()))
 #else
-        if (mesh == new_mesh)
+        if (same_cells(mesh, new_cells))
 #endif
         {
             return true;
         }
 
+        mesh_t new_mesh = {new_cells, mesh};
         update_fields(new_mesh, fields...);
         tag.mesh().swap(new_mesh);
         return false;

--- a/include/samurai/algorithm/update_fields.hpp
+++ b/include/samurai/algorithm/update_fields.hpp
@@ -190,9 +190,9 @@ namespace samurai
 
 #ifdef SAMURAI_WITH_MPI
         mpi::communicator world;
-        if (mpi::all_reduce(world, same_cells(mesh, new_cells), std::logical_and()))
+        if (mpi::all_reduce(world, mesh[mesh_id_t::cells] == new_cells, std::logical_and()))
 #else
-        if (same_cells(mesh, new_cells))
+        if (mesh[mesh_id_t::cells] == new_cells)
 #endif
         {
             return true;

--- a/include/samurai/algorithm/update_fields.hpp
+++ b/include/samurai/algorithm/update_fields.hpp
@@ -5,6 +5,7 @@
 
 #include <functional>
 #include <tuple>
+#include <type_traits>
 #include <utility>
 
 #include "../algorithm.hpp"
@@ -197,7 +198,21 @@ namespace samurai
             return true;
         }
 
-        mesh_t new_mesh = {new_cells, mesh};
+        // Not every mesh type exposes a (cell array, reference mesh)
+        // constructor - user-defined meshes often only have the cell-list one:
+        // reuse new_cells when possible, otherwise rebuild from the cell list.
+        auto make_new_mesh = [&]()
+        {
+            if constexpr (std::is_constructible_v<mesh_t, ca_type&, mesh_t&>)
+            {
+                return mesh_t{new_cells, mesh};
+            }
+            else
+            {
+                return mesh_t{cl, mesh};
+            }
+        };
+        mesh_t new_mesh = make_new_mesh();
         update_fields(new_mesh, fields...);
         tag.mesh().swap(new_mesh);
         return false;

--- a/include/samurai/mesh.hpp
+++ b/include/samurai/mesh.hpp
@@ -1507,6 +1507,30 @@ namespace samurai
         return !(mesh1 == mesh2);
     }
 
+    /**
+     * @brief Compare the cells of an existing mesh with a candidate cell array.
+     *
+     * Equivalent to building a mesh from @p ca with @p mesh as reference and
+     * testing `mesh == new_mesh`, without paying the construction of the
+     * derived mesh ids nor, with MPI, the exchange of the full meshes with the
+     * neighbouring subdomains. Used to detect the fixed point of the
+     * adaptation loop before constructing a new mesh.
+     */
+    template <class D, class Config>
+    SAMURAI_INLINE bool same_cells(const Mesh_base<D, Config>& mesh, const typename Mesh_base<D, Config>::ca_type& ca)
+    {
+        using mesh_id_t = typename Mesh_base<D, Config>::mesh_id_t;
+
+        for (std::size_t level = mesh.min_level(); level <= mesh.max_level(); ++level)
+        {
+            if (!(mesh[mesh_id_t::cells][level] == ca[level]))
+            {
+                return false;
+            }
+        }
+        return true;
+    }
+
     template <class D, class Config>
     SAMURAI_INLINE std::ostream& operator<<(std::ostream& out, const Mesh_base<D, Config>& mesh)
     {

--- a/include/samurai/mesh.hpp
+++ b/include/samurai/mesh.hpp
@@ -1507,30 +1507,6 @@ namespace samurai
         return !(mesh1 == mesh2);
     }
 
-    /**
-     * @brief Compare the cells of an existing mesh with a candidate cell array.
-     *
-     * Equivalent to building a mesh from @p ca with @p mesh as reference and
-     * testing `mesh == new_mesh`, without paying the construction of the
-     * derived mesh ids nor, with MPI, the exchange of the full meshes with the
-     * neighbouring subdomains. Used to detect the fixed point of the
-     * adaptation loop before constructing a new mesh.
-     */
-    template <class D, class Config>
-    SAMURAI_INLINE bool same_cells(const Mesh_base<D, Config>& mesh, const typename Mesh_base<D, Config>::ca_type& ca)
-    {
-        using mesh_id_t = typename Mesh_base<D, Config>::mesh_id_t;
-
-        for (std::size_t level = mesh.min_level(); level <= mesh.max_level(); ++level)
-        {
-            if (!(mesh[mesh_id_t::cells][level] == ca[level]))
-            {
-                return false;
-            }
-        }
-        return true;
-    }
-
     template <class D, class Config>
     SAMURAI_INLINE std::ostream& operator<<(std::ostream& out, const Mesh_base<D, Config>& mesh)
     {

--- a/include/samurai/mr/adapt.hpp
+++ b/include/samurai/mr/adapt.hpp
@@ -362,17 +362,22 @@ namespace samurai
 
         ca_type new_ca = update_cell_array_from_tag(mesh[mesh_id_t::cells], m_tag);
         make_graduation(new_ca, mesh.domain(), mesh.mpi_neighbourhood(), mesh.periodicity(), mesh.graduation_width(), mesh.max_stencil_radius());
-        mesh_t new_mesh{new_ca, mesh};
+
+        // Fixed-point detection BEFORE constructing the new mesh: the
+        // construction builds every derived mesh id and, with MPI, exchanges
+        // the full meshes with the neighbouring subdomains - all of it thrown
+        // away when the adaptation has converged.
 #ifdef SAMURAI_WITH_MPI
         mpi::communicator world;
-        if (mpi::all_reduce(world, mesh == new_mesh, std::logical_and()))
+        if (mpi::all_reduce(world, same_cells(mesh, new_ca), std::logical_and()))
 #else
-        if (mesh == new_mesh)
+        if (same_cells(mesh, new_ca))
 #endif // SAMURAI_WITH_MPI
         {
             times::timers.stop("mesh update");
             return true;
         }
+        mesh_t new_mesh{new_ca, mesh};
         times::timers.stop("mesh update");
         update_ghost_mr(other_fields...);
 

--- a/include/samurai/mr/adapt.hpp
+++ b/include/samurai/mr/adapt.hpp
@@ -369,9 +369,9 @@ namespace samurai
         // away when the adaptation has converged.
 #ifdef SAMURAI_WITH_MPI
         mpi::communicator world;
-        if (mpi::all_reduce(world, same_cells(mesh, new_ca), std::logical_and()))
+        if (mpi::all_reduce(world, mesh[mesh_id_t::cells] == new_ca, std::logical_and()))
 #else
-        if (same_cells(mesh, new_ca))
+        if (mesh[mesh_id_t::cells] == new_ca)
 #endif // SAMURAI_WITH_MPI
         {
             times::timers.stop("mesh update");


### PR DESCRIPTION
## Description

Constructing a mesh builds every derived mesh id, renumbers the cell arrays and, with MPI, exchanges the full meshes with the neighbouring subdomains (`find_neighbourhood`, `update_neighbour_subdomain`, `update_mesh_neighbour`). The adaptation loop paid all of that on every iteration, only to discard the new mesh when the fixed point was reached: on `advection_2d`, about half of the 830 mesh updates of a run are such no-op iterations (`fields update` is only called 420 times).

This PR detects the fixed point **before** constructing the new mesh by comparing the current cells with the candidate cell array, using the existing `CellArray::operator==`:

- `mr/adapt.hpp`: the check `mesh[cells] == new_ca` runs on `new_ca` (already built and graduated) before `mesh_t new_mesh{new_ca, mesh}`;
- `update_fields.hpp` (`update_field`): builds `ca_type{cl, false}`, compares with `mesh[cells]`, and only constructs the mesh when it actually changed. Mesh types without a (cell array, reference mesh) constructor (user-defined meshes in several demos) fall back to the cell-list constructor.

The comparison is strictly equivalent to the previous `mesh == new_mesh` test. `CellArray::operator==` reduces to full cell-array equality (levels outside the active range are empty on both sides), `Interval::operator==` ignores the storage `index`, and the mesh constructor never modifies the geometry of `m_cells[cells]` (renumbering only touches indices). The MPI decision stays collective (one `all_reduce` of a bool): either every rank skips or every rank constructs, so the communication pattern remains matched.

Measurements on `advection_2d` (Tf 0.1, min 4 / max 10, Apple M, clang Release, interleaved A/B, 3 runs):

| Config | main | this PR |
|---|---|---|
| serial | 2.44 s | 2.23 s (-8%) |
| MPI 4 ranks | 4.06 s | 3.04 s (-25%) |

Timer breakdown at 4 ranks: `mesh update` 2.61 s -> 1.62 s, `mesh construction` 830 -> 420 calls. The gain holds at 2 and 8 ranks (-20 to -30% vs main).

## How has this been tested?

- Full test suite `test_samurai_lib`: 350/350 passing.
- `advection_2d` HDF5 outputs bit-identical to `main` in serial and with MPI (`h5diff`).

## Code of Conduct
By submitting this PR, you agree to follow our [Code of Conduct](https://github.com/hpc-maths/samurai/blob/master/docs/CODE_OF_CONDUCT.md)
- [x] I agree to follow this project's Code of Conduct
