### PR TITLE
perf(mpi): token protocol for the neighbour mesh exchanges

### DIFF
--- a/include/samurai/algorithm/graduation.hpp
+++ b/include/samurai/algorithm/graduation.hpp
@@ -329,41 +329,67 @@ namespace samurai
 #endif // SAMURAI_WITH_MPI
     }
 
+    /**
+     * @brief Exchange this rank's cell array with every neighbour (token protocol).
+     *
+     * A one-int header announces whether the serialized cell array follows.
+     * `mesh_changed` must be true whenever `mesh` was modified since the
+     * previous call with the same `mpi_meshes` (and on the first call). The
+     * caller owns `mpi_meshes`, the receive-side cache: entry i keeps the last
+     * fully received cell array of neighbour i, and is left untouched when the
+     * neighbour sends a token. Inside the graduation fixed-point loop this
+     * means a rank that reached its local fixed point stops resending its
+     * (identical) cell array while a neighbour keeps refining.
+     */
     template <mesh_like mesh_t>
-    auto update_subdomains_mpi([[maybe_unused]] const mesh_t& mesh, const auto& mpi_neighbourhood)
+    void update_subdomains_mpi([[maybe_unused]] const mesh_t& mesh,
+                               [[maybe_unused]] const bool mesh_changed,
+                               const auto& mpi_neighbourhood,
+                               std::vector<mesh_t>& mpi_meshes)
     {
-        std::vector<mesh_t> mpi_meshes(mpi_neighbourhood.size());
+        mpi_meshes.resize(mpi_neighbourhood.size());
 #ifdef SAMURAI_WITH_MPI
         // No neighbour to exchange with (e.g. a sequential run or an emptied rank): serializing the whole
         // mesh below would be pure waste, so bail out before touching the archive.
         if (mpi_neighbourhood.empty())
         {
-            return mpi_meshes;
+            return;
         }
         mpi::communicator world;
         std::vector<mpi::request> req;
+        req.reserve(2 * mpi_neighbourhood.size());
 
         boost::mpi::packed_oarchive::buffer_type buffer;
-        boost::mpi::packed_oarchive oa(world, buffer);
-        oa << mesh;
+        if (mesh_changed)
+        {
+            boost::mpi::packed_oarchive oa(world, buffer);
+            oa << mesh;
+        }
+        const int flag = mesh_changed ? 1 : 0;
 
-        std::transform(mpi_neighbourhood.cbegin(),
-                       mpi_neighbourhood.cend(),
-                       std::back_inserter(req),
-                       [&](const auto& neighbour)
-                       {
-                           return world.isend(neighbour.rank, neighbour.rank, buffer);
-                       });
+        for (const auto& neighbour : mpi_neighbourhood)
+        {
+            req.push_back(world.isend(neighbour.rank, neighbour.rank, flag));
+            if (mesh_changed)
+            {
+                req.push_back(world.isend(neighbour.rank, neighbour.rank, buffer));
+            }
+        }
 
         std::size_t index = 0;
-        for (auto& neighbour : mpi_neighbourhood)
+        for (const auto& neighbour : mpi_neighbourhood)
         {
-            world.recv(neighbour.rank, world.rank(), mpi_meshes[index++]);
+            int neighbour_changed = 0;
+            world.recv(neighbour.rank, world.rank(), neighbour_changed);
+            if (neighbour_changed != 0)
+            {
+                world.recv(neighbour.rank, world.rank(), mpi_meshes[index]);
+            }
+            ++index;
         }
 
         mpi::wait_all(req.begin(), req.end());
 #endif // SAMURAI_WITH_MPI
-        return mpi_meshes;
     }
 
     template <size_t dim, typename TInterval, size_t max_size, typename TCoord>
@@ -497,17 +523,16 @@ namespace samurai
             });
     }
 
-    template <size_t dim, typename TInterval, typename MeshType, size_t max_size, typename TCoord>
+    template <size_t dim, typename TInterval, size_t max_size, typename TCoord>
     void list_intervals_to_refine(const std::size_t grad_width,
                                   const int max_stencil_radius,
                                   const CellArray<dim, TInterval, max_size>& ca,
                                   const LevelCellArray<dim, TInterval>& domain,
-                                  [[maybe_unused]] const std::vector<MPI_Subdomain<MeshType>>& mpi_neighbourhood,
+                                  const std::vector<CellArray<dim, TInterval, max_size>>& mpi_meshes,
                                   const std::array<bool, dim>& is_periodic,
                                   const std::array<int, dim>& nb_cells_finest_level,
                                   std::array<ArrayOfIntervalAndPoint<TInterval, TCoord>, CellArray<dim, TInterval, max_size>::max_size>& out)
     {
-        auto mpi_meshes = update_subdomains_mpi(ca, mpi_neighbourhood);
         list_interval_to_refine_for_graduation(grad_width, ca, domain, mpi_meshes, is_periodic, nb_cells_finest_level, out);
         if (!domain.empty())
         {
@@ -615,6 +640,10 @@ namespace samurai
         ca_type ca_remove_p;
         ca_type new_ca;
 
+        // Receive-side cache of the neighbours' cell arrays, persistent across
+        // the iterations of the fixed-point loop (see update_subdomains_mpi).
+        std::vector<ca_type> mpi_meshes;
+
         size_t nit = 0;
 #ifdef SAMURAI_WITH_MPI
         mpi::communicator world;
@@ -641,7 +670,10 @@ namespace samurai
             // Then, if the non-graduated is not tagged as keep, we coarsen it
             ca_add_p.clear();
             ca_remove_p.clear();
-            list_intervals_to_refine(grad_width, max_stencil_radius, ca, domain, mpi_neighbourhood, is_periodic, nb_cells_finest_level, remove_m_all);
+            // `ca_changed` is exactly "our ca was modified since the previous
+            // exchange" (primed to true, so the first iteration sends in full).
+            update_subdomains_mpi(ca, ca_changed, mpi_neighbourhood, mpi_meshes);
+            list_intervals_to_refine(grad_width, max_stencil_radius, ca, domain, mpi_meshes, is_periodic, nb_cells_finest_level, remove_m_all);
 
             add_p_interval.clear();
             add_p_inner_stencil.clear();

--- a/include/samurai/mesh.hpp
+++ b/include/samurai/mesh.hpp
@@ -282,6 +282,25 @@ namespace samurai
         config_t m_config;
 
 #ifdef SAMURAI_WITH_MPI
+        // State of the token exchanges (see update_mesh_neighbour and friends).
+        // A sender may replace its payload by a token only when the receivers
+        // provably hold identical data from a previous exchange:
+        // - m_same_cells_as_ref: the cells of this mesh are geometrically
+        //   identical to those of the reference mesh it was built from;
+        // - m_same_neighbourhood: the neighbour rank set is the same as the
+        //   reference mesh's (set by find_neighbourhood);
+        // - m_neighbours_cells_unchanged: every neighbour sent a token in
+        //   update_meshid_neighbour(cells), i.e. the derived mesh ids (which
+        //   depend on the neighbours' cells) are unchanged too.
+        bool m_same_cells_as_ref          = false;
+        bool m_same_neighbourhood         = false;
+        bool m_neighbours_cells_unchanged = false;
+
+        template <class Payload, class RecvInto>
+        bool exchange_with_neighbours(const Payload& payload, bool send_full, RecvInto&& recv_into);
+#endif
+
+#ifdef SAMURAI_WITH_MPI
         friend class boost::serialization::access;
 
         template <class Archive>
@@ -401,6 +420,13 @@ namespace samurai
         , m_config(ref_mesh.m_config)
     {
         m_cells[mesh_id_t::cells] = ca;
+
+#ifdef SAMURAI_WITH_MPI
+        // When the cells are identical to the reference mesh's, the neighbours
+        // already hold everything this mesh would send them: the exchanges of
+        // exchange_neighbour_meshes/finalize_mesh degrade to tokens.
+        m_same_cells_as_ref = (ref_mesh[mesh_id_t::cells] == ca);
+#endif
 
         construct_subdomain();
         exchange_neighbour_meshes();
@@ -1028,32 +1054,80 @@ namespace samurai
     }
 #endif
 
+#ifdef SAMURAI_WITH_MPI
+    /**
+     * @brief Exchange @p payload with every neighbour using a token protocol.
+     *
+     * A one-int header announces whether the serialized payload follows. When it
+     * does not (token), the receiver keeps its cached copy of the neighbour's
+     * data, carried over from the previous exchange by find_neighbourhood. A
+     * sender may only pass `send_full == false` when every receiver provably
+     * holds data identical to @p payload (see the m_same_* members).
+     *
+     * The exchange is collective over the (symmetric) neighbourhood: either
+     * every rank of a pair reaches it, or none does - as with the previous
+     * unconditional exchange.
+     *
+     * @return true when every neighbour sent a token.
+     */
+    template <class D, class Config>
+    template <class Payload, class RecvInto>
+    SAMURAI_INLINE bool Mesh_base<D, Config>::exchange_with_neighbours(const Payload& payload, bool send_full, RecvInto&& recv_into)
+    {
+        mpi::communicator world;
+        std::vector<mpi::request> req;
+        req.reserve(2 * m_mpi_neighbourhood.size());
+
+        boost::mpi::packed_oarchive::buffer_type buffer;
+        if (send_full)
+        {
+            boost::mpi::packed_oarchive oa(world, buffer);
+            oa << payload;
+        }
+        const int flag = send_full ? 1 : 0;
+
+        for (const auto& neighbour : m_mpi_neighbourhood)
+        {
+            req.push_back(world.isend(neighbour.rank, neighbour.rank, flag));
+            if (send_full)
+            {
+                req.push_back(world.isend(neighbour.rank, neighbour.rank, buffer));
+            }
+        }
+
+        bool all_tokens = true;
+        for (auto& neighbour : m_mpi_neighbourhood)
+        {
+            int neighbour_sent_full = 0;
+            world.recv(neighbour.rank, world.rank(), neighbour_sent_full);
+            if (neighbour_sent_full != 0)
+            {
+                all_tokens = false;
+                recv_into(world, neighbour);
+            }
+        }
+
+        mpi::wait_all(req.begin(), req.end());
+        return all_tokens;
+    }
+#endif
+
     template <class D, class Config>
     SAMURAI_INLINE void Mesh_base<D, Config>::update_mesh_neighbour()
     {
 #ifdef SAMURAI_WITH_MPI
-        // send/recv the meshes of the neighbouring subdomains
-        mpi::communicator world;
-        std::vector<mpi::request> req;
-
-        boost::mpi::packed_oarchive::buffer_type buffer;
-        boost::mpi::packed_oarchive oa(world, buffer);
-        oa << derived_cast();
-
-        std::transform(m_mpi_neighbourhood.cbegin(),
-                       m_mpi_neighbourhood.cend(),
-                       std::back_inserter(req),
-                       [&](const auto& neighbour)
-                       {
-                           return world.isend(neighbour.rank, neighbour.rank, buffer);
-                       });
-
-        for (auto& neighbour : m_mpi_neighbourhood)
-        {
-            world.recv(neighbour.rank, world.rank(), neighbour.mesh);
-        }
-
-        mpi::wait_all(req.begin(), req.end());
+        // send/recv the meshes of the neighbouring subdomains. The full mesh
+        // (every mesh id) is a function of our cells and of the neighbours'
+        // cells: it is unchanged - and replaced by a token - when our cells and
+        // neighbour set are those of the reference mesh AND every neighbour sent
+        // a token in update_meshid_neighbour(cells).
+        const bool send_full = !(m_same_cells_as_ref && m_same_neighbourhood && m_neighbours_cells_unchanged);
+        exchange_with_neighbours(derived_cast(),
+                                 send_full,
+                                 [](auto& world, auto& neighbour)
+                                 {
+                                     world.recv(neighbour.rank, world.rank(), neighbour.mesh);
+                                 });
 
 #ifdef SAMURAI_WITH_PETSC
         for (auto& neighbour : m_mpi_neighbourhood)
@@ -1071,32 +1145,23 @@ namespace samurai
     SAMURAI_INLINE void Mesh_base<D, Config>::update_neighbour_subdomain()
     {
 #ifdef SAMURAI_WITH_MPI
-        // send/recv the meshes of the neighbouring subdomains
-        mpi::communicator world;
-        std::vector<mpi::request> req;
-
-        boost::mpi::packed_oarchive::buffer_type buffer;
-        boost::mpi::packed_oarchive oa(world, buffer);
-        oa << derived_cast().m_subdomain;
-
-        std::transform(m_mpi_neighbourhood.cbegin(),
-                       m_mpi_neighbourhood.cend(),
-                       std::back_inserter(req),
-                       [&](const auto& neighbour)
-                       {
-                           return world.isend(neighbour.rank, neighbour.rank, buffer);
-                       });
+        // The subdomain is a function of our cells only: token when the cells
+        // and the neighbour set are those of the reference mesh.
+        const bool send_full = !(m_same_cells_as_ref && m_same_neighbourhood);
+        exchange_with_neighbours(derived_cast().m_subdomain,
+                                 send_full,
+                                 [](auto& world, auto& neighbour)
+                                 {
+                                     world.recv(neighbour.rank, world.rank(), neighbour.mesh.m_subdomain);
+                                 });
 
         for (auto& neighbour : m_mpi_neighbourhood)
         {
-            world.recv(neighbour.rank, world.rank(), neighbour.mesh.m_subdomain);
             neighbour.mesh.m_domain = m_domain;
 #ifdef SAMURAI_WITH_PETSC
             neighbour.mesh.compute_gravity_center();
 #endif
         }
-
-        mpi::wait_all(req.begin(), req.end());
 #endif
     }
 
@@ -1105,27 +1170,24 @@ namespace samurai
     SAMURAI_INLINE void Mesh_base<D, Config>::update_meshid_neighbour([[maybe_unused]] const mesh_id_t& mesh_id)
     {
 #ifdef SAMURAI_WITH_MPI
-        mpi::communicator world;
-        std::vector<mpi::request> req;
+        // Only the cells array is proven unchanged by m_same_cells_as_ref; any
+        // other mesh id is always sent in full.
+        const bool is_cells  = mesh_id == mesh_id_t::cells;
+        const bool send_full = !(is_cells && m_same_cells_as_ref && m_same_neighbourhood);
 
-        boost::mpi::packed_oarchive::buffer_type buffer;
-        boost::mpi::packed_oarchive oa(world, buffer);
-        oa << derived_cast()[mesh_id];
-
-        std::transform(m_mpi_neighbourhood.cbegin(),
-                       m_mpi_neighbourhood.cend(),
-                       std::back_inserter(req),
-                       [&](const auto& neighbour)
-                       {
-                           return world.isend(neighbour.rank, neighbour.rank, buffer);
-                       });
-
-        for (auto& neighbour : m_mpi_neighbourhood)
+        const bool all_tokens = exchange_with_neighbours(derived_cast()[mesh_id],
+                                                         send_full,
+                                                         [&mesh_id](auto& world, auto& neighbour)
+                                                         {
+                                                             world.recv(neighbour.rank, world.rank(), neighbour.mesh[mesh_id]);
+                                                         });
+        if (is_cells)
         {
-            world.recv(neighbour.rank, world.rank(), neighbour.mesh[mesh_id]);
+            // Every neighbour sent a token: the derived mesh ids built from the
+            // neighbours' cells (update_sub_mesh) are unchanged too, which
+            // update_mesh_neighbour relies on.
+            m_neighbours_cells_unchanged = all_tokens;
         }
-
-        mpi::wait_all(req.begin(), req.end());
 #endif // SAMURAI_WITH_MPI
     }
 
@@ -1342,6 +1404,11 @@ namespace samurai
             return std::max(1, static_cast<int>(std::ceil(reach / subdomain_dx)));
         };
 
+        // The previously exchanged neighbour meshes are the receive-side cache of
+        // the token exchanges (update_*_neighbour): keep them aside so the entries
+        // of ranks that remain neighbours can be carried over.
+        std::vector<mpi_subdomain_t> previous_neighbourhood = std::move(m_mpi_neighbourhood);
+
         m_mpi_neighbourhood.clear();
         for (std::size_t i = 0; i < candidate_ranks.size(); ++i)
         {
@@ -1365,6 +1432,25 @@ namespace samurai
                     m_mpi_neighbourhood.emplace_back(candidate_ranks[i]);
                     break; // No need to check other directions if we already found a neighbor
                 }
+            }
+        }
+
+        m_same_neighbourhood = previous_neighbourhood.size() == m_mpi_neighbourhood.size();
+        for (auto& neighbour : m_mpi_neighbourhood)
+        {
+            auto previous = std::find_if(previous_neighbourhood.begin(),
+                                         previous_neighbourhood.end(),
+                                         [&](const auto& p)
+                                         {
+                                             return p.rank == neighbour.rank;
+                                         });
+            if (previous != previous_neighbourhood.end())
+            {
+                neighbour.mesh = std::move(previous->mesh);
+            }
+            else
+            {
+                m_same_neighbourhood = false;
             }
         }
 

--- a/include/samurai/mesh.hpp
+++ b/include/samurai/mesh.hpp
@@ -284,6 +284,25 @@ namespace samurai
         config_t m_config;
 
 #ifdef SAMURAI_WITH_MPI
+        // State of the token exchanges (see update_mesh_neighbour and friends).
+        // A sender may replace its payload by a token only when the receivers
+        // provably hold identical data from a previous exchange:
+        // - m_same_cells_as_ref: the cells of this mesh are geometrically
+        //   identical to those of the reference mesh it was built from;
+        // - m_same_neighbourhood: the neighbour rank set is the same as the
+        //   reference mesh's (set by find_neighbourhood);
+        // - m_neighbours_cells_unchanged: every neighbour sent a token in
+        //   update_meshid_neighbour(cells), i.e. the derived mesh ids (which
+        //   depend on the neighbours' cells) are unchanged too.
+        bool m_same_cells_as_ref          = false;
+        bool m_same_neighbourhood         = false;
+        bool m_neighbours_cells_unchanged = false;
+
+        template <class Payload, class RecvInto>
+        bool exchange_with_neighbours(const Payload& payload, bool send_full, RecvInto&& recv_into);
+#endif
+
+#ifdef SAMURAI_WITH_MPI
         friend class boost::serialization::access;
 
         template <class Archive>
@@ -403,6 +422,13 @@ namespace samurai
         , m_config(ref_mesh.m_config)
     {
         m_cells[mesh_id_t::cells] = ca;
+
+#ifdef SAMURAI_WITH_MPI
+        // When the cells are identical to the reference mesh's, the neighbours
+        // already hold everything this mesh would send them: the exchanges of
+        // exchange_neighbour_meshes/finalize_mesh degrade to tokens.
+        m_same_cells_as_ref = (ref_mesh[mesh_id_t::cells] == ca);
+#endif
 
         construct_subdomain();
         exchange_neighbour_meshes();
@@ -1043,39 +1069,87 @@ namespace samurai
     }
 #endif
 
+#ifdef SAMURAI_WITH_MPI
+    /**
+     * @brief Exchange @p payload with every neighbour using a token protocol.
+     *
+     * A one-int header announces whether the serialized payload follows. When it
+     * does not (token), the receiver keeps its cached copy of the neighbour's
+     * data, carried over from the previous exchange by find_neighbourhood. A
+     * sender may only pass `send_full == false` when every receiver provably
+     * holds data identical to @p payload (see the m_same_* members).
+     *
+     * The exchange is collective over the (symmetric) neighbourhood: either
+     * every rank of a pair reaches it, or none does - as with the previous
+     * unconditional exchange.
+     *
+     * @return true when every neighbour sent a token.
+     */
+    template <class D, class Config>
+    template <class Payload, class RecvInto>
+    SAMURAI_INLINE bool Mesh_base<D, Config>::exchange_with_neighbours(const Payload& payload, bool send_full, RecvInto&& recv_into)
+    {
+        // No neighbouring subdomain (e.g. single rank): nothing to exchange.
+        // Return before serializing the payload, which is otherwise pure waste.
+        if (m_mpi_neighbourhood.empty())
+        {
+            return true;
+        }
+        mpi::communicator world;
+        std::vector<mpi::request> req;
+        req.reserve(2 * m_mpi_neighbourhood.size());
+
+        boost::mpi::packed_oarchive::buffer_type buffer;
+        if (send_full)
+        {
+            boost::mpi::packed_oarchive oa(world, buffer);
+            oa << payload;
+        }
+        const int flag = send_full ? 1 : 0;
+
+        for (const auto& neighbour : m_mpi_neighbourhood)
+        {
+            req.push_back(world.isend(neighbour.rank, neighbour.rank, flag));
+            if (send_full)
+            {
+                req.push_back(world.isend(neighbour.rank, neighbour.rank, buffer));
+            }
+        }
+
+        bool all_tokens = true;
+        for (auto& neighbour : m_mpi_neighbourhood)
+        {
+            int neighbour_sent_full = 0;
+            world.recv(neighbour.rank, world.rank(), neighbour_sent_full);
+            if (neighbour_sent_full != 0)
+            {
+                all_tokens = false;
+                recv_into(world, neighbour);
+            }
+        }
+
+        mpi::wait_all(req.begin(), req.end());
+        return all_tokens;
+    }
+#endif
+
     template <class D, class Config>
     SAMURAI_INLINE void Mesh_base<D, Config>::update_mesh_neighbour()
     {
         ScopedTimer timer("update_mesh_neighbour");
 #ifdef SAMURAI_WITH_MPI
-        // No neighbouring subdomain (e.g. single rank): nothing to exchange.
-        // Return before serializing the whole mesh, which is otherwise pure waste.
-        if (m_mpi_neighbourhood.empty())
-        {
-            return;
-        }
-        // send/recv the meshes of the neighbouring subdomains
-        mpi::communicator world;
-        std::vector<mpi::request> req;
-
-        boost::mpi::packed_oarchive::buffer_type buffer;
-        boost::mpi::packed_oarchive oa(world, buffer);
-        oa << derived_cast();
-
-        std::transform(m_mpi_neighbourhood.cbegin(),
-                       m_mpi_neighbourhood.cend(),
-                       std::back_inserter(req),
-                       [&](const auto& neighbour)
-                       {
-                           return world.isend(neighbour.rank, neighbour.rank, buffer);
-                       });
-
-        for (auto& neighbour : m_mpi_neighbourhood)
-        {
-            world.recv(neighbour.rank, world.rank(), neighbour.mesh);
-        }
-
-        mpi::wait_all(req.begin(), req.end());
+        // send/recv the meshes of the neighbouring subdomains. The full mesh
+        // (every mesh id) is a function of our cells and of the neighbours'
+        // cells: it is unchanged - and replaced by a token - when our cells and
+        // neighbour set are those of the reference mesh AND every neighbour sent
+        // a token in update_meshid_neighbour(cells).
+        const bool send_full = !(m_same_cells_as_ref && m_same_neighbourhood && m_neighbours_cells_unchanged);
+        exchange_with_neighbours(derived_cast(),
+                                 send_full,
+                                 [](auto& world, auto& neighbour)
+                                 {
+                                     world.recv(neighbour.rank, world.rank(), neighbour.mesh);
+                                 });
 
 #ifdef SAMURAI_WITH_PETSC
         for (auto& neighbour : m_mpi_neighbourhood)
@@ -1093,37 +1167,23 @@ namespace samurai
     SAMURAI_INLINE void Mesh_base<D, Config>::update_neighbour_subdomain()
     {
 #ifdef SAMURAI_WITH_MPI
-        // No neighbouring subdomain (e.g. single rank): nothing to exchange.
-        if (m_mpi_neighbourhood.empty())
-        {
-            return;
-        }
-        // send/recv the meshes of the neighbouring subdomains
-        mpi::communicator world;
-        std::vector<mpi::request> req;
-
-        boost::mpi::packed_oarchive::buffer_type buffer;
-        boost::mpi::packed_oarchive oa(world, buffer);
-        oa << derived_cast().m_subdomain;
-
-        std::transform(m_mpi_neighbourhood.cbegin(),
-                       m_mpi_neighbourhood.cend(),
-                       std::back_inserter(req),
-                       [&](const auto& neighbour)
-                       {
-                           return world.isend(neighbour.rank, neighbour.rank, buffer);
-                       });
+        // The subdomain is a function of our cells only: token when the cells
+        // and the neighbour set are those of the reference mesh.
+        const bool send_full = !(m_same_cells_as_ref && m_same_neighbourhood);
+        exchange_with_neighbours(derived_cast().m_subdomain,
+                                 send_full,
+                                 [](auto& world, auto& neighbour)
+                                 {
+                                     world.recv(neighbour.rank, world.rank(), neighbour.mesh.m_subdomain);
+                                 });
 
         for (auto& neighbour : m_mpi_neighbourhood)
         {
-            world.recv(neighbour.rank, world.rank(), neighbour.mesh.m_subdomain);
             neighbour.mesh.m_domain = m_domain;
 #ifdef SAMURAI_WITH_PETSC
             neighbour.mesh.compute_gravity_center();
 #endif
         }
-
-        mpi::wait_all(req.begin(), req.end());
 #endif
     }
 
@@ -1133,33 +1193,24 @@ namespace samurai
     {
         ScopedTimer timer("update_meshid_neighbour");
 #ifdef SAMURAI_WITH_MPI
-        // No neighbouring subdomain (e.g. single rank): nothing to exchange.
-        // Return before serializing the mesh id, which is otherwise pure waste.
-        if (m_mpi_neighbourhood.empty())
+        // Only the cells array is proven unchanged by m_same_cells_as_ref; any
+        // other mesh id is always sent in full.
+        const bool is_cells  = mesh_id == mesh_id_t::cells;
+        const bool send_full = !(is_cells && m_same_cells_as_ref && m_same_neighbourhood);
+
+        const bool all_tokens = exchange_with_neighbours(derived_cast()[mesh_id],
+                                                         send_full,
+                                                         [&mesh_id](auto& world, auto& neighbour)
+                                                         {
+                                                             world.recv(neighbour.rank, world.rank(), neighbour.mesh[mesh_id]);
+                                                         });
+        if (is_cells)
         {
-            return;
+            // Every neighbour sent a token: the derived mesh ids built from the
+            // neighbours' cells (update_sub_mesh) are unchanged too, which
+            // update_mesh_neighbour relies on.
+            m_neighbours_cells_unchanged = all_tokens;
         }
-        mpi::communicator world;
-        std::vector<mpi::request> req;
-
-        boost::mpi::packed_oarchive::buffer_type buffer;
-        boost::mpi::packed_oarchive oa(world, buffer);
-        oa << derived_cast()[mesh_id];
-
-        std::transform(m_mpi_neighbourhood.cbegin(),
-                       m_mpi_neighbourhood.cend(),
-                       std::back_inserter(req),
-                       [&](const auto& neighbour)
-                       {
-                           return world.isend(neighbour.rank, neighbour.rank, buffer);
-                       });
-
-        for (auto& neighbour : m_mpi_neighbourhood)
-        {
-            world.recv(neighbour.rank, world.rank(), neighbour.mesh[mesh_id]);
-        }
-
-        mpi::wait_all(req.begin(), req.end());
 #endif // SAMURAI_WITH_MPI
     }
 
@@ -1378,6 +1429,11 @@ namespace samurai
             return std::max(1, static_cast<int>(std::ceil(reach / subdomain_dx)));
         };
 
+        // The previously exchanged neighbour meshes are the receive-side cache of
+        // the token exchanges (update_*_neighbour): keep them aside so the entries
+        // of ranks that remain neighbours can be carried over.
+        std::vector<mpi_subdomain_t> previous_neighbourhood = std::move(m_mpi_neighbourhood);
+
         m_mpi_neighbourhood.clear();
         for (std::size_t i = 0; i < candidate_ranks.size(); ++i)
         {
@@ -1401,6 +1457,25 @@ namespace samurai
                     m_mpi_neighbourhood.emplace_back(candidate_ranks[i]);
                     break; // No need to check other directions if we already found a neighbor
                 }
+            }
+        }
+
+        m_same_neighbourhood = previous_neighbourhood.size() == m_mpi_neighbourhood.size();
+        for (auto& neighbour : m_mpi_neighbourhood)
+        {
+            auto previous = std::find_if(previous_neighbourhood.begin(),
+                                         previous_neighbourhood.end(),
+                                         [&](const auto& p)
+                                         {
+                                             return p.rank == neighbour.rank;
+                                         });
+            if (previous != previous_neighbourhood.end())
+            {
+                neighbour.mesh = std::move(previous->mesh);
+            }
+            else
+            {
+                m_same_neighbourhood = false;
             }
         }
 


### PR DESCRIPTION
- [x] I have installed [pre-commit](https://pre-commit.com/) locally and use it to validate my commits.
- [x] The PR title follows the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) convention.
      Available tags: 'build', 'chore', 'ci', 'docs', 'feat', 'fix', 'perf', 'refactor', 'revert', 'style', 'test'
- [ ] This new PR is documented.
- [x] This new PR is tested.

## Description

> Rebased on main after #490/#491.
>
> **The graduation half of this PR is dropped on rebase.** #482 replaced the graduation fixed point by the single-pass algorithm, which exchanges one level array per level (`exchange_level_mpi`) and has no repeated identical send to elide - `update_subdomains_mpi` and the fixed-point loop the token protocol hooked into no longer exist. What remains here is the mesh-exchange half.

Every mesh construction serialized and sent the full mesh state to each neighbour **three times** (subdomain, cells, then the whole mesh with every derived mesh id) - even when the receivers already held identical data from the previous construction.

This PR replaces those exchanges by a token protocol: a one-int header announces whether the serialized payload follows; when it does not, the receiver keeps its cached copy of the neighbour's data. A sender only skips the payload when the receivers provably hold identical data:

- **mesh exchanges** (`update_neighbour_subdomain`, `update_meshid_neighbour`, `update_mesh_neighbour`): cells geometrically identical to the reference mesh (`same_cells`, from #476), same neighbour set and - for the whole-mesh exchange, whose derived ids depend on the neighbours' cells - a token received from every neighbour in the cells exchange. `find_neighbourhood` now carries the previously exchanged neighbour meshes over to the rebuilt neighbourhood; they are the receive-side cache.

The exchanges stay collective over the (symmetric) neighbourhood, so the communication pattern remains matched.

Measurements on `advection_2d` (Tf 0.1, Apple M, MPICH + libfabric, interleaved A/B vs #476), taken **before the rebase**, i.e. on the pre-#482 graduation and with both halves of the original change in place. They are kept for reference; the mesh-exchange half alone on today's main has not been re-measured:

| Config | before | after |
|---|---|---|
| 8 ranks, libfabric `sockets` provider | 167 s | 120 s (**-28%**) |
| 8 ranks, `FI_PROVIDER=tcp` | 7.6-7.7 s | 7.4-7.5 s (-3%) |
| 4 ranks | 3.09-3.14 s | 3.03-3.10 s (-2%) |
| serial | parity | parity |

Tokens cut the payload **volume**, which pays hugely on expensive transports and grows with rank count and mesh size. On a sane transport at low rank counts, the remaining MPI cost of the adaptation loop is the **number of synchronous exchange rounds** - addressed in #478.

## Related issue

None.

## How has this been tested?

Outputs are unchanged by construction: a token replaces the payload only when the receiver already holds an identical copy.

Before the rebase (on the pre-#482 base):
- h5diff clean vs #476 in serial and at 4 and 8 ranks (`demos/FiniteVolume/advection_2d.cpp`, Tf 0.5);
- `tests/`: 350/350 serial; `tests/mpi/`: 24/24 at 2/3/4 ranks, including the load-balancing migration tests which exercise the carried-over neighbour caches;
- all demos build (serial and MPI).

After the rebase, the rebased branch is verified by CI.

## Code of Conduct
By submitting this PR, you agree to follow our [Code of Conduct](https://github.com/hpc-maths/samurai/blob/master/docs/CODE_OF_CONDUCT.md)
- [x] I agree to follow this project's Code of Conduct

