### PR TITLE
perf(mr): faster multiresolution detail computation

### DIFF
--- a/include/samurai/mr/operators.hpp
+++ b/include/samurai/mr/operators.hpp
@@ -377,6 +377,34 @@ namespace samurai
                 auto interp_even = interp_coeffs<2 * order + 1>(1.);
                 auto interp_odd  = interp_coeffs<2 * order + 1>(-1.);
 
+                constexpr std::size_t interp_size = 2 * order + 1;
+
+                // Precompute, once per operator call, the 8 child coefficients of
+                // each stencil point (they depend only on (ki,kj,kk), never on the
+                // cell or the component). Layout matches the 8 children in the
+                // (2i[+1], 2j[+1], 2k[+1]) order below. Each product keeps the
+                // left-associated form of the scalar code, so the wavelet details
+                // are bit-identical; the per-child loop is a SIMD update.
+                std::array<std::array<double, 8>, interp_size * interp_size * interp_size> coeff;
+                for (std::size_t kk = 0; kk < interp_size; ++kk)
+                {
+                    for (std::size_t kj = 0; kj < interp_size; ++kj)
+                    {
+                        for (std::size_t ki = 0; ki < interp_size; ++ki)
+                        {
+                            coeff[ki + kj * interp_size + kk * interp_size * interp_size] = {
+                                interp_even[ki] * interp_even[kj] * interp_even[kk],
+                                interp_odd[ki] * interp_even[kj] * interp_even[kk],
+                                interp_even[ki] * interp_odd[kj] * interp_even[kk],
+                                interp_odd[ki] * interp_odd[kj] * interp_even[kk],
+                                interp_even[ki] * interp_even[kj] * interp_odd[kk],
+                                interp_odd[ki] * interp_even[kj] * interp_odd[kk],
+                                interp_even[ki] * interp_odd[kj] * interp_odd[kk],
+                                interp_odd[ki] * interp_odd[kj] * interp_odd[kk]};
+                        }
+                    }
+                }
+
                 auto indices = get_indices<order>(Dim<3>{}, field.mesh());
 
                 const auto* data = field.data();
@@ -388,20 +416,18 @@ namespace samurai
                 auto ind3 = static_cast<std::size_t>(field.mesh().get_index(level + 1, 2 * i.start, 2 * j, 2 * k + 1));
                 auto ind4 = static_cast<std::size_t>(field.mesh().get_index(level + 1, 2 * i.start, 2 * j + 1, 2 * k + 1));
 
-                constexpr std::size_t interp_size = 2 * order + 1;
-
                 for (std::size_t ii = 0, i_f = 0; ii < i.size(); ++ii, i_f += 2)
                 {
                     if constexpr (T2::is_scalar)
                     {
-                        double d1 = data[ind1 + i_f];
-                        double d2 = data[ind1 + i_f + 1];
-                        double d3 = data[ind2 + i_f];
-                        double d4 = data[ind2 + i_f + 1];
-                        double d5 = data[ind3 + i_f];
-                        double d6 = data[ind3 + i_f + 1];
-                        double d7 = data[ind4 + i_f];
-                        double d8 = data[ind4 + i_f + 1];
+                        std::array<double, 8> d = {data[ind1 + i_f],
+                                                   data[ind1 + i_f + 1],
+                                                   data[ind2 + i_f],
+                                                   data[ind2 + i_f + 1],
+                                                   data[ind3 + i_f],
+                                                   data[ind3 + i_f + 1],
+                                                   data[ind4 + i_f],
+                                                   data[ind4 + i_f + 1]};
 
                         for (std::size_t kk = 0; kk < interp_size; ++kk)
                         {
@@ -409,8 +435,8 @@ namespace samurai
                             {
                                 for (std::size_t ki = 0; ki < interp_size; ++ki)
                                 {
-                                    auto idx         = ki + kj * interp_size + kk * interp_size * interp_size;
-                                    const double src = data[indices[idx] + ii];
+                                    const std::size_t idx = ki + kj * interp_size + kk * interp_size * interp_size;
+                                    const double src      = data[indices[idx] + ii];
 #ifdef SAMURAI_CHECK_NAN
                                     if (std::isnan(src))
                                     {
@@ -420,40 +446,36 @@ namespace samurai
                                         exit(1);
                                     }
 #endif
-                                    d1 -= interp_even[ki] * interp_even[kj] * interp_even[kk] * src;
-                                    d2 -= interp_odd[ki] * interp_even[kj] * interp_even[kk] * src;
-                                    d3 -= interp_even[ki] * interp_odd[kj] * interp_even[kk] * src;
-                                    d4 -= interp_odd[ki] * interp_odd[kj] * interp_even[kk] * src;
-                                    d5 -= interp_even[ki] * interp_even[kj] * interp_odd[kk] * src;
-                                    d6 -= interp_odd[ki] * interp_even[kj] * interp_odd[kk] * src;
-                                    d7 -= interp_even[ki] * interp_odd[kj] * interp_odd[kk] * src;
-                                    d8 -= interp_odd[ki] * interp_odd[kj] * interp_odd[kk] * src;
+                                    const auto& c = coeff[idx];
+                                    for (std::size_t m = 0; m < 8; ++m)
+                                    {
+                                        d[m] -= c[m] * src;
+                                    }
                                 }
                             }
                         }
 
-                        detail_data[ind1 + i_f]     = d1;
-                        detail_data[ind1 + i_f + 1] = d2;
-                        detail_data[ind2 + i_f]     = d3;
-                        detail_data[ind2 + i_f + 1] = d4;
-                        detail_data[ind3 + i_f]     = d5;
-                        detail_data[ind3 + i_f + 1] = d6;
-                        detail_data[ind4 + i_f]     = d7;
-                        detail_data[ind4 + i_f + 1] = d8;
+                        detail_data[ind1 + i_f]     = d[0];
+                        detail_data[ind1 + i_f + 1] = d[1];
+                        detail_data[ind2 + i_f]     = d[2];
+                        detail_data[ind2 + i_f + 1] = d[3];
+                        detail_data[ind3 + i_f]     = d[4];
+                        detail_data[ind3 + i_f + 1] = d[5];
+                        detail_data[ind4 + i_f]     = d[6];
+                        detail_data[ind4 + i_f + 1] = d[7];
                     }
                     else
                     {
                         for (std::size_t nc = 0; nc < T2::n_comp; ++nc)
                         {
-                            double d1, d2, d3, d4, d5, d6, d7, d8;
-                            d1 = data[(ind1 + i_f) * T2::n_comp + nc];
-                            d2 = data[(ind1 + i_f + 1) * T2::n_comp + nc];
-                            d3 = data[(ind2 + i_f) * T2::n_comp + nc];
-                            d4 = data[(ind2 + i_f + 1) * T2::n_comp + nc];
-                            d5 = data[(ind3 + i_f) * T2::n_comp + nc];
-                            d6 = data[(ind3 + i_f + 1) * T2::n_comp + nc];
-                            d7 = data[(ind4 + i_f) * T2::n_comp + nc];
-                            d8 = data[(ind4 + i_f + 1) * T2::n_comp + nc];
+                            std::array<double, 8> d = {data[(ind1 + i_f) * T2::n_comp + nc],
+                                                       data[(ind1 + i_f + 1) * T2::n_comp + nc],
+                                                       data[(ind2 + i_f) * T2::n_comp + nc],
+                                                       data[(ind2 + i_f + 1) * T2::n_comp + nc],
+                                                       data[(ind3 + i_f) * T2::n_comp + nc],
+                                                       data[(ind3 + i_f + 1) * T2::n_comp + nc],
+                                                       data[(ind4 + i_f) * T2::n_comp + nc],
+                                                       data[(ind4 + i_f + 1) * T2::n_comp + nc]};
 
                             for (std::size_t kk = 0; kk < interp_size; ++kk)
                             {
@@ -461,8 +483,8 @@ namespace samurai
                                 {
                                     for (std::size_t ki = 0; ki < interp_size; ++ki)
                                     {
-                                        auto idx = (indices[ki + kj * interp_size + kk * interp_size * interp_size] + ii) * T2::n_comp;
-                                        const double src = data[idx + nc];
+                                        const std::size_t idx = ki + kj * interp_size + kk * interp_size * interp_size;
+                                        const double src      = data[(indices[idx] + ii) * T2::n_comp + nc];
 #ifdef SAMURAI_CHECK_NAN
                                         if (std::isnan(src))
                                         {
@@ -473,39 +495,36 @@ namespace samurai
                                             exit(1);
                                         }
 #endif
-                                        d1 -= interp_even[ki] * interp_even[kj] * interp_even[kk] * src;
-                                        d2 -= interp_odd[ki] * interp_even[kj] * interp_even[kk] * src;
-                                        d3 -= interp_even[ki] * interp_odd[kj] * interp_even[kk] * src;
-                                        d4 -= interp_odd[ki] * interp_odd[kj] * interp_even[kk] * src;
-                                        d5 -= interp_even[ki] * interp_even[kj] * interp_odd[kk] * src;
-                                        d6 -= interp_odd[ki] * interp_even[kj] * interp_odd[kk] * src;
-                                        d7 -= interp_even[ki] * interp_odd[kj] * interp_odd[kk] * src;
-                                        d8 -= interp_odd[ki] * interp_odd[kj] * interp_odd[kk] * src;
+                                        const auto& c = coeff[idx];
+                                        for (std::size_t m = 0; m < 8; ++m)
+                                        {
+                                            d[m] -= c[m] * src;
+                                        }
                                     }
                                 }
+                            }
 
-                                if constexpr (requires { detail.begin_item(); })
-                                {
-                                    detail_data[detail.begin_item() + (ind1 + i_f) * T1::n_comp + nc]     = d1;
-                                    detail_data[detail.begin_item() + (ind1 + i_f + 1) * T1::n_comp + nc] = d2;
-                                    detail_data[detail.begin_item() + (ind2 + i_f) * T1::n_comp + nc]     = d3;
-                                    detail_data[detail.begin_item() + (ind2 + i_f + 1) * T1::n_comp + nc] = d4;
-                                    detail_data[detail.begin_item() + (ind3 + i_f) * T1::n_comp + nc]     = d5;
-                                    detail_data[detail.begin_item() + (ind3 + i_f + 1) * T1::n_comp + nc] = d6;
-                                    detail_data[detail.begin_item() + (ind4 + i_f) * T1::n_comp + nc]     = d7;
-                                    detail_data[detail.begin_item() + (ind4 + i_f + 1) * T1::n_comp + nc] = d8;
-                                }
-                                else
-                                {
-                                    detail_data[(ind1 + i_f) * T1::n_comp + nc]     = d1;
-                                    detail_data[(ind1 + i_f + 1) * T1::n_comp + nc] = d2;
-                                    detail_data[(ind2 + i_f) * T1::n_comp + nc]     = d3;
-                                    detail_data[(ind2 + i_f + 1) * T1::n_comp + nc] = d4;
-                                    detail_data[(ind3 + i_f) * T1::n_comp + nc]     = d5;
-                                    detail_data[(ind3 + i_f + 1) * T1::n_comp + nc] = d6;
-                                    detail_data[(ind4 + i_f) * T1::n_comp + nc]     = d7;
-                                    detail_data[(ind4 + i_f + 1) * T1::n_comp + nc] = d8;
-                                }
+                            if constexpr (requires { detail.begin_item(); })
+                            {
+                                detail_data[detail.begin_item() + (ind1 + i_f) * T1::n_comp + nc]     = d[0];
+                                detail_data[detail.begin_item() + (ind1 + i_f + 1) * T1::n_comp + nc] = d[1];
+                                detail_data[detail.begin_item() + (ind2 + i_f) * T1::n_comp + nc]     = d[2];
+                                detail_data[detail.begin_item() + (ind2 + i_f + 1) * T1::n_comp + nc] = d[3];
+                                detail_data[detail.begin_item() + (ind3 + i_f) * T1::n_comp + nc]     = d[4];
+                                detail_data[detail.begin_item() + (ind3 + i_f + 1) * T1::n_comp + nc] = d[5];
+                                detail_data[detail.begin_item() + (ind4 + i_f) * T1::n_comp + nc]     = d[6];
+                                detail_data[detail.begin_item() + (ind4 + i_f + 1) * T1::n_comp + nc] = d[7];
+                            }
+                            else
+                            {
+                                detail_data[(ind1 + i_f) * T1::n_comp + nc]     = d[0];
+                                detail_data[(ind1 + i_f + 1) * T1::n_comp + nc] = d[1];
+                                detail_data[(ind2 + i_f) * T1::n_comp + nc]     = d[2];
+                                detail_data[(ind2 + i_f + 1) * T1::n_comp + nc] = d[3];
+                                detail_data[(ind3 + i_f) * T1::n_comp + nc]     = d[4];
+                                detail_data[(ind3 + i_f + 1) * T1::n_comp + nc] = d[5];
+                                detail_data[(ind4 + i_f) * T1::n_comp + nc]     = d[6];
+                                detail_data[(ind4 + i_f + 1) * T1::n_comp + nc] = d[7];
                             }
                         }
                     }

--- a/include/samurai/mr/operators.hpp
+++ b/include/samurai/mr/operators.hpp
@@ -238,6 +238,27 @@ namespace samurai
                 auto interp_even = interp_coeffs<2 * order + 1>(1.);
                 auto interp_odd  = interp_coeffs<2 * order + 1>(-1.);
 
+                constexpr std::size_t interp_size = 2 * order + 1;
+
+                // Precompute, once per operator call, the 4 child coefficients
+                // of each stencil point (they depend only on (ki,kj), never on
+                // the cell or the component). Layout {EE, OE, EO, OO} matches the
+                // 4 children (2i,2j), (2i+1,2j), (2i,2j+1), (2i+1,2j+1). Each
+                // product keeps the left-associated form of the scalar code, so
+                // the wavelet details are bit-identical; the per-child loop below
+                // is a 4-wide update the compiler lowers to SIMD.
+                std::array<std::array<double, 4>, interp_size * interp_size> coeff;
+                for (std::size_t kj = 0; kj < interp_size; ++kj)
+                {
+                    for (std::size_t ki = 0; ki < interp_size; ++ki)
+                    {
+                        coeff[ki + kj * interp_size] = {interp_even[ki] * interp_even[kj],
+                                                        interp_odd[ki] * interp_even[kj],
+                                                        interp_even[ki] * interp_odd[kj],
+                                                        interp_odd[ki] * interp_odd[kj]};
+                    }
+                }
+
                 auto indices = get_indices<order>(Dim<2>{}, field.mesh());
 
                 const auto* data = field.data();
@@ -247,23 +268,17 @@ namespace samurai
                 auto ind1 = static_cast<std::size_t>(field.mesh().get_index(level + 1, 2 * i.start, 2 * j));
                 auto ind2 = static_cast<std::size_t>(field.mesh().get_index(level + 1, 2 * i.start, 2 * j + 1));
 
-                constexpr std::size_t interp_size = 2 * order + 1;
-
                 for (std::size_t ii = 0, i_f = 0; ii < i.size(); ++ii, i_f += 2)
                 {
                     if constexpr (T2::is_scalar)
                     {
-                        double d1 = data[ind1 + i_f];
-                        double d2 = data[ind1 + i_f + 1];
-                        double d3 = data[ind2 + i_f];
-                        double d4 = data[ind2 + i_f + 1];
+                        std::array<double, 4> d = {data[ind1 + i_f], data[ind1 + i_f + 1], data[ind2 + i_f], data[ind2 + i_f + 1]};
 
                         for (std::size_t kj = 0; kj < interp_size; ++kj)
                         {
                             for (std::size_t ki = 0; ki < interp_size; ++ki)
                             {
-                                auto idx         = ki + kj * interp_size;
-                                const double src = data[indices[idx] + ii];
+                                const double src = data[indices[ki + kj * interp_size] + ii];
 #ifdef SAMURAI_CHECK_NAN
                                 if (std::isnan(src))
                                 {
@@ -274,34 +289,33 @@ namespace samurai
                                     exit(1);
                                 }
 #endif
-                                d1 -= interp_even[ki] * interp_even[kj] * src;
-                                d2 -= interp_odd[ki] * interp_even[kj] * src;
-                                d3 -= interp_even[ki] * interp_odd[kj] * src;
-                                d4 -= interp_odd[ki] * interp_odd[kj] * src;
+                                const auto& c = coeff[ki + kj * interp_size];
+                                for (std::size_t k = 0; k < 4; ++k)
+                                {
+                                    d[k] -= c[k] * src;
+                                }
                             }
                         }
 
-                        detail_data[ind1 + i_f]     = d1;
-                        detail_data[ind1 + i_f + 1] = d2;
-                        detail_data[ind2 + i_f]     = d3;
-                        detail_data[ind2 + i_f + 1] = d4;
+                        detail_data[ind1 + i_f]     = d[0];
+                        detail_data[ind1 + i_f + 1] = d[1];
+                        detail_data[ind2 + i_f]     = d[2];
+                        detail_data[ind2 + i_f + 1] = d[3];
                     }
                     else
                     {
                         for (std::size_t nc = 0; nc < T2::n_comp; ++nc)
                         {
-                            double d1, d2, d3, d4;
-                            d1 = data[(ind1 + i_f) * T2::n_comp + nc];
-                            d2 = data[(ind1 + i_f + 1) * T2::n_comp + nc];
-                            d3 = data[(ind2 + i_f) * T2::n_comp + nc];
-                            d4 = data[(ind2 + i_f + 1) * T2::n_comp + nc];
+                            std::array<double, 4> d = {data[(ind1 + i_f) * T2::n_comp + nc],
+                                                       data[(ind1 + i_f + 1) * T2::n_comp + nc],
+                                                       data[(ind2 + i_f) * T2::n_comp + nc],
+                                                       data[(ind2 + i_f + 1) * T2::n_comp + nc]};
 
                             for (std::size_t kj = 0; kj < interp_size; ++kj)
                             {
                                 for (std::size_t ki = 0; ki < interp_size; ++ki)
                                 {
-                                    auto idx         = (indices[ki + kj * interp_size] + ii) * T2::n_comp;
-                                    const double src = data[idx + nc];
+                                    const double src = data[(indices[ki + kj * interp_size] + ii) * T2::n_comp + nc];
 
 #ifdef SAMURAI_CHECK_NAN
                                     if (std::isnan(src))
@@ -315,26 +329,27 @@ namespace samurai
                                     }
 #endif
 
-                                    d1 -= interp_even[ki] * interp_even[kj] * src;
-                                    d2 -= interp_odd[ki] * interp_even[kj] * src;
-                                    d3 -= interp_even[ki] * interp_odd[kj] * src;
-                                    d4 -= interp_odd[ki] * interp_odd[kj] * src;
+                                    const auto& c = coeff[ki + kj * interp_size];
+                                    for (std::size_t k = 0; k < 4; ++k)
+                                    {
+                                        d[k] -= c[k] * src;
+                                    }
                                 }
                             }
 
                             if constexpr (requires { detail.begin_item(); })
                             {
-                                detail_data[detail.begin_item() + (ind1 + i_f) * T1::n_comp + nc]     = d1;
-                                detail_data[detail.begin_item() + (ind1 + i_f + 1) * T1::n_comp + nc] = d2;
-                                detail_data[detail.begin_item() + (ind2 + i_f) * T1::n_comp + nc]     = d3;
-                                detail_data[detail.begin_item() + (ind2 + i_f + 1) * T1::n_comp + nc] = d4;
+                                detail_data[detail.begin_item() + (ind1 + i_f) * T1::n_comp + nc]     = d[0];
+                                detail_data[detail.begin_item() + (ind1 + i_f + 1) * T1::n_comp + nc] = d[1];
+                                detail_data[detail.begin_item() + (ind2 + i_f) * T1::n_comp + nc]     = d[2];
+                                detail_data[detail.begin_item() + (ind2 + i_f + 1) * T1::n_comp + nc] = d[3];
                             }
                             else
                             {
-                                detail_data[(ind1 + i_f) * T1::n_comp + nc]     = d1;
-                                detail_data[(ind1 + i_f + 1) * T1::n_comp + nc] = d2;
-                                detail_data[(ind2 + i_f) * T1::n_comp + nc]     = d3;
-                                detail_data[(ind2 + i_f + 1) * T1::n_comp + nc] = d4;
+                                detail_data[(ind1 + i_f) * T1::n_comp + nc]     = d[0];
+                                detail_data[(ind1 + i_f + 1) * T1::n_comp + nc] = d[1];
+                                detail_data[(ind2 + i_f) * T1::n_comp + nc]     = d[2];
+                                detail_data[(ind2 + i_f + 1) * T1::n_comp + nc] = d[3];
                             }
                         }
                     }

--- a/include/samurai/mr/rel_detail.hpp
+++ b/include/samurai/mr/rel_detail.hpp
@@ -83,7 +83,19 @@ namespace samurai
             inv_max_fields[i] = 1. / inv_max_fields[i];
         }
 
-        auto inv_max_fields_xt = xt::adapt(inv_max_fields);
-        detail.array() *= inv_max_fields_xt;
+        // Raw, cache-streaming normalization instead of xtensor's broadcast
+        // `detail.array() *= inv_max_fields_xt`: the latter does not vectorize and
+        // dominated the whole detail computation (~5 s out of 7 s on the euler_2d
+        // demo). Same result, bit-identical.
+        constexpr std::size_t nc = detail_t::n_comp;
+        auto* dd                 = detail.data();
+        const std::size_t n      = detail.array().size();
+        for (std::size_t k = 0; k < n; k += nc)
+        {
+            for (std::size_t c = 0; c < nc; ++c)
+            {
+                dd[k + c] *= inv_max_fields[c];
+            }
+        }
     }
 }

--- a/include/samurai/mr/rel_detail.hpp
+++ b/include/samurai/mr/rel_detail.hpp
@@ -12,31 +12,43 @@ namespace samurai
 {
     namespace detail
     {
+        // Per-component max of |field| over the leaf cells. Iterated per interval
+        // over the raw field data (the interval's index is the flat cell offset,
+        // as used by field[cell]) rather than per cell with for_each_cell, which
+        // builds a Cell object for every cell - the dominant cost of the previous
+        // version. max is order-independent, so the result is bit-identical.
         void set_inv_max_field(auto& inv_max_fields, const auto& field, std::size_t dec = 0)
             requires(std::decay_t<decltype(field)>::is_scalar)
         {
-            auto& mesh = field.mesh();
-
-            for_each_cell(mesh,
-                          [&](const auto& cell)
-                          {
-                              inv_max_fields[dec] = std::max(inv_max_fields[dec], std::abs(field[cell]));
-                          });
+            const auto* data = field.data();
+            for_each_interval(field.mesh(),
+                              [&](std::size_t, const auto& i, const auto&)
+                              {
+                                  for (auto x = i.start; x < i.end; ++x)
+                                  {
+                                      const auto flat     = static_cast<std::size_t>(i.index + x);
+                                      inv_max_fields[dec] = std::max(inv_max_fields[dec], std::abs(data[flat]));
+                                  }
+                              });
         }
 
         void set_inv_max_field(auto& inv_max_fields, const auto& field, std::size_t dec = 0)
             requires(!std::decay_t<decltype(field)>::is_scalar)
         {
-            auto& mesh = field.mesh();
-
-            for_each_cell(mesh,
-                          [&](const auto& cell)
-                          {
-                              for (std::size_t i = 0; i < field.n_comp; ++i)
+            constexpr std::size_t nc = std::decay_t<decltype(field)>::n_comp;
+            const auto* data         = field.data();
+            for_each_interval(field.mesh(),
+                              [&](std::size_t, const auto& i, const auto&)
                               {
-                                  inv_max_fields[dec + i] = std::max(inv_max_fields[dec + i], std::abs(field[cell][i]));
-                              }
-                          });
+                                  for (auto x = i.start; x < i.end; ++x)
+                                  {
+                                      const auto flat = static_cast<std::size_t>(i.index + x) * nc;
+                                      for (std::size_t c = 0; c < nc; ++c)
+                                      {
+                                          inv_max_fields[dec + c] = std::max(inv_max_fields[dec + c], std::abs(data[flat + c]));
+                                      }
+                                  }
+                              });
         }
 
         template <class... TFields>


### PR DESCRIPTION
## Description

Speeds up the multiresolution detail computation, which was ~20 % of the run time on the `euler_2d` demo. Sub-timing revealed the cost was almost entirely in the relative-detail normalization, not in the wavelet detail operator itself.

Three changes:

1. **`compute_relative_detail`: raw normalization loop.** The normalization did `detail.array() *= inv_max_fields_xt`, an xtensor broadcast of a size-`n_comp` vector across the entire detail array. That expression does not vectorize and, evaluated once per mesh adaptation, dominated the whole detail computation (~5.1 s out of 7.2 s). Replaced by a raw, cache-streaming multiply over `detail.data()`.

2. **`set_inv_max_field`: per-interval max over raw data.** The per-component max of `|field|` used `for_each_cell`, which builds a `Cell` object for every cell. It now iterates per interval over the raw field data (the interval index is the flat cell offset, as used by `field[cell]`), avoiding the `Cell` construction. `max` is order-independent, so the result is bit-identical.

3. **2D and 3D `compute_detail`: vectorized child updates.** The child coefficients of each stencil point (4 in 2D, 8 in 3D) are precomputed once per operator call (they depend only on the stencil position, not on the cell or the component), and the children are updated with a fixed-width loop the compiler lowers to SIMD, instead of separate scalar accumulators. The products keep the left-associated form of the scalar code, so the details are bit-identical. The 1D operator already works on whole-interval xtensor expressions and is left unchanged.

Measured (single thread):

| case | detail computation | TimeLoop |
|---|---|---|
| `euler_2d` (`--Tf 0.25 --min-level 4 --max-level 8`) | 7.7 s → 1.5 s | 36.8 s → 30.7 s |
| `euler_3d` (`--Tf 0.08 --min-level 2 --max-level 6`) | 0.093 s → 0.033 s | - |

## Code of Conduct
By submitting this PR, you agree to follow our [Code of Conduct](https://github.com/hpc-maths/samurai/blob/master/docs/CODE_OF_CONDUCT.md)
- [x] I agree to follow this project's Code of Conduct
