### PR TITLE
perf: speed up the multiresolution mesh-update phase

### DIFF
--- a/include/samurai/algorithm/graduation.hpp
+++ b/include/samurai/algorithm/graduation.hpp
@@ -250,13 +250,7 @@ namespace samurai
         [[maybe_unused]] const auto& mpi_meshes,
         const std::array<bool, dim>& is_periodic,
         const std::array<int, dim>& nb_cells_finest_level,
-        std::array<ArrayOfIntervalAndPoint<TInterval, TCoord>, CellArray<dim, TInterval, max_size>::max_size>& out,
-        // Incremental seed: when non-null, the LOCAL pass only cascades from these
-        // cells (the fine cells added by the previous graduation iteration) instead
-        // of from every fine cell. Exact because a graduation iteration only adds
-        // fine cells, so a new violation can only involve one of them as its fine
-        // source. MPI neighbour passes always run full (seed is local).
-        const CellArray<dim, TInterval, max_size>* seed = nullptr)
+        std::array<ArrayOfIntervalAndPoint<TInterval, TCoord>, CellArray<dim, TInterval, max_size>::max_size>& out)
     {
         const int max_width = int(grad_width);
 
@@ -326,19 +320,8 @@ namespace samurai
             }
         };
 
-        // Local pass. With a seed, cascade only from the seeded fine cells (a subset
-        // of `ca` added by the previous graduation iteration) against `ca`'s coarse
-        // targets: exact, because a graduation iteration only adds fine cells.
-        if (seed)
-        {
-            list_overlapping_intervals(*seed, ca);
-        }
-        else
-        {
-            list_overlapping_intervals(ca, ca);
-        }
+        list_overlapping_intervals(ca, ca);
 #ifdef SAMURAI_WITH_MPI
-        // Neighbour passes always run full: the seed only covers local additions.
         for (const auto& mpi_mesh : mpi_meshes)
         {
             list_overlapping_intervals(mpi_mesh, ca);
@@ -390,14 +373,7 @@ namespace samurai
         const LevelCellArray<dim, TInterval>& domain,
         [[maybe_unused]] const auto& mpi_meshes,
         const std::array<bool, dim>& is_periodic,
-        std::array<ArrayOfIntervalAndPoint<TInterval, TCoord>, CellArray<dim, TInterval, max_size>::max_size>& out,
-        // Incremental seed: when non-null, the LOCAL level->level-1 pass only considers
-        // boundary cells that are among the fine cells added by the previous graduation
-        // iteration. Exact for that pass because a graduation iteration only adds fine
-        // cells (so new boundary sources at `level` are a subset of the seed) and adding
-        // fine cells inward can only increase contiguity, never create a new violation
-        // for an existing boundary cell. MPI neighbour passes always run full.
-        const CellArray<dim, TInterval, max_size>* seed = nullptr)
+        std::array<ArrayOfIntervalAndPoint<TInterval, TCoord>, CellArray<dim, TInterval, max_size>::max_size>& out)
     {
         if (max_stencil_radius == 1)
         {
@@ -454,14 +430,9 @@ namespace samurai
                             // We therefore refine ONLY this rank's own level-1 cells (out drives the local `ca`), but from
                             // boundary cells taken from `ca` and from each neighbour mesh. In sequential runs mpi_meshes is
                             // empty and this reduces to the original single-mesh behaviour.
-                            auto refine_from = [&](const auto& src, const auto* src_seed)
+                            auto refine_from = [&](const auto& src)
                             {
-                                auto boundary_expr = difference(src[level], translate(self(domain).on(level), -translation));
-                                // With a seed, keep only the new boundary cells at this level.
-                                LevelCellArray<dim, TInterval> boundaryCells = src_seed
-                                                                                 ? LevelCellArray<dim, TInterval>(
-                                                                                       intersection(boundary_expr, (*src_seed)[level]).on(level))
-                                                                                 : LevelCellArray<dim, TInterval>(boundary_expr.on(level));
+                                auto boundaryCells = difference(src[level], translate(self(domain).on(level), -translation)).on(level);
                                 for (int i = 2; i <= n_contiguous_boundary_cells; i += 2)
                                 {
                                     // Here, the set algebra doesn't work, so we put the translation in a LevelCellArray before
@@ -475,12 +446,11 @@ namespace samurai
                                         });
                                 }
                             };
-                            refine_from(ca, seed);
+                            refine_from(ca);
 #ifdef SAMURAI_WITH_MPI
                             for (const auto& mpi_mesh : mpi_meshes)
                             {
-                                // Neighbour passes always run full: the seed only covers local additions.
-                                refine_from(mpi_mesh, decltype(seed){nullptr});
+                                refine_from(mpi_mesh);
                             }
 #endif
                         }
@@ -535,15 +505,13 @@ namespace samurai
                                   [[maybe_unused]] const std::vector<MPI_Subdomain<MeshType>>& mpi_neighbourhood,
                                   const std::array<bool, dim>& is_periodic,
                                   const std::array<int, dim>& nb_cells_finest_level,
-                                  std::array<ArrayOfIntervalAndPoint<TInterval, TCoord>, CellArray<dim, TInterval, max_size>::max_size>& out,
-                                  // Incremental seed forwarded to the interior graduation pass (see there).
-                                  const CellArray<dim, TInterval, max_size>* seed = nullptr)
+                                  std::array<ArrayOfIntervalAndPoint<TInterval, TCoord>, CellArray<dim, TInterval, max_size>::max_size>& out)
     {
         auto mpi_meshes = update_subdomains_mpi(ca, mpi_neighbourhood);
-        list_interval_to_refine_for_graduation(grad_width, ca, domain, mpi_meshes, is_periodic, nb_cells_finest_level, out, seed);
+        list_interval_to_refine_for_graduation(grad_width, ca, domain, mpi_meshes, is_periodic, nb_cells_finest_level, out);
         if (!domain.empty())
         {
-            list_interval_to_refine_for_contiguous_boundary_cells(max_stencil_radius, ca, domain, mpi_meshes, is_periodic, out, seed);
+            list_interval_to_refine_for_contiguous_boundary_cells(max_stencil_radius, ca, domain, mpi_meshes, is_periodic, out);
         }
     }
 
@@ -657,17 +625,7 @@ namespace samurai
         // `new_ca != ca` test, this lets us skip both the full `new_ca` reconstruction and the whole-array
         // comparison whenever an iteration produces no cell to refine (the common case: an already-graduated mesh),
         // for which `new_ca == ca` holds algebraically.
-        // Incremental graduation. The first iteration scans the whole mesh. Each
-        // subsequent iteration only needs to look for new violations around the fine
-        // cells the previous iteration added: a graduation iteration only ADDS fine
-        // cells, so those are the only possible new fine sources. Seeding the interior
-        // pass with them is therefore exact (the boundary pass still runs full each
-        // iteration). Under-seeding could only ever miss a refinement, never add a
-        // spurious one, so `is_graduated(ca)` on the result is a complete correctness
-        // check (enabled by SAMURAI_DEBUG_GRADUATION below).
-        ca_type prev_add_p;
-        const ca_type* iteration_seed = nullptr;
-        bool ca_changed               = true;
+        bool ca_changed = true;
         while (
 #ifdef SAMURAI_WITH_MPI
             mpi::all_reduce(world, ca_changed, std::logical_or())
@@ -683,15 +641,7 @@ namespace samurai
             // Then, if the non-graduated is not tagged as keep, we coarsen it
             ca_add_p.clear();
             ca_remove_p.clear();
-            list_intervals_to_refine(grad_width,
-                                     max_stencil_radius,
-                                     ca,
-                                     domain,
-                                     mpi_neighbourhood,
-                                     is_periodic,
-                                     nb_cells_finest_level,
-                                     remove_m_all,
-                                     iteration_seed);
+            list_intervals_to_refine(grad_width, max_stencil_radius, ca, domain, mpi_neighbourhood, is_periodic, nb_cells_finest_level, remove_m_all);
 
             add_p_interval.clear();
             add_p_inner_stencil.clear();
@@ -770,23 +720,7 @@ namespace samurai
             // effectively unchanged: keep the explicit comparison here as the loop's termination guarantee.
             ca_changed = (new_ca != ca);
             std::swap(new_ca, ca);
-
-            // Seed the next iteration's interior pass with the fine cells just added.
-            prev_add_p     = ca_add_p;
-            iteration_seed = &prev_add_p;
         }
-
-#ifdef SAMURAI_DEBUG_GRADUATION
-        // Complete correctness gate for the incremental scan: because seeding can
-        // only ever under-refine (never add a spurious refinement), a graduated
-        // result is necessarily identical to the full-scan result. Explicit check
-        // (not assert) so it also fires in NDEBUG builds when the flag is set.
-        if (!is_graduated(ca))
-        {
-            std::cerr << "[SAMURAI_DEBUG_GRADUATION] incremental graduation produced a non-graduated mesh\n";
-            std::abort();
-        }
-#endif
 
         return nit - 1;
     }

--- a/include/samurai/algorithm/graduation.hpp
+++ b/include/samurai/algorithm/graduation.hpp
@@ -250,7 +250,13 @@ namespace samurai
         [[maybe_unused]] const auto& mpi_meshes,
         const std::array<bool, dim>& is_periodic,
         const std::array<int, dim>& nb_cells_finest_level,
-        std::array<ArrayOfIntervalAndPoint<TInterval, TCoord>, CellArray<dim, TInterval, max_size>::max_size>& out)
+        std::array<ArrayOfIntervalAndPoint<TInterval, TCoord>, CellArray<dim, TInterval, max_size>::max_size>& out,
+        // Incremental seed: when non-null, the LOCAL pass only cascades from these
+        // cells (the fine cells added by the previous graduation iteration) instead
+        // of from every fine cell. Exact because a graduation iteration only adds
+        // fine cells, so a new violation can only involve one of them as its fine
+        // source. MPI neighbour passes always run full (seed is local).
+        const CellArray<dim, TInterval, max_size>* seed = nullptr)
     {
         const int max_width = int(grad_width);
 
@@ -320,8 +326,19 @@ namespace samurai
             }
         };
 
-        list_overlapping_intervals(ca, ca);
+        // Local pass. With a seed, cascade only from the seeded fine cells (a subset
+        // of `ca` added by the previous graduation iteration) against `ca`'s coarse
+        // targets: exact, because a graduation iteration only adds fine cells.
+        if (seed)
+        {
+            list_overlapping_intervals(*seed, ca);
+        }
+        else
+        {
+            list_overlapping_intervals(ca, ca);
+        }
 #ifdef SAMURAI_WITH_MPI
+        // Neighbour passes always run full: the seed only covers local additions.
         for (const auto& mpi_mesh : mpi_meshes)
         {
             list_overlapping_intervals(mpi_mesh, ca);
@@ -373,7 +390,14 @@ namespace samurai
         const LevelCellArray<dim, TInterval>& domain,
         [[maybe_unused]] const auto& mpi_meshes,
         const std::array<bool, dim>& is_periodic,
-        std::array<ArrayOfIntervalAndPoint<TInterval, TCoord>, CellArray<dim, TInterval, max_size>::max_size>& out)
+        std::array<ArrayOfIntervalAndPoint<TInterval, TCoord>, CellArray<dim, TInterval, max_size>::max_size>& out,
+        // Incremental seed: when non-null, the LOCAL level->level-1 pass only considers
+        // boundary cells that are among the fine cells added by the previous graduation
+        // iteration. Exact for that pass because a graduation iteration only adds fine
+        // cells (so new boundary sources at `level` are a subset of the seed) and adding
+        // fine cells inward can only increase contiguity, never create a new violation
+        // for an existing boundary cell. MPI neighbour passes always run full.
+        const CellArray<dim, TInterval, max_size>* seed = nullptr)
     {
         if (max_stencil_radius == 1)
         {
@@ -430,9 +454,14 @@ namespace samurai
                             // We therefore refine ONLY this rank's own level-1 cells (out drives the local `ca`), but from
                             // boundary cells taken from `ca` and from each neighbour mesh. In sequential runs mpi_meshes is
                             // empty and this reduces to the original single-mesh behaviour.
-                            auto refine_from = [&](const auto& src)
+                            auto refine_from = [&](const auto& src, const auto* src_seed)
                             {
-                                auto boundaryCells = difference(src[level], translate(self(domain).on(level), -translation)).on(level);
+                                auto boundary_expr = difference(src[level], translate(self(domain).on(level), -translation));
+                                // With a seed, keep only the new boundary cells at this level.
+                                LevelCellArray<dim, TInterval> boundaryCells = src_seed
+                                                                                 ? LevelCellArray<dim, TInterval>(
+                                                                                       intersection(boundary_expr, (*src_seed)[level]).on(level))
+                                                                                 : LevelCellArray<dim, TInterval>(boundary_expr.on(level));
                                 for (int i = 2; i <= n_contiguous_boundary_cells; i += 2)
                                 {
                                     // Here, the set algebra doesn't work, so we put the translation in a LevelCellArray before
@@ -446,11 +475,12 @@ namespace samurai
                                         });
                                 }
                             };
-                            refine_from(ca);
+                            refine_from(ca, seed);
 #ifdef SAMURAI_WITH_MPI
                             for (const auto& mpi_mesh : mpi_meshes)
                             {
-                                refine_from(mpi_mesh);
+                                // Neighbour passes always run full: the seed only covers local additions.
+                                refine_from(mpi_mesh, decltype(seed){nullptr});
                             }
 #endif
                         }
@@ -505,13 +535,15 @@ namespace samurai
                                   [[maybe_unused]] const std::vector<MPI_Subdomain<MeshType>>& mpi_neighbourhood,
                                   const std::array<bool, dim>& is_periodic,
                                   const std::array<int, dim>& nb_cells_finest_level,
-                                  std::array<ArrayOfIntervalAndPoint<TInterval, TCoord>, CellArray<dim, TInterval, max_size>::max_size>& out)
+                                  std::array<ArrayOfIntervalAndPoint<TInterval, TCoord>, CellArray<dim, TInterval, max_size>::max_size>& out,
+                                  // Incremental seed forwarded to the interior graduation pass (see there).
+                                  const CellArray<dim, TInterval, max_size>* seed = nullptr)
     {
         auto mpi_meshes = update_subdomains_mpi(ca, mpi_neighbourhood);
-        list_interval_to_refine_for_graduation(grad_width, ca, domain, mpi_meshes, is_periodic, nb_cells_finest_level, out);
+        list_interval_to_refine_for_graduation(grad_width, ca, domain, mpi_meshes, is_periodic, nb_cells_finest_level, out, seed);
         if (!domain.empty())
         {
-            list_interval_to_refine_for_contiguous_boundary_cells(max_stencil_radius, ca, domain, mpi_meshes, is_periodic, out);
+            list_interval_to_refine_for_contiguous_boundary_cells(max_stencil_radius, ca, domain, mpi_meshes, is_periodic, out, seed);
         }
     }
 
@@ -625,7 +657,59 @@ namespace samurai
         // `new_ca != ca` test, this lets us skip both the full `new_ca` reconstruction and the whole-array
         // comparison whenever an iteration produces no cell to refine (the common case: an already-graduated mesh),
         // for which `new_ca == ca` holds algebraically.
-        bool ca_changed = true;
+        // Incremental graduation. The first iteration scans the whole mesh. Each
+        // subsequent iteration only needs to look for new violations around the fine
+        // cells the previous iteration added: a graduation iteration only ADDS fine
+        // cells, so those are the only possible new fine sources. Seeding the interior
+        // pass with them is therefore exact (the boundary pass still runs full each
+        // iteration). Under-seeding could only ever miss a refinement, never add a
+        // spurious one, so `is_graduated(ca)` on the result is a complete correctness
+        // check (enabled by SAMURAI_DEBUG_GRADUATION below).
+        //
+        // A new violation of iteration i+1 involves a cell ADDED by iteration i either
+        // as its fine SOURCE or as its (coarser) TARGET - the latter happens on a
+        // multi-level cascade, where an old fine cell forces a cell iteration i just
+        // added one level up. Seeding only from the additions (as sources) misses the
+        // target case, so the seed must be the mesh cells in the NEIGHBOURHOOD of the
+        // additions: ca INTER expand(additions, roi_width), projected across levels.
+        // This lets the scan cascade from the old fine cells near the new targets too.
+        // roi_width covers the interior grading reach (2*grad_width) and the boundary
+        // contiguity reach.
+        const int roi_width = std::max(2 * static_cast<int>(grad_width), std::max(max_stencil_radius, 2 * (max_stencil_radius - 2)));
+
+        auto build_roi = [&](const ca_type& additions) -> ca_type
+        {
+            using lca_t = typename ca_type::lca_type;
+            ca_type roi;
+            for (size_t L = ca.min_level(); L <= ca.max_level(); ++L)
+            {
+                lca_t acc;
+                bool has = false;
+                for (size_t d = additions.min_level(); d <= additions.max_level(); ++d)
+                {
+                    if (additions[d].empty())
+                    {
+                        continue;
+                    }
+                    lca_t contrib(nestedExpand(self(additions[d]).on(L), roi_width));
+                    acc = has ? lca_t(union_(acc, contrib).on(L)) : contrib;
+                    has = true;
+                }
+                if (has)
+                {
+                    intersection(ca[L], acc)(
+                        [&](const auto& i, const auto& idx)
+                        {
+                            roi[L].add_interval_back(i, idx);
+                        });
+                }
+            }
+            return roi;
+        };
+
+        ca_type prev_roi;
+        const ca_type* iteration_seed = nullptr;
+        bool ca_changed               = true;
         while (
 #ifdef SAMURAI_WITH_MPI
             mpi::all_reduce(world, ca_changed, std::logical_or())
@@ -641,7 +725,15 @@ namespace samurai
             // Then, if the non-graduated is not tagged as keep, we coarsen it
             ca_add_p.clear();
             ca_remove_p.clear();
-            list_intervals_to_refine(grad_width, max_stencil_radius, ca, domain, mpi_neighbourhood, is_periodic, nb_cells_finest_level, remove_m_all);
+            list_intervals_to_refine(grad_width,
+                                     max_stencil_radius,
+                                     ca,
+                                     domain,
+                                     mpi_neighbourhood,
+                                     is_periodic,
+                                     nb_cells_finest_level,
+                                     remove_m_all,
+                                     iteration_seed);
 
             add_p_interval.clear();
             add_p_inner_stencil.clear();
@@ -720,7 +812,25 @@ namespace samurai
             // effectively unchanged: keep the explicit comparison here as the loop's termination guarantee.
             ca_changed = (new_ca != ca);
             std::swap(new_ca, ca);
+
+            // Seed the next iteration with the mesh cells around the ones just added
+            // (see the roi comment above): this covers additions acting as fine sources
+            // and old fine cells forcing additions that became coarser targets.
+            prev_roi       = build_roi(ca_add_p);
+            iteration_seed = &prev_roi;
         }
+
+#ifdef SAMURAI_DEBUG_GRADUATION
+        // Complete correctness gate for the incremental scan: because seeding can
+        // only ever under-refine (never add a spurious refinement), a graduated
+        // result is necessarily identical to the full-scan result. Explicit check
+        // (not assert) so it also fires in NDEBUG builds when the flag is set.
+        if (!is_graduated(ca))
+        {
+            std::cerr << "[SAMURAI_DEBUG_GRADUATION] incremental graduation produced a non-graduated mesh\n";
+            std::abort();
+        }
+#endif
 
         return nit - 1;
     }

--- a/include/samurai/algorithm/graduation.hpp
+++ b/include/samurai/algorithm/graduation.hpp
@@ -250,7 +250,13 @@ namespace samurai
         [[maybe_unused]] const auto& mpi_meshes,
         const std::array<bool, dim>& is_periodic,
         const std::array<int, dim>& nb_cells_finest_level,
-        std::array<ArrayOfIntervalAndPoint<TInterval, TCoord>, CellArray<dim, TInterval, max_size>::max_size>& out)
+        std::array<ArrayOfIntervalAndPoint<TInterval, TCoord>, CellArray<dim, TInterval, max_size>::max_size>& out,
+        // Incremental seed: when non-null, the LOCAL pass only cascades from these
+        // cells (the fine cells added by the previous graduation iteration) instead
+        // of from every fine cell. Exact because a graduation iteration only adds
+        // fine cells, so a new violation can only involve one of them as its fine
+        // source. MPI neighbour passes always run full (seed is local).
+        const CellArray<dim, TInterval, max_size>* seed = nullptr)
     {
         const int max_width = int(grad_width);
 
@@ -320,8 +326,19 @@ namespace samurai
             }
         };
 
-        list_overlapping_intervals(ca, ca);
+        // Local pass. With a seed, cascade only from the seeded fine cells (a subset
+        // of `ca` added by the previous graduation iteration) against `ca`'s coarse
+        // targets: exact, because a graduation iteration only adds fine cells.
+        if (seed)
+        {
+            list_overlapping_intervals(*seed, ca);
+        }
+        else
+        {
+            list_overlapping_intervals(ca, ca);
+        }
 #ifdef SAMURAI_WITH_MPI
+        // Neighbour passes always run full: the seed only covers local additions.
         for (const auto& mpi_mesh : mpi_meshes)
         {
             list_overlapping_intervals(mpi_mesh, ca);
@@ -373,7 +390,14 @@ namespace samurai
         const LevelCellArray<dim, TInterval>& domain,
         [[maybe_unused]] const auto& mpi_meshes,
         const std::array<bool, dim>& is_periodic,
-        std::array<ArrayOfIntervalAndPoint<TInterval, TCoord>, CellArray<dim, TInterval, max_size>::max_size>& out)
+        std::array<ArrayOfIntervalAndPoint<TInterval, TCoord>, CellArray<dim, TInterval, max_size>::max_size>& out,
+        // Incremental seed: when non-null, the LOCAL level->level-1 pass only considers
+        // boundary cells that are among the fine cells added by the previous graduation
+        // iteration. Exact for that pass because a graduation iteration only adds fine
+        // cells (so new boundary sources at `level` are a subset of the seed) and adding
+        // fine cells inward can only increase contiguity, never create a new violation
+        // for an existing boundary cell. MPI neighbour passes always run full.
+        const CellArray<dim, TInterval, max_size>* seed = nullptr)
     {
         if (max_stencil_radius == 1)
         {
@@ -430,9 +454,14 @@ namespace samurai
                             // We therefore refine ONLY this rank's own level-1 cells (out drives the local `ca`), but from
                             // boundary cells taken from `ca` and from each neighbour mesh. In sequential runs mpi_meshes is
                             // empty and this reduces to the original single-mesh behaviour.
-                            auto refine_from = [&](const auto& src)
+                            auto refine_from = [&](const auto& src, const auto* src_seed)
                             {
-                                auto boundaryCells = difference(src[level], translate(self(domain).on(level), -translation)).on(level);
+                                auto boundary_expr = difference(src[level], translate(self(domain).on(level), -translation));
+                                // With a seed, keep only the new boundary cells at this level.
+                                LevelCellArray<dim, TInterval> boundaryCells = src_seed
+                                                                                 ? LevelCellArray<dim, TInterval>(
+                                                                                       intersection(boundary_expr, (*src_seed)[level]).on(level))
+                                                                                 : LevelCellArray<dim, TInterval>(boundary_expr.on(level));
                                 for (int i = 2; i <= n_contiguous_boundary_cells; i += 2)
                                 {
                                     // Here, the set algebra doesn't work, so we put the translation in a LevelCellArray before
@@ -446,11 +475,12 @@ namespace samurai
                                         });
                                 }
                             };
-                            refine_from(ca);
+                            refine_from(ca, seed);
 #ifdef SAMURAI_WITH_MPI
                             for (const auto& mpi_mesh : mpi_meshes)
                             {
-                                refine_from(mpi_mesh);
+                                // Neighbour passes always run full: the seed only covers local additions.
+                                refine_from(mpi_mesh, decltype(seed){nullptr});
                             }
 #endif
                         }
@@ -505,13 +535,15 @@ namespace samurai
                                   [[maybe_unused]] const std::vector<MPI_Subdomain<MeshType>>& mpi_neighbourhood,
                                   const std::array<bool, dim>& is_periodic,
                                   const std::array<int, dim>& nb_cells_finest_level,
-                                  std::array<ArrayOfIntervalAndPoint<TInterval, TCoord>, CellArray<dim, TInterval, max_size>::max_size>& out)
+                                  std::array<ArrayOfIntervalAndPoint<TInterval, TCoord>, CellArray<dim, TInterval, max_size>::max_size>& out,
+                                  // Incremental seed forwarded to the interior graduation pass (see there).
+                                  const CellArray<dim, TInterval, max_size>* seed = nullptr)
     {
         auto mpi_meshes = update_subdomains_mpi(ca, mpi_neighbourhood);
-        list_interval_to_refine_for_graduation(grad_width, ca, domain, mpi_meshes, is_periodic, nb_cells_finest_level, out);
+        list_interval_to_refine_for_graduation(grad_width, ca, domain, mpi_meshes, is_periodic, nb_cells_finest_level, out, seed);
         if (!domain.empty())
         {
-            list_interval_to_refine_for_contiguous_boundary_cells(max_stencil_radius, ca, domain, mpi_meshes, is_periodic, out);
+            list_interval_to_refine_for_contiguous_boundary_cells(max_stencil_radius, ca, domain, mpi_meshes, is_periodic, out, seed);
         }
     }
 
@@ -625,7 +657,17 @@ namespace samurai
         // `new_ca != ca` test, this lets us skip both the full `new_ca` reconstruction and the whole-array
         // comparison whenever an iteration produces no cell to refine (the common case: an already-graduated mesh),
         // for which `new_ca == ca` holds algebraically.
-        bool ca_changed = true;
+        // Incremental graduation. The first iteration scans the whole mesh. Each
+        // subsequent iteration only needs to look for new violations around the fine
+        // cells the previous iteration added: a graduation iteration only ADDS fine
+        // cells, so those are the only possible new fine sources. Seeding the interior
+        // pass with them is therefore exact (the boundary pass still runs full each
+        // iteration). Under-seeding could only ever miss a refinement, never add a
+        // spurious one, so `is_graduated(ca)` on the result is a complete correctness
+        // check (enabled by SAMURAI_DEBUG_GRADUATION below).
+        ca_type prev_add_p;
+        const ca_type* iteration_seed = nullptr;
+        bool ca_changed              = true;
         while (
 #ifdef SAMURAI_WITH_MPI
             mpi::all_reduce(world, ca_changed, std::logical_or())
@@ -641,7 +683,15 @@ namespace samurai
             // Then, if the non-graduated is not tagged as keep, we coarsen it
             ca_add_p.clear();
             ca_remove_p.clear();
-            list_intervals_to_refine(grad_width, max_stencil_radius, ca, domain, mpi_neighbourhood, is_periodic, nb_cells_finest_level, remove_m_all);
+            list_intervals_to_refine(grad_width,
+                                     max_stencil_radius,
+                                     ca,
+                                     domain,
+                                     mpi_neighbourhood,
+                                     is_periodic,
+                                     nb_cells_finest_level,
+                                     remove_m_all,
+                                     iteration_seed);
 
             add_p_interval.clear();
             add_p_inner_stencil.clear();
@@ -720,7 +770,23 @@ namespace samurai
             // effectively unchanged: keep the explicit comparison here as the loop's termination guarantee.
             ca_changed = (new_ca != ca);
             std::swap(new_ca, ca);
+
+            // Seed the next iteration's interior pass with the fine cells just added.
+            prev_add_p    = ca_add_p;
+            iteration_seed = &prev_add_p;
         }
+
+#ifdef SAMURAI_DEBUG_GRADUATION
+        // Complete correctness gate for the incremental scan: because seeding can
+        // only ever under-refine (never add a spurious refinement), a graduated
+        // result is necessarily identical to the full-scan result. Explicit check
+        // (not assert) so it also fires in NDEBUG builds when the flag is set.
+        if (!is_graduated(ca))
+        {
+            std::cerr << "[SAMURAI_DEBUG_GRADUATION] incremental graduation produced a non-graduated mesh\n";
+            std::abort();
+        }
+#endif
 
         return nit - 1;
     }

--- a/include/samurai/algorithm/graduation.hpp
+++ b/include/samurai/algorithm/graduation.hpp
@@ -816,8 +816,18 @@ namespace samurai
             // Seed the next iteration with the mesh cells around the ones just added
             // (see the roi comment above): this covers additions acting as fine sources
             // and old fine cells forcing additions that became coarser targets.
-            prev_roi       = build_roi(ca_add_p);
-            iteration_seed = &prev_roi;
+            //
+            // Only when there is no MPI neighbour (sequential run, or a rank with no
+            // neighbour). With neighbours the scan must stay FULL: the seed is built
+            // from this rank's LOCAL additions, which depend on the domain
+            // decomposition, so seeding would make the graduation - and hence the mesh -
+            // partition-dependent. The full scan is partition-independent (as on main),
+            // and a single-rank incremental result is bit-identical to it.
+            if (mpi_neighbourhood.empty())
+            {
+                prev_roi       = build_roi(ca_add_p);
+                iteration_seed = &prev_roi;
+            }
         }
 
 #ifdef SAMURAI_DEBUG_GRADUATION

--- a/include/samurai/algorithm/graduation.hpp
+++ b/include/samurai/algorithm/graduation.hpp
@@ -667,7 +667,7 @@ namespace samurai
         // check (enabled by SAMURAI_DEBUG_GRADUATION below).
         ca_type prev_add_p;
         const ca_type* iteration_seed = nullptr;
-        bool ca_changed              = true;
+        bool ca_changed               = true;
         while (
 #ifdef SAMURAI_WITH_MPI
             mpi::all_reduce(world, ca_changed, std::logical_or())
@@ -772,7 +772,7 @@ namespace samurai
             std::swap(new_ca, ca);
 
             // Seed the next iteration's interior pass with the fine cells just added.
-            prev_add_p    = ca_add_p;
+            prev_add_p     = ca_add_p;
             iteration_seed = &prev_add_p;
         }
 

--- a/include/samurai/algorithm/graduation.hpp
+++ b/include/samurai/algorithm/graduation.hpp
@@ -308,11 +308,11 @@ namespace samurai
                     {
                         return;
                     }
-                    const lca_t boundary_cells(difference(fine_l, translate(domain[l], -t)).on(l));
+                    const lca_t boundary_cells(difference(fine_l, translate(domain[l], -t)));
                     for (int i = 2; i <= n_contig; i += 2)
                     {
-                        lca_t inside(intersection(translate(boundary_cells, -i * t), domain[l]).on(l));
-                        extra = have ? lca_t(union_(extra, inside).on(l)) : std::move(inside);
+                        lca_t inside(intersection(translate(boundary_cells, -i * t), domain[l]));
+                        extra = have ? lca_t(union_(extra, inside)) : std::move(inside);
                         have  = true;
                     }
                 });
@@ -350,11 +350,11 @@ namespace samurai
                     {
                         return;
                     }
-                    const lca_t face_coarse(difference(domain[lc], translate(domain[lc], -t)).on(lc));
+                    const lca_t face_coarse(difference(domain[lc], translate(domain[lc], -t)));
                     for (int i = 1; i < max_stencil_radius; ++i)
                     {
-                        lca_t ref(self(lca_t(intersection(face_coarse, translate(fine_on_c, i * t)).on(lc))).on(l));
-                        extra = have ? lca_t(union_(extra, ref).on(l)) : std::move(ref);
+                        lca_t ref(self(lca_t(intersection(face_coarse, translate(fine_on_c, i * t)))).on(l));
+                        extra = have ? lca_t(union_(extra, ref)) : std::move(ref);
                         have  = true;
                     }
                 });
@@ -527,13 +527,13 @@ namespace samurai
                     continue;
                 }
                 lca_t projected(self(ca[l]).on(ca.max_level()));
-                coverage = first ? projected : lca_t(union_(coverage, projected).on(ca.max_level()));
+                coverage = first ? projected : lca_t(union_(coverage, projected));
                 first    = false;
             }
         }
         const auto clip = [&](lca_t&& x, size_t l) -> lca_t
         {
-            return use_coverage ? lca_t(intersection(x, self(coverage).on(l)).on(l)) : lca_t(intersection(x, domain[l]).on(l));
+            return use_coverage ? lca_t(intersection(x, self(coverage).on(l))) : lca_t(intersection(x, domain[l]));
         };
 
         std::array<lca_t, max_size> F;
@@ -555,6 +555,15 @@ namespace samurai
         {
             if constexpr (FoldBoundary)
             {
+                // Case-1 inward thickness (fine cells) forced along a physical face, as the max of two
+                // lower bounds (see PR hpc-maths/samurai#320 for figures):
+                //  - 2*(R-2): to keep a coarse (l-1) cell's radius-R stencil inside the domain we need R
+                //    contiguous l-1 cells; one is the exterior ghost carrying the projected B.C. and one is
+                //    the boundary cell itself, so only R-2 must be backed by real cells inward -> 2*(R-2)
+                //    fine cells (one l-1 cell = 2 level-l cells).
+                //  - R: the fine level's own stencil still needs R contiguous cells at the boundary; for
+                //    small R (2, 3) the 2*(R-2) term collapses to 0/2, so this floor takes over.
+                // The two terms cross at R=4; below it R wins, above it 2*(R-2) (slope 2R-4) wins.
                 const int n_contig = std::max(max_stencil_radius, 2 * (max_stencil_radius - 2));
                 if (max_stencil_radius <= 1 || domain.empty() || n_contig <= 1)
                 {
@@ -563,7 +572,7 @@ namespace samurai
                 // The actual level-l cells (F[l] also carries everything required finer).
                 const auto graded_level = [&](size_t ll) -> lca_t
                 {
-                    return (ll < max_level) ? lca_t(difference(F[ll], self(F[ll + 1]).on(ll)).on(ll)) : F[ll];
+                    return (ll < max_level) ? lca_t(difference(F[ll], self(F[ll + 1]).on(ll))) : F[ll];
                 };
                 const auto exchange_graded_level = [&](const lca_t& graded_l, size_t ll, int phase) -> std::vector<lca_t>
                 {
@@ -575,7 +584,7 @@ namespace samurai
                 };
                 const auto grow_F = [&](size_t ll, lca_t&& piece)
                 {
-                    lca_t req(union_(F[ll], piece).on(ll));
+                    lca_t req(union_(F[ll], piece));
                     F[ll] = (ll > min_level) ? clip(lca_t(self(req).on(ll - 1).on(ll)), ll) : clip(std::move(req), ll);
                 };
                 const auto sources = [&](const lca_t& my_fine, const std::vector<lca_t>& nbr_fine)
@@ -636,9 +645,9 @@ namespace samurai
             lca_t finer = F[l + 1];
             for (const auto& nf : neighbour_F[l + 1])
             {
-                // Union accumulation with a per-step .on() reconstruction: a raw loop reads better than std::accumulate.
+                // Union accumulation with a per-step lca_t reconstruction: a raw loop reads better than std::accumulate.
                 // cppcheck-suppress useStlAlgorithm
-                finer = lca_t(union_(finer, nf).on(l + 1));
+                finer = lca_t(union_(finer, nf));
             }
 
             lca_t expanded(nestedExpand(self(finer).on(l), w));
@@ -649,12 +658,12 @@ namespace samurai
                 const lca_t base = expanded;
                 for (const auto& d : detail::get_periodic_directions(nb_cells_finest_level, int(domain.max_level()) - int(l), is_periodic))
                 {
-                    // Union accumulation with a per-step .on() reconstruction: a raw loop reads better than std::accumulate.
+                    // Union accumulation with a per-step lca_t reconstruction: a raw loop reads better than std::accumulate.
                     // cppcheck-suppress useStlAlgorithm
-                    expanded = lca_t(union_(expanded, translate(base, d)).on(l));
+                    expanded = lca_t(union_(expanded, translate(base, d)));
                 }
             }
-            lca_t req(union_(ca[l], expanded).on(l));
+            lca_t req(union_(ca[l], expanded));
             // Round up to whole (l-1) parents (complete-tree invariant) then clip.
             F[l] = (l > min_level) ? clip(lca_t(self(req).on(l - 1).on(l)), l) : clip(std::move(req), l);
             extend_boundary(l);
@@ -672,10 +681,10 @@ namespace samurai
                 graded_ca[l].add_interval_back(x_interval, yz);
             };
         };
-        self(F[max_level]).on(max_level)(collect(max_level));
+        graded_ca[max_level] = F[max_level];
         for (size_t l = min_level; l < max_level; ++l)
         {
-            difference(F[l], self(F[l + 1]).on(l)).on(l)(collect(l));
+            difference(F[l], self(F[l + 1]).on(l))(collect(l));
         }
         std::swap(ca, graded_ca);
     }

--- a/include/samurai/algorithm/graduation.hpp
+++ b/include/samurai/algorithm/graduation.hpp
@@ -246,7 +246,7 @@ namespace samurai
     void list_interval_to_refine_for_graduation(
         const size_t grad_width,
         const CellArray<dim, TInterval, max_size>& ca,
-        const LevelCellArray<dim, TInterval>& domain,
+        const CellArray<dim, TInterval, max_size>& domain,
         [[maybe_unused]] const auto& mpi_meshes,
         const std::array<bool, dim>& is_periodic,
         const std::array<int, dim>& nb_cells_finest_level,
@@ -316,7 +316,7 @@ namespace samurai
                 {
                     continue;
                 }
-                const int delta_l = int(domain.level() - fine_level);
+                const int delta_l = int(domain.max_level() - fine_level);
                 auto directions   = detail::get_periodic_directions(nb_cells_finest_level, delta_l, is_periodic);
                 cascade_refine(fine_lca, fine_level);
                 for (const auto& d : directions)
@@ -387,7 +387,7 @@ namespace samurai
     void list_interval_to_refine_for_contiguous_boundary_cells(
         const int max_stencil_radius,
         const CellArray<dim, TInterval, max_size>& ca,
-        const LevelCellArray<dim, TInterval>& domain,
+        const CellArray<dim, TInterval, max_size>& domain,
         [[maybe_unused]] const auto& mpi_meshes,
         const std::array<bool, dim>& is_periodic,
         std::array<ArrayOfIntervalAndPoint<TInterval, TCoord>, CellArray<dim, TInterval, max_size>::max_size>& out,
@@ -456,7 +456,7 @@ namespace samurai
                             // empty and this reduces to the original single-mesh behaviour.
                             auto refine_from = [&](const auto& src, const auto* src_seed)
                             {
-                                auto boundary_expr = difference(src[level], translate(self(domain).on(level), -translation));
+                                auto boundary_expr = difference(src[level], translate(domain[level], -translation));
                                 // With a seed, keep only the new boundary cells at this level.
                                 LevelCellArray<dim, TInterval> boundaryCells = src_seed
                                                                                  ? LevelCellArray<dim, TInterval>(
@@ -500,7 +500,7 @@ namespace samurai
                             // `ca` and from every neighbour mesh, but refine only this rank's own level+1 cells.
                             auto refine_from = [&](const auto& src)
                             {
-                                auto boundaryCells = difference(src[level], translate(self(domain).on(level), -translation));
+                                auto boundaryCells = difference(src[level], translate(domain[level], -translation));
                                 for (int i = 1; i != max_stencil_radius; ++i)
                                 {
                                     auto refine_subset = translate(
@@ -531,7 +531,7 @@ namespace samurai
     void list_intervals_to_refine(const std::size_t grad_width,
                                   const int max_stencil_radius,
                                   const CellArray<dim, TInterval, max_size>& ca,
-                                  const LevelCellArray<dim, TInterval>& domain,
+                                  const CellArray<dim, TInterval, max_size>& domain,
                                   [[maybe_unused]] const std::vector<MPI_Subdomain<MeshType>>& mpi_neighbourhood,
                                   const std::array<bool, dim>& is_periodic,
                                   const std::array<int, dim>& nb_cells_finest_level,
@@ -602,9 +602,204 @@ namespace samurai
         } // end for
     }
 
+    // Single-pass graded closure (no MPI neighbour, no periodicity, no boundary
+    // contiguity - interior grading only). One top-down sweep, no fixed-point.
+    //
+    // F[l] = the region required at level >= l, as whole level-l cells, built from the
+    // finest level down:
+    //   F[max] = ca[max]
+    //   F[l]   = ( ca[l] UNION expand(F[l+1].on(l), grad_width) ) rounded up to whole
+    //            level-(l-1) parents
+    // The rounding enforces samurai's complete-tree invariant: a cell of level l exists
+    // iff its (l-1) parent is refined, which forces ALL that parent's children to level
+    // >= l. So a coarse cell touched by grading is refined IN FULL - never partially,
+    // which is what would leave a hole. A cell sits at exactly level l where it is
+    // required at l but not at l+1:
+    //   graded[l] = F[l] \ F[l+1].on(l)
+    template <std::size_t dim, class TInterval, size_t max_size>
+    void graded_closure_single_pass(CellArray<dim, TInterval, max_size>& ca,
+                                    const CellArray<dim, TInterval, max_size>& domain,
+                                    const std::array<bool, dim>& is_periodic,
+                                    const size_t grad_width)
+    {
+        using ca_type = CellArray<dim, TInterval, max_size>;
+        using lca_t   = typename ca_type::lca_type;
+
+        const size_t max_level = ca.max_level();
+        const size_t min_level = ca.min_level();
+        if (max_level <= min_level)
+        {
+            return; // a single level is always graded
+        }
+        const int w = static_cast<int>(grad_width);
+
+        const bool any_periodic = std::any_of(is_periodic.begin(), is_periodic.end(), [](bool b) { return b; });
+        std::array<int, dim> nb_cells_finest_level{};
+        if (any_periodic)
+        {
+            const auto& mn = domain[domain.max_level()].min_indices();
+            const auto& mx = domain[domain.max_level()].max_indices();
+            for (size_t d = 0; d != mx.size(); ++d)
+            {
+                nb_cells_finest_level[d] = mx[d] - mn[d];
+            }
+        }
+
+        // Graduation only ever refines EXISTING cells (the iterative version intersects
+        // with ca[coarse_level] at each step), so every F[l] must be clipped to the mesh
+        // coverage - otherwise the grading expansion would spill cells outside the
+        // mesh/domain. The mesh fills its domain, so the precomputed domain pyramid
+        // domain[l] IS that coverage at level l (cheap). When no domain is available
+        // (the standalone make_graduation(ca) overload), fall back to computing the
+        // coverage from ca itself.
+        const bool has_domain = !domain.empty();
+        lca_t coverage;
+        if (!has_domain)
+        {
+            bool first = true;
+            for (size_t l = min_level; l <= max_level; ++l)
+            {
+                if (ca[l].empty())
+                {
+                    continue;
+                }
+                lca_t projected(self(ca[l]).on(max_level));
+                coverage = first ? projected : lca_t(union_(coverage, projected).on(max_level));
+                first    = false;
+            }
+        }
+        const auto clip = [&](lca_t&& x, size_t l) -> lca_t
+        {
+            return has_domain ? lca_t(intersection(x, domain[l]).on(l)) : lca_t(intersection(x, self(coverage).on(l)).on(l));
+        };
+
+        std::array<lca_t, max_size> F;
+        F[max_level] = ca[max_level];
+        for (size_t l = max_level; l-- > min_level;)
+        {
+            // Grading buffer at level l: the finer requirement, expanded by grad_width.
+            lca_t expanded(nestedExpand(self(F[l + 1]).on(l), w));
+            // Periodicity: a finer cell near a periodic boundary must also force
+            // refinement near the opposite boundary. Add the wrapped copies of the
+            // buffer (translated by the domain size at level l).
+            if (any_periodic)
+            {
+                const lca_t base = expanded;
+                for (const auto& d : detail::get_periodic_directions(nb_cells_finest_level, int(domain.max_level()) - int(l), is_periodic))
+                {
+                    expanded = lca_t(union_(expanded, translate(base, d)).on(l));
+                }
+            }
+            lca_t req(union_(ca[l], expanded).on(l));
+            // Round up to whole (l-1) parents (complete-tree invariant) - except at
+            // min_level, which has no coarser parent in the mesh - then clip so nothing
+            // spills outside the domain.
+            F[l] = (l > min_level) ? clip(lca_t(self(req).on(l - 1).on(l)), l) : clip(std::move(req), l);
+        }
+
+        ca_type graded_ca;
+        const auto collect = [&](size_t l)
+        {
+            return [&, l](const auto& x_interval, const auto& yz)
+            {
+                graded_ca[l].add_interval_back(x_interval, yz);
+            };
+        };
+        self(F[max_level]).on(max_level)(collect(max_level));
+        for (size_t l = min_level; l < max_level; ++l)
+        {
+            difference(F[l], self(F[l + 1]).on(l)).on(l)(collect(l));
+        }
+        std::swap(ca, graded_ca);
+    }
+
+    // Apply a refinement list (produced by list_interval_to_refine_*): each flagged
+    // cell at level l is removed and replaced by its 2^dim children at level l+1.
+    // Returns whether `ca` actually changed. Shared by the fixed-point loop and the
+    // single-pass boundary-contiguity loop.
+    template <std::size_t dim, class TInterval, size_t max_size, class TCoord>
+    bool apply_refinement_list(CellArray<dim, TInterval, max_size>& ca,
+                               std::array<ArrayOfIntervalAndPoint<TInterval, TCoord>, max_size>& out)
+    {
+        using ca_type    = CellArray<dim, TInterval, max_size>;
+        using coord_type = typename ca_type::lca_type::coord_type;
+
+        const size_t max_level = ca.max_level();
+        const size_t min_level = ca.min_level();
+
+        ca_type ca_add_p;
+        ca_type ca_remove_p;
+        std::vector<TInterval> add_p_interval;
+        std::vector<coord_type> add_p_inner_stencil;
+        std::vector<size_t> add_p_idx;
+
+        bool any_change = false;
+        for (size_t level = min_level; level < max_level + 1; ++level)
+        {
+            out[level].remove_overlapping_intervals();
+            const size_t imax = out[level].size();
+            if (imax > 0)
+            {
+                any_change = true;
+            }
+            for (size_t i = 0; i != imax; ++i)
+            {
+                const auto& x_interval = out[level][i].first;
+                const auto& yz         = out[level][i].second;
+                ca_remove_p[level].add_interval_back(x_interval, yz);
+                if constexpr (dim == 1)
+                {
+                    ca_add_p[level + 1].add_interval_back(2 * x_interval, 2 * yz);
+                }
+                else
+                {
+                    nestedLoop<dim - 1, 0, dim - 2>(0,
+                                                    2,
+                                                    [&](const auto& inner_stencil)
+                                                    {
+                                                        add_p_interval.push_back(2 * x_interval);
+                                                        if constexpr (dim > 2)
+                                                        {
+                                                            add_p_inner_stencil.emplace_back(2 * yz + inner_stencil);
+                                                            add_p_idx.push_back(add_p_interval.size() - 1);
+                                                        }
+                                                    });
+                }
+                if (dim != 1 and (i + 1 == imax or yz[dim - 2] != out[level].get_coord(i + 1)[dim - 2]))
+                {
+                    add_list_of_interval_back(add_p_interval, coord_type(2 * yz), add_p_inner_stencil, add_p_idx, ca_add_p[level + 1]);
+                    add_p_interval.clear();
+                    add_p_inner_stencil.clear();
+                    add_p_idx.clear();
+                }
+            }
+        }
+
+        if (!any_change)
+        {
+            return false;
+        }
+
+        ca_type new_ca;
+        for (std::size_t level = std::min(ca.min_level(), ca_add_p.min_level());
+             level < std::max(ca.max_level(), ca_add_p.max_level()) + 1;
+             ++level)
+        {
+            auto set = difference(union_(ca[level], ca_add_p[level]), ca_remove_p[level]);
+            set(
+                [&](const auto& x_interval, const auto& yz)
+                {
+                    new_ca[level].add_interval_back(x_interval, yz);
+                });
+        }
+        const bool changed = (new_ca != ca);
+        std::swap(new_ca, ca);
+        return changed;
+    }
+
     template <std::size_t dim, class TInterval, class MeshType, size_t max_size>
     size_t make_graduation(CellArray<dim, TInterval, max_size>& ca,
-                           const LevelCellArray<dim, TInterval>& domain,
+                           const CellArray<dim, TInterval, max_size>& domain,
                            [[maybe_unused]] const std::vector<MPI_Subdomain<MeshType>>& mpi_neighbourhood,
                            const std::array<bool, dim>& is_periodic,
                            const size_t grad_width      = 1,
@@ -619,6 +814,44 @@ namespace samurai
         const size_t max_level = ca.max_level();
         const size_t min_level = ca.min_level();
 
+        // Single-pass fast path: no MPI neighbour (a cross-rank cascade needs the
+        // cells the neighbour creates, which only the fixed-point loop's per-iteration
+        // mesh exchange provides). The interior grading is done in one top-down sweep
+        // by graded_closure_single_pass (periodicity handled inside). When the scheme
+        // needs boundary contiguity (max_stencil_radius > 1), that pass ADDS cells that
+        // can create new interior violations, so we re-grade in a short outer loop -
+        // usually one or two turns, and skipped entirely for max_stencil_radius == 1.
+        if (mpi_neighbourhood.empty())
+        {
+            size_t nit   = 0;
+            bool changed = true;
+            while (changed)
+            {
+                ++nit;
+                graded_closure_single_pass(ca, domain, is_periodic, grad_width);
+                changed = false;
+                if (max_stencil_radius > 1 && !domain.empty())
+                {
+                    std::array<ArrayOfIntervalAndPoint<TInterval, coord_type>, max_size> boundary_out;
+                    for (auto& o : boundary_out)
+                    {
+                        o.clear();
+                    }
+                    const std::vector<ca_type> no_neighbour_meshes;
+                    list_interval_to_refine_for_contiguous_boundary_cells(max_stencil_radius, ca, domain, no_neighbour_meshes, is_periodic, boundary_out);
+                    changed = apply_refinement_list(ca, boundary_out);
+                }
+            }
+#ifdef SAMURAI_DEBUG_GRADUATION
+            if (!is_graduated(ca))
+            {
+                std::cerr << "[SAMURAI_DEBUG_GRADUATION] single-pass graduation produced a non-graduated mesh\n";
+                std::abort();
+            }
+#endif
+            return nit;
+        }
+
         std::array<int, dim> nb_cells_finest_level;
 
         if (std::any_of(is_periodic.begin(),
@@ -628,8 +861,8 @@ namespace samurai
                             return b;
                         }))
         {
-            const auto& min_indices = domain.min_indices();
-            const auto& max_indices = domain.max_indices();
+            const auto& min_indices = domain[domain.max_level()].min_indices();
+            const auto& max_indices = domain[domain.max_level()].max_indices();
 
             for (size_t d = 0; d != max_indices.size(); ++d)
             {
@@ -854,7 +1087,7 @@ namespace samurai
 
         std::vector<MPI_Subdomain<DummyMesh>> mpi_neighbourhood;
         std::array<bool, dim> is_periodic;
-        LevelCellArray<dim, TInterval> domain;
+        CellArray<dim, TInterval, max_size> domain;
 
         is_periodic.fill(false);
         return make_graduation(ca, domain, mpi_neighbourhood, is_periodic, grad_width);

--- a/include/samurai/algorithm/graduation.hpp
+++ b/include/samurai/algorithm/graduation.hpp
@@ -14,7 +14,6 @@
 namespace mpi = boost::mpi;
 #endif
 
-#include "../array_of_interval_and_point.hpp"
 #include "../cell_flag.hpp"
 #include "../concepts.hpp"
 #include "../mesh.hpp"
@@ -242,48 +241,11 @@ namespace samurai
         return true;
     }
 
-    template <mesh_like mesh_t>
-    auto update_subdomains_mpi([[maybe_unused]] const mesh_t& mesh, const auto& mpi_neighbourhood)
-    {
-        std::vector<mesh_t> mpi_meshes(mpi_neighbourhood.size());
-#ifdef SAMURAI_WITH_MPI
-        // No neighbour to exchange with (e.g. a sequential run or an emptied rank): serializing the whole
-        // mesh below would be pure waste, so bail out before touching the archive.
-        if (mpi_neighbourhood.empty())
-        {
-            return mpi_meshes;
-        }
-        mpi::communicator world;
-        std::vector<mpi::request> req;
-
-        boost::mpi::packed_oarchive::buffer_type buffer;
-        boost::mpi::packed_oarchive oa(world, buffer);
-        oa << mesh;
-
-        std::transform(mpi_neighbourhood.cbegin(),
-                       mpi_neighbourhood.cend(),
-                       std::back_inserter(req),
-                       [&](const auto& neighbour)
-                       {
-                           return world.isend(neighbour.rank, neighbour.rank, buffer);
-                       });
-
-        std::size_t index = 0;
-        for (auto& neighbour : mpi_neighbourhood)
-        {
-            world.recv(neighbour.rank, world.rank(), mpi_meshes[index++]);
-        }
-
-        mpi::wait_all(req.begin(), req.end());
-#endif // SAMURAI_WITH_MPI
-        return mpi_meshes;
-    }
-
     // Exchange a SINGLE level-array with the MPI neighbours (one message per neighbour),
     // returning their level-arrays. Used by the single-pass graduation to share, at each
     // level of its top-down sweep, only that level's cells - instead of serializing the
-    // whole multi-level mesh as update_subdomains_mpi does. The message tag is the level
-    // so the per-level exchanges (issued in lock-step across ranks) never cross.
+    // whole multi-level mesh. The message tag is the level so the per-level exchanges
+    // (issued in lock-step across ranks) never cross.
     template <size_t dim, typename TInterval>
     std::vector<LevelCellArray<dim, TInterval>> exchange_level_mpi([[maybe_unused]] const LevelCellArray<dim, TInterval>& lca,
                                                                    [[maybe_unused]] const auto& mpi_neighbourhood,
@@ -316,136 +278,88 @@ namespace samurai
         return neighbour_levels;
     }
 
-    template <size_t dim, typename TInterval, size_t max_size, typename TCoord>
-    void list_interval_to_refine_for_contiguous_boundary_cells(
-        const int max_stencil_radius,
-        const CellArray<dim, TInterval, max_size>& ca,
-        const CellArray<dim, TInterval, max_size>& domain,
-        [[maybe_unused]] const auto& mpi_meshes,
-        const std::array<bool, dim>& is_periodic,
-        std::array<ArrayOfIntervalAndPoint<TInterval, TCoord>, CellArray<dim, TInterval, max_size>::max_size>& out)
+    // Boundary-contiguity cells folded into the single-pass graduation (see
+    // graded_closure_single_pass). Both helpers are PURE functions of the graded level-l
+    // cells they are given: `fine_sources` is this rank's graded level-l cells followed by
+    // each neighbour's, so the result depends only on the UNION of the boundary cells and is
+    // therefore INDEPENDENT of how the MPI partition splits them between ranks (the caller
+    // then clips the result to the local coverage to keep only the cells it owns). This is
+    // the single-pass analogue of list_interval_to_refine_for_contiguous_boundary_cells.
+
+    // Case 1 (jump l -> l-1): the level-l cells sitting on each non-periodic physical face,
+    // thickened n_contig cells inward (fine-cell units) so a coarser cell's wide stencil
+    // never reaches past the domain. Returns the level-l cells to add.
+    template <size_t dim, typename TInterval>
+    LevelCellArray<dim, TInterval> boundary_case1_cells(size_t l,
+                                                        int n_contig,
+                                                        const CellArray<dim, TInterval>& domain,
+                                                        const std::array<bool, dim>& is_periodic,
+                                                        const std::vector<LevelCellArray<dim, TInterval>>& fine_sources)
     {
-        if (max_stencil_radius == 1)
+        using lca_t = LevelCellArray<dim, TInterval>;
+        lca_t extra;
+        bool have = false;
+        for (const auto& fine_l : fine_sources)
         {
-            return;
-        }
-
-        size_t max_level = ca.max_level();
-        size_t min_level = ca.min_level();
-
-        for (const auto& mpi_mesh : mpi_meshes)
-        {
-            max_level = std::max(max_level, mpi_mesh.max_level());
-            min_level = std::min(min_level, mpi_mesh.min_level());
-        }
-
-        // An empty (sub)mesh with no non-empty neighbour -- e.g. a rank emptied by
-        // load balancing -- has no boundary cells to refine. Its min_level is
-        // max_size + 1 and max_level is 0, so min_level > max_level: bail out
-        // before the descending level loops below underflow size_t. Local set
-        // algebra only here (no collective), so an early return cannot deadlock.
-        if (min_level > max_level)
-        {
-            return;
-        }
-
-        // We want to avoid a flux being computed with ghosts outside of the domain if the cell doesn't touch the boundary,
-        // because we only want to apply the B.C. on the cells that touch the boundary.
-        // For details and figures, see https://github.com/hpc-maths/samurai/pull/320
-
-        for_each_cartesian_direction<dim>(
-            [&](const auto direction_idx, const auto& translation)
-            {
-                if (not is_periodic[direction_idx])
+            for_each_cartesian_direction<dim>(
+                [&](const auto dir, const auto& t)
                 {
-                    // 1. Jump level --> level-1
-                    // Case where the boundary is at level L and the jump is going down to L-1:
-                    //     We want to have enough contiguous boundary cells to ensure that the stencil at the lower level
-                    //     won't go outside the domain.
-                    //     To ensure max_stencil_radius at L-1, we need 2*max_stencil_radius at level L.
-                    //     However, since we project the B.C. in the first outside ghost at level L-1, we can reduce the number of
-                    //     contiguous cells by 1 at level L-1. This makes, at level L, 2*(max_stencil_radius - 2) contiguous cells.
-                    //     (One cell is a real cell, the other is a ghost cell outside of the domain, which makes max_stencil_radius - 2
-                    //     ghosts cells inside the domain).
-
-                    int n_contiguous_boundary_cells = std::max(max_stencil_radius, 2 * (max_stencil_radius - 2));
-
-                    if (n_contiguous_boundary_cells > 1)
+                    if (is_periodic[dir])
                     {
-                        for (size_t level = max_level; level != min_level; --level)
-                        {
-                            // The boundary cells that drive the inward refinement must be seen from EVERY mesh (this rank
-                            // and all its neighbours), otherwise the set of boundary cells - and hence the refinement -
-                            // depends on the MPI partition: a boundary cell owned by a neighbour would be invisible here.
-                            // We therefore refine ONLY this rank's own level-1 cells (out drives the local `ca`), but from
-                            // boundary cells taken from `ca` and from each neighbour mesh. In sequential runs mpi_meshes is
-                            // empty and this reduces to the original single-mesh behaviour.
-                            auto refine_from = [&](const auto& src)
-                            {
-                                auto boundary_expr = difference(src[level], translate(domain[level], -translation));
-                                LevelCellArray<dim, TInterval> boundaryCells(boundary_expr.on(level));
-                                for (int i = 2; i <= n_contiguous_boundary_cells; i += 2)
-                                {
-                                    // Here, the set algebra doesn't work, so we put the translation in a LevelCellArray before
-                                    // computing the intersection.
-                                    LevelCellArray<dim, TInterval> translated_boundary(translate(boundaryCells, -i * translation));
-                                    auto refine_subset = intersection(translated_boundary, ca[level - 1]).on(level - 1);
-                                    refine_subset(
-                                        [&](const auto& x_interval, const auto& yz)
-                                        {
-                                            out[level - 1].push_back(x_interval, yz);
-                                        });
-                                }
-                            };
-                            refine_from(ca);
-#ifdef SAMURAI_WITH_MPI
-                            for (const auto& mpi_mesh : mpi_meshes)
-                            {
-                                refine_from(mpi_mesh);
-                            }
-#endif
-                        }
+                        return;
                     }
-
-                    // 2. Jump level --> level+1
-                    // Case where the boundary is at level L and jump is going up:
-                    //    If the number of boundary contiguous cells is >= ceil(max_stencil_radius/2), then there is nothing to do,
-                    //    since the half stencil at L+1 will not go out of the domain. Here, we just test if max_stencil_radius > 2 by
-                    //    simplicity, but at some point it would be nice to implement the real test. Otherwise, ensuring
-                    //    max_stencil_radius contiguous cells at level L+1 is enough.
-                    if (max_stencil_radius > 2)
+                    const lca_t boundary_cells(difference(fine_l, translate(domain[l], -t)).on(l));
+                    for (int i = 2; i <= n_contig; i += 2)
                     {
-                        for (size_t level = max_level - 1; level != min_level - 1; --level)
-                        {
-                            // Same partition-independence concern as the level-1 case above: take the boundary cells from
-                            // `ca` and from every neighbour mesh, but refine only this rank's own level+1 cells.
-                            auto refine_from = [&](const auto& src)
-                            {
-                                auto boundaryCells = difference(src[level], translate(domain[level], -translation));
-                                for (int i = 1; i != max_stencil_radius; ++i)
-                                {
-                                    auto refine_subset = translate(
-                                                             intersection(translate(boundaryCells, -i * translation), ca[level + 1]).on(level),
-                                                             i * translation)
-                                                             .on(level);
-                                    refine_subset(
-                                        [&](const auto& x_interval, const auto& yz)
-                                        {
-                                            out[level].push_back(x_interval, yz);
-                                        });
-                                }
-                            };
-                            refine_from(ca);
-#ifdef SAMURAI_WITH_MPI
-                            for (const auto& mpi_mesh : mpi_meshes)
-                            {
-                                refine_from(mpi_mesh);
-                            }
-#endif
-                        }
+                        lca_t inside(intersection(translate(boundary_cells, -i * t), domain[l]).on(l));
+                        extra = have ? lca_t(union_(extra, inside).on(l)) : std::move(inside);
+                        have  = true;
                     }
-                }
-            });
+                });
+        }
+        return extra;
+    }
+
+    // Case 2 (jump l-1 -> l, max_stencil_radius > 2): a coarse (l-1) face cell with a fine
+    // cell within (radius-1) COARSE cells inward is refined to level l, pulling the fine
+    // level out to the physical boundary. Expressed at l-1 (coarse domain face from the
+    // pyramid + fine cells projected down) because the distance unit is the coarse cell.
+    // Returns the level-l cells to add.
+    template <size_t dim, typename TInterval>
+    LevelCellArray<dim, TInterval> boundary_case2_cells(size_t l,
+                                                        int max_stencil_radius,
+                                                        const CellArray<dim, TInterval>& domain,
+                                                        const std::array<bool, dim>& is_periodic,
+                                                        const std::vector<LevelCellArray<dim, TInterval>>& fine_sources)
+    {
+        using lca_t = LevelCellArray<dim, TInterval>;
+        lca_t extra;
+        bool have = false;
+        if (max_stencil_radius <= 2 || l == 0)
+        {
+            return extra;
+        }
+        const size_t lc = l - 1;
+        for (const auto& fine_l : fine_sources)
+        {
+            const lca_t fine_on_c(self(fine_l).on(lc));
+            for_each_cartesian_direction<dim>(
+                [&](const auto dir, const auto& t)
+                {
+                    if (is_periodic[dir])
+                    {
+                        return;
+                    }
+                    const lca_t face_coarse(difference(domain[lc], translate(domain[lc], -t)).on(lc));
+                    for (int i = 1; i < max_stencil_radius; ++i)
+                    {
+                        lca_t ref(self(lca_t(intersection(face_coarse, translate(fine_on_c, i * t)).on(lc))).on(l));
+                        extra = have ? lca_t(union_(extra, ref).on(l)) : std::move(ref);
+                        have  = true;
+                    }
+                });
+        }
+        return extra;
     }
 
     // if add the intervals in add_m_interval
@@ -535,12 +449,17 @@ namespace samurai
     // that level's F is exchanged with the neighbours (exchange_level_mpi) - so a cascade
     // crossing a partition boundary is captured, without the whole-mesh exchange the
     // fixed-point loop does per iteration.
-    template <std::size_t dim, class TInterval, size_t max_size, class MeshType>
+    // FoldBoundary is a COMPILE-TIME switch: when false the whole boundary-contiguity
+    // machinery is `if constexpr`-eliminated, so the interior-only sweep (the common
+    // max_stencil_radius == 1 case) pays exactly zero for it. make_graduation picks the
+    // <false> instantiation for radius <= 1, so that case is byte-for-byte the interior sweep.
+    template <std::size_t dim, class TInterval, size_t max_size, class MeshType, bool FoldBoundary = false>
     void graded_closure_single_pass(CellArray<dim, TInterval, max_size>& ca,
                                     const CellArray<dim, TInterval, max_size>& domain,
                                     const std::array<bool, dim>& is_periodic,
                                     const size_t grad_width,
-                                    [[maybe_unused]] const std::vector<MPI_Subdomain<MeshType>>& mpi_neighbourhood)
+                                    [[maybe_unused]] const std::vector<MPI_Subdomain<MeshType>>& mpi_neighbourhood,
+                                    [[maybe_unused]] const int max_stencil_radius = 1)
     {
         using ca_type = CellArray<dim, TInterval, max_size>;
         using lca_t   = typename ca_type::lca_type;
@@ -618,8 +537,69 @@ namespace samurai
         };
 
         std::array<lca_t, max_size> F;
+
+        // Fold the boundary contiguity into the sweep at level l. The ENTIRE body is behind
+        // `if constexpr (FoldBoundary)`, so for the interior-only instantiation (radius <= 1)
+        // this lambda is empty and its per-level calls cost nothing - the common case pays
+        // zero for the boundary machinery.
+        //
+        // When folding: case 2 runs FIRST (it can add boundary cells), then case 1 runs on
+        // the UPDATED level-l cells, so it thickens the run case 2 just created - the
+        // boundary->boundary feedback the looped algorithm needs a whole re-grade turn for.
+        // Case 1 only ever adds cells inward (never new face cells), so a single case2 ->
+        // case1 order converges with no within-level iteration. The driving level-l cells are
+        // taken from THIS rank AND every neighbour (per-level graded-cell exchange, tags
+        // disjoint from the F[l] exchange and from each other), so the result is independent
+        // of the MPI partition.
+        const auto extend_boundary = [&]([[maybe_unused]] size_t l)
+        {
+            if constexpr (FoldBoundary)
+            {
+                const int n_contig = std::max(max_stencil_radius, 2 * (max_stencil_radius - 2));
+                if (max_stencil_radius <= 1 || domain.empty() || n_contig <= 1)
+                {
+                    return;
+                }
+                // The actual level-l cells (F[l] also carries everything required finer).
+                const auto graded_level = [&](size_t ll) -> lca_t
+                {
+                    return (ll < max_level) ? lca_t(difference(F[ll], self(F[ll + 1]).on(ll)).on(ll)) : F[ll];
+                };
+                const auto exchange_graded_level = [&](const lca_t& graded_l, size_t ll, int phase) -> std::vector<lca_t>
+                {
+                    if (!has_neighbour)
+                    {
+                        return {};
+                    }
+                    return exchange_level_mpi(graded_l, mpi_neighbourhood, static_cast<int>(max_size * (1 + phase) + ll));
+                };
+                const auto grow_F = [&](size_t ll, lca_t&& piece)
+                {
+                    lca_t req(union_(F[ll], piece).on(ll));
+                    F[ll] = (ll > min_level) ? clip(lca_t(self(req).on(ll - 1).on(ll)), ll) : clip(std::move(req), ll);
+                };
+                const auto sources = [&](const lca_t& my_fine, const std::vector<lca_t>& nbr_fine)
+                {
+                    std::vector<lca_t> s;
+                    s.reserve(1 + nbr_fine.size());
+                    s.push_back(my_fine);
+                    s.insert(s.end(), nbr_fine.begin(), nbr_fine.end());
+                    return s;
+                };
+
+                lca_t g = graded_level(l);
+                if (max_stencil_radius > 2 && l > 0)
+                {
+                    grow_F(l, boundary_case2_cells(l, max_stencil_radius, domain, is_periodic, sources(g, exchange_graded_level(g, l, 0))));
+                    g = graded_level(l); // refresh: case 1 must see the cells case 2 just added
+                }
+                grow_F(l, boundary_case1_cells(l, n_contig, domain, is_periodic, sources(g, exchange_graded_level(g, l, 1))));
+            }
+        };
+
         std::array<std::vector<lca_t>, max_size> neighbour_F;
         F[max_level] = ca[max_level];
+        extend_boundary(max_level);
         if (has_neighbour)
         {
             neighbour_F[max_level] = exchange_level_mpi(F[max_level], mpi_neighbourhood, static_cast<int>(max_level));
@@ -655,6 +635,7 @@ namespace samurai
             lca_t req(union_(ca[l], expanded).on(l));
             // Round up to whole (l-1) parents (complete-tree invariant) then clip.
             F[l] = (l > min_level) ? clip(lca_t(self(req).on(l - 1).on(l)), l) : clip(std::move(req), l);
+            extend_boundary(l);
             if (has_neighbour)
             {
                 neighbour_F[l] = exchange_level_mpi(F[l], mpi_neighbourhood, static_cast<int>(l));
@@ -677,167 +658,46 @@ namespace samurai
         std::swap(ca, graded_ca);
     }
 
-    // Apply a refinement list (produced by list_interval_to_refine_*): each flagged
-    // cell at level l is removed and replaced by its 2^dim children at level l+1.
-    // Returns whether `ca` actually changed. Shared by the fixed-point loop and the
-    // single-pass boundary-contiguity loop.
-    template <std::size_t dim, class TInterval, size_t max_size, class TCoord>
-    bool apply_refinement_list(CellArray<dim, TInterval, max_size>& ca, std::array<ArrayOfIntervalAndPoint<TInterval, TCoord>, max_size>& out)
-    {
-        using ca_type    = CellArray<dim, TInterval, max_size>;
-        using coord_type = typename ca_type::lca_type::coord_type;
-
-        const size_t max_level = ca.max_level();
-        const size_t min_level = ca.min_level();
-
-        ca_type ca_add_p;
-        ca_type ca_remove_p;
-        std::vector<TInterval> add_p_interval;
-        std::vector<coord_type> add_p_inner_stencil;
-        std::vector<size_t> add_p_idx;
-
-        bool any_change = false;
-        for (size_t level = min_level; level < max_level + 1; ++level)
-        {
-            out[level].remove_overlapping_intervals();
-            const size_t imax = out[level].size();
-            if (imax > 0)
-            {
-                any_change = true;
-            }
-            for (size_t i = 0; i != imax; ++i)
-            {
-                const auto& x_interval = out[level][i].first;
-                const auto& yz         = out[level][i].second;
-                ca_remove_p[level].add_interval_back(x_interval, yz);
-                if constexpr (dim == 1)
-                {
-                    ca_add_p[level + 1].add_interval_back(2 * x_interval, 2 * yz);
-                }
-                else
-                {
-                    nestedLoop<dim - 1, 0, dim - 2>(0,
-                                                    2,
-                                                    [&](const auto& inner_stencil)
-                                                    {
-                                                        add_p_interval.push_back(2 * x_interval);
-                                                        if constexpr (dim > 2)
-                                                        {
-                                                            add_p_inner_stencil.emplace_back(2 * yz + inner_stencil);
-                                                            add_p_idx.push_back(add_p_interval.size() - 1);
-                                                        }
-                                                    });
-                }
-                if (dim != 1 and (i + 1 == imax or yz[dim - 2] != out[level].get_coord(i + 1)[dim - 2]))
-                {
-                    add_list_of_interval_back(add_p_interval, coord_type(2 * yz), add_p_inner_stencil, add_p_idx, ca_add_p[level + 1]);
-                    add_p_interval.clear();
-                    add_p_inner_stencil.clear();
-                    add_p_idx.clear();
-                }
-            }
-        }
-
-        if (!any_change)
-        {
-            return false;
-        }
-
-        ca_type new_ca;
-        for (std::size_t level = std::min(ca.min_level(), ca_add_p.min_level()); level < std::max(ca.max_level(), ca_add_p.max_level()) + 1;
-             ++level)
-        {
-            auto set = difference(union_(ca[level], ca_add_p[level]), ca_remove_p[level]);
-            set(
-                [&](const auto& x_interval, const auto& yz)
-                {
-                    new_ca[level].add_interval_back(x_interval, yz);
-                });
-        }
-        const bool changed = (new_ca != ca);
-        std::swap(new_ca, ca);
-        return changed;
-    }
-
+    // Graduate `ca` in a SINGLE top-down sweep: interior 2:1 grading AND boundary contiguity
+    // are folded into one pass (no outer fixed-point loop). At each level the boundary run is
+    // extended BEFORE the next coarser level is graded, so the boundary->interior feedback is
+    // captured within the same pass (see graded_closure_single_pass / extend_boundary). Both
+    // boundary cases are handled - case 1 (jump l -> l-1, thicken the run inward) and case 2
+    // (max_stencil_radius > 2, jump l-1 -> l, pull the fine level out to the boundary) - and
+    // under MPI the boundary cells are gathered from the neighbours so the graded mesh is
+    // independent of the partition. Returns 1 (the sweep is not iterative).
+    //
+    // Radius <= 1 (no boundary contiguity to enforce) dispatches to the <FoldBoundary=false>
+    // instantiation: the plain interior sweep, with none of the boundary machinery compiled in.
     template <std::size_t dim, class TInterval, class MeshType, size_t max_size>
     size_t make_graduation(CellArray<dim, TInterval, max_size>& ca,
                            const CellArray<dim, TInterval, max_size>& domain,
-                           [[maybe_unused]] const std::vector<MPI_Subdomain<MeshType>>& mpi_neighbourhood,
+                           const std::vector<MPI_Subdomain<MeshType>>& mpi_neighbourhood,
                            const std::array<bool, dim>& is_periodic,
                            const size_t grad_width      = 1,
                            const int max_stencil_radius = 1 // half of width of the numerical scheme's stencil.
     )
     {
         ScopedTimer timer("make_graduation");
-
-        using ca_type    = CellArray<dim, TInterval, max_size>;
-        using coord_type = typename ca_type::lca_type::coord_type;
-
-        // Single-pass interior grading (one top-down sweep). With MPI neighbours the
-        // sweep is synchronised and exchanges only the current level's cells at each
-        // step (see graded_closure_single_pass), so it replaces the fixed-point loop's
-        // whole-mesh exchanges. When there is no boundary contiguity to enforce
-        // (max_stencil_radius == 1) a single sweep is the whole graduation.
-        if (max_stencil_radius == 1)
+        if (max_stencil_radius <= 1)
         {
-            graded_closure_single_pass(ca, domain, is_periodic, grad_width, mpi_neighbourhood);
-#ifdef SAMURAI_DEBUG_GRADUATION
-            // is_graduated is a purely local check; under MPI the boundary grading is
-            // completed by the neighbours, so only assert in the sequential case.
-            if (mpi_neighbourhood.empty() && !is_graduated(ca))
-            {
-                std::cerr << "[SAMURAI_DEBUG_GRADUATION] single-pass graduation produced a non-graduated mesh\n";
-                std::abort();
-            }
-#endif
-            return 1;
+            graded_closure_single_pass<dim, TInterval, max_size, MeshType, false>(ca,
+                                                                                  domain,
+                                                                                  is_periodic,
+                                                                                  grad_width,
+                                                                                  mpi_neighbourhood,
+                                                                                  max_stencil_radius);
         }
-
-        // Boundary contiguity (max_stencil_radius > 1): the interior single-pass grades
-        // in one sweep, but the boundary pass ADDS cells that can create new interior
-        // violations, so re-grade in a short outer loop (usually one or two turns). This
-        // handles both the sequential and the MPI case - the neighbour cells the boundary
-        // pass needs are fetched with update_subdomains_mpi (a no-op without neighbours),
-        // and the outer-loop termination is agreed with one collective per turn.
+        else
         {
-#ifdef SAMURAI_WITH_MPI
-            mpi::communicator world;
-#endif
-            size_t nit   = 0;
-            bool changed = true;
-            while (
-#ifdef SAMURAI_WITH_MPI
-                mpi::all_reduce(world, changed, std::logical_or())
-#else
-                changed
-#endif
-            )
-            {
-                ++nit;
-                graded_closure_single_pass(ca, domain, is_periodic, grad_width, mpi_neighbourhood);
-                changed = false;
-                if (!domain.empty())
-                {
-                    const auto mpi_meshes = update_subdomains_mpi(ca, mpi_neighbourhood);
-                    std::array<ArrayOfIntervalAndPoint<TInterval, coord_type>, max_size> boundary_out;
-                    for (auto& o : boundary_out)
-                    {
-                        o.clear();
-                    }
-                    list_interval_to_refine_for_contiguous_boundary_cells(max_stencil_radius, ca, domain, mpi_meshes, is_periodic, boundary_out);
-                    changed = apply_refinement_list(ca, boundary_out);
-                }
-            }
-#ifdef SAMURAI_DEBUG_GRADUATION
-            // is_graduated is a purely local check; only assert without neighbours.
-            if (mpi_neighbourhood.empty() && !is_graduated(ca))
-            {
-                std::cerr << "[SAMURAI_DEBUG_GRADUATION] single-pass graduation produced a non-graduated mesh\n";
-                std::abort();
-            }
-#endif
-            return nit;
+            graded_closure_single_pass<dim, TInterval, max_size, MeshType, true>(ca,
+                                                                                 domain,
+                                                                                 is_periodic,
+                                                                                 grad_width,
+                                                                                 mpi_neighbourhood,
+                                                                                 max_stencil_radius);
         }
+        return 1;
     }
 
     template <std::size_t dim, class TInterval, size_t max_size>

--- a/include/samurai/algorithm/graduation.hpp
+++ b/include/samurai/algorithm/graduation.hpp
@@ -587,13 +587,35 @@ namespace samurai
                     return s;
                 };
 
-                lca_t g = graded_level(l);
-                if (max_stencil_radius > 2 && l > 0)
+                // Corner coupling: extending the run along one boundary face can create
+                // cells that sit on a PERPENDICULAR face, which then need their own boundary
+                // extension. Repeat case2+case1 until F[l] stops growing (bounded, local to
+                // the corner region). Under MPI the continuation is agreed with one small
+                // all_reduce per turn so every rank runs the same number of exchange turns
+                // (a data-dependent local count would desynchronise the collective).
+#ifdef SAMURAI_WITH_MPI
+                mpi::communicator world;
+#endif
+                bool changed = true;
+                while (
+#ifdef SAMURAI_WITH_MPI
+                    world.size() > 1 ? mpi::all_reduce(world, changed, std::logical_or()) : changed
+#else
+                    changed
+#endif
+                )
                 {
-                    grow_F(l, boundary_case2_cells(l, max_stencil_radius, domain, is_periodic, sources(g, exchange_graded_level(g, l, 0))));
-                    g = graded_level(l); // refresh: case 1 must see the cells case 2 just added
+                    const lca_t before = F[l];
+                    lca_t g            = graded_level(l);
+                    if (max_stencil_radius > 2 && l > 0)
+                    {
+                        grow_F(l,
+                               boundary_case2_cells(l, max_stencil_radius, domain, is_periodic, sources(g, exchange_graded_level(g, l, 0))));
+                        g = graded_level(l); // refresh: case 1 must see the cells case 2 just added
+                    }
+                    grow_F(l, boundary_case1_cells(l, n_contig, domain, is_periodic, sources(g, exchange_graded_level(g, l, 1))));
+                    changed = !(F[l] == before);
                 }
-                grow_F(l, boundary_case1_cells(l, n_contig, domain, is_periodic, sources(g, exchange_graded_level(g, l, 1))));
             }
         };
 

--- a/include/samurai/algorithm/graduation.hpp
+++ b/include/samurai/algorithm/graduation.hpp
@@ -242,110 +242,6 @@ namespace samurai
         return true;
     }
 
-    template <size_t dim, typename TInterval, size_t max_size, typename TCoord>
-    void list_interval_to_refine_for_graduation(
-        const size_t grad_width,
-        const CellArray<dim, TInterval, max_size>& ca,
-        const CellArray<dim, TInterval, max_size>& domain,
-        [[maybe_unused]] const auto& mpi_meshes,
-        const std::array<bool, dim>& is_periodic,
-        const std::array<int, dim>& nb_cells_finest_level,
-        std::array<ArrayOfIntervalAndPoint<TInterval, TCoord>, CellArray<dim, TInterval, max_size>::max_size>& out,
-        // Incremental seed: when non-null, the LOCAL pass only cascades from these
-        // cells (the fine cells added by the previous graduation iteration) instead
-        // of from every fine cell. Exact because a graduation iteration only adds
-        // fine cells, so a new violation can only involve one of them as its fine
-        // source. MPI neighbour passes always run full (seed is local).
-        const CellArray<dim, TInterval, max_size>* seed = nullptr)
-    {
-        const int max_width = int(grad_width);
-
-        for (size_t i = 0; i != max_size; ++i)
-        {
-            out[i].clear();
-        }
-
-        const auto list_overlapping_intervals = [&](const auto& lhs_ca, const auto& rhs_ca)
-        {
-            // The fine cells that force a refinement come from lhs_ca, the
-            // coarse cells to refine from rhs_ca: the level bounds must be
-            // taken accordingly. In particular the coarse bound must come from
-            // rhs_ca: in the MPI pass (lhs = neighbour, rhs = local), a
-            // neighbour owning only fine cells used to bound the coarse loop
-            // above the local coarse levels, so the violation was never seen
-            // (decomposition-dependent graduation with non-stripe partitions).
-            const size_t max_level      = lhs_ca.max_level() + 1;
-            const size_t min_level      = rhs_ca.min_level();
-            const size_t min_fine_level = (min_level + 2) - 1; // fine_level =  max_level, max_level-1, ..., min_level+2. Thus fine_level !=
-                                                               // min_level+2-1
-
-            using lca_t = LevelCellArray<dim, TInterval>;
-
-            // The fine cells at `fine_level`, expanded by 2*max_width, must force the refinement of every coarser
-            // cell they overlap, from `fine_level - 2` down to `min_level`. Instead of re-expanding and re-projecting
-            // the (potentially huge) fine array once per coarse level, we materialize the expanded set projected on
-            // `fine_level - 2` a single time, then coarsen it by one level at each step. Coarsening is
-            // level-composable (`X.on(l-1) == X.on(l).on(l-1)`), so the result is identical while the fine array is
-            // walked only once instead of O(fine_level - min_level) times.
-            auto cascade_refine = [&](const auto& fine_set, size_t fine_level)
-            {
-                lca_t proj(nestedExpand(fine_set, 2 * max_width).on(fine_level - 2));
-                for (size_t coarse_level = fine_level - 2;; --coarse_level)
-                {
-                    if (!proj.empty())
-                    {
-                        auto refine_subset = intersection(proj, rhs_ca[coarse_level]);
-                        refine_subset(
-                            [&](const auto& x_interval, const auto& yz)
-                            {
-                                out[coarse_level].push_back(x_interval, yz);
-                            });
-                    }
-                    if (coarse_level == min_level || proj.empty())
-                    {
-                        break;
-                    }
-                    proj = lca_t(self(proj).on(coarse_level - 1));
-                }
-            };
-
-            for (size_t fine_level = max_level; fine_level > min_fine_level; --fine_level)
-            {
-                auto& fine_lca = lhs_ca[fine_level];
-                if (fine_lca.empty())
-                {
-                    continue;
-                }
-                const int delta_l = int(domain.max_level() - fine_level);
-                auto directions   = detail::get_periodic_directions(nb_cells_finest_level, delta_l, is_periodic);
-                cascade_refine(fine_lca, fine_level);
-                for (const auto& d : directions)
-                {
-                    cascade_refine(translate(fine_lca, d), fine_level);
-                }
-            }
-        };
-
-        // Local pass. With a seed, cascade only from the seeded fine cells (a subset
-        // of `ca` added by the previous graduation iteration) against `ca`'s coarse
-        // targets: exact, because a graduation iteration only adds fine cells.
-        if (seed)
-        {
-            list_overlapping_intervals(*seed, ca);
-        }
-        else
-        {
-            list_overlapping_intervals(ca, ca);
-        }
-#ifdef SAMURAI_WITH_MPI
-        // Neighbour passes always run full: the seed only covers local additions.
-        for (const auto& mpi_mesh : mpi_meshes)
-        {
-            list_overlapping_intervals(mpi_mesh, ca);
-        }
-#endif // SAMURAI_WITH_MPI
-    }
-
     template <mesh_like mesh_t>
     auto update_subdomains_mpi([[maybe_unused]] const mesh_t& mesh, const auto& mpi_neighbourhood)
     {
@@ -383,6 +279,43 @@ namespace samurai
         return mpi_meshes;
     }
 
+    // Exchange a SINGLE level-array with the MPI neighbours (one message per neighbour),
+    // returning their level-arrays. Used by the single-pass graduation to share, at each
+    // level of its top-down sweep, only that level's cells - instead of serializing the
+    // whole multi-level mesh as update_subdomains_mpi does. The message tag is the level
+    // so the per-level exchanges (issued in lock-step across ranks) never cross.
+    template <size_t dim, typename TInterval>
+    std::vector<LevelCellArray<dim, TInterval>> exchange_level_mpi([[maybe_unused]] const LevelCellArray<dim, TInterval>& lca,
+                                                                   [[maybe_unused]] const auto& mpi_neighbourhood,
+                                                                   [[maybe_unused]] const int tag)
+    {
+        std::vector<LevelCellArray<dim, TInterval>> neighbour_levels(mpi_neighbourhood.size());
+#ifdef SAMURAI_WITH_MPI
+        if (mpi_neighbourhood.empty())
+        {
+            return neighbour_levels;
+        }
+        mpi::communicator world;
+        std::vector<mpi::request> req;
+
+        boost::mpi::packed_oarchive::buffer_type buffer;
+        boost::mpi::packed_oarchive oa(world, buffer);
+        oa << lca;
+
+        for (const auto& neighbour : mpi_neighbourhood)
+        {
+            req.push_back(world.isend(neighbour.rank, tag, buffer));
+        }
+        std::size_t index = 0;
+        for (const auto& neighbour : mpi_neighbourhood)
+        {
+            world.recv(neighbour.rank, tag, neighbour_levels[index++]);
+        }
+        mpi::wait_all(req.begin(), req.end());
+#endif // SAMURAI_WITH_MPI
+        return neighbour_levels;
+    }
+
     template <size_t dim, typename TInterval, size_t max_size, typename TCoord>
     void list_interval_to_refine_for_contiguous_boundary_cells(
         const int max_stencil_radius,
@@ -390,14 +323,7 @@ namespace samurai
         const CellArray<dim, TInterval, max_size>& domain,
         [[maybe_unused]] const auto& mpi_meshes,
         const std::array<bool, dim>& is_periodic,
-        std::array<ArrayOfIntervalAndPoint<TInterval, TCoord>, CellArray<dim, TInterval, max_size>::max_size>& out,
-        // Incremental seed: when non-null, the LOCAL level->level-1 pass only considers
-        // boundary cells that are among the fine cells added by the previous graduation
-        // iteration. Exact for that pass because a graduation iteration only adds fine
-        // cells (so new boundary sources at `level` are a subset of the seed) and adding
-        // fine cells inward can only increase contiguity, never create a new violation
-        // for an existing boundary cell. MPI neighbour passes always run full.
-        const CellArray<dim, TInterval, max_size>* seed = nullptr)
+        std::array<ArrayOfIntervalAndPoint<TInterval, TCoord>, CellArray<dim, TInterval, max_size>::max_size>& out)
     {
         if (max_stencil_radius == 1)
         {
@@ -454,14 +380,10 @@ namespace samurai
                             // We therefore refine ONLY this rank's own level-1 cells (out drives the local `ca`), but from
                             // boundary cells taken from `ca` and from each neighbour mesh. In sequential runs mpi_meshes is
                             // empty and this reduces to the original single-mesh behaviour.
-                            auto refine_from = [&](const auto& src, const auto* src_seed)
+                            auto refine_from = [&](const auto& src)
                             {
                                 auto boundary_expr = difference(src[level], translate(domain[level], -translation));
-                                // With a seed, keep only the new boundary cells at this level.
-                                LevelCellArray<dim, TInterval> boundaryCells = src_seed
-                                                                                 ? LevelCellArray<dim, TInterval>(
-                                                                                       intersection(boundary_expr, (*src_seed)[level]).on(level))
-                                                                                 : LevelCellArray<dim, TInterval>(boundary_expr.on(level));
+                                LevelCellArray<dim, TInterval> boundaryCells(boundary_expr.on(level));
                                 for (int i = 2; i <= n_contiguous_boundary_cells; i += 2)
                                 {
                                     // Here, the set algebra doesn't work, so we put the translation in a LevelCellArray before
@@ -475,12 +397,11 @@ namespace samurai
                                         });
                                 }
                             };
-                            refine_from(ca, seed);
+                            refine_from(ca);
 #ifdef SAMURAI_WITH_MPI
                             for (const auto& mpi_mesh : mpi_meshes)
                             {
-                                // Neighbour passes always run full: the seed only covers local additions.
-                                refine_from(mpi_mesh, decltype(seed){nullptr});
+                                refine_from(mpi_mesh);
                             }
 #endif
                         }
@@ -525,26 +446,6 @@ namespace samurai
                     }
                 }
             });
-    }
-
-    template <size_t dim, typename TInterval, typename MeshType, size_t max_size, typename TCoord>
-    void list_intervals_to_refine(const std::size_t grad_width,
-                                  const int max_stencil_radius,
-                                  const CellArray<dim, TInterval, max_size>& ca,
-                                  const CellArray<dim, TInterval, max_size>& domain,
-                                  [[maybe_unused]] const std::vector<MPI_Subdomain<MeshType>>& mpi_neighbourhood,
-                                  const std::array<bool, dim>& is_periodic,
-                                  const std::array<int, dim>& nb_cells_finest_level,
-                                  std::array<ArrayOfIntervalAndPoint<TInterval, TCoord>, CellArray<dim, TInterval, max_size>::max_size>& out,
-                                  // Incremental seed forwarded to the interior graduation pass (see there).
-                                  const CellArray<dim, TInterval, max_size>* seed = nullptr)
-    {
-        auto mpi_meshes = update_subdomains_mpi(ca, mpi_neighbourhood);
-        list_interval_to_refine_for_graduation(grad_width, ca, domain, mpi_meshes, is_periodic, nb_cells_finest_level, out, seed);
-        if (!domain.empty())
-        {
-            list_interval_to_refine_for_contiguous_boundary_cells(max_stencil_radius, ca, domain, mpi_meshes, is_periodic, out, seed);
-        }
     }
 
     // if add the intervals in add_m_interval
@@ -616,24 +517,67 @@ namespace samurai
     // which is what would leave a hole. A cell sits at exactly level l where it is
     // required at l but not at l+1:
     //   graded[l] = F[l] \ F[l+1].on(l)
-    template <std::size_t dim, class TInterval, size_t max_size>
+    // Single-pass graded closure - interior grading only, one top-down sweep, no
+    // fixed-point.
+    //
+    // F[l] = the region required at level >= l, as whole level-l cells, built from the
+    // finest level down:
+    //   F[max] = ca[max]
+    //   F[l]   = ( ca[l] UNION expand( (F[l+1] U neighbours' F[l+1]).on(l), grad_width) )
+    //            rounded up to whole level-(l-1) parents, clipped to the mesh coverage
+    // Rounding to whole parents enforces samurai's complete-tree invariant (a coarse
+    // cell touched by grading is refined IN FULL, never partially - which would leave a
+    // hole). A cell sits at exactly level l where it is required at l but not at l+1:
+    //   graded[l] = F[l] \ F[l+1].on(l)
+    //
+    // MPI: the sweep is synchronised across ranks over the GLOBAL level range (one tiny
+    // all_reduce of the level bounds, once - not per iteration), and at each level only
+    // that level's F is exchanged with the neighbours (exchange_level_mpi) - so a cascade
+    // crossing a partition boundary is captured, without the whole-mesh exchange the
+    // fixed-point loop does per iteration.
+    template <std::size_t dim, class TInterval, size_t max_size, class MeshType>
     void graded_closure_single_pass(CellArray<dim, TInterval, max_size>& ca,
                                     const CellArray<dim, TInterval, max_size>& domain,
                                     const std::array<bool, dim>& is_periodic,
-                                    const size_t grad_width)
+                                    const size_t grad_width,
+                                    [[maybe_unused]] const std::vector<MPI_Subdomain<MeshType>>& mpi_neighbourhood)
     {
         using ca_type = CellArray<dim, TInterval, max_size>;
         using lca_t   = typename ca_type::lca_type;
 
-        const size_t max_level = ca.max_level();
-        const size_t min_level = ca.min_level();
+        const bool has_neighbour = !mpi_neighbourhood.empty();
+
+        size_t max_level = ca.max_level();
+        size_t min_level = ca.min_level();
+#ifdef SAMURAI_WITH_MPI
+        // Sweep over the GLOBAL level range so every rank issues the same per-level
+        // exchanges in lock-step (an empty rank still participates with empty level
+        // arrays). One tiny all_reduce (two ints) gives the TIGHT global range: this is
+        // cheaper than the alternative of using the domain's full 0..max_level range,
+        // which would make every rank exchange several empty coarse levels (extra
+        // latency-bound messages per call). Gated on world.size() (identical on every
+        // rank) so a neighbour-less rank still joins the collective and does not deadlock.
+        {
+            mpi::communicator world;
+            if (world.size() > 1)
+            {
+                max_level = mpi::all_reduce(world, max_level, mpi::maximum<size_t>());
+                min_level = mpi::all_reduce(world, min_level, mpi::minimum<size_t>());
+            }
+        }
+#endif
         if (max_level <= min_level)
         {
             return; // a single level is always graded
         }
         const int w = static_cast<int>(grad_width);
 
-        const bool any_periodic = std::any_of(is_periodic.begin(), is_periodic.end(), [](bool b) { return b; });
+        const bool any_periodic = std::any_of(is_periodic.begin(),
+                                              is_periodic.end(),
+                                              [](bool b)
+                                              {
+                                                  return b;
+                                              });
         std::array<int, dim> nb_cells_finest_level{};
         if (any_periodic)
         {
@@ -645,56 +589,76 @@ namespace samurai
             }
         }
 
-        // Graduation only ever refines EXISTING cells (the iterative version intersects
-        // with ca[coarse_level] at each step), so every F[l] must be clipped to the mesh
-        // coverage - otherwise the grading expansion would spill cells outside the
-        // mesh/domain. The mesh fills its domain, so the precomputed domain pyramid
-        // domain[l] IS that coverage at level l (cheap). When no domain is available
-        // (the standalone make_graduation(ca) overload), fall back to computing the
-        // coverage from ca itself.
-        const bool has_domain = !domain.empty();
+        // Graduation only ever refines EXISTING cells, so every F[l] must be clipped to
+        // the mesh coverage - otherwise the grading expansion would spill cells outside
+        // the mesh. Without neighbours the mesh fills its domain, so the precomputed
+        // domain pyramid domain[l] IS that coverage (cheap). With neighbours the local
+        // mesh is only a subdomain, so we must clip to the LOCAL coverage (its own cells)
+        // - clipping to the global domain would let a rank claim cells it does not own.
+        const bool has_domain   = !domain.empty();
+        const bool use_coverage = has_neighbour || !has_domain;
         lca_t coverage;
-        if (!has_domain)
+        if (use_coverage)
         {
             bool first = true;
-            for (size_t l = min_level; l <= max_level; ++l)
+            for (size_t l = ca.min_level(); l <= ca.max_level(); ++l)
             {
                 if (ca[l].empty())
                 {
                     continue;
                 }
-                lca_t projected(self(ca[l]).on(max_level));
-                coverage = first ? projected : lca_t(union_(coverage, projected).on(max_level));
+                lca_t projected(self(ca[l]).on(ca.max_level()));
+                coverage = first ? projected : lca_t(union_(coverage, projected).on(ca.max_level()));
                 first    = false;
             }
         }
         const auto clip = [&](lca_t&& x, size_t l) -> lca_t
         {
-            return has_domain ? lca_t(intersection(x, domain[l]).on(l)) : lca_t(intersection(x, self(coverage).on(l)).on(l));
+            return use_coverage ? lca_t(intersection(x, self(coverage).on(l)).on(l)) : lca_t(intersection(x, domain[l]).on(l));
         };
 
         std::array<lca_t, max_size> F;
+        std::array<std::vector<lca_t>, max_size> neighbour_F;
         F[max_level] = ca[max_level];
+        if (has_neighbour)
+        {
+            neighbour_F[max_level] = exchange_level_mpi(F[max_level], mpi_neighbourhood, static_cast<int>(max_level));
+        }
         for (size_t l = max_level; l-- > min_level;)
         {
-            // Grading buffer at level l: the finer requirement, expanded by grad_width.
-            lca_t expanded(nestedExpand(self(F[l + 1]).on(l), w));
+            // Finer requirement driving grading at level l: this rank's F[l+1] plus the
+            // neighbours' F[l+1] (so a cascade from a neighbour reaches across the shared
+            // boundary). The neighbour cells outside this subdomain are removed by the
+            // coverage clip below; those within grad_width of the boundary force the local
+            // boundary cells.
+            lca_t finer = F[l + 1];
+            for (const auto& nf : neighbour_F[l + 1])
+            {
+                // Union accumulation with a per-step .on() reconstruction: a raw loop reads better than std::accumulate.
+                // cppcheck-suppress useStlAlgorithm
+                finer = lca_t(union_(finer, nf).on(l + 1));
+            }
+
+            lca_t expanded(nestedExpand(self(finer).on(l), w));
             // Periodicity: a finer cell near a periodic boundary must also force
-            // refinement near the opposite boundary. Add the wrapped copies of the
-            // buffer (translated by the domain size at level l).
+            // refinement near the opposite boundary (wrapped copies of the buffer).
             if (any_periodic)
             {
                 const lca_t base = expanded;
                 for (const auto& d : detail::get_periodic_directions(nb_cells_finest_level, int(domain.max_level()) - int(l), is_periodic))
                 {
+                    // Union accumulation with a per-step .on() reconstruction: a raw loop reads better than std::accumulate.
+                    // cppcheck-suppress useStlAlgorithm
                     expanded = lca_t(union_(expanded, translate(base, d)).on(l));
                 }
             }
             lca_t req(union_(ca[l], expanded).on(l));
-            // Round up to whole (l-1) parents (complete-tree invariant) - except at
-            // min_level, which has no coarser parent in the mesh - then clip so nothing
-            // spills outside the domain.
+            // Round up to whole (l-1) parents (complete-tree invariant) then clip.
             F[l] = (l > min_level) ? clip(lca_t(self(req).on(l - 1).on(l)), l) : clip(std::move(req), l);
+            if (has_neighbour)
+            {
+                neighbour_F[l] = exchange_level_mpi(F[l], mpi_neighbourhood, static_cast<int>(l));
+            }
         }
 
         ca_type graded_ca;
@@ -718,8 +682,7 @@ namespace samurai
     // Returns whether `ca` actually changed. Shared by the fixed-point loop and the
     // single-pass boundary-contiguity loop.
     template <std::size_t dim, class TInterval, size_t max_size, class TCoord>
-    bool apply_refinement_list(CellArray<dim, TInterval, max_size>& ca,
-                               std::array<ArrayOfIntervalAndPoint<TInterval, TCoord>, max_size>& out)
+    bool apply_refinement_list(CellArray<dim, TInterval, max_size>& ca, std::array<ArrayOfIntervalAndPoint<TInterval, TCoord>, max_size>& out)
     {
         using ca_type    = CellArray<dim, TInterval, max_size>;
         using coord_type = typename ca_type::lca_type::coord_type;
@@ -781,8 +744,7 @@ namespace samurai
         }
 
         ca_type new_ca;
-        for (std::size_t level = std::min(ca.min_level(), ca_add_p.min_level());
-             level < std::max(ca.max_level(), ca_add_p.max_level()) + 1;
+        for (std::size_t level = std::min(ca.min_level(), ca_add_p.min_level()); level < std::max(ca.max_level(), ca_add_p.max_level()) + 1;
              ++level)
         {
             auto set = difference(union_(ca[level], ca_add_p[level]), ca_remove_p[level]);
@@ -811,39 +773,64 @@ namespace samurai
         using ca_type    = CellArray<dim, TInterval, max_size>;
         using coord_type = typename ca_type::lca_type::coord_type;
 
-        const size_t max_level = ca.max_level();
-        const size_t min_level = ca.min_level();
-
-        // Single-pass fast path: no MPI neighbour (a cross-rank cascade needs the
-        // cells the neighbour creates, which only the fixed-point loop's per-iteration
-        // mesh exchange provides). The interior grading is done in one top-down sweep
-        // by graded_closure_single_pass (periodicity handled inside). When the scheme
-        // needs boundary contiguity (max_stencil_radius > 1), that pass ADDS cells that
-        // can create new interior violations, so we re-grade in a short outer loop -
-        // usually one or two turns, and skipped entirely for max_stencil_radius == 1.
-        if (mpi_neighbourhood.empty())
+        // Single-pass interior grading (one top-down sweep). With MPI neighbours the
+        // sweep is synchronised and exchanges only the current level's cells at each
+        // step (see graded_closure_single_pass), so it replaces the fixed-point loop's
+        // whole-mesh exchanges. When there is no boundary contiguity to enforce
+        // (max_stencil_radius == 1) a single sweep is the whole graduation.
+        if (max_stencil_radius == 1)
         {
+            graded_closure_single_pass(ca, domain, is_periodic, grad_width, mpi_neighbourhood);
+#ifdef SAMURAI_DEBUG_GRADUATION
+            // is_graduated is a purely local check; under MPI the boundary grading is
+            // completed by the neighbours, so only assert in the sequential case.
+            if (mpi_neighbourhood.empty() && !is_graduated(ca))
+            {
+                std::cerr << "[SAMURAI_DEBUG_GRADUATION] single-pass graduation produced a non-graduated mesh\n";
+                std::abort();
+            }
+#endif
+            return 1;
+        }
+
+        // Boundary contiguity (max_stencil_radius > 1): the interior single-pass grades
+        // in one sweep, but the boundary pass ADDS cells that can create new interior
+        // violations, so re-grade in a short outer loop (usually one or two turns). This
+        // handles both the sequential and the MPI case - the neighbour cells the boundary
+        // pass needs are fetched with update_subdomains_mpi (a no-op without neighbours),
+        // and the outer-loop termination is agreed with one collective per turn.
+        {
+#ifdef SAMURAI_WITH_MPI
+            mpi::communicator world;
+#endif
             size_t nit   = 0;
             bool changed = true;
-            while (changed)
+            while (
+#ifdef SAMURAI_WITH_MPI
+                mpi::all_reduce(world, changed, std::logical_or())
+#else
+                changed
+#endif
+            )
             {
                 ++nit;
-                graded_closure_single_pass(ca, domain, is_periodic, grad_width);
+                graded_closure_single_pass(ca, domain, is_periodic, grad_width, mpi_neighbourhood);
                 changed = false;
-                if (max_stencil_radius > 1 && !domain.empty())
+                if (!domain.empty())
                 {
+                    const auto mpi_meshes = update_subdomains_mpi(ca, mpi_neighbourhood);
                     std::array<ArrayOfIntervalAndPoint<TInterval, coord_type>, max_size> boundary_out;
                     for (auto& o : boundary_out)
                     {
                         o.clear();
                     }
-                    const std::vector<ca_type> no_neighbour_meshes;
-                    list_interval_to_refine_for_contiguous_boundary_cells(max_stencil_radius, ca, domain, no_neighbour_meshes, is_periodic, boundary_out);
+                    list_interval_to_refine_for_contiguous_boundary_cells(max_stencil_radius, ca, domain, mpi_meshes, is_periodic, boundary_out);
                     changed = apply_refinement_list(ca, boundary_out);
                 }
             }
 #ifdef SAMURAI_DEBUG_GRADUATION
-            if (!is_graduated(ca))
+            // is_graduated is a purely local check; only assert without neighbours.
+            if (mpi_neighbourhood.empty() && !is_graduated(ca))
             {
                 std::cerr << "[SAMURAI_DEBUG_GRADUATION] single-pass graduation produced a non-graduated mesh\n";
                 std::abort();
@@ -851,231 +838,6 @@ namespace samurai
 #endif
             return nit;
         }
-
-        std::array<int, dim> nb_cells_finest_level;
-
-        if (std::any_of(is_periodic.begin(),
-                        is_periodic.end(),
-                        [](const bool& b)
-                        {
-                            return b;
-                        }))
-        {
-            const auto& min_indices = domain[domain.max_level()].min_indices();
-            const auto& max_indices = domain[domain.max_level()].max_indices();
-
-            for (size_t d = 0; d != max_indices.size(); ++d)
-            {
-                nb_cells_finest_level[d] = max_indices[d] - min_indices[d];
-            }
-        }
-
-        std::vector<TInterval> add_p_interval;
-        std::vector<coord_type> add_p_inner_stencil;
-        std::vector<size_t> add_p_idx;
-
-        std::array<ArrayOfIntervalAndPoint<TInterval, coord_type>, max_size> remove_m_all;
-
-        ca_type ca_add_p;
-        ca_type ca_remove_p;
-        ca_type new_ca;
-
-        size_t nit = 0;
-#ifdef SAMURAI_WITH_MPI
-        mpi::communicator world;
-#endif // SAMURAI_WITH_MPI
-
-        // `ca_changed` drives the fixed-point loop: it is true as long as the local `ca` was modified during the
-        // previous iteration. It is primed to true so the loop runs at least once. Compared to the former
-        // `new_ca != ca` test, this lets us skip both the full `new_ca` reconstruction and the whole-array
-        // comparison whenever an iteration produces no cell to refine (the common case: an already-graduated mesh),
-        // for which `new_ca == ca` holds algebraically.
-        // Incremental graduation. The first iteration scans the whole mesh. Each
-        // subsequent iteration only needs to look for new violations around the fine
-        // cells the previous iteration added: a graduation iteration only ADDS fine
-        // cells, so those are the only possible new fine sources. Seeding the interior
-        // pass with them is therefore exact (the boundary pass still runs full each
-        // iteration). Under-seeding could only ever miss a refinement, never add a
-        // spurious one, so `is_graduated(ca)` on the result is a complete correctness
-        // check (enabled by SAMURAI_DEBUG_GRADUATION below).
-        //
-        // A new violation of iteration i+1 involves a cell ADDED by iteration i either
-        // as its fine SOURCE or as its (coarser) TARGET - the latter happens on a
-        // multi-level cascade, where an old fine cell forces a cell iteration i just
-        // added one level up. Seeding only from the additions (as sources) misses the
-        // target case, so the seed must be the mesh cells in the NEIGHBOURHOOD of the
-        // additions: ca INTER expand(additions, roi_width), projected across levels.
-        // This lets the scan cascade from the old fine cells near the new targets too.
-        // roi_width covers the interior grading reach (2*grad_width) and the boundary
-        // contiguity reach.
-        const int roi_width = std::max(2 * static_cast<int>(grad_width), std::max(max_stencil_radius, 2 * (max_stencil_radius - 2)));
-
-        auto build_roi = [&](const ca_type& additions) -> ca_type
-        {
-            using lca_t = typename ca_type::lca_type;
-            ca_type roi;
-            for (size_t L = ca.min_level(); L <= ca.max_level(); ++L)
-            {
-                lca_t acc;
-                bool has = false;
-                for (size_t d = additions.min_level(); d <= additions.max_level(); ++d)
-                {
-                    if (additions[d].empty())
-                    {
-                        continue;
-                    }
-                    lca_t contrib(nestedExpand(self(additions[d]).on(L), roi_width));
-                    acc = has ? lca_t(union_(acc, contrib).on(L)) : contrib;
-                    has = true;
-                }
-                if (has)
-                {
-                    intersection(ca[L], acc)(
-                        [&](const auto& i, const auto& idx)
-                        {
-                            roi[L].add_interval_back(i, idx);
-                        });
-                }
-            }
-            return roi;
-        };
-
-        ca_type prev_roi;
-        const ca_type* iteration_seed = nullptr;
-        bool ca_changed               = true;
-        while (
-#ifdef SAMURAI_WITH_MPI
-            mpi::all_reduce(world, ca_changed, std::logical_or())
-#else
-            ca_changed
-#endif // SAMURAI_WITH_MPI
-        )
-        {
-            ++nit;
-
-            // test if mesh is correctly graduated.
-            // We first build a set of non-graduated cells
-            // Then, if the non-graduated is not tagged as keep, we coarsen it
-            ca_add_p.clear();
-            ca_remove_p.clear();
-            list_intervals_to_refine(grad_width,
-                                     max_stencil_radius,
-                                     ca,
-                                     domain,
-                                     mpi_neighbourhood,
-                                     is_periodic,
-                                     nb_cells_finest_level,
-                                     remove_m_all,
-                                     iteration_seed);
-
-            add_p_interval.clear();
-            add_p_inner_stencil.clear();
-            add_p_idx.clear();
-            // Whether any cell was flagged for refinement this iteration. When nothing is flagged, `ca_add_p` and
-            // `ca_remove_p` stay empty, so the reconstruction below would rebuild `ca` identically: we skip it.
-            bool any_change = false;
-            // `<` not `!=`: on an empty rank min_level (max_size + 1) > max_level
-            // (0), so this runs zero times instead of walking off remove_m_all.
-            // The empty rank must still reach the collective all_reduce above, so
-            // it cannot early-return -- it just does no per-level work.
-            for (size_t level = min_level; level < max_level + 1; ++level)
-            {
-                remove_m_all[level].remove_overlapping_intervals();
-                const size_t imax = remove_m_all[level].size();
-                if (imax > 0)
-                {
-                    any_change = true;
-                }
-                for (size_t i = 0; i != imax; ++i)
-                {
-                    const auto& x_interval = remove_m_all[level][i].first;
-                    const auto& yz         = remove_m_all[level][i].second;
-                    ca_remove_p[level].add_interval_back(x_interval, yz);
-                    if constexpr (dim == 1)
-                    {
-                        ca_add_p[level + 1].add_interval_back(2 * x_interval, 2 * yz);
-                    }
-                    else
-                    {
-                        nestedLoop<dim - 1, 0, dim - 2>(0,
-                                                        2,
-                                                        [&](const auto& inner_stencil)
-                                                        {
-                                                            add_p_interval.push_back(2 * x_interval);
-                                                            if constexpr (dim > 2)
-                                                            {
-                                                                add_p_inner_stencil.emplace_back(2 * yz + inner_stencil);
-                                                                add_p_idx.push_back(add_p_interval.size() - 1); // std::iota on
-                                                                                                                // the fly
-                                                            }
-                                                        });
-                    }
-                    if (dim != 1 and (i + 1 == imax or yz[dim - 2] != remove_m_all[level].get_coord(i + 1)[dim - 2]))
-                    {
-                        add_list_of_interval_back(add_p_interval, coord_type(2 * yz), add_p_inner_stencil, add_p_idx, ca_add_p[level + 1]);
-                        add_p_interval.clear();
-                        add_p_inner_stencil.clear();
-                        add_p_idx.clear();
-                    }
-                } // end for remove_m_all
-            } // end for level
-
-            if (!any_change)
-            {
-                // Nothing was flagged: `ca` is unchanged, so this rank has reached its fixed point. We still loop
-                // back to the collective all_reduce (a neighbour may keep refining), but do no more local work.
-                ca_changed = false;
-                continue;
-            }
-
-            // We then create new_ca as ca U ca_add
-            new_ca.clear();
-            for (std::size_t level = std::min(ca.min_level(), ca_add_p.min_level());
-                 level < std::max(ca.max_level(), ca_add_p.max_level()) + 1;
-                 ++level)
-            {
-                auto set = difference(union_(ca[level], ca_add_p[level]), ca_remove_p[level]);
-                set(
-                    [&](const auto& x_interval, const auto& yz)
-                    {
-                        new_ca[level].add_interval_back(x_interval, yz);
-                    });
-            }
-            // Even though something was flagged, the flagged cells may already be refined, leaving `ca`
-            // effectively unchanged: keep the explicit comparison here as the loop's termination guarantee.
-            ca_changed = (new_ca != ca);
-            std::swap(new_ca, ca);
-
-            // Seed the next iteration with the mesh cells around the ones just added
-            // (see the roi comment above): this covers additions acting as fine sources
-            // and old fine cells forcing additions that became coarser targets.
-            //
-            // Only when there is no MPI neighbour (sequential run, or a rank with no
-            // neighbour). With neighbours the scan must stay FULL: the seed is built
-            // from this rank's LOCAL additions, which depend on the domain
-            // decomposition, so seeding would make the graduation - and hence the mesh -
-            // partition-dependent. The full scan is partition-independent (as on main),
-            // and a single-rank incremental result is bit-identical to it.
-            if (mpi_neighbourhood.empty())
-            {
-                prev_roi       = build_roi(ca_add_p);
-                iteration_seed = &prev_roi;
-            }
-        }
-
-#ifdef SAMURAI_DEBUG_GRADUATION
-        // Complete correctness gate for the incremental scan: because seeding can
-        // only ever under-refine (never add a spurious refinement), a graduated
-        // result is necessarily identical to the full-scan result. Explicit check
-        // (not assert) so it also fires in NDEBUG builds when the flag is set.
-        if (!is_graduated(ca))
-        {
-            std::cerr << "[SAMURAI_DEBUG_GRADUATION] incremental graduation produced a non-graduated mesh\n";
-            std::abort();
-        }
-#endif
-
-        return nit - 1;
     }
 
     template <std::size_t dim, class TInterval, size_t max_size>

--- a/include/samurai/algorithm/update_fields.hpp
+++ b/include/samurai/algorithm/update_fields.hpp
@@ -27,7 +27,7 @@ namespace samurai
         template <class PredictionFn, class DestTuple, class SrcTuple, class Mesh, std::size_t... Is>
         void update_fields_impl(PredictionFn&& prediction_fn, Mesh& new_mesh, DestTuple& dests, SrcTuple& srcs, std::index_sequence<Is...>)
         {
-            ScopedTimer timer("fields update");
+            ScopedTimer timer("field transfer");
             using mesh_id_t = typename Mesh::mesh_id_t;
 
             auto& mesh     = std::get<0>(srcs).mesh();
@@ -36,20 +36,26 @@ namespace samurai
 
             // Single loop over levels: copy reference -> cells for ALL fields in
             // a single traversal of the set (variadic copy over the two tuples).
-            for (std::size_t level = min_level; level <= max_level; ++level)
             {
-                auto set = intersection(mesh[mesh_id_t::reference][level], new_mesh[mesh_id_t::cells][level]);
-                set.apply_op(copy(dests, srcs));
+                ScopedTimer timer_copy("copy unchanged");
+                for (std::size_t level = min_level; level <= max_level; ++level)
+                {
+                    auto set = intersection(mesh[mesh_id_t::reference][level], new_mesh[mesh_id_t::cells][level]);
+                    set.apply_op(copy(dests, srcs));
+                }
             }
 
             // Single loop over levels: coarsen and refine for ALL fields
-            for (std::size_t level = min_level + 1; level <= max_level; ++level)
             {
-                auto set_coarsen = intersection(mesh[mesh_id_t::cells][level], new_mesh[mesh_id_t::cells][level - 1]).on(level - 1);
-                set_coarsen.apply_op(projection(dests, srcs));
+                ScopedTimer timer_cr("coarsen + refine");
+                for (std::size_t level = min_level + 1; level <= max_level; ++level)
+                {
+                    auto set_coarsen = intersection(mesh[mesh_id_t::cells][level], new_mesh[mesh_id_t::cells][level - 1]).on(level - 1);
+                    set_coarsen.apply_op(projection(dests, srcs));
 
-                auto set_refine = intersection(new_mesh[mesh_id_t::cells][level], mesh[mesh_id_t::cells][level - 1]).on(level - 1);
-                (set_refine.apply_op(prediction_fn(std::get<Is>(dests), std::get<Is>(srcs))), ...);
+                    auto set_refine = intersection(new_mesh[mesh_id_t::cells][level], mesh[mesh_id_t::cells][level - 1]).on(level - 1);
+                    (set_refine.apply_op(prediction_fn(std::get<Is>(dests), std::get<Is>(srcs))), ...);
+                }
             }
         }
 
@@ -103,12 +109,14 @@ namespace samurai
     void update_fields(PredictionFn&& prediction_fn, Mesh& new_mesh, Field& field, Fields&... fields)
     {
         auto src_tuple = std::tuple_cat(get_elements(field), std::tie(fields...));
+        times::timers.start("field allocation");
         auto dst_tuple = std::apply(
             [&](auto&... args)
             {
                 return std::make_tuple(detail::make_new_field<std::decay_t<decltype(args)>>("new_f", new_mesh)...);
             },
             src_tuple);
+        times::timers.stop("field allocation");
 
         update_fields(std::forward<PredictionFn>(prediction_fn), new_mesh, dst_tuple, src_tuple);
 

--- a/include/samurai/mesh.hpp
+++ b/include/samurai/mesh.hpp
@@ -21,6 +21,7 @@
 #include "static_algorithm.hpp"
 #include "stencil.hpp"
 #include "subset/node.hpp"
+#include "timers.hpp"
 
 #ifdef SAMURAI_WITH_MPI
 #include <boost/serialization/vector.hpp>
@@ -416,6 +417,7 @@ namespace samurai
     template <class D, class Config>
     SAMURAI_INLINE void Mesh_base<D, Config>::exchange_neighbour_meshes()
     {
+        ScopedTimer timer("exchange neighbour meshes");
 #ifdef SAMURAI_WITH_MPI
         find_neighbourhood();
         update_neighbour_subdomain();
@@ -893,6 +895,7 @@ namespace samurai
     template <class D, class Config>
     SAMURAI_INLINE void Mesh_base<D, Config>::renumbering()
     {
+        ScopedTimer timer("renumbering");
         m_cells[mesh_id_t::reference].update_index();
 
         for (std::size_t id = 0; id < static_cast<std::size_t>(mesh_id_t::count); ++id)
@@ -916,6 +919,7 @@ namespace samurai
         static_assert(
             dim <= 6,
             "Corner construction is currently only implemented up to 6D due to the combinatorial number of cases. Please implement the general ND version if you need higher dimensions.");
+        ScopedTimer timer("construct_corners");
         if constexpr (dim > 1)
         {
             using direction_t = DirectionVector<dim>;
@@ -1031,6 +1035,7 @@ namespace samurai
     template <class D, class Config>
     SAMURAI_INLINE void Mesh_base<D, Config>::update_mesh_neighbour()
     {
+        ScopedTimer timer("update_mesh_neighbour");
 #ifdef SAMURAI_WITH_MPI
         // send/recv the meshes of the neighbouring subdomains
         mpi::communicator world;
@@ -1104,6 +1109,7 @@ namespace samurai
     template <class D, class Config>
     SAMURAI_INLINE void Mesh_base<D, Config>::update_meshid_neighbour([[maybe_unused]] const mesh_id_t& mesh_id)
     {
+        ScopedTimer timer("update_meshid_neighbour");
 #ifdef SAMURAI_WITH_MPI
         mpi::communicator world;
         std::vector<mpi::request> req;
@@ -1159,6 +1165,7 @@ namespace samurai
     template <class D, class Config>
     SAMURAI_INLINE void Mesh_base<D, Config>::construct_subdomain()
     {
+        ScopedTimer timer("construct_subdomain");
 #ifdef SAMURAI_WITH_MPI
         mpi::communicator world;
         if (world.size() > 1 || m_domain.empty())
@@ -1230,6 +1237,7 @@ namespace samurai
     template <class D, class Config>
     SAMURAI_INLINE void Mesh_base<D, Config>::construct_union()
     {
+        ScopedTimer timer("construct_union");
         std::size_t max_lvl = max_level();
 
         // Construction of union cells

--- a/include/samurai/mesh.hpp
+++ b/include/samurai/mesh.hpp
@@ -1037,6 +1037,12 @@ namespace samurai
     {
         ScopedTimer timer("update_mesh_neighbour");
 #ifdef SAMURAI_WITH_MPI
+        // No neighbouring subdomain (e.g. single rank): nothing to exchange.
+        // Return before serializing the whole mesh, which is otherwise pure waste.
+        if (m_mpi_neighbourhood.empty())
+        {
+            return;
+        }
         // send/recv the meshes of the neighbouring subdomains
         mpi::communicator world;
         std::vector<mpi::request> req;
@@ -1076,6 +1082,11 @@ namespace samurai
     SAMURAI_INLINE void Mesh_base<D, Config>::update_neighbour_subdomain()
     {
 #ifdef SAMURAI_WITH_MPI
+        // No neighbouring subdomain (e.g. single rank): nothing to exchange.
+        if (m_mpi_neighbourhood.empty())
+        {
+            return;
+        }
         // send/recv the meshes of the neighbouring subdomains
         mpi::communicator world;
         std::vector<mpi::request> req;
@@ -1111,6 +1122,12 @@ namespace samurai
     {
         ScopedTimer timer("update_meshid_neighbour");
 #ifdef SAMURAI_WITH_MPI
+        // No neighbouring subdomain (e.g. single rank): nothing to exchange.
+        // Return before serializing the mesh id, which is otherwise pure waste.
+        if (m_mpi_neighbourhood.empty())
+        {
+            return;
+        }
         mpi::communicator world;
         std::vector<mpi::request> req;
 

--- a/include/samurai/mesh.hpp
+++ b/include/samurai/mesh.hpp
@@ -172,6 +172,7 @@ namespace samurai
         double min_cell_length() const;
         const lca_type& domain() const;
         const lca_type& domain(std::size_t level) const;
+        const ca_type& domain_pyramid() const;
         const lca_type& subdomain() const;
         const lca_type& subdomain(std::size_t level) const;
 
@@ -716,6 +717,16 @@ namespace samurai
     SAMURAI_INLINE auto Mesh_base<D, Config>::domain(std::size_t level) const -> const lca_type&
     {
         return m_domain[level];
+    }
+
+    // Whole-domain pyramid: the domain represented at every level (m_domain[level]
+    // is precomputed for all levels). Exposed so that consumers needing the domain
+    // at several levels - e.g. make_graduation - can index domain[level] directly
+    // instead of projecting the finest-level domain with self(domain).on(level).
+    template <class D, class Config>
+    SAMURAI_INLINE auto Mesh_base<D, Config>::domain_pyramid() const -> const ca_type&
+    {
+        return m_domain;
     }
 
     template <class D, class Config>

--- a/include/samurai/mr/adapt.hpp
+++ b/include/samurai/mr/adapt.hpp
@@ -367,17 +367,26 @@ namespace samurai
         // construction builds every derived mesh id and, with MPI, exchanges
         // the full meshes with the neighbouring subdomains - all of it thrown
         // away when the adaptation has converged.
+        bool fixed_point;
+        {
+            times::timers.start("fixed-point check");
 #ifdef SAMURAI_WITH_MPI
-        mpi::communicator world;
-        if (mpi::all_reduce(world, mesh[mesh_id_t::cells] == new_ca, std::logical_and()))
+            mpi::communicator world;
+            fixed_point = mpi::all_reduce(world, mesh[mesh_id_t::cells] == new_ca, std::logical_and());
 #else
-        if (mesh[mesh_id_t::cells] == new_ca)
+            fixed_point = (mesh[mesh_id_t::cells] == new_ca);
 #endif // SAMURAI_WITH_MPI
+            times::timers.stop("fixed-point check");
+        }
+        if (fixed_point)
         {
             times::timers.stop("mesh update");
             return true;
         }
+
+        times::timers.start("mesh construction");
         mesh_t new_mesh{new_ca, mesh};
+        times::timers.stop("mesh construction");
         times::timers.stop("mesh update");
         update_ghost_mr(other_fields...);
 

--- a/include/samurai/mr/adapt.hpp
+++ b/include/samurai/mr/adapt.hpp
@@ -361,7 +361,7 @@ namespace samurai
         using ca_type = typename mesh_t::ca_type;
 
         ca_type new_ca = update_cell_array_from_tag(mesh[mesh_id_t::cells], m_tag);
-        make_graduation(new_ca, mesh.domain(), mesh.mpi_neighbourhood(), mesh.periodicity(), mesh.graduation_width(), mesh.max_stencil_radius());
+        make_graduation(new_ca, mesh.domain_pyramid(), mesh.mpi_neighbourhood(), mesh.periodicity(), mesh.graduation_width(), mesh.max_stencil_radius());
 
         // Fixed-point detection BEFORE constructing the new mesh: the
         // construction builds every derived mesh id and, with MPI, exchanges

--- a/include/samurai/mr/adapt.hpp
+++ b/include/samurai/mr/adapt.hpp
@@ -361,7 +361,12 @@ namespace samurai
         using ca_type = typename mesh_t::ca_type;
 
         ca_type new_ca = update_cell_array_from_tag(mesh[mesh_id_t::cells], m_tag);
-        make_graduation(new_ca, mesh.domain_pyramid(), mesh.mpi_neighbourhood(), mesh.periodicity(), mesh.graduation_width(), mesh.max_stencil_radius());
+        make_graduation(new_ca,
+                        mesh.domain_pyramid(),
+                        mesh.mpi_neighbourhood(),
+                        mesh.periodicity(),
+                        mesh.graduation_width(),
+                        mesh.max_stencil_radius());
 
         // Fixed-point detection BEFORE constructing the new mesh: the
         // construction builds every derived mesh id and, with MPI, exchanges

--- a/include/samurai/mr/mesh.hpp
+++ b/include/samurai/mr/mesh.hpp
@@ -221,7 +221,7 @@ namespace samurai
     template <class Config>
     SAMURAI_INLINE void MRMesh<Config>::update_sub_mesh_impl()
     {
-        ScopedTimer timer_mesh("mesh construction");
+        ScopedTimer timer_mesh("update_sub_mesh");
 
         cl_type cell_list(this->origin_point(), this->scaling_factor());
 

--- a/tests/test_graduation.cpp
+++ b/tests/test_graduation.cpp
@@ -106,6 +106,76 @@ namespace samurai
         expect_boundary_refined(3);
     }
 
+    // Corner coupling (2D). At a domain corner two physical boundary faces meet, so the
+    // boundary run extended along one face can create cells that then need extension along
+    // the perpendicular face. This reproduces the exact mesh (a central level-5 block inside
+    // a level-4 frame, radius 3) that exposed a fused single-pass under-refinement at the
+    // corners: the fine level must be pulled into the corner, which needs the per-level
+    // extension to be iterated until the corner region stabilises.
+    TEST(graduation, boundary_contiguity_corner_2d)
+    {
+        constexpr size_t dim = 2;
+
+        // domain pyramid: [0, 16)^2 at level 4 (= [0, 32)^2 at level 5), down to level 0.
+        CellList<dim> domain_cl;
+        for (int l = 5; l >= 0; --l)
+        {
+            const int n = 32 >> (5 - l);
+            for (int j = 0; j < n; ++j)
+            {
+                domain_cl[static_cast<std::size_t>(l)][{j}].add_interval({0, n});
+            }
+        }
+        CellArray<dim> domain{domain_cl};
+
+        // Tiling input: central level-5 block [4,28)^2 (= [2,14)^2 at level 4) surrounded by
+        // a level-4 frame filling [0,16)^2.
+        CellList<dim> cl;
+        for (int j = 0; j < 16; ++j) // level-4 rows
+        {
+            if (j < 2 || j >= 14)
+            {
+                cl[4][{j}].add_interval({0, 16});
+            }
+            else
+            {
+                cl[4][{j}].add_interval({0, 2});
+                cl[4][{j}].add_interval({14, 16});
+            }
+        }
+        for (int j = 4; j < 28; ++j) // level-5 rows of the central block
+        {
+            cl[5][{j}].add_interval({4, 28});
+        }
+        CellArray<dim> ca{cl};
+
+        const std::array<bool, dim> is_periodic{false, false};
+
+        struct DummyMesh
+        {
+        };
+
+        std::vector<MPI_Subdomain<DummyMesh>> no_neighbours;
+        make_graduation(ca, domain, no_neighbours, is_periodic, size_t{1}, 3);
+
+        EXPECT_TRUE(is_graduated(ca));
+
+        // The fine level (5) must be pulled into the bottom-left corner: level 4 must NOT
+        // remain at the very corner cell (x=[0,2)@L4, row 0). The buggy single pass left L4
+        // there instead of refining to L5.
+        CellList<dim> corner_cl;
+        corner_cl[4][{0}].add_interval({0, 2});
+        const LevelCellArray<dim> corner = CellArray<dim>{corner_cl}[4];
+        size_t remaining                 = 0;
+        intersection(ca[4], corner)
+            .on(4)(
+                [&](const auto&, const auto&)
+                {
+                    ++remaining;
+                });
+        EXPECT_EQ(remaining, 0u) << "the fine level must be pulled into the domain corner (corner coupling)";
+    }
+
     static size_t count_intervals(size_t l, const LevelCellArray<1>& a)
     {
         size_t n = 0;

--- a/tests/test_graduation.cpp
+++ b/tests/test_graduation.cpp
@@ -68,9 +68,14 @@ namespace samurai
         using coord_type = typename ca_type::lca_type::coord_type;
         using out_t      = std::array<ArrayOfIntervalAndPoint<interval_t, coord_type>, ca_type::max_size>;
 
+        // Domain pyramid: [0, 16) at level 4, [0, 8) at level 3. make_graduation now
+        // receives the domain as a multi-level CellArray and indexes domain[level]
+        // directly (no self(domain).on(level) projection), so the helper is exercised
+        // with the same per-level domain it gets from mesh.domain_pyramid().
         CellList<dim> domain_cl;
         domain_cl[4][{}].add_interval({0, 16});
-        LevelCellArray<dim> domain(domain_cl[4]);
+        domain_cl[3][{}].add_interval({0, 8});
+        CellArray<dim> domain{domain_cl};
 
         const std::array<bool, dim> is_periodic{false};
 

--- a/tests/test_graduation.cpp
+++ b/tests/test_graduation.cpp
@@ -44,72 +44,144 @@ namespace samurai
         EXPECT_TRUE(is_graduated(ca));
     }
 
-#ifdef SAMURAI_WITH_MPI
-    // Non-regression test for the partition-dependence bug fixed alongside this test:
-    // list_interval_to_refine_for_contiguous_boundary_cells (active only when
-    // max_stencil_radius > 1) used to look for physical-boundary cells in the local
-    // `ca` only, so a boundary cell owned by a neighbour rank was invisible and the
-    // refinement it must trigger on the neighbouring inner cells depended on the MPI
-    // partition. The fix takes boundary cells from `ca` AND from every mesh in
-    // `mpi_meshes`, while still refining only the local rank's own cells.
-    //
-    // Domain: x in [0, 16) at level 4. A single coarse cell (level 3, index 6, i.e.
-    // fine x in [12, 14)) sits close enough to the right physical boundary
-    // (x = 16) that it must be refined to level 4 for a scheme with
-    // max_stencil_radius = 3, regardless of which rank owns the level-4 boundary
-    // cells (fine x in [14, 16)) that trigger this refinement.
-    TEST(graduation, contiguous_boundary_partition_independent)
+    // Build the 1D domain pyramid [0, n) at `top_level`, projected down to level 0, as the
+    // multi-level CellArray make_graduation expects (domain[l] = domain at level l).
+    static CellArray<1> domain_pyramid_1d(int top_level, int n_cells_top)
     {
-        constexpr size_t dim         = 1;
-        constexpr int stencil_radius = 3;
+        CellList<1> cl;
+        for (int l = top_level; l >= 0; --l)
+        {
+            const int n = n_cells_top >> (top_level - l);
+            cl[static_cast<std::size_t>(l)][{}].add_interval({0, n});
+        }
+        return CellArray<1>{cl};
+    }
 
-        using ca_type    = CellArray<dim>;
-        using interval_t = typename ca_type::interval_t;
-        using coord_type = typename ca_type::lca_type::coord_type;
-        using out_t      = std::array<ArrayOfIntervalAndPoint<interval_t, coord_type>, ca_type::max_size>;
+    // Boundary contiguity exercised end to end through the production make_graduation (the
+    // folded single pass). A level-4 run [14,16) touches the right physical boundary and a
+    // level-3 cell [6,7) (fine [12,14)) sits one coarse cell inside it. For a wide stencil
+    // that L3 cell must be refined to level 4 so the boundary run is thick enough. The mesh
+    // tiles the domain (coverage == domain).
+    static void expect_boundary_refined(int radius)
+    {
+        const std::array<bool, 1> is_periodic{false};
 
-        // Domain pyramid: [0, 16) at level 4, [0, 8) at level 3. make_graduation now
-        // receives the domain as a multi-level CellArray and indexes domain[level]
-        // directly (no self(domain).on(level) projection), so the helper is exercised
-        // with the same per-level domain it gets from mesh.domain_pyramid().
-        CellList<dim> domain_cl;
+        struct DummyMesh
+        {
+        };
+
+        std::vector<MPI_Subdomain<DummyMesh>> no_neighbours;
+
+        CellList<1> cl;
+        cl[4][{}].add_interval({14, 16});
+        cl[3][{}].add_interval({0, 7});
+        CellArray<1> ca{cl};
+
+        make_graduation(ca, domain_pyramid_1d(4, 16), no_neighbours, is_periodic, size_t{1}, radius);
+
+        EXPECT_TRUE(is_graduated(ca));
+
+        // The boundary-adjacent level-3 cell [6,7) must have been refined to level 4, so
+        // nothing remains at level 3 there.
+        CellList<1> hole_cl;
+        hole_cl[3][{}].add_interval({6, 7});
+        const LevelCellArray<1> hole = CellArray<1>{hole_cl}[3];
+        size_t remaining             = 0;
+        intersection(ca[3], hole)
+            .on(3)(
+                [&](const auto&, const auto&)
+                {
+                    ++remaining;
+                });
+        EXPECT_EQ(remaining, 0u) << "the boundary-adjacent level-3 cell must be refined (radius=" << radius << ")";
+    }
+
+    TEST(graduation, boundary_contiguity_radius2)
+    {
+        expect_boundary_refined(2);
+    }
+
+    TEST(graduation, boundary_contiguity_radius3)
+    {
+        expect_boundary_refined(3);
+    }
+
+    static size_t count_intervals(size_t l, const LevelCellArray<1>& a)
+    {
+        size_t n = 0;
+        self(a).on(l)(
+            [&](const auto&, const auto&)
+            {
+                ++n;
+            });
+        return n;
+    }
+
+    static bool same_lca(size_t l, const LevelCellArray<1>& a, const LevelCellArray<1>& b)
+    {
+        return count_intervals(l, LevelCellArray<1>(difference(a, b).on(l))) == 0
+            && count_intervals(l, LevelCellArray<1>(difference(b, a).on(l))) == 0;
+    }
+
+    // The fused single-pass boundary helpers (boundary_case1_cells / boundary_case2_cells)
+    // must be INDEPENDENT of the MPI partition: a physical-boundary cell owned by a
+    // NEIGHBOUR rank must drive exactly the same refinement as if this rank owned it. This
+    // is the single-pass analogue of graduation.contiguous_boundary_partition_independent,
+    // tested directly on the pure helpers (no real MPI needed) by feeding the boundary run
+    // either as this rank's own cells or as a neighbour source.
+    TEST(graduation, fused_boundary_case1_partition_independent)
+    {
+        CellList<1> domain_cl;
         domain_cl[4][{}].add_interval({0, 16});
         domain_cl[3][{}].add_interval({0, 8});
-        CellArray<dim> domain{domain_cl};
+        CellArray<1> domain{domain_cl};
+        const std::array<bool, 1> is_periodic{false};
+        const int radius   = 3;
+        const int n_contig = std::max(radius, 2 * (radius - 2)); // = 3
 
-        const std::array<bool, dim> is_periodic{false};
+        CellList<1> bcl;
+        bcl[4][{}].add_interval({14, 16}); // level-4 run on the right physical boundary
+        const LevelCellArray<1> boundary = CellArray<1>{bcl}[4];
+        const LevelCellArray<1> empty4;
 
-        // Scenario A: this rank owns everything, including the boundary cells.
-        CellList<dim> cl_local;
-        cl_local[4][{}].add_interval({14, 16});
-        cl_local[3][{}].add_interval({6, 7});
-        ca_type ca_all_local{cl_local};
+        const LevelCellArray<1> all_local = boundary_case1_cells(size_t{4},
+                                                                 n_contig,
+                                                                 domain,
+                                                                 is_periodic,
+                                                                 std::vector<LevelCellArray<1>>{boundary});
+        const LevelCellArray<1> split     = boundary_case1_cells(size_t{4},
+                                                             n_contig,
+                                                             domain,
+                                                             is_periodic,
+                                                             std::vector<LevelCellArray<1>>{empty4, boundary});
 
-        out_t out_single_rank{};
-        std::vector<ca_type> no_neighbours;
-        list_interval_to_refine_for_contiguous_boundary_cells(stencil_radius, ca_all_local, domain, no_neighbours, is_periodic, out_single_rank);
-
-        // Scenario B: this rank owns only the interior coarse cell; a neighbour rank
-        // owns the boundary cells (as can happen after load balancing moves a
-        // subdomain boundary into an active region).
-        CellList<dim> cl_interior_only;
-        cl_interior_only[3][{}].add_interval({6, 7});
-        ca_type ca_without_boundary{cl_interior_only};
-
-        CellList<dim> cl_neighbour;
-        cl_neighbour[4][{}].add_interval({14, 16});
-        ca_type neighbour_ca{cl_neighbour};
-        std::vector<ca_type> mpi_meshes{neighbour_ca};
-
-        out_t out_split_rank{};
-        list_interval_to_refine_for_contiguous_boundary_cells(stencil_radius, ca_without_boundary, domain, mpi_meshes, is_periodic, out_split_rank);
-
-        // The coarse cell must be flagged for refinement in both cases, identically,
-        // whether the boundary cells that trigger it are local or owned by a
-        // neighbour.
-        ASSERT_EQ(out_single_rank[3].size(), 1u);
-        ASSERT_EQ(out_split_rank[3].size(), 1u);
-        EXPECT_EQ(out_single_rank[3].get_interval(0), out_split_rank[3].get_interval(0));
+        EXPECT_GT(count_intervals(4, all_local), 0u) << "the boundary run must force an inner refinement";
+        EXPECT_TRUE(same_lca(4, all_local, split)) << "case-1 refinement must not depend on which rank owns the boundary cell";
     }
-#endif // SAMURAI_WITH_MPI
+
+    TEST(graduation, fused_boundary_case2_partition_independent)
+    {
+        CellList<1> domain_cl;
+        domain_cl[4][{}].add_interval({0, 16});
+        domain_cl[3][{}].add_interval({0, 8});
+        CellArray<1> domain{domain_cl};
+        const std::array<bool, 1> is_periodic{false};
+        const int radius = 3;
+
+        // A level-4 (fine) cell sitting one coarse cell inside the right boundary, so case 2
+        // must pull the fine level out to the boundary. Provided either locally or by a neighbour.
+        CellList<1> fcl;
+        fcl[4][{}].add_interval({12, 14});
+        const LevelCellArray<1> fine = CellArray<1>{fcl}[4];
+        const LevelCellArray<1> empty4;
+
+        const LevelCellArray<1> all_local = boundary_case2_cells(size_t{4}, radius, domain, is_periodic, std::vector<LevelCellArray<1>>{fine});
+        const LevelCellArray<1> split = boundary_case2_cells(size_t{4},
+                                                             radius,
+                                                             domain,
+                                                             is_periodic,
+                                                             std::vector<LevelCellArray<1>>{empty4, fine});
+
+        EXPECT_TRUE(same_lca(4, all_local, split)) << "case-2 refinement must not depend on which rank owns the fine cell";
+    }
 }


### PR DESCRIPTION
## Description
<!-- A clear and concise description of what you have done in this PR. -->

Speeds up the `mesh update` phase of the MR adaptation loop (`harten`), profiled on the
Euler 2D case. Three parts:

1. **Fine-grained timers** for the `mesh update` and `fields update` phases. The whole
   mesh constructor is now accounted for (previously ~50% of `mesh construction` was
   untimed), and a duplicate `"fields update"` timer name is disambiguated.

2. **Skip neighbour serialization when the neighbourhood is empty.**
   `update_mesh_neighbour` / `update_neighbour_subdomain` / `update_meshid_neighbour`
   serialized the whole mesh into a packed archive *before* checking whether there was
   any neighbour to send it to. On a single rank (empty neighbourhood) that is pure
   waste - return early when `m_mpi_neighbourhood` is empty. Multi-rank behaviour is
   unchanged.

3. **Single-pass graduation.** `make_graduation` replaces the fixed-point loop by a single
   top-down sweep. Graduation only ever *adds* fine cells, so a sweep from the finest
   level to the coarsest computes, for each level, the region required at level `>= l`:
   ```
   F[l]      = round_to_parents( ca[l] UNION expand(finer.on(l), grad_width) ) clipped to the coverage
   graded[l] = F[l] \ F[l+1].on(l)
   ```
   Rounding the requirement up to whole parent cells enforces the complete-tree invariant
   (a coarse cell touched by grading is refined *in full*, never partially, which would
   otherwise leave a hole); clipping keeps the refinement inside the mesh. This uses the
   domain pyramid directly (new `Mesh_base::domain_pyramid()`, `domain[level]` instead of
   `self(domain).on(level)`). Periodicity adds the wrapped grading buffer. **Boundary contiguity**
   (`max_stencil_radius > 1`) is **folded into the same sweep**: at each level, before
   the coarser level is graded, the boundary run is thickened inward (case 1) and, for
   wide stencils (`max_stencil_radius > 2`), the fine level is pulled out to the physical
   boundary (case 2). The per-level extension is iterated until the corner region
   stabilises (two physical faces meeting at a domain corner couple across directions).
   Under MPI the driving boundary cells are gathered from the neighbours (a per-level
   graded-cell exchange), so the boundary refinement is independent of the partition.

   **Under MPI** the sweep is synchronised across ranks and, at each level, exchanges only
   that level's cells with the neighbours (a boundary-layer halo) instead of serializing
   the whole mesh, so a cascade crossing a partition boundary is still captured. The
   global level range is agreed with a single small `all_reduce`; there is no
   per-iteration collective.

   The single pass now covers every case (sequential and MPI, all radii), **including
   boundary contiguity**, so the previous fixed-point loop, its ROI-seeding **and the
   separate boundary re-grade loop** are removed - a net simplification.

### Impact (`make_graduation`)

| Case | before (fixed-point) | after (single-pass) |
|---|--:|--:|
| Euler/Burgers 2D, sequential | 1.0x | ~2x faster |
| Burgers 2D MPI (deep mesh, radius 2), 2-8 ranks | 1.0x | ~5x faster |

## How has this been tested?
<!-- Give the list of files used to test this new implementation. -->

- The single-pass result is bit-identical to the former fixed-point result, checked with
  `h5diff` on `scalar_burgers_2d` (sequential), `advection_1d` (periodic) and
  `burgers_os_2d_mpi` (MPI), and by an assertion on `is_graduated` over full runs
  (`SAMURAI_DEBUG_GRADUATION`).
- Boundary contiguity (cases 1 and 2) and the 2D corner coupling are covered by unit
  tests (`graduation.boundary_contiguity_radius2/3`, `boundary_contiguity_corner_2d`,
  `fused_boundary_case{1,2}_partition_independent`) and by the `h5diff` demo tests
  (`burgers`, `lid_driven_cavity`, LBM von Karman).

## Code of Conduct
By submitting this PR, you agree to follow our [Code of Conduct](https://github.com/hpc-maths/samurai/blob/master/docs/CODE_OF_CONDUCT.md)
- [x] I agree to follow this project's Code of Conduct

