### PR TITLE
perf(lbm): faster multi-level stream (slice reconstruction, hoisted scalar-loop stencils)

### DIFF
--- a/include/samurai/reconstruction.hpp
+++ b/include/samurai/reconstruction.hpp
@@ -559,45 +559,75 @@ namespace samurai
 
     namespace detail
     {
+        // Accumulate into @a out the (linear) prediction maps of every sub-cell of a signed box
+        // [start, end) of sub-cell indices, one map per sub-cell. Compile-time recursion over the
+        // dimensions with a *signed* value_t counter: sub-cell indices may be negative (e.g. the LBM
+        // donor slice shifted by -c), unlike the std::size_t multi_dim_loop used elsewhere.
+        template <std::size_t prediction_stencil_radius, class value_t, std::size_t dim, class PMap, class Prefix>
+        void accumulate_slice(PMap& out,
+                              std::size_t delta_l,
+                              const std::array<value_t, dim>& start,
+                              const std::array<value_t, dim>& end,
+                              const Prefix& prefix)
+        {
+            constexpr std::size_t d = std::tuple_size_v<Prefix>;
+            if constexpr (d == dim)
+            {
+                out += std::apply(
+                    [&](auto... idx)
+                    {
+                        return prediction<prediction_stencil_radius, value_t>(delta_l, idx...);
+                    },
+                    prefix);
+            }
+            else
+            {
+                for (value_t k = start[d]; k < end[d]; ++k)
+                {
+                    accumulate_slice<prediction_stencil_radius, value_t, dim>(out, delta_l, start, end, std::tuple_cat(prefix, std::make_tuple(k)));
+                }
+            }
+        }
+
+        // Slice variant: each sub-cell index is a full interval instead of a scalar. Because the
+        // reconstruction is linear, the prediction map of the whole slice is the sum of the maps of
+        // its sub-cells; that sum is built once and cached, so a single application then reconstructs
+        // (and sums) the entire slice at once. This is what makes the LBM stream cheap: one interval
+        // call replaces 2^{delta_l.dim} scalar calls (see LBMScheme::portion_column). Nonlinear users
+        // (e.g. the FV flux) must keep the scalar path and recompute each sub-cell.
         template <std::size_t prediction_stencil_radius, class Field, class... index_t>
-            requires(Field::dim == sizeof...(index_t) + 1 && (std::same_as<typename Field::interval_t, index_t> && ...))
+            requires(Field::dim == sizeof...(index_t) && (std::same_as<typename Field::interval_t, index_t> && ...))
         decltype(auto) get_prediction(std::size_t level, std::size_t delta_l, const std::tuple<index_t...>& ii)
         {
             static constexpr std::size_t dim = Field::dim;
             using value_t                    = typename Field::interval_t::value_t;
-            static std::unordered_map<std::tuple<std::size_t, std::size_t, typename Field::interval_t, index_t...>, prediction_map<dim, value_t>>
-                values;
+            static std::unordered_map<std::tuple<std::size_t, std::size_t, index_t...>, prediction_map<dim, value_t>> values;
 
-            auto iter = std::apply(
-                [&](auto&... index)
-                {
-                    return values.find({prediction_stencil_radius, level, index...});
-                },
-                ii);
-
-            if (iter == values.end())
-            {
-                multi_dim_loop(
-                    ii,
-                    [&](auto... ii_)
-                    {
-                        std::apply(
-                            [&](auto&... index)
-                            {
-                                values[{prediction_stencil_radius, level, index...}] += prediction<prediction_stencil_radius, value_t>(
-                                    delta_l,
-                                    ii_...);
-                            },
-                            ii);
-                    });
-            }
-
-            return std::apply(
+            auto& map = std::apply(
                 [&](auto&... index) -> auto&
                 {
                     return values[{prediction_stencil_radius, level, index...}];
                 },
                 ii);
+
+            if (map.coeff.empty())
+            {
+                const auto start = std::apply(
+                    [](const auto&... iv)
+                    {
+                        return std::array<value_t, dim>{iv.start...};
+                    },
+                    ii);
+                const auto end = std::apply(
+                    [](const auto&... iv)
+                    {
+                        return std::array<value_t, dim>{iv.end...};
+                    },
+                    ii);
+                accumulate_slice<prediction_stencil_radius, value_t, dim>(map, delta_l, start, end, std::tuple<>{});
+            }
+
+            return map;
         }
 
         template <std::size_t prediction_stencil_radius, class Field, class... index_t>

--- a/include/samurai/reconstruction.hpp
+++ b/include/samurai/reconstruction.hpp
@@ -14,9 +14,39 @@
 #include "subset/node.hpp"
 #include "utils.hpp"
 
+/**
+ * @file reconstruction.hpp
+ *
+ * Multiresolution prediction and reconstruction: recovering the value a field
+ * would take on a grid finer than the one it is stored on.
+ *
+ * A cell at level @c l splits into @c 2^dim children at level @c l+1. samurai
+ * keeps only the cells actually present in the adapted mesh; the value of an
+ * absent finer cell is @e predicted from its coarser neighbours through the
+ * wavelet interpolation of half-width @c prediction_stencil_radius (the
+ * @c interp_coeffs<2*radius+1> of numeric/prediction.hpp). Prediction is linear,
+ * so the predicted value is a fixed linear combination of coarse-cell values
+ * that depends only on the level gap and on the child position inside its coarse
+ * cell, never on the field. Three layers build on that fact:
+ *
+ *   - @ref prediction_map        the combination itself: a sparse map
+ *                                {coarse-cell offset -> weight}.
+ *   - @ref prediction "prediction(delta_l, ii)"
+ *                                builds and memoises the map predicting child
+ *                                @c ii, @c delta_l levels below its coarse cell.
+ *   - @ref portion "portion(f, ...)"
+ *                                applies such a map to a field @c f, vectorised
+ *                                over a whole x-interval of coarse cells.
+ *
+ * Two higher-level operations consume them: @ref reconstruction projects an
+ * adapted field onto a uniform fine mesh (I/O, post-processing), and
+ * @ref transfer moves a field from one adapted mesh to another.
+ */
+
 namespace samurai
 {
-    // Hash function for std::array
+    /// Hash a std::array by folding element hashes (boost::hash_combine mix), so
+    /// an offset key can index the unordered_map of a @ref prediction_map.
     template <typename T, std::size_t N>
     struct ArrayHash
     {
@@ -32,6 +62,18 @@ namespace samurai
         }
     };
 
+    /**
+     * Sparse linear combination of cell values. @c coeff maps a @c dim-D integer
+     * offset @c k (relative to a reference cell) to its weight, so the map stands
+     * for  @c sum_k coeff[k] * value(reference + k).
+     *
+     * The class is the algebra of such combinations: @c += / @c -= merge or cancel
+     * the weights of matching offsets, @c *= and the scalar @c += scale or shift
+     * every weight. Because prediction is linear, summing the maps of several
+     * children yields the map of their sum in one object (used by the slice form
+     * of @ref get_prediction). The single-offset constructor is the identity
+     * combination @c value(reference + k) (weight 1).
+     */
     template <std::size_t dim, class index_t = default_config::value_t>
     class prediction_map
     {
@@ -46,6 +88,7 @@ namespace samurai
             coeff[k] = 1.;
         }
 
+        /// Weight of offset @c k, inserted at 0 if absent (so it can be accumulated into).
         double& operator()(const key_t& k)
         {
             auto it = coeff.find(k);
@@ -122,13 +165,11 @@ namespace samurai
             }
         }
 
+        /// Print each `offset: weight` entry, one per line (debugging).
         void to_stream(std::ostream& out) const
         {
             for (const auto& c : coeff)
             {
-                for (const auto& i : c.first)
-                {
-                }
                 out << fmt::format("({}):  {}", c.first, c.second) << std::endl;
             }
         }
@@ -177,6 +218,9 @@ namespace samurai
 
     namespace detail
     {
+        /// Shift @c parent_indices by the stencil offset of a tensor-product node: per
+        /// direction, @c loop_indices runs over @c [0, 2*order+1) and @c loop_index - order
+        /// is the signed offset around the parent (0 at the stencil centre).
         template <std::size_t... Is>
         auto compute_new_indices(auto order, const auto& parent_indices, const auto& loop_indices, std::index_sequence<Is...>)
         {
@@ -192,6 +236,8 @@ namespace samurai
                                        std::make_index_sequence<std::tuple_size_v<std::decay_t<decltype(parent_indices)>>>{});
         }
 
+        /// Tensor-product weight of a stencil node: the product over the directions of the
+        /// per-direction interpolation coefficients @c interp_coeffs[d][indices[d]].
         template <std::size_t... Is>
         auto compute_coeff(const auto& interp_coeffs, const auto& indices, std::index_sequence<Is...>)
         {
@@ -203,6 +249,17 @@ namespace samurai
             return compute_coeff(interp_coeffs, indices, std::make_index_sequence<std::tuple_size_v<std::decay_t<decltype(interp_coeffs)>>>{});
         }
 
+        /**
+         * Cartesian-product loop: call @c func once per node of the box
+         * @c [start, end) (one range per direction), passing the @c dim indices of
+         * the node. @c compute_idx_func maps each raw counter to the index handed to
+         * @c func. The convenience overloads below take a tuple of coefficient arrays
+         * (range @c [0, size)) or of intervals (range @c [start, end)).
+         *
+         * @note The counter is @c std::size_t, so the ranges must be non-negative.
+         *       A signed range (e.g. sub-cell indices shifted below 0) needs its own
+         *       loop, see @ref accumulate_slice.
+         */
         template <class FuncIdx, class Func, std::size_t d>
         void multi_dim_loop(auto& current_index,
                             const auto& start,
@@ -307,6 +364,29 @@ namespace samurai
 
     }
 
+    /**
+     * Prediction stencil of a single fine child, as a @ref prediction_map.
+     *
+     * Returns the linear combination of coarse-cell values that predicts the child
+     * whose integer position is @c indices, sitting @c level levels below a
+     * reference coarse cell placed at the origin; the map offsets are in coarse-cell
+     * units, relative to that reference. For @c indices in @c [0, 2^level)^dim the
+     * child lies inside the reference cell; outside that box the stencil reaches into
+     * the neighbouring coarse cells (this is how the LBM stream expresses a shift by
+     * crossing coarse-cell boundaries).
+     *
+     * @tparam order  half-width of the wavelet interpolation, i.e.
+     *                @c prediction_stencil_radius (uses @c interp_coeffs<2*order+1>).
+     * @param  level  the level gap @c delta_l (NOT an absolute level). @c 0 is the
+     *                identity map @c {indices: 1} (the cell itself).
+     *
+     * Built by recursion on the gap: the child's parent is @c indices>>1 one level up,
+     * and the odd/even parity @c indices&1 picks the interpolation sign per direction.
+     * The map is the parent's stencil plus the tensor-product interpolation correction
+     * of the non-central neighbours, each itself a @c level-1 stencil, so composing the
+     * one-level wavelet prediction @c level times. Every intermediate map is memoised in
+     * a static cache keyed by @c (order, level, indices).
+     */
     template <std::size_t order = 1, class... index_t>
     auto& prediction(std::size_t level, index_t... indices)
     {
@@ -364,44 +444,22 @@ namespace samurai
         return values[key];
     }
 
+    /**
+     * Subset operator used by @ref reconstruction. On the intersection of a coarse
+     * level with the uniform reconstruction level, it writes every fine child of the
+     * coarse cells: for each of the @c 2^{delta_l.dim} sub-positions it applies the
+     * @ref prediction stencil of that child. The whole coarse x-interval is handled at
+     * once by addressing its fine cells with a strided interval (@c i_f.step), so the
+     * prediction of a given sub-position is broadcast over the interval. @c delta_l == 0
+     * (source already at the reconstruction level) is a plain copy. One overload per
+     * dimension, same logic with one more nested sub-position loop.
+     */
     template <std::size_t dim, class TInterval>
     class reconstruction_op_ : public field_operator_base<dim, TInterval>
     {
       public:
 
         INIT_OPERATOR(reconstruction_op_)
-
-        // template <std::size_t d, class T1, class T2>
-        // SAMURAI_INLINE void operator()(Dim<d>, std::size_t& reconstruct_level, T1& dest, const T2& src) const
-        // {
-        //     using index_t                          = typename T2::interval_t::value_t;
-        //     constexpr std::size_t prediction_stencil_radius = T2::mesh_t::config_t::prediction_stencil_radius;
-
-        //     std::size_t delta_l = reconstruct_level - level;
-        //     if (delta_l == 0)
-        //     {
-        //         dest(level, i, index) = src(level, i, index);
-        //     }
-        //     else
-        //     {
-        //         index_t nb_cells = 1 << delta_l;
-        //         detail::multi_dim_loop(interp_coeff_values,
-        //                                  [&](auto&... out_indices)
-        //                                  {
-        //                                      auto& pred = prediction<prediction_stencil_radius, index_t>(delta_l, out_indices...);
-        //                                      for (const auto& kv : pred.coeff)
-        //                                      {
-        //                                          std::apply(
-        //                                              [&](auto&... in_indices)
-        //                                              {
-        //                                                  dest(reconstruct_level, out_indices...) += kv.second * src(level,
-        //                                                  in_indices...);
-        //                                              },
-        //                                              detail::compute_new_indices(0, i, kv.first));
-        //                                      }
-        //                                  });
-        //     }
-        // }
 
         template <class T1, class T2>
         SAMURAI_INLINE void operator()(Dim<1>, std::size_t& reconstruct_level, T1& dest, const T2& src) const
@@ -501,6 +559,7 @@ namespace samurai
         }
     };
 
+    /// Wrap @ref reconstruction_op_ as a subset operator (see @c apply_op).
     template <class T1, class T2>
     SAMURAI_INLINE auto make_reconstruction(std::size_t& reconstruct_level, T1&& reconstruct_field, T2&& field)
     {
@@ -509,6 +568,15 @@ namespace samurai
                                                                 std::forward<T2>(field));
     }
 
+    /**
+     * Reconstruct an adapted field onto the uniform grid at the domain (finest) level
+     * and return it as a new field on that grid. Every coarse cell is expanded into its
+     * fine children by @ref reconstruction_op_. Mainly for I/O and post-processing, where
+     * a single-resolution image of the solution is wanted.
+     *
+     * Requires at least two boundary ghosts (the prediction stencil reaches two coarse
+     * cells); throws otherwise. Ghosts are refreshed first via @c update_ghost_mr_if_needed.
+     */
     template <class Field>
     auto reconstruction(Field& field)
     {
@@ -559,10 +627,13 @@ namespace samurai
 
     namespace detail
     {
-        // Accumulate into @a out the (linear) prediction maps of every sub-cell of a signed box
-        // [start, end) of sub-cell indices, one map per sub-cell. Compile-time recursion over the
-        // dimensions with a *signed* value_t counter: sub-cell indices may be negative (e.g. the LBM
-        // donor slice shifted by -c), unlike the std::size_t multi_dim_loop used elsewhere.
+        /**
+         * Sum into @a out the @ref prediction stencils of every child of a signed box
+         * @c [start, end) of child indices, one @ref prediction call per child.
+         * Compile-time recursion over the directions with a @e signed @c value_t counter:
+         * child indices may be negative (e.g. the LBM donor slice shifted by @c -c),
+         * which the @c std::size_t @ref multi_dim_loop cannot iterate.
+         */
         template <std::size_t prediction_stencil_radius, class value_t, std::size_t dim, class PMap, class Prefix>
         void accumulate_slice(PMap& out,
                               std::size_t delta_l,
@@ -589,12 +660,26 @@ namespace samurai
             }
         }
 
-        // Slice variant: each sub-cell index is a full interval instead of a scalar. Because the
-        // reconstruction is linear, the prediction map of the whole slice is the sum of the maps of
-        // its sub-cells; that sum is built once and cached, so a single application then reconstructs
-        // (and sums) the entire slice at once. This is what makes the LBM stream cheap: one interval
-        // call replaces 2^{delta_l.dim} scalar calls (see LBMScheme::portion_column). Nonlinear users
-        // (e.g. the FV flux) must keep the scalar path and recompute each sub-cell.
+        /**
+         * Prediction stencil to apply for a @ref portion request, dispatched on the type
+         * of the child index @a ii. Two forms:
+         *
+         *  - @b scalar (@c ii all @c value_t): the stencil of that single child, i.e.
+         *    @ref prediction "prediction(delta_l, ii)". The scalar overload just forwards
+         *    to the already-cached @ref prediction and ignores @a level.
+         *
+         *  - @b slice (@c ii all @c interval_t, this overload): each direction is a range
+         *    of children, so @a ii describes a whole box of them. Reconstruction is linear,
+         *    so the box's stencil is the sum of its children's stencils; that sum is built
+         *    once (via @ref accumulate_slice) and cached, keyed by @c (radius, level, ii).
+         *    A later @ref portion then reconstructs and sums the whole box in one pass over
+         *    a small, gap-independent stencil, instead of one call per child. This is what
+         *    makes the LBM stream cheap (see @c LBMScheme::portion_column); a nonlinear user
+         *    such as the FV flux must instead recompute each child with the scalar form.
+         *
+         * @param level  coarse level where the field is read; only a cache discriminator,
+         *               the stencil itself depends on @c delta_l and @a ii alone.
+         */
         template <std::size_t prediction_stencil_radius, class Field, class... index_t>
             requires(Field::dim == sizeof...(index_t) && (std::same_as<typename Field::interval_t, index_t> && ...))
         decltype(auto) get_prediction(std::size_t level, std::size_t delta_l, const std::tuple<index_t...>& ii)
@@ -630,6 +715,7 @@ namespace samurai
             return map;
         }
 
+        /// Scalar form of @ref get_prediction: the stencil of the single child @a ii.
         template <std::size_t prediction_stencil_radius, class Field, class... index_t>
             requires((std::same_as<typename Field::interval_t::value_t, index_t> && ...))
         decltype(auto) get_prediction(std::size_t, std::size_t delta_l, const std::tuple<index_t...>& ii)
@@ -643,6 +729,14 @@ namespace samurai
                 ii);
         }
 
+        /**
+         * Apply the @ref get_prediction stencil of the child(ren) @a ii to a field, over a
+         * whole coarse cell / interval: @c result = sum_k weight_k * get_f(level, i + offset_k).
+         * @a get_f reads the field (a component, the full vector, ...); @a i is the coarse
+         * location, its first entry an interval so the whole row is reconstructed at once, its
+         * remaining entries the transverse coarse indices. @a ii selects the child (scalar) or
+         * the child box (interval slice, summed by @ref get_prediction).
+         */
         template <std::size_t prediction_stencil_radius, class Field, class Func, class... index_t, class... cell_index_t>
             requires(Field::dim == sizeof...(index_t) + 1 && Field::dim == sizeof...(cell_index_t)
                      && ((std::same_as<typename Field::interval_t, cell_index_t> && ...)
@@ -687,6 +781,24 @@ namespace samurai
         }
     }
 
+    /**
+     * Reconstructed value of the child(ren) @a ii of the coarse cell(s) @a i, for a field
+     * @a f stored @a delta_l levels coarser than those children.
+     *
+     * @param f       the field, read at @a level.
+     * @param element (per-component overloads only) reconstruct just this component.
+     * @param level   coarse level where @a f is read.
+     * @param delta_l level gap between @a f and the children (0 = same level = plain read).
+     * @param i       coarse location: its first entry is an interval (the reconstruction is
+     *                vectorised over that whole row of coarse cells), the rest are the
+     *                transverse coarse indices.
+     * @param ii      one child index per direction: a @c value_t picks a single child, an
+     *                @c interval_t sums the whole child slice at once (see @ref get_prediction).
+     *
+     * The @c (result, ...) overloads accumulate into a caller-provided buffer; the returning
+     * overloads allocate a zeroed result first. The stencil half-width defaults to the mesh's
+     * @c prediction_stencil_radius, or is given explicitly as the first template argument.
+     */
     template <class Field, class... index_t, class... cell_index_t>
     void portion(auto& result,
                  const Field& f,
@@ -721,6 +833,7 @@ namespace samurai
         return result;
     }
 
+    /// Whole-field @ref portion (no @c element): reconstructs every component at once.
     template <std::size_t prediction_stencil_radius, class Field, class... index_t, class... cell_index_t>
     void portion(auto& result,
                  const Field& f,
@@ -777,6 +890,8 @@ namespace samurai
 
     namespace detail
     {
+        /// Turn a coarse-cell index array into the @a i tuple @ref portion expects: the x index
+        /// becomes the degenerate interval @c [x, x+1), the transverse indices are kept scalar.
         template <std::size_t dim, class interval_t>
         auto extract_src_tuple(const auto& src_indices)
         {
@@ -786,6 +901,8 @@ namespace samurai
             }(std::make_index_sequence<dim - 1>{});
         }
 
+        /// Turn a child index array into the @a ii tuple @ref portion expects (kept scalar,
+        /// one child per direction).
         template <std::size_t dim>
         auto extract_dst_tuple([[maybe_unused]] auto delta_l, const auto& dst_indices)
         {
@@ -798,7 +915,9 @@ namespace samurai
         }
     }
 
-    // N-D
+    /// Single-cell @ref portion taking plain index arrays (a coarse cell and one of its
+    /// children) instead of the interval tuples; convenience for @ref transfer. Reconstructs
+    /// component 0 for a vector field.
     template <class Field>
     void portion(auto& result,
                  const Field& f,
@@ -829,6 +948,14 @@ namespace samurai
         detail::portion_impl<Field::mesh_t::config_t::prediction_stencil_radius, Field>(result, get_f, level, delta_l, src_tuple, dst_tuple);
     }
 
+    /**
+     * Copy a field from one adapted mesh onto another (of the same domain), resampling where
+     * the two meshes differ in resolution. For each destination level, a cell is filled from
+     * the source by one of three cases: an exact copy where the source has the same cell; a
+     * projection (average of the @c 2^{shift.dim} finer source cells) where the source is finer;
+     * or a @ref portion prediction where the source is coarser. Requires at least two boundary
+     * ghosts on the source (prediction stencil); throws otherwise.
+     */
     template <class Field_src, class Field_dst>
     void transfer(Field_src& field_src, Field_dst& field_dst)
     {
@@ -852,6 +979,7 @@ namespace samurai
 
         for (std::size_t level_dst = mesh_dst.min_level(); level_dst <= mesh_dst.max_level(); ++level_dst)
         {
+            // Case 1: same cell on both meshes -> copy.
             auto same_cell = intersection(mesh_dst[mesh_id_t::cells][level_dst], mesh_src[mesh_id_t::cells][level_dst]);
             same_cell(
                 [&](const auto& i, const auto& index)
@@ -859,6 +987,7 @@ namespace samurai
                     field_dst(level_dst, i, index) = field_src(level_dst, i, index);
                 });
 
+            // Case 2: source finer -> average its children onto the destination cell.
             for (std::size_t level_src = level_dst + 1; level_src <= mesh_src.max_level(); ++level_src)
             {
                 auto proj_cell = intersection(mesh_dst[mesh_id_t::cells][level_dst], mesh_src[mesh_id_t::cells][level_src]).on(level_src);
@@ -885,6 +1014,7 @@ namespace samurai
                     });
             }
 
+            // Case 3: source coarser -> predict each destination child from it (see @ref portion).
             for (std::size_t level_src = mesh_src.min_level(); level_src < level_dst; ++level_src)
             {
                 auto pred_cell = intersection(mesh_dst[mesh_id_t::cells][level_dst], mesh_src[mesh_id_t::cells][level_src]).on(level_dst);

--- a/include/samurai/reconstruction.hpp
+++ b/include/samurai/reconstruction.hpp
@@ -655,7 +655,11 @@ namespace samurai
             {
                 for (value_t k = start[d]; k < end[d]; ++k)
                 {
-                    accumulate_slice<prediction_stencil_radius, value_t, dim>(out, delta_l, start, end, std::tuple_cat(prefix, std::make_tuple(k)));
+                    accumulate_slice<prediction_stencil_radius, value_t, dim>(out,
+                                                                              delta_l,
+                                                                              start,
+                                                                              end,
+                                                                              std::tuple_cat(prefix, std::make_tuple(k)));
                 }
             }
         }

--- a/include/samurai/schemes/lbm/lbm_scheme.hpp
+++ b/include/samurai/schemes/lbm/lbm_scheme.hpp
@@ -184,6 +184,8 @@ namespace samurai
         template <class MField>
         void operator()(field_t& f, MField& m, double dt = 0.) const
         {
+            ScopedTimer timer_op(m_name + " operator");
+
             update_ghost_mr(f);
 
             // Reuse a worker field for the streamed distributions instead of reallocating it every
@@ -199,9 +201,15 @@ namespace samurai
                 m_f_stream->resize();
             }
 
-            stream(f, *m_f_stream);
+            {
+                ScopedTimer timer_stream("lbm stream");
+                stream(f, *m_f_stream);
+            }
             std::swap(f.array(), m_f_stream->array());
-            collide(f, m, dt);
+            {
+                ScopedTimer timer_collide("lbm collide");
+                collide(f, m, dt);
+            }
         }
 
       private:

--- a/include/samurai/schemes/lbm/lbm_scheme.hpp
+++ b/include/samurai/schemes/lbm/lbm_scheme.hpp
@@ -331,6 +331,7 @@ namespace samurai
             const std::size_t max_level = mesh.max_level(); // configured finest level of the hierarchy
 
             std::array<std::vector<stencil_tap>, n_comp> stencil;
+            std::vector<double> res; // reused accumulation buffer, sized to the current strip
 
             for (std::size_t level = mesh.min_level(); level <= mesh.max_level(); ++level)
             {
@@ -353,14 +354,34 @@ namespace samurai
                                       for (std::size_t comp = 0; comp < n_comp; ++comp)
                                       {
                                           const auto& taps = stencil[comp];
-                                          // Accumulate into a contiguous temporary (cache-resident), then write the
-                                          // strided component strip of f_out once, rather than accumulating in place.
-                                          auto res = xt::eval(taps[0].w * access(f_in, comp, lvl, i, index, taps[0].off, tseq));
+                                          auto out         = access(f_out, comp, lvl, i, index, no_shift, tseq);
+                                          const std::size_t sz = static_cast<std::size_t>(out.size());
+
+                                          // Accumulate the taps into a reused contiguous buffer with plain scalar
+                                          // loops (no temporary allocation, no lazy-expression machinery), then write
+                                          // the strided f_out strip once.
+                                          res.resize(sz);
+                                          {
+                                              auto vin       = access(f_in, comp, lvl, i, index, taps[0].off, tseq);
+                                              const double w = taps[0].w;
+                                              for (std::size_t ic = 0; ic < sz; ++ic)
+                                              {
+                                                  res[ic] = w * vin(ic);
+                                              }
+                                          }
                                           for (std::size_t t = 1; t < taps.size(); ++t)
                                           {
-                                              res += taps[t].w * access(f_in, comp, lvl, i, index, taps[t].off, tseq);
+                                              auto vin       = access(f_in, comp, lvl, i, index, taps[t].off, tseq);
+                                              const double w = taps[t].w;
+                                              for (std::size_t ic = 0; ic < sz; ++ic)
+                                              {
+                                                  res[ic] += w * vin(ic);
+                                              }
                                           }
-                                          access(f_out, comp, lvl, i, index, no_shift, tseq) = res;
+                                          for (std::size_t ic = 0; ic < sz; ++ic)
+                                          {
+                                              out(ic) = res[ic];
+                                          }
                                       }
                                   });
             }

--- a/include/samurai/schemes/lbm/lbm_scheme.hpp
+++ b/include/samurai/schemes/lbm/lbm_scheme.hpp
@@ -353,8 +353,8 @@ namespace samurai
                                   {
                                       for (std::size_t comp = 0; comp < n_comp; ++comp)
                                       {
-                                          const auto& taps = stencil[comp];
-                                          auto out         = access(f_out, comp, lvl, i, index, no_shift, tseq);
+                                          const auto& taps     = stencil[comp];
+                                          auto out             = access(f_out, comp, lvl, i, index, no_shift, tseq);
                                           const std::size_t sz = static_cast<std::size_t>(out.size());
 
                                           // Accumulate the taps into a reused contiguous buffer with plain scalar

--- a/include/samurai/schemes/lbm/lbm_scheme.hpp
+++ b/include/samurai/schemes/lbm/lbm_scheme.hpp
@@ -10,6 +10,7 @@
 #include <string>
 #include <tuple>
 #include <utility>
+#include <vector>
 
 #include "../../algorithm.hpp"
 #include "../../algorithm/update_ghost_mr.hpp"
@@ -255,49 +256,51 @@ namespace samurai
         using interval_t = typename field_t::interval_t;
         using value_t    = typename interval_t::value_t;
 
-        /**
-         * Streamed value of one velocity at a coarse interval, using the library's cached portion().
-         *
-         * The streamed coarse value is the projection (average) over the coarse cell's 2^{j.dim}
-         * fine sub-cells of their reconstructed donor value (the sub-cell shifted by -c at the
-         * finest level):
-         *
-         *     f_out(C) = (1/2^{j.dim}) sum_{local in [0,2^j)^dim} reconstruct(f, C, local - c).
-         *
-         * The stream operator is linear, so this whole sum is a single application of the prediction
-         * map of the sub-cell *slice* [0,2^j)^dim shifted by -c: per direction the donor sub-cell
-         * index runs over the interval [-c[d], 2^j - c[d]). We pass that interval tuple to portion(),
-         * which builds the slice's combined prediction map once and caches it (see the interval
-         * overload of get_prediction in reconstruction.hpp); every later step is then one vectorised
-         * pass over that small combined stencil instead of 2^{j.dim} separate reconstructions. This
-         * handles axial, diagonal and |c| > 1 velocities uniformly; at the finest level (j == 0) the
-         * slice is the single sub-cell {-c}, i.e. the plain shift by -c. The caller applies the
-         * 1/2^{j.dim} projection weight.
-         *
-         * @c transverse_seq is 0..dim-2 (the coarse-cell transverse indices), @c dim_seq is
-         * 0..dim-1 (one sub-cell interval per direction).
-         */
-        template <std::size_t... T, std::size_t... D>
-        static auto portion_column(const field_t& f,
-                                   std::size_t comp,
-                                   std::size_t level,
-                                   std::size_t j,
-                                   const auto& i,
-                                   const auto& index,
-                                   const velocity_t& c,
-                                   std::index_sequence<T...> /*transverse_seq*/,
-                                   std::index_sequence<D...> /*dim_seq*/)
+        // One tap of a stream stencil: read f_in at offset @c off and add it, weighted by @c w (the
+        // 1/2^{j.dim} projection already folded in), into f_out.
+        struct stencil_tap
         {
-            const auto width   = static_cast<value_t>(std::size_t{1} << j); // 2^j sub-cells per direction
-            const auto i_tuple = std::make_tuple(i, index[T]...);
+            std::array<int, dim> off;
+            double w;
+        };
 
-            // Donor sub-cell slice: index runs over [-c[d], 2^j - c[d]) in each direction, i.e. the
-            // full 2^{j.dim} column shifted by -c. portion() sums it via one cached combined map.
-            const auto slice = std::make_tuple(interval_t{-static_cast<value_t>(c[D]), width - static_cast<value_t>(c[D])}...);
+        /**
+         * Flattened stream stencil of one velocity at a level gap @a j: the combined slice prediction
+         * map (@ref get_prediction), with the 1/2^{j.dim} projection weight @a inv_nc folded into
+         * every coefficient. The streamed value of a coarse cell C is then simply
+         *
+         *     f_out(C) = sum_tap tap.w * f_in(C + tap.off).
+         *
+         * The stream is linear, so the projection (average) over the 2^{j.dim} fine sub-cells of their
+         * reconstructed donor value is a single application of the summed prediction map of the donor
+         * sub-cell slice [-c[d], 2^j - c[d]) (one interval per direction, the full column shifted by
+         * -c). That map depends only on (j, c), not on the cell, so the stencil is built once per
+         * (level, component) and reused over the whole level. It handles axial, diagonal and |c| > 1
+         * velocities uniformly; at the finest level (j == 0) it is the plain shift by -c, and for the
+         * rest velocity c == 0 it reduces to the identity (mean conservation).
+         */
+        template <std::size_t... D>
+        static std::vector<stencil_tap>
+        build_stencil(std::size_t level, std::size_t j, const velocity_t& c, double inv_nc, std::index_sequence<D...> /*dim_seq*/)
+        {
+            constexpr std::size_t radius = field_t::mesh_t::config_t::prediction_stencil_radius;
+            const auto width             = static_cast<value_t>(std::size_t{1} << j); // 2^j sub-cells per direction
+            const auto slice             = std::make_tuple(interval_t{-static_cast<value_t>(c[D]), width - static_cast<value_t>(c[D])}...);
 
-            // Reconstruct only component @a comp (the one owning velocity c), vectorised over the
-            // coarse interval; portion() caches the underlying prediction map (reconstruction.hpp).
-            return portion(f, comp, level, j, i_tuple, slice);
+            const auto& map = detail::get_prediction<radius, field_t>(level, j, slice);
+
+            std::vector<stencil_tap> taps;
+            taps.reserve(map.coeff.size());
+            for (const auto& kv : map.coeff)
+            {
+                std::array<int, dim> off{};
+                for (std::size_t d = 0; d < dim; ++d)
+                {
+                    off[d] = static_cast<int>(kv.first[d]);
+                }
+                taps.push_back({off, inv_nc * kv.second});
+            }
+            return taps;
         }
 
         // Read/write f(comp, level, i + off[0], index[.] + off[.+1]) unpacking the transverse dims.
@@ -313,36 +316,52 @@ namespace samurai
             return f(comp, level, i + off[0], (index[K] + off[K + 1])...);
         }
 
-        // stream: multi-level transport via the library's cached portion().
+        // stream: multi-level linear transport. For each level the per-component stencils are built
+        // once (build_stencil; the underlying prediction maps are cached across steps), then applied
+        // to every cell strip - reading f_in and writing f_out directly, with no per-strip prediction
+        // lookup and no temporary.
         void stream(const field_t& f_in, field_t& f_out) const
         {
             using mesh_id_t     = typename field_t::mesh_t::mesh_id_t;
             constexpr auto tseq = std::make_index_sequence<dim - 1>{}; // transverse indices of the coarse cell
-            constexpr auto dseq = std::make_index_sequence<dim>{};     // one sub-cell range per direction
+            constexpr auto dseq = std::make_index_sequence<dim>{};     // one sub-cell interval per direction
             const std::array<int, dim> no_shift{};
 
             auto& mesh                  = f_in.mesh();
             const std::size_t max_level = mesh.max_level(); // configured finest level of the hierarchy
+
+            std::array<std::vector<stencil_tap>, n_comp> stencil;
 
             for (std::size_t level = mesh.min_level(); level <= mesh.max_level(); ++level)
             {
                 const std::size_t j = max_level - level;
                 const double inv_nc = 1. / static_cast<double>(std::size_t{1} << (j * dim)); // 1/2^{j.dim} projection weight
 
+                for_each_block(
+                    [&](const auto& block, std::size_t offset)
+                    {
+                        constexpr std::size_t q = std::decay_t<decltype(block)>::q;
+                        for (std::size_t a = 0; a < q; ++a)
+                        {
+                            stencil[offset + a] = build_stencil(level, j, block.velocities[a], inv_nc, dseq);
+                        }
+                    });
+
                 for_each_interval(mesh[mesh_id_t::cells][level],
                                   [&](std::size_t lvl, const auto& i, const auto& index)
                                   {
-                                      for_each_block(
-                                          [&](const auto& block, std::size_t offset)
+                                      for (std::size_t comp = 0; comp < n_comp; ++comp)
+                                      {
+                                          const auto& taps = stencil[comp];
+                                          // Accumulate into a contiguous temporary (cache-resident), then write the
+                                          // strided component strip of f_out once, rather than accumulating in place.
+                                          auto res = xt::eval(taps[0].w * access(f_in, comp, lvl, i, index, taps[0].off, tseq));
+                                          for (std::size_t t = 1; t < taps.size(); ++t)
                                           {
-                                              constexpr std::size_t q = std::decay_t<decltype(block)>::q;
-                                              for (std::size_t a = 0; a < q; ++a)
-                                              {
-                                                  const std::size_t comp = offset + a;
-                                                  auto res = portion_column(f_in, comp, lvl, j, i, index, block.velocities[a], tseq, dseq);
-                                                  access(f_out, comp, lvl, i, index, no_shift, tseq) = inv_nc * res;
-                                              }
-                                          });
+                                              res += taps[t].w * access(f_in, comp, lvl, i, index, taps[t].off, tseq);
+                                          }
+                                          access(f_out, comp, lvl, i, index, no_shift, tseq) = res;
+                                      }
                                   });
             }
         }

--- a/include/samurai/schemes/lbm/lbm_scheme.hpp
+++ b/include/samurai/schemes/lbm/lbm_scheme.hpp
@@ -264,14 +264,18 @@ namespace samurai
          *
          *     f_out(C) = (1/2^{j.dim}) sum_{local in [0,2^j)^dim} reconstruct(f, C, local - c).
          *
-         * Each term is one portion() call reconstructing sub-cell (local - c) of the coarse cell,
-         * vectorised over the whole coarse interval; portion() caches the underlying prediction map
-         * (reconstruction.hpp). The caller applies the 1/2^{j.dim} projection weight. This handles
-         * axial, diagonal and |c| > 1 velocities uniformly; at the finest level (j == 0) the column
-         * is the single sub-cell {-c}, i.e. the plain shift by -c.
+         * The stream operator is linear, so this whole sum is a single application of the prediction
+         * map of the sub-cell *slice* [0,2^j)^dim shifted by -c: per direction the donor sub-cell
+         * index runs over the interval [-c[d], 2^j - c[d]). We pass that interval tuple to portion(),
+         * which builds the slice's combined prediction map once and caches it (see the interval
+         * overload of get_prediction in reconstruction.hpp); every later step is then one vectorised
+         * pass over that small combined stencil instead of 2^{j.dim} separate reconstructions. This
+         * handles axial, diagonal and |c| > 1 velocities uniformly; at the finest level (j == 0) the
+         * slice is the single sub-cell {-c}, i.e. the plain shift by -c. The caller applies the
+         * 1/2^{j.dim} projection weight.
          *
          * @c transverse_seq is 0..dim-2 (the coarse-cell transverse indices), @c dim_seq is
-         * 0..dim-1 (used to decode the sub-cell offsets, one per direction).
+         * 0..dim-1 (one sub-cell interval per direction).
          */
         template <std::size_t... T, std::size_t... D>
         static auto portion_column(const field_t& f,
@@ -284,24 +288,16 @@ namespace samurai
                                    std::index_sequence<T...> /*transverse_seq*/,
                                    std::index_sequence<D...> /*dim_seq*/)
         {
-            const auto width     = std::size_t{1} << j;         // 2^j sub-cells per direction
-            const std::size_t nc = std::size_t{1} << (j * dim); // 2^{j.dim} sub-cells in the column
-            const auto i_tuple   = std::make_tuple(i, index[T]...);
+            const auto width   = static_cast<value_t>(std::size_t{1} << j); // 2^j sub-cells per direction
+            const auto i_tuple = std::make_tuple(i, index[T]...);
 
-            // Sub-cell offsets (donor = local - c) of the n-th fine sub-cell, as a value_t tuple.
-            auto sub = [&](std::size_t n)
-            {
-                return std::make_tuple((static_cast<value_t>((n >> (D * j)) & (width - 1)) - static_cast<value_t>(c[D]))...);
-            };
+            // Donor sub-cell slice: index runs over [-c[d], 2^j - c[d]) in each direction, i.e. the
+            // full 2^{j.dim} column shifted by -c. portion() sums it via one cached combined map.
+            const auto slice = std::make_tuple(interval_t{-static_cast<value_t>(c[D]), width - static_cast<value_t>(c[D])}...);
 
             // Reconstruct only component @a comp (the one owning velocity c), vectorised over the
             // coarse interval; portion() caches the underlying prediction map (reconstruction.hpp).
-            auto res = portion(f, comp, level, j, i_tuple, sub(0));
-            for (std::size_t n = 1; n < nc; ++n)
-            {
-                res += portion(f, comp, level, j, i_tuple, sub(n));
-            }
-            return res;
+            return portion(f, comp, level, j, i_tuple, slice);
         }
 
         // Read/write f(comp, level, i + off[0], index[.] + off[.+1]) unpacking the transverse dims.

--- a/tests/test_portion.cpp
+++ b/tests/test_portion.cpp
@@ -1,3 +1,5 @@
+#include <cmath>
+
 #include <gtest/gtest.h>
 #include <samurai/algorithm.hpp>
 #include <samurai/box.hpp>
@@ -5,10 +7,21 @@
 #include <samurai/reconstruction.hpp>
 #include <samurai/uniform_mesh.hpp>
 
+// Tests for portion() (include/samurai/reconstruction.hpp): the reconstructed value a field would
+// take on a virtually finer grid. Two forms are exercised:
+//   - scalar child index  ii = {k...}          : one fine child, used by the FV flux and transfer();
+//   - interval child index ii = {[a, b)...}    : a whole slice of children summed at once, used by
+//                                                the LBM stream (LBMScheme::portion_column).
+// The reconstruction is done on a single-level uniform mesh, so portion reads only real cells; the
+// coarse cells are kept in the interior so the prediction stencil never reaches outside the domain.
+
 namespace samurai
 {
+    // Affine field u = sum of the cell-centre coordinates (u = x in 1D, x + y in 2D, ...). The
+    // radius-1 wavelet prediction reproduces affine fields exactly, so the reconstruction of any
+    // child must equal that child's exact centre coordinate sum.
     template <class Mesh>
-    auto init(Mesh& mesh)
+    auto init_affine(Mesh& mesh)
     {
         using mesh_id_t = typename Mesh::mesh_id_t;
         auto u          = make_scalar_field<double>("u", mesh);
@@ -20,39 +33,266 @@ namespace samurai
         return u;
     }
 
-    TEST(portion, 1D)
+    // A deliberately non-affine field: the linearity and mean-conservation identities below hold for
+    // any field, so using one the predictor does NOT reproduce exactly makes sure those tests check
+    // the aggregation logic rather than accidental exactness.
+    template <class Mesh>
+    auto init_nonlinear(Mesh& mesh)
+    {
+        static constexpr std::size_t dim = Mesh::dim;
+        using mesh_id_t                  = typename Mesh::mesh_id_t;
+        auto u                           = make_scalar_field<double>("u", mesh);
+        for_each_cell(mesh[mesh_id_t::cells],
+                      [&](const auto& cell)
+                      {
+                          const auto c = cell.center();
+                          double v     = 1.;
+                          for (std::size_t d = 0; d < dim; ++d)
+                          {
+                              v += static_cast<double>(d + 1) * c[d] * c[d] + std::cos(static_cast<double>(d + 2) * c[d]);
+                          }
+                          u[cell] = v;
+                      });
+        return u;
+    }
+
+    // ------------------------------------------------------------------ exactness on an affine field
+    // portion of a single child must return that child's exact value. The radius-1 predictor is exact
+    // on affine fields, so this pins the scalar form (the per-child usage of FV flux / transfer) down
+    // to the analytic cell-centre value, for every child of a coarse cell, in 1D/2D/3D.
+
+    TEST(portion, affine_all_children_1d)
     {
         constexpr std::size_t dim = 1;
         using config              = UniformConfig<dim>;
-        using interval_t          = typename UniformConfig<dim>::interval_t;
-        auto mesh                 = UniformMesh<config>(Box<double, dim>({0}, {1}), 5);
-        auto u                    = init(mesh);
+        using interval_t          = typename config::interval_t;
+        constexpr std::size_t L   = 5;
+        constexpr std::size_t dl  = 4; // reconstruct four levels below -> level 9
+        auto mesh                 = UniformMesh<config>(Box<double, dim>({0}, {1}), L);
+        auto u                    = init_affine(mesh);
 
-        auto p = portion<1>(u, 5, 4, std::make_tuple(interval_t{2, 3}), std::make_tuple(0));
-        EXPECT_EQ(p[0], ((2 << 4) + .5) / (1 << 9));
+        const int i = 2;
+        for (int ii = 0; ii < (1 << dl); ++ii)
+        {
+            auto p                = portion<1>(u, L, dl, std::make_tuple(interval_t{i, i + 1}), std::make_tuple(ii));
+            const double fine_ctr = ((i << dl) + ii + .5) / (1 << (L + dl));
+            EXPECT_DOUBLE_EQ(p[0], fine_ctr) << "child " << ii;
+        }
     }
 
-    TEST(portion, 2D)
+    TEST(portion, affine_all_children_2d)
     {
         constexpr std::size_t dim = 2;
         using config              = UniformConfig<dim>;
-        using interval_t          = typename UniformConfig<dim>::interval_t;
-        auto mesh                 = UniformMesh<config>(Box<double, dim>({0, 0}, {1, 1}), 5);
-        auto u                    = init(mesh);
+        using interval_t          = typename config::interval_t;
+        constexpr std::size_t L   = 5;
+        constexpr std::size_t dl  = 4;
+        auto mesh                 = UniformMesh<config>(Box<double, dim>({0, 0}, {1, 1}), L);
+        auto u                    = init_affine(mesh);
 
-        auto p = portion<1>(u, 5, 4, std::make_tuple(interval_t{2, 3}, 2), std::make_tuple(0, 0));
-        EXPECT_EQ(p[0], 2 * ((2 << 4) + .5) / (1 << 9));
+        const int i = 2, j = 2;
+        for (int jj = 0; jj < (1 << dl); ++jj)
+        {
+            for (int ii = 0; ii < (1 << dl); ++ii)
+            {
+                auto p             = portion<1>(u, L, dl, std::make_tuple(interval_t{i, i + 1}, j), std::make_tuple(ii, jj));
+                const double x_ctr = ((i << dl) + ii + .5) / (1 << (L + dl));
+                const double y_ctr = ((j << dl) + jj + .5) / (1 << (L + dl));
+                EXPECT_DOUBLE_EQ(p[0], x_ctr + y_ctr) << "child (" << ii << ", " << jj << ")";
+            }
+        }
     }
 
-    TEST(portion, 3D)
+    TEST(portion, affine_all_children_3d)
     {
         constexpr std::size_t dim = 3;
         using config              = UniformConfig<dim>;
-        using interval_t          = typename UniformConfig<dim>::interval_t;
-        auto mesh                 = UniformMesh<config>(Box<double, dim>({0, 0, 0}, {1, 1, 1}), 5);
-        auto u                    = init(mesh);
+        using interval_t          = typename config::interval_t;
+        constexpr std::size_t L   = 4;
+        constexpr std::size_t dl  = 3;
+        auto mesh                 = UniformMesh<config>(Box<double, dim>({0, 0, 0}, {1, 1, 1}), L);
+        auto u                    = init_affine(mesh);
 
-        auto p = portion<1>(u, 5, 4, std::make_tuple(interval_t{2, 3}, 2, 2), std::make_tuple(0, 0, 0));
-        EXPECT_EQ(p[0], 3 * ((2 << 4) + .5) / (1 << 9));
+        const int i = 2, j = 2, k = 2;
+        for (int kk = 0; kk < (1 << dl); ++kk)
+        {
+            for (int jj = 0; jj < (1 << dl); ++jj)
+            {
+                for (int ii = 0; ii < (1 << dl); ++ii)
+                {
+                    auto p             = portion<1>(u, L, dl, std::make_tuple(interval_t{i, i + 1}, j, k), std::make_tuple(ii, jj, kk));
+                    const double x_ctr = ((i << dl) + ii + .5) / (1 << (L + dl));
+                    const double y_ctr = ((j << dl) + jj + .5) / (1 << (L + dl));
+                    const double z_ctr = ((k << dl) + kk + .5) / (1 << (L + dl));
+                    EXPECT_DOUBLE_EQ(p[0], x_ctr + y_ctr + z_ctr);
+                }
+            }
+        }
+    }
+
+    // ------------------------------------------------------------------ delta_l == 0 (identity)
+    // Base case of the prediction recursion: no refinement, so portion must return the coarse value
+    // unchanged. This is the path taken at the finest level of the LBM stream and by the same-level
+    // copy of transfer().
+
+    TEST(portion, identity_delta_l_zero)
+    {
+        constexpr std::size_t dim = 1;
+        using config              = UniformConfig<dim>;
+        using interval_t          = typename config::interval_t;
+        constexpr std::size_t L   = 5;
+        auto mesh                 = UniformMesh<config>(Box<double, dim>({0}, {1}), L);
+        auto u                    = init_nonlinear(mesh);
+
+        for (int i = 4; i < 8; ++i)
+        {
+            auto p = portion<1>(u, L, 0, std::make_tuple(interval_t{i, i + 1}), std::make_tuple(0));
+            EXPECT_DOUBLE_EQ(p[0], u(L, interval_t{i, i + 1})(0)) << "cell " << i;
+        }
+    }
+
+    // ------------------------------------------------------------------ mean conservation (slice form)
+    // The predictor preserves the cell average: the 2^{dl.dim} children of a coarse cell reconstruct
+    // to values whose mean is exactly the coarse value, for ANY field. The slice form sums that full
+    // column (without the 1/2^{dl.dim} weight the caller applies), so it must return 2^{dl.dim} times
+    // the coarse value. This is precisely the projection the LBM stream relies on for mass conservation.
+
+    TEST(portion, mean_conservation_full_column_1d)
+    {
+        constexpr std::size_t dim = 1;
+        using config              = UniformConfig<dim>;
+        using interval_t          = typename config::interval_t;
+        constexpr std::size_t L   = 5;
+        auto mesh                 = UniformMesh<config>(Box<double, dim>({0}, {1}), L);
+        auto u                    = init_nonlinear(mesh);
+
+        const int i = 8;
+        for (std::size_t dl = 0; dl <= 4; ++dl)
+        {
+            const int n   = 1 << dl;
+            auto column   = portion<1>(u, L, dl, std::make_tuple(interval_t{i, i + 1}), std::make_tuple(interval_t{0, n}));
+            const double c = u(L, interval_t{i, i + 1})(0);
+            EXPECT_NEAR(column[0], n * c, 1e-12) << "dl = " << dl;
+        }
+    }
+
+    TEST(portion, mean_conservation_full_column_2d)
+    {
+        constexpr std::size_t dim = 2;
+        using config              = UniformConfig<dim>;
+        using interval_t          = typename config::interval_t;
+        constexpr std::size_t L   = 5;
+        auto mesh                 = UniformMesh<config>(Box<double, dim>({0, 0}, {1, 1}), L);
+        auto u                    = init_nonlinear(mesh);
+
+        const int i = 8, j = 8;
+        for (std::size_t dl = 0; dl <= 3; ++dl)
+        {
+            const int n    = 1 << dl;
+            auto column    = portion<1>(u, L, dl, std::make_tuple(interval_t{i, i + 1}, j), std::make_tuple(interval_t{0, n}, interval_t{0, n}));
+            const double c = u(L, interval_t{i, i + 1}, j)(0);
+            EXPECT_NEAR(column[0], (n * n) * c, 1e-12) << "dl = " << dl;
+        }
+    }
+
+    // ------------------------------------------------------------------ slice == sum of scalar children
+    // The interval form must equal summing the scalar form over the same children (the reconstruction
+    // is linear). This directly guards the slice aggregation that makes the LBM stream cheap. The
+    // boxes cover the corner cases the aggregation must handle:
+    //   - the full column [0, 2^dl)               : the LBM projection;
+    //   - a partial sub-box [a, b)                : arbitrary slice;
+    //   - a box starting below 0                  : the LBM donor slice shifted by -c, which needs the
+    //                                               signed accumulate_slice loop (a size_t loop would
+    //                                               wrap and this is the case that once failed to build);
+    //   - a single child [k, k+1)                 : degenerate slice, must equal the scalar form.
+
+    TEST(portion, slice_equals_sum_of_children_1d)
+    {
+        constexpr std::size_t dim = 1;
+        using config              = UniformConfig<dim>;
+        using interval_t          = typename config::interval_t;
+        constexpr std::size_t L   = 5;
+        constexpr std::size_t dl  = 2; // children in [0, 4)
+        auto mesh                 = UniformMesh<config>(Box<double, dim>({0}, {1}), L);
+        auto u                    = init_nonlinear(mesh);
+
+        const int i = 8;
+        auto coarse = std::make_tuple(interval_t{i, i + 1});
+
+        // {full column, partial box, box starting below 0, single child}
+        for (auto box : {interval_t{0, 4}, interval_t{1, 3}, interval_t{-1, 3}, interval_t{2, 3}})
+        {
+            double ref = 0.;
+            for (int k = box.start; k < box.end; ++k)
+            {
+                ref += portion<1>(u, L, dl, coarse, std::make_tuple(k))[0];
+            }
+            auto slice = portion<1>(u, L, dl, coarse, std::make_tuple(box));
+            EXPECT_NEAR(slice[0], ref, 1e-12) << "box [" << box.start << ", " << box.end << ")";
+        }
+    }
+
+    TEST(portion, slice_equals_sum_of_children_2d)
+    {
+        constexpr std::size_t dim = 2;
+        using config              = UniformConfig<dim>;
+        using interval_t          = typename config::interval_t;
+        constexpr std::size_t L   = 5;
+        constexpr std::size_t dl  = 2;
+        auto mesh                 = UniformMesh<config>(Box<double, dim>({0, 0}, {1, 1}), L);
+        auto u                    = init_nonlinear(mesh);
+
+        const int i = 8, j = 8;
+        auto coarse = std::make_tuple(interval_t{i, i + 1}, j);
+
+        // A box negative in one direction and partial in the other (a diagonal-like LBM donor slice).
+        const interval_t box_x{-1, 3};
+        const interval_t box_y{0, 4};
+        double ref = 0.;
+        for (int kj = box_y.start; kj < box_y.end; ++kj)
+        {
+            for (int ki = box_x.start; ki < box_x.end; ++ki)
+            {
+                ref += portion<1>(u, L, dl, coarse, std::make_tuple(ki, kj))[0];
+            }
+        }
+        auto slice = portion<1>(u, L, dl, coarse, std::make_tuple(box_x, box_y));
+        EXPECT_NEAR(slice[0], ref, 1e-12);
+    }
+
+    // ------------------------------------------------------------------ vector fields
+    // The stream is applied to vector fields (the LBM distributions); reconstruction must act on each
+    // component independently. On an affine vector field with two distinct components, the whole-vector
+    // reconstruction must return each component's exact value. (The per-component form portion(f, comp,
+    // ...) used by the LBM shares the same get_prediction / portion_impl path; it always reads the
+    // radius from the mesh config, which the single-level UniformMesh here does not carry, so it is
+    // covered on the adapted meshes of test_projection_prediction_roundtrip instead.)
+
+    TEST(portion, vector_reconstructs_each_component)
+    {
+        constexpr std::size_t dim   = 1;
+        constexpr std::size_t ncomp = 2;
+        using config                = UniformConfig<dim>;
+        using interval_t            = typename config::interval_t;
+        constexpr std::size_t L     = 5;
+        constexpr std::size_t dl    = 4;
+        using mesh_id_t             = typename UniformMesh<config>::mesh_id_t;
+
+        auto mesh = UniformMesh<config>(Box<double, dim>({0}, {1}), L);
+        auto u    = make_vector_field<double, ncomp>("u", mesh);
+        // component 0 = x, component 1 = 2x: two distinct affine fields.
+        for_each_cell(mesh[mesh_id_t::cells],
+                      [&](const auto& cell)
+                      {
+                          const double x = cell.center()[0];
+                          u[cell](0)     = x;
+                          u[cell](1)     = 2. * x;
+                      });
+
+        const int i = 2, child = 3;
+        auto pv     = portion<1>(u, L, dl, std::make_tuple(interval_t{i, i + 1}), std::make_tuple(child));
+        const double x0 = ((i << dl) + child + .5) / (1 << (L + dl));
+        EXPECT_DOUBLE_EQ(pv(0, 0), x0);
+        EXPECT_DOUBLE_EQ(pv(0, 1), 2. * x0);
     }
 }

--- a/tests/test_portion.cpp
+++ b/tests/test_portion.cpp
@@ -2,8 +2,11 @@
 
 #include <gtest/gtest.h>
 #include <samurai/algorithm.hpp>
+#include <samurai/algorithm/update_ghost_mr.hpp>
 #include <samurai/box.hpp>
+#include <samurai/cell_list.hpp>
 #include <samurai/field.hpp>
+#include <samurai/mr/mesh.hpp>
 #include <samurai/reconstruction.hpp>
 #include <samurai/uniform_mesh.hpp>
 
@@ -294,5 +297,57 @@ namespace samurai
         const double x0 = ((i << dl) + child + .5) / (1 << (L + dl));
         EXPECT_DOUBLE_EQ(pv(0, 0), x0);
         EXPECT_DOUBLE_EQ(pv(0, 1), 2. * x0);
+    }
+
+    // Reconstruction across a refinement boundary must use the real finer leaves, not the projected
+    // coarse value. A flat delta_l >= 2 portion reconstructs from level l only: where a level-l
+    // stencil neighbour is refined, it reads that neighbour's projection (its exact average) and so
+    // skips the real detail carried by the finer leaves at the intermediate levels. Descending one
+    // level at a time and reading the real leaves gives a different - and more accurate - value.
+    //
+    // This test pins that difference down, so a real-aware reconstruction can be validated against
+    // the descending answer (which it must reproduce) rather than the flat one (which it must not).
+    TEST(portion, reconstruction_uses_real_cells_across_refinement)
+    {
+        constexpr std::size_t dim = 1;
+        using config              = mesh_config<dim>;
+        using Mesh                = MRMesh<config>;
+        using interval_t          = typename Mesh::interval_t;
+        using mesh_id_t           = typename Mesh::mesh_id_t;
+
+        // Graded 1D mesh: level-1 leaves 0..3, level-1 cells 4-5 refined to level-2 leaves 8..11,
+        // level-1 cells 6-7 refined to level-3 leaves 24..31. Cell 3 (level 1) is a coarse leaf whose
+        // right neighbour (cell 4) is refined, so its level-2 children 8,9 are real leaves.
+        CellList<dim> cl;
+        cl[1][{}].add_interval({0, 4});
+        cl[2][{}].add_interval({8, 12});
+        cl[3][{}].add_interval({24, 32});
+        auto cfg  = config().min_level(1).max_level(3).max_stencil_radius(2);
+        auto mesh = mra::make_mesh(cl, cfg);
+
+        auto u = make_scalar_field<double>("u", mesh);
+        u.fill(0.);
+        for_each_cell(mesh[mesh_id_t::cells],
+                      [&](const auto& cell)
+                      {
+                          u[cell] = std::cos(3. * cell.center()[0]); // non-affine: carries real detail
+                      });
+        update_ghost_mr(u);
+
+        // Reconstruct the same level-3 cell 15 (right grandchild of the coarse leaf cell 3) two ways.
+        // flat: from level 1, delta_l = 2 -> reads level-1 cells only (neighbour via its projection).
+        const double flat = portion<1>(u, 1, 2, std::make_tuple(interval_t{3, 4}), std::make_tuple(3))(0);
+        // descending / real-aware: from level 2, delta_l = 1 -> its stencil reads level-2 cell 8, a
+        // REAL leaf under the refined neighbour. After update_ghost_mr the level-2 strip blends real
+        // leaves with prediction ghosts, so this is exactly the real-aware answer.
+        const double descending = portion<1>(u, 2, 1, std::make_tuple(interval_t{7, 8}), std::make_tuple(1))(0);
+
+        // The two disagree: the flat reconstruction ignored the neighbour's real level-2 leaf.
+        EXPECT_GT(std::abs(flat - descending), 1e-4);
+
+        // ... and the descending one is closer to the true field (both carry the coarse-cell
+        // truncation error, but the flat one adds the projection error on top).
+        const double truth = std::cos(3. * (15 + 0.5) / (1 << 3));
+        EXPECT_LT(std::abs(descending - truth), std::abs(flat - truth));
     }
 }

--- a/tests/test_portion.cpp
+++ b/tests/test_portion.cpp
@@ -172,8 +172,8 @@ namespace samurai
         const int i = 8;
         for (std::size_t dl = 0; dl <= 4; ++dl)
         {
-            const int n   = 1 << dl;
-            auto column   = portion<1>(u, L, dl, std::make_tuple(interval_t{i, i + 1}), std::make_tuple(interval_t{0, n}));
+            const int n    = 1 << dl;
+            auto column    = portion<1>(u, L, dl, std::make_tuple(interval_t{i, i + 1}), std::make_tuple(interval_t{0, n}));
             const double c = u(L, interval_t{i, i + 1})(0);
             EXPECT_NEAR(column[0], n * c, 1e-12) << "dl = " << dl;
         }
@@ -191,8 +191,8 @@ namespace samurai
         const int i = 8, j = 8;
         for (std::size_t dl = 0; dl <= 3; ++dl)
         {
-            const int n    = 1 << dl;
-            auto column    = portion<1>(u, L, dl, std::make_tuple(interval_t{i, i + 1}, j), std::make_tuple(interval_t{0, n}, interval_t{0, n}));
+            const int n = 1 << dl;
+            auto column = portion<1>(u, L, dl, std::make_tuple(interval_t{i, i + 1}, j), std::make_tuple(interval_t{0, n}, interval_t{0, n}));
             const double c = u(L, interval_t{i, i + 1}, j)(0);
             EXPECT_NEAR(column[0], (n * n) * c, 1e-12) << "dl = " << dl;
         }
@@ -223,7 +223,12 @@ namespace samurai
         auto coarse = std::make_tuple(interval_t{i, i + 1});
 
         // {full column, partial box, box starting below 0, single child}
-        for (auto box : {interval_t{0, 4}, interval_t{1, 3}, interval_t{-1, 3}, interval_t{2, 3}})
+        for (auto box : {
+                 interval_t{0,  4},
+                 interval_t{1,  3},
+                 interval_t{-1, 3},
+                 interval_t{2,  3}
+        })
         {
             double ref = 0.;
             for (int k = box.start; k < box.end; ++k)
@@ -293,7 +298,7 @@ namespace samurai
                       });
 
         const int i = 2, child = 3;
-        auto pv     = portion<1>(u, L, dl, std::make_tuple(interval_t{i, i + 1}), std::make_tuple(child));
+        auto pv         = portion<1>(u, L, dl, std::make_tuple(interval_t{i, i + 1}), std::make_tuple(child));
         const double x0 = ((i << dl) + child + .5) / (1 << (L + dl));
         EXPECT_DOUBLE_EQ(pv(0, 0), x0);
         EXPECT_DOUBLE_EQ(pv(0, 1), 2. * x0);


### PR DESCRIPTION
## Description

Make the multi-level LBM `stream` fast, and document/test the underlying prediction machinery.

The stream reconstructs each streamed value as the projection over a coarse cell's `2^{j.dim}` fine sub-cells of their reconstructed donor value. This was done with one `portion()` call per sub-cell, whose cost grows with the level gap and dominated the whole scheme.

- **Slice reconstruction.** The stream is linear, so the whole sub-cell column is a single application of the summed prediction map of the donor slice. Restore the interval (slice) form of `portion()` / the `get_prediction` overload (an interval per direction as the sub-cell index), which builds and caches that combined map once instead of `2^{j.dim}` separate reconstructions.
- **Hoisted, flat stencils.** The map depends only on the level gap and the velocity, so the per-component stencils are built once per level (with the projection weight folded in) and reused over the whole level, dropping the per-strip prediction lookup and the temporary.
- **Scalar-loop apply.** Applying the stencils with plain scalar loops over a reused buffer instead of lazy xtensor expressions removes the remaining bottleneck.

On the D2Q5444 Rayleigh-Taylor case (`--min-level 2 --max-level 8 --Tf 0.2`): stream `11.8 s -> 0.36 s`, total runtime `13.5 s -> 2.0 s`. All `new_D2Q*` demos stay bit-identical.

Also included:
- `reconstruction.hpp` is now fully documented (the `prediction_map` / `prediction` / `portion` layers, the `level` vs `delta_l` and `i` vs `ii` conventions, the scalar vs slice forms), plus two small dead-code removals.
- `--timers` now breaks the LBM step into `lbm stream` / `lbm collide` / operator phases.

## How has this been tested?

- `tests/test_portion.cpp`: extended to cover the scalar and slice forms of `portion()` (exactness on affine fields, `delta_l == 0` identity, mean conservation, slice == sum of children including a negative-start slice, vector fields) and reconstruction across a refinement boundary.
- `tests/test_lbm.cpp` and `tests/reference/lbm/` (existing gtest + h5diff references): all `new_D2Q*` demos remain bit-identical.
- `tests/test_projection_prediction_roundtrip.cpp` and the FV operator tests still pass (the shared prediction/reconstruction machinery is unchanged apart from the restored interval overload).

## Code of Conduct
- [x] I agree to follow this project's Code of Conduct
