### PR TITLE
feat(subset): dynamic (runtime) set algebra

### DIFF
--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -28,6 +28,7 @@ find_package(Threads)
 set(SAMURAI_BENCHMARK_SOURCES
     benchmark_celllist_construction.cpp
     benchmark_detail_computation.cpp
+    benchmark_dynamic_set.cpp
     benchmark_fv_scheme.cpp
     benchmark_search.cpp
     benchmark_set.cpp

--- a/benchmark/benchmark_dynamic_set.cpp
+++ b/benchmark/benchmark_dynamic_set.cpp
@@ -1,0 +1,276 @@
+// Copyright 2018-2025 the samurai's authors
+// SPDX-License-Identifier:  BSD-3-Clause
+
+// Static vs dynamic set algebra: the price of the runtime version.
+//
+// The static algebra (include/samurai/subset/) encodes the whole expression
+// in the C++ type system: the traversal is fully inlined, no virtual calls,
+// no heap. The dynamic algebra (include/samurai/subset/dynamic/) trades that
+// for a tree decided at runtime: each node is heap-allocated (shared_ptr) and
+// every interval flows through a virtual ISetTraverser call.
+//
+// Each pattern below is measured in both forms, side by side, so the ratio is
+// read directly off the report (compare BM_*_static vs BM_*_dynamic). Both
+// build the expression inside the timed loop, matching benchmark_set.cpp and
+// the realistic usage where the mesh - hence the set - changes every step. So
+// the dynamic figure is the *end-to-end* cost: node construction + virtual
+// traversal, which is what a caller actually pays.
+//
+// Tiers mirror benchmark_set.cpp:
+//   - "uniform": raw operator cost on three fixed overlapping boxes;
+//   - "adapted": the cross-level projection / stencil footprints on a real
+//     MR-adapted mesh, the patterns that dominate mesh adaptation.
+
+#include <cstddef>
+#include <vector>
+
+#include <benchmark/benchmark.h>
+
+#include <xtensor/containers/xfixed.hpp>
+
+#include <samurai/algorithm.hpp>
+#include <samurai/box.hpp>
+#include <samurai/field.hpp>
+#include <samurai/level_cell_array.hpp>
+#include <samurai/mr/adapt.hpp>
+#include <samurai/mr/mesh.hpp>
+#include <samurai/subset/dynamic/dynamic.hpp>
+#include <samurai/subset/node.hpp>
+
+namespace
+{
+    template <std::size_t dim>
+    auto make_three_boxes()
+    {
+        constexpr std::size_t level = 8;
+        samurai::Box<int, dim> box1({0, 0}, {1 << level, 1 << level});
+        samurai::Box<int, dim> box2({0, 0}, {(1 << (level - 1)), (1 << (level - 1))});
+        samurai::Box<int, dim> box3({1, 1}, {(1 << (level - 1)) + 1, (1 << (level - 1)) + 1});
+        return std::make_tuple(samurai::LevelCellArray<dim>{level, box1},
+                               samurai::LevelCellArray<dim>{level, box2},
+                               samurai::LevelCellArray<dim>{level, box3});
+    }
+
+    template <std::size_t dim>
+    auto make_adapted_mesh(double eps, std::size_t max_level)
+    {
+        xt::xtensor_fixed<double, xt::xshape<dim>> min_corner;
+        xt::xtensor_fixed<double, xt::xshape<dim>> max_corner;
+        min_corner.fill(0);
+        max_corner.fill(1);
+        const samurai::Box<double, dim> box(min_corner, max_corner);
+
+        auto config = samurai::mesh_config<dim>().min_level(4).max_level(max_level).max_stencil_size(2).disable_minimal_ghost_width();
+        auto mesh   = samurai::mra::make_mesh(box, config);
+
+        auto u = samurai::make_scalar_field<double>("u", mesh);
+        samurai::for_each_cell(mesh,
+                               [&](auto& cell)
+                               {
+                                   auto c   = cell.center();
+                                   double r = 0;
+                                   for (std::size_t d = 0; d < dim; ++d)
+                                   {
+                                       r += (c[d] - 0.3) * (c[d] - 0.3);
+                                   }
+                                   u[cell] = (r <= 0.04) ? 1. : 0.;
+                               });
+        samurai::make_MRAdapt(u)(samurai::mra_config().epsilon(eps));
+        return mesh;
+    }
+
+    // Iterate a set and accumulate interval sizes into a sink so the lazy
+    // expression is actually evaluated.
+    template <class Set>
+    std::size_t consume(const Set& set)
+    {
+        std::size_t acc = 0;
+        set(
+            [&](const auto& i, const auto&)
+            {
+                acc += i.size();
+            });
+        return acc;
+    }
+} // namespace
+
+// --- Tier 1: raw operator on fixed uniform boxes ---------------------------
+
+static void BM_Intersection3_uniform_static(benchmark::State& state)
+{
+    auto [s1, s2, s3] = make_three_boxes<2>();
+    for (auto _ : state)
+    {
+        benchmark::DoNotOptimize(consume(samurai::intersection(samurai::intersection(s1, s2), s3)));
+    }
+}
+
+static void BM_Intersection3_uniform_dynamic(benchmark::State& state)
+{
+    auto [s1, s2, s3] = make_three_boxes<2>();
+    for (auto _ : state)
+    {
+        benchmark::DoNotOptimize(consume(samurai::dyn::intersection(samurai::dyn::self(s1), samurai::dyn::self(s2), samurai::dyn::self(s3))));
+    }
+}
+
+static void BM_Intersection3_on_uniform_static(benchmark::State& state)
+{
+    auto [s1, s2, s3] = make_three_boxes<2>();
+    for (auto _ : state)
+    {
+        benchmark::DoNotOptimize(consume(samurai::intersection(samurai::intersection(s1, s2), s3).on(7)));
+    }
+}
+
+static void BM_Intersection3_on_uniform_dynamic(benchmark::State& state)
+{
+    auto [s1, s2, s3] = make_three_boxes<2>();
+    for (auto _ : state)
+    {
+        benchmark::DoNotOptimize(
+            consume(samurai::dyn::intersection(samurai::dyn::self(s1), samurai::dyn::self(s2), samurai::dyn::self(s3)).on(7)));
+    }
+}
+
+static void BM_TranslatedIntersection_uniform_static(benchmark::State& state)
+{
+    auto [s1, s2, s3]                          = make_three_boxes<2>();
+    xt::xtensor_fixed<int, xt::xshape<2>> sten = {1, 0};
+    for (auto _ : state)
+    {
+        benchmark::DoNotOptimize(consume(samurai::intersection(s1, samurai::translate(s2, sten))));
+    }
+}
+
+static void BM_TranslatedIntersection_uniform_dynamic(benchmark::State& state)
+{
+    auto [s1, s2, s3]                          = make_three_boxes<2>();
+    xt::xtensor_fixed<int, xt::xshape<2>> sten = {1, 0};
+    for (auto _ : state)
+    {
+        benchmark::DoNotOptimize(
+            consume(samurai::dyn::intersection(samurai::dyn::self(s1), samurai::dyn::translate(samurai::dyn::self(s2), sten))));
+    }
+}
+
+BENCHMARK(BM_Intersection3_uniform_static);
+BENCHMARK(BM_Intersection3_uniform_dynamic);
+BENCHMARK(BM_Intersection3_on_uniform_static);
+BENCHMARK(BM_Intersection3_on_uniform_dynamic);
+BENCHMARK(BM_TranslatedIntersection_uniform_static);
+BENCHMARK(BM_TranslatedIntersection_uniform_dynamic);
+
+// --- Tier 2: cross-level set algebra on an adapted mesh --------------------
+
+// intersection(all_cells[l], cells[l+1]).on(l): projection footprint.
+template <std::size_t dim>
+static void BM_ProjectionFootprint_adapted_static(benchmark::State& state)
+{
+    const std::size_t max_level = (dim == 2) ? 11 : 8;
+    auto mesh                   = make_adapted_mesh<dim>(1. / static_cast<double>(state.range(0)), max_level);
+    using mesh_id_t             = typename std::decay_t<decltype(mesh)>::mesh_id_t;
+
+    const auto min_l = mesh[mesh_id_t::cells].min_level();
+    const auto max_l = mesh[mesh_id_t::cells].max_level();
+
+    for (auto _ : state)
+    {
+        std::size_t acc = 0;
+        for (std::size_t level = min_l; level < max_l; ++level)
+        {
+            acc += consume(samurai::intersection(mesh[mesh_id_t::all_cells][level], mesh[mesh_id_t::cells][level + 1]).on(level));
+        }
+        benchmark::DoNotOptimize(acc);
+    }
+    state.counters["cells"] = static_cast<double>(mesh.nb_cells(mesh_id_t::cells));
+}
+
+template <std::size_t dim>
+static void BM_ProjectionFootprint_adapted_dynamic(benchmark::State& state)
+{
+    const std::size_t max_level = (dim == 2) ? 11 : 8;
+    auto mesh                   = make_adapted_mesh<dim>(1. / static_cast<double>(state.range(0)), max_level);
+    using mesh_id_t             = typename std::decay_t<decltype(mesh)>::mesh_id_t;
+
+    const auto min_l = mesh[mesh_id_t::cells].min_level();
+    const auto max_l = mesh[mesh_id_t::cells].max_level();
+
+    for (auto _ : state)
+    {
+        std::size_t acc = 0;
+        for (std::size_t level = min_l; level < max_l; ++level)
+        {
+            acc += consume(samurai::dyn::intersection(samurai::dyn::self(mesh[mesh_id_t::all_cells][level]),
+                                                      samurai::dyn::self(mesh[mesh_id_t::cells][level + 1]))
+                               .on(level));
+        }
+        benchmark::DoNotOptimize(acc);
+    }
+    state.counters["cells"] = static_cast<double>(mesh.nb_cells(mesh_id_t::cells));
+}
+
+// intersection(cells[l], translate(cells[l], stencil)): ghost-filling stencil.
+template <std::size_t dim>
+static void BM_StencilTranslation_adapted_static(benchmark::State& state)
+{
+    const std::size_t max_level = (dim == 2) ? 11 : 8;
+    auto mesh                   = make_adapted_mesh<dim>(1. / static_cast<double>(state.range(0)), max_level);
+    using mesh_id_t             = typename std::decay_t<decltype(mesh)>::mesh_id_t;
+
+    const auto min_l = mesh[mesh_id_t::cells].min_level();
+    const auto max_l = mesh[mesh_id_t::cells].max_level();
+
+    xt::xtensor_fixed<int, xt::xshape<dim>> stencil;
+    stencil.fill(0);
+    stencil[0] = 1;
+
+    for (auto _ : state)
+    {
+        std::size_t acc = 0;
+        for (std::size_t level = min_l; level <= max_l; ++level)
+        {
+            acc += consume(samurai::intersection(mesh[mesh_id_t::cells][level], samurai::translate(mesh[mesh_id_t::cells][level], stencil)));
+        }
+        benchmark::DoNotOptimize(acc);
+    }
+    state.counters["cells"] = static_cast<double>(mesh.nb_cells(mesh_id_t::cells));
+}
+
+template <std::size_t dim>
+static void BM_StencilTranslation_adapted_dynamic(benchmark::State& state)
+{
+    const std::size_t max_level = (dim == 2) ? 11 : 8;
+    auto mesh                   = make_adapted_mesh<dim>(1. / static_cast<double>(state.range(0)), max_level);
+    using mesh_id_t             = typename std::decay_t<decltype(mesh)>::mesh_id_t;
+
+    const auto min_l = mesh[mesh_id_t::cells].min_level();
+    const auto max_l = mesh[mesh_id_t::cells].max_level();
+
+    xt::xtensor_fixed<int, xt::xshape<dim>> stencil;
+    stencil.fill(0);
+    stencil[0] = 1;
+
+    for (auto _ : state)
+    {
+        std::size_t acc = 0;
+        for (std::size_t level = min_l; level <= max_l; ++level)
+        {
+            acc += consume(samurai::dyn::intersection(samurai::dyn::self(mesh[mesh_id_t::cells][level]),
+                                                      samurai::dyn::translate(samurai::dyn::self(mesh[mesh_id_t::cells][level]), stencil)));
+        }
+        benchmark::DoNotOptimize(acc);
+    }
+    state.counters["cells"] = static_cast<double>(mesh.nb_cells(mesh_id_t::cells));
+}
+
+BENCHMARK(BM_ProjectionFootprint_adapted_static<2>)->Arg(1000)->Arg(100000);
+BENCHMARK(BM_ProjectionFootprint_adapted_dynamic<2>)->Arg(1000)->Arg(100000);
+BENCHMARK(BM_ProjectionFootprint_adapted_static<3>)->Arg(1000)->Arg(100000);
+BENCHMARK(BM_ProjectionFootprint_adapted_dynamic<3>)->Arg(1000)->Arg(100000);
+BENCHMARK(BM_StencilTranslation_adapted_static<2>)->Arg(1000)->Arg(100000);
+BENCHMARK(BM_StencilTranslation_adapted_dynamic<2>)->Arg(1000)->Arg(100000);
+BENCHMARK(BM_StencilTranslation_adapted_static<3>)->Arg(1000)->Arg(100000);
+BENCHMARK(BM_StencilTranslation_adapted_dynamic<3>)->Arg(1000)->Arg(100000);
+
+BENCHMARK_MAIN();

--- a/include/samurai/subset/dynamic/any_traverser.hpp
+++ b/include/samurai/subset/dynamic/any_traverser.hpp
@@ -1,0 +1,193 @@
+// Copyright 2018-2025 the samurai's authors
+// SPDX-License-Identifier:  BSD-3-Clause
+
+#pragma once
+
+#include <memory>
+#include <utility>
+
+#include "../../samurai_config.hpp"
+#include "../traversers/set_traverser_base.hpp"
+
+namespace samurai
+{
+    ////////////////////////////////////////////////////////////////////////
+    //// Runtime traverser interface
+    ////////////////////////////////////////////////////////////////////////
+
+    /**
+     * Runtime (type-erased) counterpart of the static traverser concept
+     * described by `SetTraverserBase`.
+     *
+     * It exposes exactly the same three primitives -- `is_empty`,
+     * `next_interval`, `current_interval` -- but through virtual calls, so a
+     * traverser whose concrete type is only known at runtime can be used
+     * uniformly.
+     *
+     * `clone` returns an independent copy carrying the same iteration state.
+     * It is needed because the static traversers store their children *by
+     * value* (see e.g. `IntersectionTraverser`), so any traverser plugged into
+     * them must be copyable.
+     */
+    template <class TInterval>
+    class ISetTraverser
+    {
+      public:
+
+        using interval_t = TInterval;
+
+        virtual ~ISetTraverser() = default;
+
+        virtual std::unique_ptr<ISetTraverser> clone() const = 0;
+
+        virtual bool is_empty() const = 0;
+
+        virtual void next_interval() = 0;
+
+        virtual interval_t current_interval() const = 0;
+
+      protected:
+
+        // Prevent slicing: copies go through `clone`.
+        ISetTraverser()                                = default;
+        ISetTraverser(const ISetTraverser&)            = default;
+        ISetTraverser(ISetTraverser&&)                 = default;
+        ISetTraverser& operator=(const ISetTraverser&) = default;
+        ISetTraverser& operator=(ISetTraverser&&)      = default;
+    };
+
+    ////////////////////////////////////////////////////////////////////////
+    //// AnyTraverser: the dynamic -> static bridge
+    ////////////////////////////////////////////////////////////////////////
+
+    template <class TInterval>
+    class AnyTraverser;
+
+    template <class TInterval>
+    struct SetTraverserTraits<AnyTraverser<TInterval>>
+    {
+        using interval_t = TInterval;
+        // Type erasure loses the reference: `current_interval` returns a value.
+        using current_interval_t = interval_t;
+    };
+
+    /**
+     * A *static* traverser (it models `SetTraverserBase`) that forwards to a
+     * runtime `ISetTraverser`.
+     *
+     * This is the single boundary where the dynamic world meets the static
+     * one: because `AnyTraverser` satisfies the static traverser concept, it
+     * can be used as the `traverser_t<d>` of any existing static traverser
+     * (union, intersection, difference, ...) without changing a single line of
+     * those algorithms.
+     */
+    template <class TInterval>
+    class AnyTraverser : public SetTraverserBase<AnyTraverser<TInterval>>
+    {
+        using Self = AnyTraverser<TInterval>;
+
+      public:
+
+        SAMURAI_SET_TRAVERSER_TYPEDEFS
+
+        explicit AnyTraverser(std::unique_ptr<ISetTraverser<TInterval>> impl)
+            : m_impl(std::move(impl))
+        {
+        }
+
+        AnyTraverser(const AnyTraverser& other)
+            : m_impl(other.m_impl->clone())
+        {
+        }
+
+        AnyTraverser(AnyTraverser&&) noexcept            = default;
+        AnyTraverser& operator=(AnyTraverser&&) noexcept = default;
+        ~AnyTraverser()                                  = default;
+
+        AnyTraverser& operator=(const AnyTraverser& other)
+        {
+            if (this != &other)
+            {
+                m_impl = other.m_impl->clone();
+            }
+            return *this;
+        }
+
+        SAMURAI_INLINE bool is_empty_impl() const
+        {
+            return m_impl->is_empty();
+        }
+
+        SAMURAI_INLINE void next_interval_impl()
+        {
+            m_impl->next_interval();
+        }
+
+        SAMURAI_INLINE current_interval_t current_interval_impl() const
+        {
+            return m_impl->current_interval();
+        }
+
+      private:
+
+        std::unique_ptr<ISetTraverser<TInterval>> m_impl;
+    };
+
+    ////////////////////////////////////////////////////////////////////////
+    //// SetTraverserModel: the static -> dynamic bridge
+    ////////////////////////////////////////////////////////////////////////
+
+    /**
+     * Wraps a concrete static traverser into the runtime `ISetTraverser`
+     * interface. This is the other direction of the bridge: it lets a leaf's
+     * traverser (or a whole static sub-expression's traverser) be handed out
+     * behind the virtual interface.
+     */
+    template <class SetTraverser>
+    class SetTraverserModel final : public ISetTraverser<typename SetTraverser::interval_t>
+    {
+      public:
+
+        using interval_t = typename SetTraverser::interval_t;
+
+        explicit SetTraverserModel(SetTraverser traverser)
+            : m_traverser(std::move(traverser))
+        {
+        }
+
+        std::unique_ptr<ISetTraverser<interval_t>> clone() const override
+        {
+            return std::make_unique<SetTraverserModel>(m_traverser);
+        }
+
+        bool is_empty() const override
+        {
+            return m_traverser.is_empty();
+        }
+
+        void next_interval() override
+        {
+            m_traverser.next_interval();
+        }
+
+        interval_t current_interval() const override
+        {
+            return m_traverser.current_interval();
+        }
+
+      private:
+
+        SetTraverser m_traverser;
+    };
+
+    /**
+     * Erase the type of a static traverser into an `AnyTraverser`.
+     */
+    template <class SetTraverser>
+    AnyTraverser<typename SetTraverser::interval_t> make_any_traverser(SetTraverser traverser)
+    {
+        using interval_t = typename SetTraverser::interval_t;
+        return AnyTraverser<interval_t>(std::make_unique<SetTraverserModel<SetTraverser>>(std::move(traverser)));
+    }
+
+} // namespace samurai

--- a/include/samurai/subset/dynamic/any_traverser.hpp
+++ b/include/samurai/subset/dynamic/any_traverser.hpp
@@ -3,11 +3,13 @@
 
 #pragma once
 
-#include <memory>
+#include <concepts>
+#include <cstddef>
 #include <utility>
 
 #include "../../samurai_config.hpp"
 #include "../traversers/set_traverser_base.hpp"
+#include "small_object.hpp"
 
 namespace samurai
 {
@@ -17,17 +19,10 @@ namespace samurai
 
     /**
      * Runtime (type-erased) counterpart of the static traverser concept
-     * described by `SetTraverserBase`.
-     *
-     * It exposes exactly the same three primitives -- `is_empty`,
-     * `next_interval`, `current_interval` -- but through virtual calls, so a
-     * traverser whose concrete type is only known at runtime can be used
-     * uniformly.
-     *
-     * `clone` returns an independent copy carrying the same iteration state.
-     * It is needed because the static traversers store their children *by
-     * value* (see e.g. `IntersectionTraverser`), so any traverser plugged into
-     * them must be copyable.
+     * described by `SetTraverserBase`. It exposes the same three primitives --
+     * `is_empty`, `next_interval`, `current_interval` -- through virtual calls,
+     * plus the `copy_to` / `move_to` that let it live in a `sbo::SmallObject`.
+     * Concrete models get `copy_to` / `move_to` for free from `sbo::Cloneable`.
      */
     template <class TInterval>
     class ISetTraverser
@@ -38,22 +33,64 @@ namespace samurai
 
         virtual ~ISetTraverser() = default;
 
-        virtual std::unique_ptr<ISetTraverser> clone() const = 0;
-
         virtual bool is_empty() const = 0;
 
         virtual void next_interval() = 0;
 
         virtual interval_t current_interval() const = 0;
 
+        virtual sbo::PlacedObject<ISetTraverser> copy_to(void* buffer, std::size_t capacity) const = 0;
+
+        virtual sbo::PlacedObject<ISetTraverser> move_to(void* buffer, std::size_t capacity) = 0;
+
       protected:
 
-        // Prevent slicing: copies go through `clone`.
         ISetTraverser()                                = default;
         ISetTraverser(const ISetTraverser&)            = default;
         ISetTraverser(ISetTraverser&&)                 = default;
         ISetTraverser& operator=(const ISetTraverser&) = default;
         ISetTraverser& operator=(ISetTraverser&&)      = default;
+    };
+
+    ////////////////////////////////////////////////////////////////////////
+    //// SetTraverserModel: wraps a concrete static traverser
+    ////////////////////////////////////////////////////////////////////////
+
+    /**
+     * Wraps a concrete static traverser into the runtime `ISetTraverser`
+     * interface, so a leaf's traverser (or a whole static sub-expression's
+     * traverser) can be handed out behind the virtual interface.
+     */
+    template <class SetTraverser>
+    class SetTraverserModel final : public sbo::Cloneable<ISetTraverser<typename SetTraverser::interval_t>, SetTraverserModel<SetTraverser>>
+    {
+      public:
+
+        using interval_t = typename SetTraverser::interval_t;
+
+        explicit SetTraverserModel(SetTraverser traverser)
+            : m_traverser(std::move(traverser))
+        {
+        }
+
+        bool is_empty() const override
+        {
+            return m_traverser.is_empty();
+        }
+
+        void next_interval() override
+        {
+            m_traverser.next_interval();
+        }
+
+        interval_t current_interval() const override
+        {
+            return m_traverser.current_interval();
+        }
+
+      private:
+
+        SetTraverser m_traverser;
     };
 
     ////////////////////////////////////////////////////////////////////////
@@ -80,104 +117,49 @@ namespace samurai
      * can be used as the `traverser_t<d>` of any existing static traverser
      * (union, intersection, difference, ...) without changing a single line of
      * those algorithms.
+     *
+     * The erased traverser is held in a `sbo::SmallObject`, so leaf traversers
+     * (and their copies into the parent operators' tuples, the bulk of a
+     * traversal's allocations) stay inline instead of hitting the heap.
      */
     template <class TInterval>
     class AnyTraverser : public SetTraverserBase<AnyTraverser<TInterval>>
     {
-        using Self = AnyTraverser<TInterval>;
+        using Self   = AnyTraverser<TInterval>;
+        using impl_t = ISetTraverser<TInterval>;
+
+        // Sized to hold a leaf model (a couple of iterators + vptr) with margin.
+        static constexpr std::size_t buffer_size = 48;
 
       public:
 
         SAMURAI_SET_TRAVERSER_TYPEDEFS
 
-        explicit AnyTraverser(std::unique_ptr<ISetTraverser<TInterval>> impl)
-            : m_impl(std::move(impl))
+        template <class SetTraverser>
+            requires(IsSetTraverser<SetTraverser>::value && !std::same_as<SetTraverser, Self>)
+        explicit AnyTraverser(SetTraverser traverser)
+            : m_impl(SetTraverserModel<SetTraverser>(std::move(traverser)))
         {
-        }
-
-        AnyTraverser(const AnyTraverser& other)
-            : m_impl(other.m_impl->clone())
-        {
-        }
-
-        AnyTraverser(AnyTraverser&&) noexcept            = default;
-        AnyTraverser& operator=(AnyTraverser&&) noexcept = default;
-        ~AnyTraverser()                                  = default;
-
-        AnyTraverser& operator=(const AnyTraverser& other)
-        {
-            if (this != &other)
-            {
-                m_impl = other.m_impl->clone();
-            }
-            return *this;
         }
 
         SAMURAI_INLINE bool is_empty_impl() const
         {
-            return m_impl->is_empty();
+            return m_impl.get()->is_empty();
         }
 
         SAMURAI_INLINE void next_interval_impl()
         {
-            m_impl->next_interval();
+            m_impl.get()->next_interval();
         }
 
         SAMURAI_INLINE current_interval_t current_interval_impl() const
         {
-            return m_impl->current_interval();
+            return m_impl.get()->current_interval();
         }
 
       private:
 
-        std::unique_ptr<ISetTraverser<TInterval>> m_impl;
-    };
-
-    ////////////////////////////////////////////////////////////////////////
-    //// SetTraverserModel: the static -> dynamic bridge
-    ////////////////////////////////////////////////////////////////////////
-
-    /**
-     * Wraps a concrete static traverser into the runtime `ISetTraverser`
-     * interface. This is the other direction of the bridge: it lets a leaf's
-     * traverser (or a whole static sub-expression's traverser) be handed out
-     * behind the virtual interface.
-     */
-    template <class SetTraverser>
-    class SetTraverserModel final : public ISetTraverser<typename SetTraverser::interval_t>
-    {
-      public:
-
-        using interval_t = typename SetTraverser::interval_t;
-
-        explicit SetTraverserModel(SetTraverser traverser)
-            : m_traverser(std::move(traverser))
-        {
-        }
-
-        std::unique_ptr<ISetTraverser<interval_t>> clone() const override
-        {
-            return std::make_unique<SetTraverserModel>(m_traverser);
-        }
-
-        bool is_empty() const override
-        {
-            return m_traverser.is_empty();
-        }
-
-        void next_interval() override
-        {
-            m_traverser.next_interval();
-        }
-
-        interval_t current_interval() const override
-        {
-            return m_traverser.current_interval();
-        }
-
-      private:
-
-        SetTraverser m_traverser;
+        sbo::SmallObject<impl_t, buffer_size> m_impl;
     };
 
     /**
@@ -186,8 +168,7 @@ namespace samurai
     template <class SetTraverser>
     AnyTraverser<typename SetTraverser::interval_t> make_any_traverser(SetTraverser traverser)
     {
-        using interval_t = typename SetTraverser::interval_t;
-        return AnyTraverser<interval_t>(std::make_unique<SetTraverserModel<SetTraverser>>(std::move(traverser)));
+        return AnyTraverser<typename SetTraverser::interval_t>(std::move(traverser));
     }
 
 } // namespace samurai

--- a/include/samurai/subset/dynamic/any_traverser.hpp
+++ b/include/samurai/subset/dynamic/any_traverser.hpp
@@ -129,6 +129,11 @@ namespace samurai
         using impl_t = ISetTraverser<TInterval>;
 
         // Sized to hold a leaf model (a couple of iterators + vptr) with margin.
+        // Only leaf traversers can ever fit: operator/modifier traversers embed
+        // AnyTraverser children, so their size grows with the buffer and they
+        // never fit whatever the size. A larger buffer therefore does not inline
+        // more, it only makes the (numerous) inline leaves costlier to copy - a
+        // buffer sweep confirmed 48 is the sweet spot.
         static constexpr std::size_t buffer_size = 48;
 
       public:

--- a/include/samurai/subset/dynamic/dynamic.hpp
+++ b/include/samurai/subset/dynamic/dynamic.hpp
@@ -1,0 +1,11 @@
+// Copyright 2018-2025 the samurai's authors
+// SPDX-License-Identifier:  BSD-3-Clause
+
+#pragma once
+
+// Runtime (dynamic) counterpart of the static set algebra in `subset/`.
+// Use it when the structure of a set expression is only known at runtime, or
+// to expose set operations to bindings such as Python.
+#include "any_traverser.hpp"
+#include "dynamic_set.hpp"
+#include "node.hpp"

--- a/include/samurai/subset/dynamic/dynamic_set.hpp
+++ b/include/samurai/subset/dynamic/dynamic_set.hpp
@@ -1,0 +1,176 @@
+// Copyright 2018-2025 the samurai's authors
+// SPDX-License-Identifier:  BSD-3-Clause
+
+#pragma once
+
+#include <cstddef>
+#include <memory>
+#include <utility>
+
+#include <xtensor/containers/xfixed.hpp>
+
+#include "../../samurai_config.hpp"
+#include "../set_base.hpp"
+#include "any_traverser.hpp"
+
+namespace samurai
+{
+    ////////////////////////////////////////////////////////////////////////
+    //// Runtime set interface
+    ////////////////////////////////////////////////////////////////////////
+
+    /**
+     * Runtime (type-erased) counterpart of the static set concept described by
+     * `SetBase`. It exposes the same primitives through virtual calls, so a set
+     * expression whose structure is only known at runtime can be manipulated
+     * uniformly (and, later, exposed to bindings such as Python).
+     *
+     * Traversers are handed out as `AnyTraverser`, and the dimension `d`
+     * becomes a runtime argument (instead of a template parameter). The
+     * traversal scratch memory - the static `Workspace` - is kept *inside* each
+     * concrete `ISet`, so the virtual signatures stay free of an erased
+     * workspace type. Thread-safety is then obtained the same way the static
+     * side gets it: `clone()` a tree per thread.
+     */
+    template <std::size_t dim_, class TInterval>
+    class ISet
+    {
+      public:
+
+        static constexpr std::size_t dim = dim_;
+
+        using interval_t  = TInterval;
+        using value_t     = typename interval_t::value_t;
+        using yz_index_t  = xt::xtensor_fixed<value_t, xt::xshape<dim - 1>>;
+        using traverser_t = AnyTraverser<interval_t>;
+
+        virtual ~ISet() = default;
+
+        /// Deep copy carrying independent traversal scratch (for per-thread use).
+        virtual std::shared_ptr<ISet> clone() const = 0;
+
+        virtual std::size_t level() const = 0;
+
+        virtual bool exist() const = 0;
+
+        virtual bool empty() const = 0;
+
+        virtual void init_workspace(std::size_t d, std::size_t n_traversers) = 0;
+
+        virtual traverser_t get_traverser(std::size_t d, const yz_index_t& index) = 0;
+
+        virtual traverser_t get_traverser_unordered(std::size_t d, const yz_index_t& index) = 0;
+
+      protected:
+
+        ISet()                       = default;
+        ISet(const ISet&)            = default;
+        ISet(ISet&&)                 = default;
+        ISet& operator=(const ISet&) = default;
+        ISet& operator=(ISet&&)      = default;
+    };
+
+    ////////////////////////////////////////////////////////////////////////
+    //// DynamicSetAdaptor: the dynamic -> static bridge
+    ////////////////////////////////////////////////////////////////////////
+
+    template <std::size_t dim_, class TInterval>
+    class DynamicSetAdaptor;
+
+    template <std::size_t dim_, class TInterval>
+    struct SetTraits<DynamicSetAdaptor<dim_, TInterval>>
+    {
+        template <std::size_t>
+        using traverser_t = AnyTraverser<TInterval>;
+
+        // The real scratch memory lives inside the ISet, so nothing is needed here.
+        struct Workspace
+        {
+        };
+
+        static constexpr std::size_t dim()
+        {
+            return dim_;
+        }
+    };
+
+    /**
+     * A *static* set (it models `SetBase`) that forwards to a runtime `ISet`.
+     *
+     * This is the single boundary where the dynamic world meets the static one
+     * at the set level: because `DynamicSetAdaptor` satisfies the static set
+     * concept, it can be plugged as a child of *any* existing static combinator
+     * (translation, projection, expansion, contraction, n-ary operators, ...)
+     * without changing those templates. This is what lets the dynamic algebra
+     * reuse the static algorithms verbatim.
+     */
+    template <std::size_t dim_, class TInterval>
+    class DynamicSetAdaptor : public SetBase<DynamicSetAdaptor<dim_, TInterval>>
+    {
+        using Self = DynamicSetAdaptor<dim_, TInterval>;
+
+      public:
+
+        SAMURAI_SET_TYPEDEFS
+
+        using iset_t = ISet<dim_, TInterval>;
+
+        explicit DynamicSetAdaptor(std::shared_ptr<iset_t> set)
+            : m_set(std::move(set))
+        {
+        }
+
+        SAMURAI_INLINE std::size_t level_impl() const
+        {
+            return m_set->level();
+        }
+
+        SAMURAI_INLINE bool exist_impl() const
+        {
+            return m_set->exist();
+        }
+
+        SAMURAI_INLINE bool empty_impl() const
+        {
+            return m_set->empty();
+        }
+
+        template <std::size_t d>
+        SAMURAI_INLINE void init_workspace_impl(const std::size_t n_traversers, std::integral_constant<std::size_t, d>, Workspace&) const
+        {
+            m_set->init_workspace(d, n_traversers);
+        }
+
+        template <std::size_t d>
+        SAMURAI_INLINE traverser_t<d> get_traverser_impl(const yz_index_t& index, std::integral_constant<std::size_t, d>, Workspace&) const
+        {
+            return m_set->get_traverser(d, index);
+        }
+
+        template <std::size_t d>
+        SAMURAI_INLINE traverser_t<d>
+        get_traverser_unordered_impl(const yz_index_t& index, std::integral_constant<std::size_t, d>, Workspace&) const
+        {
+            return m_set->get_traverser_unordered(d, index);
+        }
+
+        const std::shared_ptr<iset_t>& ptr() const
+        {
+            return m_set;
+        }
+
+      private:
+
+        std::shared_ptr<iset_t> m_set;
+    };
+
+    /**
+     * Wrap a runtime `ISet` into a static `DynamicSetAdaptor`.
+     */
+    template <std::size_t dim_, class TInterval>
+    DynamicSetAdaptor<dim_, TInterval> as_static_set(std::shared_ptr<ISet<dim_, TInterval>> set)
+    {
+        return DynamicSetAdaptor<dim_, TInterval>(std::move(set));
+    }
+
+} // namespace samurai

--- a/include/samurai/subset/dynamic/node.hpp
+++ b/include/samurai/subset/dynamic/node.hpp
@@ -284,24 +284,23 @@ namespace samurai
             template <SetOperator op, std::size_t dim, class TInterval>
             DynamicSet<dim, TInterval> binary(const DynamicSet<dim, TInterval>& a, const DynamicSet<dim, TInterval>& b)
             {
-                return make_node<dim, TInterval>(
-                    {a.ptr(), b.ptr()},
-                    [](const auto& children)
-                    {
-                        using adaptor_t = DynamicSetAdaptor<dim, TInterval>;
-                        if constexpr (op == SetOperator::UNION)
-                        {
-                            return union_(adaptor_t(children[0]), adaptor_t(children[1]));
-                        }
-                        else if constexpr (op == SetOperator::INTERSECTION)
-                        {
-                            return intersection(adaptor_t(children[0]), adaptor_t(children[1]));
-                        }
-                        else
-                        {
-                            return difference(adaptor_t(children[0]), adaptor_t(children[1]));
-                        }
-                    });
+                return make_node<dim, TInterval>({a.ptr(), b.ptr()},
+                                                 [](const auto& children)
+                                                 {
+                                                     using adaptor_t = DynamicSetAdaptor<dim, TInterval>;
+                                                     if constexpr (op == SetOperator::UNION)
+                                                     {
+                                                         return union_(adaptor_t(children[0]), adaptor_t(children[1]));
+                                                     }
+                                                     else if constexpr (op == SetOperator::INTERSECTION)
+                                                     {
+                                                         return intersection(adaptor_t(children[0]), adaptor_t(children[1]));
+                                                     }
+                                                     else
+                                                     {
+                                                         return difference(adaptor_t(children[0]), adaptor_t(children[1]));
+                                                     }
+                                                 });
             }
 
             template <SetOperator op, std::size_t dim, class TInterval>
@@ -406,8 +405,7 @@ namespace samurai
         }
 
         template <std::size_t dim, class TInterval>
-        DynamicSet<dim, TInterval>
-        contract(const DynamicSet<dim, TInterval>& set, std::size_t width, const std::array<bool, dim>& directions)
+        DynamicSet<dim, TInterval> contract(const DynamicSet<dim, TInterval>& set, std::size_t width, const std::array<bool, dim>& directions)
         {
             return make_node<dim, TInterval>({set.ptr()},
                                              [width, directions](const auto& children)

--- a/include/samurai/subset/dynamic/node.hpp
+++ b/include/samurai/subset/dynamic/node.hpp
@@ -61,8 +61,7 @@ namespace samurai
     template <class StaticSet>
     class ExecNode : public ISet<StaticSet::dim, typename StaticSet::interval_t>
     {
-        using Base                       = ISet<StaticSet::dim, typename StaticSet::interval_t>;
-        static constexpr std::size_t dim = StaticSet::dim;
+        using Base = ISet<StaticSet::dim, typename StaticSet::interval_t>;
 
       public:
 
@@ -86,29 +85,29 @@ namespace samurai
 
         void init_workspace(std::size_t d, std::size_t n_traversers) override
         {
-            detail::static_switch<dim>(d,
-                                       [&](auto d_ic)
-                                       {
-                                           m_exec.init_workspace(n_traversers, d_ic, m_ws);
-                                       });
+            detail::static_switch<Base::dim>(d,
+                                             [&](auto d_ic)
+                                             {
+                                                 m_exec.init_workspace(n_traversers, d_ic, m_ws);
+                                             });
         }
 
         traverser_t get_traverser(std::size_t d, const yz_index_t& index) override
         {
-            return detail::static_switch<dim>(d,
-                                              [&](auto d_ic)
-                                              {
-                                                  return make_any_traverser(m_exec.get_traverser(index, d_ic, m_ws));
-                                              });
+            return detail::static_switch<Base::dim>(d,
+                                                    [&](auto d_ic)
+                                                    {
+                                                        return make_any_traverser(m_exec.get_traverser(index, d_ic, m_ws));
+                                                    });
         }
 
         traverser_t get_traverser_unordered(std::size_t d, const yz_index_t& index) override
         {
-            return detail::static_switch<dim>(d,
-                                              [&](auto d_ic)
-                                              {
-                                                  return make_any_traverser(m_exec.get_traverser_unordered(index, d_ic, m_ws));
-                                              });
+            return detail::static_switch<Base::dim>(d,
+                                                    [&](auto d_ic)
+                                                    {
+                                                        return make_any_traverser(m_exec.get_traverser_unordered(index, d_ic, m_ws));
+                                                    });
         }
 
       protected:
@@ -188,8 +187,6 @@ namespace samurai
     class DynamicSet
     {
       public:
-
-        static constexpr std::size_t dim = dim_;
 
         using interval_t = TInterval;
         using iset_t     = ISet<dim_, TInterval>;

--- a/include/samurai/subset/dynamic/node.hpp
+++ b/include/samurai/subset/dynamic/node.hpp
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <array>
 #include <cassert>
 #include <concepts>
 #include <cstddef>
@@ -11,6 +12,7 @@
 #include <utility>
 #include <vector>
 
+#include "../../box.hpp"
 #include "../../static_algorithm.hpp"
 #include "../node.hpp" // the static set DSL (self, intersection, translate, ...)
 #include "dynamic_set.hpp"
@@ -266,6 +268,17 @@ namespace samurai
                                              });
         }
 
+        template <class TValue, std::size_t Dim>
+        DynamicSet<Dim, Interval<TValue>> box(std::size_t level, const Box<TValue, Dim>& b)
+        {
+            // `b` must outlive the returned set, as for the static `asBoxView`.
+            return make_node<Dim, Interval<TValue>>({},
+                                                    [level, box_ptr = &b](const auto&)
+                                                    {
+                                                        return asBoxView(level, *box_ptr);
+                                                    });
+        }
+
         namespace detail
         {
             template <SetOperator op, std::size_t dim, class TInterval>
@@ -379,6 +392,27 @@ namespace samurai
                                              [width](const auto& children)
                                              {
                                                  return nestedExpand(as_static_set(children[0]), width);
+                                             });
+        }
+
+        template <std::size_t dim, class TInterval>
+        DynamicSet<dim, TInterval> contract(const DynamicSet<dim, TInterval>& set, std::size_t width)
+        {
+            return make_node<dim, TInterval>({set.ptr()},
+                                             [width](const auto& children)
+                                             {
+                                                 return samurai::contract(as_static_set(children[0]), width);
+                                             });
+        }
+
+        template <std::size_t dim, class TInterval>
+        DynamicSet<dim, TInterval>
+        contract(const DynamicSet<dim, TInterval>& set, std::size_t width, const std::array<bool, dim>& directions)
+        {
+            return make_node<dim, TInterval>({set.ptr()},
+                                             [width, directions](const auto& children)
+                                             {
+                                                 return samurai::contract(as_static_set(children[0]), width, directions);
                                              });
         }
     } // namespace dyn

--- a/include/samurai/subset/dynamic/node.hpp
+++ b/include/samurai/subset/dynamic/node.hpp
@@ -1,0 +1,392 @@
+// Copyright 2018-2025 the samurai's authors
+// SPDX-License-Identifier:  BSD-3-Clause
+
+#pragma once
+
+#include <cassert>
+#include <concepts>
+#include <cstddef>
+#include <memory>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+#include "../../static_algorithm.hpp"
+#include "../node.hpp" // the static set DSL (self, intersection, translate, ...)
+#include "dynamic_set.hpp"
+
+namespace samurai
+{
+    namespace detail
+    {
+        /**
+         * Turn a runtime dimension `target` into the compile-time
+         * `std::integral_constant` expected by the static algebra, and invoke
+         * `f` with it. All `dim` branches return the same type, so this works
+         * both for value-returning calls (get_traverser) and void ones
+         * (init_workspace).
+         */
+        template <std::size_t dim, std::size_t d = 0, class Func>
+        SAMURAI_INLINE decltype(auto) static_switch(std::size_t target, Func&& f)
+        {
+            if constexpr (d + 1 < dim)
+            {
+                if (target == d)
+                {
+                    return f(std::integral_constant<std::size_t, d>{});
+                }
+                return static_switch<dim, d + 1>(target, std::forward<Func>(f));
+            }
+            else
+            {
+                assert(target == d && "dimension out of range");
+                return f(std::integral_constant<std::size_t, d>{});
+            }
+        }
+    } // namespace detail
+
+    ////////////////////////////////////////////////////////////////////////
+    //// ExecNode: drives a static set behind the runtime ISet interface
+    ////////////////////////////////////////////////////////////////////////
+
+    /**
+     * Runs a concrete static set `StaticSet` behind the virtual `ISet`
+     * interface. It owns the set and its traversal scratch (`Workspace`), and
+     * forwards each runtime call to the matching compile-time one via
+     * `static_switch`. `clone` stays abstract: only a concrete node knows how
+     * to deep-copy the dynamic children the static set was built from.
+     */
+    template <class StaticSet>
+    class ExecNode : public ISet<StaticSet::dim, typename StaticSet::interval_t>
+    {
+        using Base                       = ISet<StaticSet::dim, typename StaticSet::interval_t>;
+        static constexpr std::size_t dim = StaticSet::dim;
+
+      public:
+
+        using typename Base::traverser_t;
+        using typename Base::yz_index_t;
+
+        std::size_t level() const override
+        {
+            return m_exec.level();
+        }
+
+        bool exist() const override
+        {
+            return m_exec.exist();
+        }
+
+        bool empty() const override
+        {
+            return m_exec.empty();
+        }
+
+        void init_workspace(std::size_t d, std::size_t n_traversers) override
+        {
+            detail::static_switch<dim>(d,
+                                       [&](auto d_ic)
+                                       {
+                                           m_exec.init_workspace(n_traversers, d_ic, m_ws);
+                                       });
+        }
+
+        traverser_t get_traverser(std::size_t d, const yz_index_t& index) override
+        {
+            return detail::static_switch<dim>(d,
+                                              [&](auto d_ic)
+                                              {
+                                                  return make_any_traverser(m_exec.get_traverser(index, d_ic, m_ws));
+                                              });
+        }
+
+        traverser_t get_traverser_unordered(std::size_t d, const yz_index_t& index) override
+        {
+            return detail::static_switch<dim>(d,
+                                              [&](auto d_ic)
+                                              {
+                                                  return make_any_traverser(m_exec.get_traverser_unordered(index, d_ic, m_ws));
+                                              });
+        }
+
+      protected:
+
+        explicit ExecNode(StaticSet exec)
+            : m_exec(std::move(exec))
+        {
+        }
+
+      private:
+
+        StaticSet m_exec;
+        typename StaticSet::Workspace m_ws;
+    };
+
+    ////////////////////////////////////////////////////////////////////////
+    //// Node: a static set + the dynamic children it was built from
+    ////////////////////////////////////////////////////////////////////////
+
+    /**
+     * The single concrete `ISet` node. It stores:
+     *   - the dynamic children (`shared_ptr<ISet>`), which it owns for cloning;
+     *   - a `rebuild` functor that turns those children into the static set
+     *     actually executed.
+     *
+     * A leaf passes no children and a `rebuild` that captures the data (e.g. an
+     * LCA); a modifier passes one child; a binary operator passes two. `clone`
+     * is uniform: deep-copy the children, then rebuild.
+     */
+    template <std::size_t dim_,
+              class TInterval,
+              class Rebuild,
+              class StaticSet = std::invoke_result_t<Rebuild&, const std::vector<std::shared_ptr<ISet<dim_, TInterval>>>&>>
+    class Node final : public ExecNode<StaticSet>
+    {
+        using iset_t    = ISet<dim_, TInterval>;
+        using child_vec = std::vector<std::shared_ptr<iset_t>>;
+
+        static_assert(StaticSet::dim == dim_);
+
+      public:
+
+        Node(child_vec children, Rebuild rebuild)
+            : ExecNode<StaticSet>(rebuild(children))
+            , m_children(std::move(children))
+            , m_rebuild(std::move(rebuild))
+        {
+        }
+
+        std::shared_ptr<iset_t> clone() const override
+        {
+            child_vec cloned;
+            cloned.reserve(m_children.size());
+            for (const auto& child : m_children)
+            {
+                cloned.push_back(child->clone());
+            }
+            return std::make_shared<Node>(std::move(cloned), m_rebuild);
+        }
+
+      private:
+
+        child_vec m_children;
+        Rebuild m_rebuild;
+    };
+
+    ////////////////////////////////////////////////////////////////////////
+    //// DynamicSet: the user-facing handle
+    ////////////////////////////////////////////////////////////////////////
+
+    /**
+     * A cheap value handle over a runtime set expression. Mirrors the static
+     * set surface (`on`, `operator()`, `to_lca`, `level`) and is the natural
+     * type to expose to bindings.
+     */
+    template <std::size_t dim_, class TInterval>
+    class DynamicSet
+    {
+      public:
+
+        static constexpr std::size_t dim = dim_;
+
+        using interval_t = TInterval;
+        using iset_t     = ISet<dim_, TInterval>;
+
+        explicit DynamicSet(std::shared_ptr<iset_t> set)
+            : m_set(std::move(set))
+        {
+        }
+
+        const std::shared_ptr<iset_t>& ptr() const
+        {
+            return m_set;
+        }
+
+        std::size_t level() const
+        {
+            return m_set->level();
+        }
+
+        /// Independent deep copy, safe to traverse from another thread.
+        DynamicSet clone() const
+        {
+            return DynamicSet(m_set->clone());
+        }
+
+        DynamicSet on(std::size_t level) const; // defined below, once `dyn::on` is available
+
+        template <class Func>
+        void operator()(Func&& func) const
+        {
+            apply(as_static_set(m_set), std::forward<Func>(func));
+        }
+
+        auto to_lca() const
+        {
+            return as_static_set(m_set).to_lca();
+        }
+
+      private:
+
+        std::shared_ptr<iset_t> m_set;
+    };
+
+    /// Build a `DynamicSet` from a child list and a rebuild functor.
+    template <std::size_t dim_, class TInterval, class Rebuild>
+    DynamicSet<dim_, TInterval> make_node(std::vector<std::shared_ptr<ISet<dim_, TInterval>>> children, Rebuild rebuild)
+    {
+        auto node = std::make_shared<Node<dim_, TInterval, Rebuild>>(std::move(children), std::move(rebuild));
+        return DynamicSet<dim_, TInterval>(std::move(node));
+    }
+
+    template <class T>
+    struct is_dynamic_set : std::false_type
+    {
+    };
+
+    template <std::size_t dim_, class TInterval>
+    struct is_dynamic_set<DynamicSet<dim_, TInterval>> : std::true_type
+    {
+    };
+
+    ////////////////////////////////////////////////////////////////////////
+    //// Dynamic DSL - mirrors the static free functions
+    ////////////////////////////////////////////////////////////////////////
+
+    namespace dyn
+    {
+        template <std::size_t Dim, class TInterval>
+        DynamicSet<Dim, TInterval> self(const LevelCellArray<Dim, TInterval>& lca)
+        {
+            using LCA = LevelCellArray<Dim, TInterval>;
+            return make_node<Dim, TInterval>({},
+                                             [lca_ptr = &lca](const auto&)
+                                             {
+                                                 return LCAView<LCA>(*lca_ptr);
+                                             });
+        }
+
+        namespace detail
+        {
+            template <SetOperator op, std::size_t dim, class TInterval>
+            DynamicSet<dim, TInterval> binary(const DynamicSet<dim, TInterval>& a, const DynamicSet<dim, TInterval>& b)
+            {
+                return make_node<dim, TInterval>(
+                    {a.ptr(), b.ptr()},
+                    [](const auto& children)
+                    {
+                        using adaptor_t = DynamicSetAdaptor<dim, TInterval>;
+                        if constexpr (op == SetOperator::UNION)
+                        {
+                            return union_(adaptor_t(children[0]), adaptor_t(children[1]));
+                        }
+                        else if constexpr (op == SetOperator::INTERSECTION)
+                        {
+                            return intersection(adaptor_t(children[0]), adaptor_t(children[1]));
+                        }
+                        else
+                        {
+                            return difference(adaptor_t(children[0]), adaptor_t(children[1]));
+                        }
+                    });
+            }
+
+            template <SetOperator op, std::size_t dim, class TInterval>
+            DynamicSet<dim, TInterval> fold(const std::vector<DynamicSet<dim, TInterval>>& sets)
+            {
+                assert(!sets.empty());
+                DynamicSet<dim, TInterval> acc = sets.front();
+                for (std::size_t i = 1; i < sets.size(); ++i)
+                {
+                    acc = binary<op>(acc, sets[i]);
+                }
+                return acc;
+            }
+        } // namespace detail
+
+        // Runtime overloads: the number of operands is a std::vector known at
+        // runtime (the natural entry point for bindings).
+
+        template <std::size_t dim, class TInterval>
+        DynamicSet<dim, TInterval> union_(const std::vector<DynamicSet<dim, TInterval>>& sets)
+        {
+            return detail::fold<SetOperator::UNION>(sets);
+        }
+
+        template <std::size_t dim, class TInterval>
+        DynamicSet<dim, TInterval> intersection(const std::vector<DynamicSet<dim, TInterval>>& sets)
+        {
+            assert(sets.size() >= 2);
+            return detail::fold<SetOperator::INTERSECTION>(sets);
+        }
+
+        template <std::size_t dim, class TInterval>
+        DynamicSet<dim, TInterval> difference(const std::vector<DynamicSet<dim, TInterval>>& sets)
+        {
+            assert(sets.size() >= 2);
+            return detail::fold<SetOperator::DIFFERENCE>(sets);
+        }
+
+        // Variadic overloads: mirror the static DSL, `dim`/`TInterval` deduced
+        // from the arguments. Constrained to DynamicSet so a single std::vector
+        // argument routes to the runtime overloads above.
+
+        template <class Set, class... Sets>
+            requires(is_dynamic_set<Set>::value && (std::same_as<Set, Sets> && ...))
+        Set union_(const Set& first, const Sets&... rest)
+        {
+            return union_(std::vector<Set>{first, rest...});
+        }
+
+        template <class Set, class... Sets>
+            requires(is_dynamic_set<Set>::value && (std::same_as<Set, Sets> && ...) && sizeof...(Sets) >= 1)
+        Set intersection(const Set& first, const Sets&... rest)
+        {
+            return intersection(std::vector<Set>{first, rest...});
+        }
+
+        template <class Set, class... Sets>
+            requires(is_dynamic_set<Set>::value && (std::same_as<Set, Sets> && ...) && sizeof...(Sets) >= 1)
+        Set difference(const Set& first, const Sets&... rest)
+        {
+            return difference(std::vector<Set>{first, rest...});
+        }
+
+        template <std::size_t dim, class TInterval>
+        DynamicSet<dim, TInterval> on(const DynamicSet<dim, TInterval>& set, std::size_t level)
+        {
+            return make_node<dim, TInterval>({set.ptr()},
+                                             [level](const auto& children)
+                                             {
+                                                 return as_static_set(children[0]).on(level);
+                                             });
+        }
+
+        template <std::size_t dim, class TInterval, class Translation>
+        DynamicSet<dim, TInterval> translate(const DynamicSet<dim, TInterval>& set, const Translation& t)
+        {
+            return make_node<dim, TInterval>({set.ptr()},
+                                             [t](const auto& children)
+                                             {
+                                                 return samurai::translate(as_static_set(children[0]), t);
+                                             });
+        }
+
+        template <std::size_t dim, class TInterval>
+        DynamicSet<dim, TInterval> expand(const DynamicSet<dim, TInterval>& set, int width)
+        {
+            return make_node<dim, TInterval>({set.ptr()},
+                                             [width](const auto& children)
+                                             {
+                                                 return nestedExpand(as_static_set(children[0]), width);
+                                             });
+        }
+    } // namespace dyn
+
+    template <std::size_t dim_, class TInterval>
+    DynamicSet<dim_, TInterval> DynamicSet<dim_, TInterval>::on(std::size_t level) const
+    {
+        return dyn::on(*this, level);
+    }
+
+} // namespace samurai

--- a/include/samurai/subset/dynamic/small_object.hpp
+++ b/include/samurai/subset/dynamic/small_object.hpp
@@ -1,0 +1,207 @@
+// Copyright 2018-2025 the samurai's authors
+// SPDX-License-Identifier:  BSD-3-Clause
+
+#pragma once
+
+#include <concepts>
+#include <cstddef>
+#include <memory>
+#include <new>
+#include <type_traits>
+#include <utility>
+
+// Small-buffer optimization for a value-semantic, type-erased object.
+//
+// This is the whole (and only) place where placement-new lives. It lets a
+// polymorphic object be stored *inside* its holder when it is small enough,
+// and on the heap otherwise, while the holder keeps clean value semantics
+// (deep copy / move). No raw owning `new`/`delete`: the inline case uses
+// placement-new (which allocates nothing) plus a manual destructor call, and
+// the heap fallback is a plain `std::unique_ptr`.
+namespace samurai::sbo
+{
+    /**
+     * Result of placing a copy/move of a polymorphic object: `ptr` always
+     * points at the new object; `owner` holds it iff it went on the heap, and
+     * is null when it was placement-constructed into the caller's buffer.
+     */
+    template <class Interface>
+    struct PlacedObject
+    {
+        Interface* ptr = nullptr;
+        std::unique_ptr<Interface> owner;
+    };
+
+    /**
+     * CRTP mixin that gives a concrete `Derived : Interface` the `copy_to` /
+     * `move_to` operations `SmallObject` needs. A concrete type placed in a
+     * `SmallObject` should derive from `Cloneable<Interface, Derived>` instead
+     * of directly from `Interface`.
+     */
+    template <class Interface, class Derived>
+    class Cloneable : public Interface
+    {
+      public:
+
+        PlacedObject<Interface> copy_to(void* buffer, std::size_t capacity) const final
+        {
+            if (fits(capacity))
+            {
+                Interface* placed = std::construct_at(static_cast<Derived*>(buffer), as_derived());
+                return {placed, nullptr};
+            }
+            std::unique_ptr<Interface> owner = std::make_unique<Derived>(as_derived());
+            Interface* placed                = owner.get();
+            return {placed, std::move(owner)};
+        }
+
+        PlacedObject<Interface> move_to(void* buffer, std::size_t capacity) final
+        {
+            if (fits(capacity))
+            {
+                Interface* placed = std::construct_at(static_cast<Derived*>(buffer), std::move(as_derived()));
+                return {placed, nullptr};
+            }
+            std::unique_ptr<Interface> owner = std::make_unique<Derived>(std::move(as_derived()));
+            Interface* placed                = owner.get();
+            return {placed, std::move(owner)};
+        }
+
+      private:
+
+        static constexpr bool fits(std::size_t capacity)
+        {
+            return sizeof(Derived) <= capacity && alignof(Derived) <= alignof(std::max_align_t);
+        }
+
+        const Derived& as_derived() const
+        {
+            return static_cast<const Derived&>(*this);
+        }
+
+        Derived& as_derived()
+        {
+            return static_cast<Derived&>(*this);
+        }
+    };
+
+    /**
+     * A value handle over a polymorphic `Interface` object, stored inline in a
+     * `BufferSize`-byte buffer when it fits and on the heap otherwise. Copy and
+     * move are deep. `Interface` must expose `copy_to` / `move_to`; derive the
+     * concrete types from `Cloneable` to get them for free.
+     */
+    template <class Interface, std::size_t BufferSize>
+    class SmallObject
+    {
+      public:
+
+        template <class Concrete>
+            requires std::derived_from<std::remove_cvref_t<Concrete>, Interface>
+        explicit SmallObject(Concrete&& object)
+        {
+            using T = std::remove_cvref_t<Concrete>;
+            if constexpr (sizeof(T) <= BufferSize && alignof(T) <= alignof(std::max_align_t))
+            {
+                m_ptr = std::construct_at(static_cast<T*>(static_cast<void*>(m_storage)), std::forward<Concrete>(object));
+            }
+            else
+            {
+                m_heap = std::make_unique<T>(std::forward<Concrete>(object));
+                m_ptr  = m_heap.get();
+            }
+        }
+
+        SmallObject(const SmallObject& other)
+        {
+            adopt(other.m_ptr->copy_to(m_storage, BufferSize));
+        }
+
+        SmallObject(SmallObject&& other) noexcept
+        {
+            steal_from(other);
+        }
+
+        SmallObject& operator=(const SmallObject& other)
+        {
+            if (this != &other)
+            {
+                reset();
+                adopt(other.m_ptr->copy_to(m_storage, BufferSize));
+            }
+            return *this;
+        }
+
+        SmallObject& operator=(SmallObject&& other) noexcept
+        {
+            if (this != &other)
+            {
+                reset();
+                steal_from(other);
+            }
+            return *this;
+        }
+
+        ~SmallObject()
+        {
+            reset();
+        }
+
+        Interface* get()
+        {
+            return m_ptr;
+        }
+
+        const Interface* get() const
+        {
+            return m_ptr;
+        }
+
+      private:
+
+        // Whatever `m_ptr` points at that is not owned by `m_heap` lives in the
+        // inline buffer and must be destroyed by hand.
+        bool is_inline() const
+        {
+            return m_ptr != nullptr && m_heap == nullptr;
+        }
+
+        void reset()
+        {
+            if (is_inline())
+            {
+                std::destroy_at(m_ptr);
+            }
+            m_heap.reset();
+            m_ptr = nullptr;
+        }
+
+        void adopt(PlacedObject<Interface> placed)
+        {
+            m_ptr  = placed.ptr;
+            m_heap = std::move(placed.owner);
+        }
+
+        void steal_from(SmallObject& other)
+        {
+            if (other.m_heap != nullptr)
+            {
+                // Heap object: transfer ownership. Nothing left to destroy in `other`.
+                m_heap       = std::move(other.m_heap);
+                m_ptr        = m_heap.get();
+                other.m_ptr  = nullptr;
+            }
+            else if (other.m_ptr != nullptr)
+            {
+                // Inline object: move-construct into our buffer, then destroy the source.
+                adopt(other.m_ptr->move_to(m_storage, BufferSize));
+                other.reset();
+            }
+        }
+
+        alignas(std::max_align_t) std::byte m_storage[BufferSize];
+        std::unique_ptr<Interface> m_heap;
+        Interface* m_ptr = nullptr;
+    };
+
+} // namespace samurai::sbo

--- a/include/samurai/subset/dynamic/small_object.hpp
+++ b/include/samurai/subset/dynamic/small_object.hpp
@@ -187,9 +187,9 @@ namespace samurai::sbo
             if (other.m_heap != nullptr)
             {
                 // Heap object: transfer ownership. Nothing left to destroy in `other`.
-                m_heap       = std::move(other.m_heap);
-                m_ptr        = m_heap.get();
-                other.m_ptr  = nullptr;
+                m_heap      = std::move(other.m_heap);
+                m_ptr       = m_heap.get();
+                other.m_ptr = nullptr;
             }
             else if (other.m_ptr != nullptr)
             {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -60,6 +60,7 @@ set(SAMURAI_TESTS
     test_stencil.cpp
     test_subdomain_bbox.cpp
     test_subset.cpp
+    test_subset_dynamic.cpp
     test_timers.cpp
     test_utils.cpp
     test_version.cpp

--- a/tests/test_subset_dynamic.cpp
+++ b/tests/test_subset_dynamic.cpp
@@ -2,15 +2,18 @@
 // SPDX-License-Identifier:  BSD-3-Clause
 
 #include <string>
+#include <utility>
 #include <vector>
 
 #include <xtensor/containers/xfixed.hpp>
 
 #include <gtest/gtest.h>
 
+#include <samurai/box.hpp>
 #include <samurai/cell_list.hpp>
 #include <samurai/level_cell_array.hpp>
 #include <samurai/subset/node.hpp>
+#include <samurai/subset/traversers/range_traverser.hpp>
 
 #include <samurai/subset/dynamic/dynamic.hpp>
 
@@ -80,6 +83,16 @@ namespace samurai
                 lcl[{y}].add_interval({x0, x1});
             }
             return LevelCellArray<2>(lcl);
+        }
+
+        LevelCellArray<3> lca3(std::size_t level, std::initializer_list<std::tuple<int, int, int, int>> boxes)
+        {
+            LevelCellList<3> lcl{level};
+            for (auto [y, z, x0, x1] : boxes)
+            {
+                lcl[{y, z}].add_interval({x0, x1});
+            }
+            return LevelCellArray<3>(lcl);
         }
     } // namespace
 
@@ -195,6 +208,107 @@ namespace samurai
         auto c = lca2(3, {{1, 1, 7}, {2, 0, 10}});
         EXPECT_EQ(traverse_static(intersection(nestedExpand(self(a), 1), self(c))),
                   traverse_dynamic(dyn::intersection(dyn::expand(dyn::self(a), 1), dyn::self(c))));
+    }
+
+    TEST(subset_dynamic, box)
+    {
+        auto a = lca2(0, {{0, 0, 10}, {1, 0, 10}, {2, 0, 10}, {3, 0, 10}});
+        Box<int, 2> b({1, 1}, {5, 4});
+
+        // box alone, and combined with an LCA leaf (mixing box + self).
+        EXPECT_EQ(traverse_static(asBoxView(0, b)), traverse_dynamic(dyn::box(0, b)));
+        EXPECT_EQ(traverse_static(intersection(self(a), asBoxView(0, b))),
+                  traverse_dynamic(dyn::intersection(dyn::self(a), dyn::box(0, b))));
+    }
+
+    TEST(subset_dynamic, contract)
+    {
+        auto a = lca2(0, {{0, 0, 10}, {1, 0, 10}, {2, 0, 10}, {3, 0, 10}});
+        EXPECT_EQ(traverse_static(contract(self(a), 1)), traverse_dynamic(dyn::contract(dyn::self(a), 1)));
+
+        std::array<bool, 2> directions{true, false};
+        EXPECT_EQ(traverse_static(contract(self(a), 1, directions)),
+                  traverse_dynamic(dyn::contract(dyn::self(a), 1, directions)));
+    }
+
+    ////////////////////////////////////////////////////////////////////////
+    //// 3D equivalence (deepest runtime -> compile-time dimension switch)
+    ////////////////////////////////////////////////////////////////////////
+
+    TEST(subset_dynamic, intersection_3d)
+    {
+        auto a = lca3(2, {{0, 0, 0, 6}, {1, 0, 2, 8}, {0, 1, 1, 5}});
+        auto b = lca3(2, {{0, 0, 3, 9}, {1, 0, 0, 4}, {0, 1, 2, 7}});
+        EXPECT_EQ(traverse_static(intersection(self(a), self(b))),
+                  traverse_dynamic(dyn::intersection(dyn::self(a), dyn::self(b))));
+    }
+
+    TEST(subset_dynamic, difference_3d)
+    {
+        auto a = lca3(2, {{0, 0, 0, 6}, {1, 0, 2, 8}, {0, 1, 1, 5}});
+        auto b = lca3(2, {{0, 0, 3, 9}, {1, 0, 0, 4}, {0, 1, 2, 7}});
+        EXPECT_EQ(traverse_static(difference(self(a), self(b))),
+                  traverse_dynamic(dyn::difference(dyn::self(a), dyn::self(b))));
+    }
+
+    TEST(subset_dynamic, projection_3d)
+    {
+        auto a = lca3(2, {{0, 0, 0, 6}, {1, 0, 2, 8}, {0, 1, 1, 5}});
+        auto b = lca3(2, {{0, 0, 3, 9}, {1, 0, 0, 4}, {0, 1, 2, 7}});
+        EXPECT_EQ(traverse_static(intersection(self(a), self(b)).on(1)),
+                  traverse_dynamic(dyn::intersection(dyn::self(a), dyn::self(b)).on(1)));
+    }
+
+    ////////////////////////////////////////////////////////////////////////
+    //// Empty / disjoint results (exercises exist() / empty() and no output)
+    ////////////////////////////////////////////////////////////////////////
+
+    TEST(subset_dynamic, disjoint_intersection_is_empty)
+    {
+        auto a = lca1(0, {{0, 5}});
+        auto b = lca1(0, {{10, 15}});
+
+        auto dyn_result = traverse_dynamic(dyn::intersection(dyn::self(a), dyn::self(b)));
+        EXPECT_TRUE(dyn_result.empty());
+        EXPECT_EQ(traverse_static(intersection(self(a), self(b))), dyn_result);
+
+        // to_lca of an empty dynamic set is empty, and matches the static one.
+        EXPECT_TRUE(dyn::intersection(dyn::self(a), dyn::self(b)).to_lca().empty());
+        EXPECT_EQ(intersection(self(a), self(b)).to_lca(), dyn::intersection(dyn::self(a), dyn::self(b)).to_lca());
+    }
+
+    TEST(subset_dynamic, difference_emptied_by_cover)
+    {
+        auto a = lca1(0, {{2, 6}});
+        auto b = lca1(0, {{0, 10}});
+        auto dyn_result = traverse_dynamic(dyn::difference(dyn::self(a), dyn::self(b)));
+        EXPECT_TRUE(dyn_result.empty());
+        EXPECT_EQ(traverse_static(difference(self(a), self(b))), dyn_result);
+    }
+
+    ////////////////////////////////////////////////////////////////////////
+    //// AnyTraverser move (exercises the small-buffer move path)
+    ////////////////////////////////////////////////////////////////////////
+
+    TEST(subset_dynamic, any_traverser_move)
+    {
+        using interval_t = LevelCellArray<1>::interval_t;
+        auto lca         = lca1(0, {{0, 5}, {8, 12}});
+
+        // A leaf traverser is held inline in the small buffer; moving it must
+        // move-construct into the destination's buffer, not dangle.
+        AnyTraverser<interval_t> source = make_any_traverser(RangeTraverser(lca[0].cbegin(), lca[0].cend()));
+
+        AnyTraverser<interval_t> moved = std::move(source); // move ctor -> SmallObject move
+        EXPECT_FALSE(moved.is_empty());
+        EXPECT_EQ(moved.current_interval(), interval_t(0, 5));
+        moved.next_interval();
+        EXPECT_EQ(moved.current_interval(), interval_t(8, 12));
+
+        // Move assignment onto an existing holder.
+        AnyTraverser<interval_t> target = make_any_traverser(RangeTraverser(lca[0].cbegin(), lca[0].cend()));
+        target                          = std::move(moved);
+        EXPECT_EQ(target.current_interval(), interval_t(8, 12));
     }
 
     ////////////////////////////////////////////////////////////////////////

--- a/tests/test_subset_dynamic.cpp
+++ b/tests/test_subset_dynamic.cpp
@@ -102,15 +102,32 @@ namespace samurai
 
     TEST(subset_dynamic, leaf)
     {
-        auto a = lca1(0, {{0, 2}, {5, 9}, {12, 14}});
+        auto a = lca1(0,
+                      {
+                          {0,  2 },
+                          {5,  9 },
+                          {12, 14}
+        });
         EXPECT_EQ(traverse_static(self(a)), traverse_dynamic(dyn::self(a)));
     }
 
     TEST(subset_dynamic, intersection_1d)
     {
-        auto a = lca1(2, {{0, 5}, {8, 12}});
-        auto b = lca1(2, {{3, 9}, {11, 20}});
-        auto c = lca1(2, {{4, 7}, {10, 30}});
+        auto a = lca1(2,
+                      {
+                          {0, 5 },
+                          {8, 12}
+        });
+        auto b = lca1(2,
+                      {
+                          {3,  9 },
+                          {11, 20}
+        });
+        auto c = lca1(2,
+                      {
+                          {4,  7 },
+                          {10, 30}
+        });
 
         EXPECT_EQ(traverse_static(intersection(self(a), self(b), self(c))),
                   traverse_dynamic(dyn::intersection(dyn::self(a), dyn::self(b), dyn::self(c))));
@@ -118,9 +135,21 @@ namespace samurai
 
     TEST(subset_dynamic, union_1d)
     {
-        auto a = lca1(2, {{0, 5}, {8, 12}});
-        auto b = lca1(2, {{3, 9}, {11, 20}});
-        auto c = lca1(2, {{4, 7}, {10, 30}});
+        auto a = lca1(2,
+                      {
+                          {0, 5 },
+                          {8, 12}
+        });
+        auto b = lca1(2,
+                      {
+                          {3,  9 },
+                          {11, 20}
+        });
+        auto c = lca1(2,
+                      {
+                          {4,  7 },
+                          {10, 30}
+        });
 
         EXPECT_EQ(traverse_static(union_(self(a), self(b), self(c))),
                   traverse_dynamic(dyn::union_(dyn::self(a), dyn::self(b), dyn::self(c))));
@@ -128,9 +157,21 @@ namespace samurai
 
     TEST(subset_dynamic, difference_1d)
     {
-        auto a = lca1(2, {{0, 5}, {8, 12}});
-        auto b = lca1(2, {{3, 9}, {11, 20}});
-        auto c = lca1(2, {{4, 7}, {10, 30}});
+        auto a = lca1(2,
+                      {
+                          {0, 5 },
+                          {8, 12}
+        });
+        auto b = lca1(2,
+                      {
+                          {3,  9 },
+                          {11, 20}
+        });
+        auto c = lca1(2,
+                      {
+                          {4,  7 },
+                          {10, 30}
+        });
 
         EXPECT_EQ(traverse_static(difference(self(a), self(b), self(c))),
                   traverse_dynamic(dyn::difference(dyn::self(a), dyn::self(b), dyn::self(c))));
@@ -138,9 +179,21 @@ namespace samurai
 
     TEST(subset_dynamic, nested_1d)
     {
-        auto a = lca1(2, {{0, 5}, {8, 12}});
-        auto b = lca1(2, {{3, 9}, {11, 20}});
-        auto c = lca1(2, {{4, 7}, {10, 30}});
+        auto a = lca1(2,
+                      {
+                          {0, 5 },
+                          {8, 12}
+        });
+        auto b = lca1(2,
+                      {
+                          {3,  9 },
+                          {11, 20}
+        });
+        auto c = lca1(2,
+                      {
+                          {4,  7 },
+                          {10, 30}
+        });
 
         auto stat = union_(intersection(self(a), self(b)).on(1), self(c));
         auto dynv = dyn::union_(dyn::intersection(dyn::self(a), dyn::self(b)).on(1), dyn::self(c));
@@ -149,10 +202,16 @@ namespace samurai
 
     TEST(subset_dynamic, mixed_levels_1d)
     {
-        auto a = lca1(2, {{0, 5}, {8, 12}});
-        auto d = lca1(4, {{0, 40}});
-        EXPECT_EQ(traverse_static(intersection(self(a), self(d))),
-                  traverse_dynamic(dyn::intersection(dyn::self(a), dyn::self(d))));
+        auto a = lca1(2,
+                      {
+                          {0, 5 },
+                          {8, 12}
+        });
+        auto d = lca1(4,
+                      {
+                          {0, 40}
+        });
+        EXPECT_EQ(traverse_static(intersection(self(a), self(d))), traverse_dynamic(dyn::intersection(dyn::self(a), dyn::self(d))));
     }
 
     ////////////////////////////////////////////////////////////////////////
@@ -161,41 +220,93 @@ namespace samurai
 
     TEST(subset_dynamic, intersection_2d)
     {
-        auto a = lca2(3, {{0, 0, 5}, {1, 2, 8}, {2, 0, 4}});
-        auto b = lca2(3, {{0, 3, 9}, {1, 0, 6}, {2, 1, 3}});
-        EXPECT_EQ(traverse_static(intersection(self(a), self(b))),
-                  traverse_dynamic(dyn::intersection(dyn::self(a), dyn::self(b))));
+        auto a = lca2(3,
+                      {
+                          {0, 0, 5},
+                          {1, 2, 8},
+                          {2, 0, 4}
+        });
+        auto b = lca2(3,
+                      {
+                          {0, 3, 9},
+                          {1, 0, 6},
+                          {2, 1, 3}
+        });
+        EXPECT_EQ(traverse_static(intersection(self(a), self(b))), traverse_dynamic(dyn::intersection(dyn::self(a), dyn::self(b))));
     }
 
     TEST(subset_dynamic, union_2d)
     {
-        auto a = lca2(3, {{0, 0, 5}, {1, 2, 8}, {2, 0, 4}});
-        auto b = lca2(3, {{0, 3, 9}, {1, 0, 6}, {2, 1, 3}});
-        auto c = lca2(3, {{1, 1, 7}, {2, 0, 10}});
+        auto a = lca2(3,
+                      {
+                          {0, 0, 5},
+                          {1, 2, 8},
+                          {2, 0, 4}
+        });
+        auto b = lca2(3,
+                      {
+                          {0, 3, 9},
+                          {1, 0, 6},
+                          {2, 1, 3}
+        });
+        auto c = lca2(3,
+                      {
+                          {1, 1, 7 },
+                          {2, 0, 10}
+        });
         EXPECT_EQ(traverse_static(union_(self(a), self(b), self(c))),
                   traverse_dynamic(dyn::union_(dyn::self(a), dyn::self(b), dyn::self(c))));
     }
 
     TEST(subset_dynamic, difference_2d)
     {
-        auto a = lca2(3, {{0, 0, 5}, {1, 2, 8}, {2, 0, 4}});
-        auto b = lca2(3, {{0, 3, 9}, {1, 0, 6}, {2, 1, 3}});
-        EXPECT_EQ(traverse_static(difference(self(a), self(b))),
-                  traverse_dynamic(dyn::difference(dyn::self(a), dyn::self(b))));
+        auto a = lca2(3,
+                      {
+                          {0, 0, 5},
+                          {1, 2, 8},
+                          {2, 0, 4}
+        });
+        auto b = lca2(3,
+                      {
+                          {0, 3, 9},
+                          {1, 0, 6},
+                          {2, 1, 3}
+        });
+        EXPECT_EQ(traverse_static(difference(self(a), self(b))), traverse_dynamic(dyn::difference(dyn::self(a), dyn::self(b))));
     }
 
     TEST(subset_dynamic, projection_2d)
     {
-        auto a = lca2(3, {{0, 0, 5}, {1, 2, 8}, {2, 0, 4}});
-        auto b = lca2(3, {{0, 3, 9}, {1, 0, 6}, {2, 1, 3}});
+        auto a = lca2(3,
+                      {
+                          {0, 0, 5},
+                          {1, 2, 8},
+                          {2, 0, 4}
+        });
+        auto b = lca2(3,
+                      {
+                          {0, 3, 9},
+                          {1, 0, 6},
+                          {2, 1, 3}
+        });
         EXPECT_EQ(traverse_static(intersection(self(a), self(b)).on(2)),
                   traverse_dynamic(dyn::intersection(dyn::self(a), dyn::self(b)).on(2)));
     }
 
     TEST(subset_dynamic, translate_2d)
     {
-        auto a = lca2(3, {{0, 0, 5}, {1, 2, 8}, {2, 0, 4}});
-        auto b = lca2(3, {{0, 3, 9}, {1, 0, 6}, {2, 1, 3}});
+        auto a = lca2(3,
+                      {
+                          {0, 0, 5},
+                          {1, 2, 8},
+                          {2, 0, 4}
+        });
+        auto b = lca2(3,
+                      {
+                          {0, 3, 9},
+                          {1, 0, 6},
+                          {2, 1, 3}
+        });
 
         xt::xtensor_fixed<int, xt::xshape<2>> t{1, 2};
         EXPECT_EQ(traverse_static(intersection(translate(self(a), t), self(b))),
@@ -204,31 +315,50 @@ namespace samurai
 
     TEST(subset_dynamic, expand_2d)
     {
-        auto a = lca2(3, {{0, 0, 5}, {1, 2, 8}, {2, 0, 4}});
-        auto c = lca2(3, {{1, 1, 7}, {2, 0, 10}});
+        auto a = lca2(3,
+                      {
+                          {0, 0, 5},
+                          {1, 2, 8},
+                          {2, 0, 4}
+        });
+        auto c = lca2(3,
+                      {
+                          {1, 1, 7 },
+                          {2, 0, 10}
+        });
         EXPECT_EQ(traverse_static(intersection(nestedExpand(self(a), 1), self(c))),
                   traverse_dynamic(dyn::intersection(dyn::expand(dyn::self(a), 1), dyn::self(c))));
     }
 
     TEST(subset_dynamic, box)
     {
-        auto a = lca2(0, {{0, 0, 10}, {1, 0, 10}, {2, 0, 10}, {3, 0, 10}});
+        auto a = lca2(0,
+                      {
+                          {0, 0, 10},
+                          {1, 0, 10},
+                          {2, 0, 10},
+                          {3, 0, 10}
+        });
         Box<int, 2> b({1, 1}, {5, 4});
 
         // box alone, and combined with an LCA leaf (mixing box + self).
         EXPECT_EQ(traverse_static(asBoxView(0, b)), traverse_dynamic(dyn::box(0, b)));
-        EXPECT_EQ(traverse_static(intersection(self(a), asBoxView(0, b))),
-                  traverse_dynamic(dyn::intersection(dyn::self(a), dyn::box(0, b))));
+        EXPECT_EQ(traverse_static(intersection(self(a), asBoxView(0, b))), traverse_dynamic(dyn::intersection(dyn::self(a), dyn::box(0, b))));
     }
 
     TEST(subset_dynamic, contract)
     {
-        auto a = lca2(0, {{0, 0, 10}, {1, 0, 10}, {2, 0, 10}, {3, 0, 10}});
+        auto a = lca2(0,
+                      {
+                          {0, 0, 10},
+                          {1, 0, 10},
+                          {2, 0, 10},
+                          {3, 0, 10}
+        });
         EXPECT_EQ(traverse_static(contract(self(a), 1)), traverse_dynamic(dyn::contract(dyn::self(a), 1)));
 
         std::array<bool, 2> directions{true, false};
-        EXPECT_EQ(traverse_static(contract(self(a), 1, directions)),
-                  traverse_dynamic(dyn::contract(dyn::self(a), 1, directions)));
+        EXPECT_EQ(traverse_static(contract(self(a), 1, directions)), traverse_dynamic(dyn::contract(dyn::self(a), 1, directions)));
     }
 
     ////////////////////////////////////////////////////////////////////////
@@ -237,24 +367,52 @@ namespace samurai
 
     TEST(subset_dynamic, intersection_3d)
     {
-        auto a = lca3(2, {{0, 0, 0, 6}, {1, 0, 2, 8}, {0, 1, 1, 5}});
-        auto b = lca3(2, {{0, 0, 3, 9}, {1, 0, 0, 4}, {0, 1, 2, 7}});
-        EXPECT_EQ(traverse_static(intersection(self(a), self(b))),
-                  traverse_dynamic(dyn::intersection(dyn::self(a), dyn::self(b))));
+        auto a = lca3(2,
+                      {
+                          {0, 0, 0, 6},
+                          {1, 0, 2, 8},
+                          {0, 1, 1, 5}
+        });
+        auto b = lca3(2,
+                      {
+                          {0, 0, 3, 9},
+                          {1, 0, 0, 4},
+                          {0, 1, 2, 7}
+        });
+        EXPECT_EQ(traverse_static(intersection(self(a), self(b))), traverse_dynamic(dyn::intersection(dyn::self(a), dyn::self(b))));
     }
 
     TEST(subset_dynamic, difference_3d)
     {
-        auto a = lca3(2, {{0, 0, 0, 6}, {1, 0, 2, 8}, {0, 1, 1, 5}});
-        auto b = lca3(2, {{0, 0, 3, 9}, {1, 0, 0, 4}, {0, 1, 2, 7}});
-        EXPECT_EQ(traverse_static(difference(self(a), self(b))),
-                  traverse_dynamic(dyn::difference(dyn::self(a), dyn::self(b))));
+        auto a = lca3(2,
+                      {
+                          {0, 0, 0, 6},
+                          {1, 0, 2, 8},
+                          {0, 1, 1, 5}
+        });
+        auto b = lca3(2,
+                      {
+                          {0, 0, 3, 9},
+                          {1, 0, 0, 4},
+                          {0, 1, 2, 7}
+        });
+        EXPECT_EQ(traverse_static(difference(self(a), self(b))), traverse_dynamic(dyn::difference(dyn::self(a), dyn::self(b))));
     }
 
     TEST(subset_dynamic, projection_3d)
     {
-        auto a = lca3(2, {{0, 0, 0, 6}, {1, 0, 2, 8}, {0, 1, 1, 5}});
-        auto b = lca3(2, {{0, 0, 3, 9}, {1, 0, 0, 4}, {0, 1, 2, 7}});
+        auto a = lca3(2,
+                      {
+                          {0, 0, 0, 6},
+                          {1, 0, 2, 8},
+                          {0, 1, 1, 5}
+        });
+        auto b = lca3(2,
+                      {
+                          {0, 0, 3, 9},
+                          {1, 0, 0, 4},
+                          {0, 1, 2, 7}
+        });
         EXPECT_EQ(traverse_static(intersection(self(a), self(b)).on(1)),
                   traverse_dynamic(dyn::intersection(dyn::self(a), dyn::self(b)).on(1)));
     }
@@ -265,8 +423,14 @@ namespace samurai
 
     TEST(subset_dynamic, disjoint_intersection_is_empty)
     {
-        auto a = lca1(0, {{0, 5}});
-        auto b = lca1(0, {{10, 15}});
+        auto a = lca1(0,
+                      {
+                          {0, 5}
+        });
+        auto b = lca1(0,
+                      {
+                          {10, 15}
+        });
 
         auto dyn_result = traverse_dynamic(dyn::intersection(dyn::self(a), dyn::self(b)));
         EXPECT_TRUE(dyn_result.empty());
@@ -279,8 +443,14 @@ namespace samurai
 
     TEST(subset_dynamic, difference_emptied_by_cover)
     {
-        auto a = lca1(0, {{2, 6}});
-        auto b = lca1(0, {{0, 10}});
+        auto a          = lca1(0,
+                               {
+                          {2, 6}
+        });
+        auto b          = lca1(0,
+                               {
+                          {0, 10}
+        });
         auto dyn_result = traverse_dynamic(dyn::difference(dyn::self(a), dyn::self(b)));
         EXPECT_TRUE(dyn_result.empty());
         EXPECT_EQ(traverse_static(difference(self(a), self(b))), dyn_result);
@@ -293,7 +463,11 @@ namespace samurai
     TEST(subset_dynamic, any_traverser_move)
     {
         using interval_t = LevelCellArray<1>::interval_t;
-        auto lca         = lca1(0, {{0, 5}, {8, 12}});
+        auto lca         = lca1(0,
+                                {
+                            {0, 5 },
+                            {8, 12}
+        });
 
         // A leaf traverser is held inline in the small buffer; moving it must
         // move-construct into the destination's buffer, not dangle.
@@ -319,9 +493,18 @@ namespace samurai
     // bindings. Must match the variadic form.
     TEST(subset_dynamic, runtime_vector_api)
     {
-        auto a = lca1(0, {{0, 10}});
-        auto b = lca1(0, {{5, 15}});
-        auto c = lca1(0, {{2, 8}});
+        auto a = lca1(0,
+                      {
+                          {0, 10}
+        });
+        auto b = lca1(0,
+                      {
+                          {5, 15}
+        });
+        auto c = lca1(0,
+                      {
+                          {2, 8}
+        });
 
         using set_t = DynamicSet<1, LevelCellArray<1>::interval_t>;
         std::vector<set_t> operands{dyn::self(a), dyn::self(b), dyn::self(c)};
@@ -333,8 +516,14 @@ namespace samurai
     // clone() must yield an independent tree giving the same result.
     TEST(subset_dynamic, clone_is_independent)
     {
-        auto a = lca1(0, {{0, 10}});
-        auto b = lca1(0, {{5, 15}});
+        auto a = lca1(0,
+                      {
+                          {0, 10}
+        });
+        auto b = lca1(0,
+                      {
+                          {5, 15}
+        });
 
         auto original = dyn::intersection(dyn::self(a), dyn::self(b));
         auto copy     = original.clone();
@@ -347,8 +536,16 @@ namespace samurai
     // to_lca() of a dynamic expression equals the static one.
     TEST(subset_dynamic, to_lca)
     {
-        auto a = lca1(2, {{0, 5}, {8, 12}});
-        auto b = lca1(2, {{3, 9}, {11, 20}});
+        auto a = lca1(2,
+                      {
+                          {0, 5 },
+                          {8, 12}
+        });
+        auto b = lca1(2,
+                      {
+                          {3,  9 },
+                          {11, 20}
+        });
 
         auto static_lca  = intersection(self(a), self(b)).on(1).to_lca();
         auto dynamic_lca = dyn::intersection(dyn::self(a), dyn::self(b)).on(1).to_lca();

--- a/tests/test_subset_dynamic.cpp
+++ b/tests/test_subset_dynamic.cpp
@@ -1,0 +1,244 @@
+// Copyright 2018-2025 the samurai's authors
+// SPDX-License-Identifier:  BSD-3-Clause
+
+#include <string>
+#include <vector>
+
+#include <xtensor/containers/xfixed.hpp>
+
+#include <gtest/gtest.h>
+
+#include <samurai/cell_list.hpp>
+#include <samurai/level_cell_array.hpp>
+#include <samurai/subset/node.hpp>
+
+#include <samurai/subset/dynamic/dynamic.hpp>
+
+namespace samurai
+{
+    namespace
+    {
+        // The point set produced by traversing a set, as (index, interval)
+        // pairs. Comparing these for a static and a dynamic expression is the
+        // equivalence check throughout this file.
+        template <class Interval>
+        using traversal_t = std::vector<std::pair<std::string, Interval>>;
+
+        template <class Func>
+        auto record(Func&& traverse)
+        {
+            using interval_t = typename LevelCellArray<1>::interval_t;
+            traversal_t<interval_t> out;
+            traverse(
+                [&](const auto& i, const auto& index)
+                {
+                    std::string idx;
+                    for (std::size_t d = 0; d < index.size(); ++d)
+                    {
+                        idx += std::to_string(index[d]) + ",";
+                    }
+                    out.emplace_back(idx, i);
+                });
+            return out;
+        }
+
+        template <class Set>
+        auto traverse_static(const Set& set)
+        {
+            return record(
+                [&](auto&& func)
+                {
+                    apply(set, func);
+                });
+        }
+
+        template <std::size_t dim, class TInterval>
+        auto traverse_dynamic(const DynamicSet<dim, TInterval>& set)
+        {
+            return record(
+                [&](auto&& func)
+                {
+                    set(func);
+                });
+        }
+
+        LevelCellArray<1> lca1(std::size_t level, std::initializer_list<std::pair<int, int>> intervals)
+        {
+            LevelCellList<1> lcl{level};
+            for (auto [a, b] : intervals)
+            {
+                lcl[{}].add_interval({a, b});
+            }
+            return lcl;
+        }
+
+        LevelCellArray<2> lca2(std::size_t level, std::initializer_list<std::tuple<int, int, int>> boxes)
+        {
+            LevelCellList<2> lcl{level};
+            for (auto [y, x0, x1] : boxes)
+            {
+                lcl[{y}].add_interval({x0, x1});
+            }
+            return LevelCellArray<2>(lcl);
+        }
+    } // namespace
+
+    ////////////////////////////////////////////////////////////////////////
+    //// 1D equivalence with the static algebra
+    ////////////////////////////////////////////////////////////////////////
+
+    TEST(subset_dynamic, leaf)
+    {
+        auto a = lca1(0, {{0, 2}, {5, 9}, {12, 14}});
+        EXPECT_EQ(traverse_static(self(a)), traverse_dynamic(dyn::self(a)));
+    }
+
+    TEST(subset_dynamic, intersection_1d)
+    {
+        auto a = lca1(2, {{0, 5}, {8, 12}});
+        auto b = lca1(2, {{3, 9}, {11, 20}});
+        auto c = lca1(2, {{4, 7}, {10, 30}});
+
+        EXPECT_EQ(traverse_static(intersection(self(a), self(b), self(c))),
+                  traverse_dynamic(dyn::intersection(dyn::self(a), dyn::self(b), dyn::self(c))));
+    }
+
+    TEST(subset_dynamic, union_1d)
+    {
+        auto a = lca1(2, {{0, 5}, {8, 12}});
+        auto b = lca1(2, {{3, 9}, {11, 20}});
+        auto c = lca1(2, {{4, 7}, {10, 30}});
+
+        EXPECT_EQ(traverse_static(union_(self(a), self(b), self(c))),
+                  traverse_dynamic(dyn::union_(dyn::self(a), dyn::self(b), dyn::self(c))));
+    }
+
+    TEST(subset_dynamic, difference_1d)
+    {
+        auto a = lca1(2, {{0, 5}, {8, 12}});
+        auto b = lca1(2, {{3, 9}, {11, 20}});
+        auto c = lca1(2, {{4, 7}, {10, 30}});
+
+        EXPECT_EQ(traverse_static(difference(self(a), self(b), self(c))),
+                  traverse_dynamic(dyn::difference(dyn::self(a), dyn::self(b), dyn::self(c))));
+    }
+
+    TEST(subset_dynamic, nested_1d)
+    {
+        auto a = lca1(2, {{0, 5}, {8, 12}});
+        auto b = lca1(2, {{3, 9}, {11, 20}});
+        auto c = lca1(2, {{4, 7}, {10, 30}});
+
+        auto stat = union_(intersection(self(a), self(b)).on(1), self(c));
+        auto dynv = dyn::union_(dyn::intersection(dyn::self(a), dyn::self(b)).on(1), dyn::self(c));
+        EXPECT_EQ(traverse_static(stat), traverse_dynamic(dynv));
+    }
+
+    TEST(subset_dynamic, mixed_levels_1d)
+    {
+        auto a = lca1(2, {{0, 5}, {8, 12}});
+        auto d = lca1(4, {{0, 40}});
+        EXPECT_EQ(traverse_static(intersection(self(a), self(d))),
+                  traverse_dynamic(dyn::intersection(dyn::self(a), dyn::self(d))));
+    }
+
+    ////////////////////////////////////////////////////////////////////////
+    //// 2D equivalence (exercises the runtime -> compile-time dimension switch)
+    ////////////////////////////////////////////////////////////////////////
+
+    TEST(subset_dynamic, intersection_2d)
+    {
+        auto a = lca2(3, {{0, 0, 5}, {1, 2, 8}, {2, 0, 4}});
+        auto b = lca2(3, {{0, 3, 9}, {1, 0, 6}, {2, 1, 3}});
+        EXPECT_EQ(traverse_static(intersection(self(a), self(b))),
+                  traverse_dynamic(dyn::intersection(dyn::self(a), dyn::self(b))));
+    }
+
+    TEST(subset_dynamic, union_2d)
+    {
+        auto a = lca2(3, {{0, 0, 5}, {1, 2, 8}, {2, 0, 4}});
+        auto b = lca2(3, {{0, 3, 9}, {1, 0, 6}, {2, 1, 3}});
+        auto c = lca2(3, {{1, 1, 7}, {2, 0, 10}});
+        EXPECT_EQ(traverse_static(union_(self(a), self(b), self(c))),
+                  traverse_dynamic(dyn::union_(dyn::self(a), dyn::self(b), dyn::self(c))));
+    }
+
+    TEST(subset_dynamic, difference_2d)
+    {
+        auto a = lca2(3, {{0, 0, 5}, {1, 2, 8}, {2, 0, 4}});
+        auto b = lca2(3, {{0, 3, 9}, {1, 0, 6}, {2, 1, 3}});
+        EXPECT_EQ(traverse_static(difference(self(a), self(b))),
+                  traverse_dynamic(dyn::difference(dyn::self(a), dyn::self(b))));
+    }
+
+    TEST(subset_dynamic, projection_2d)
+    {
+        auto a = lca2(3, {{0, 0, 5}, {1, 2, 8}, {2, 0, 4}});
+        auto b = lca2(3, {{0, 3, 9}, {1, 0, 6}, {2, 1, 3}});
+        EXPECT_EQ(traverse_static(intersection(self(a), self(b)).on(2)),
+                  traverse_dynamic(dyn::intersection(dyn::self(a), dyn::self(b)).on(2)));
+    }
+
+    TEST(subset_dynamic, translate_2d)
+    {
+        auto a = lca2(3, {{0, 0, 5}, {1, 2, 8}, {2, 0, 4}});
+        auto b = lca2(3, {{0, 3, 9}, {1, 0, 6}, {2, 1, 3}});
+
+        xt::xtensor_fixed<int, xt::xshape<2>> t{1, 2};
+        EXPECT_EQ(traverse_static(intersection(translate(self(a), t), self(b))),
+                  traverse_dynamic(dyn::intersection(dyn::translate(dyn::self(a), t), dyn::self(b))));
+    }
+
+    TEST(subset_dynamic, expand_2d)
+    {
+        auto a = lca2(3, {{0, 0, 5}, {1, 2, 8}, {2, 0, 4}});
+        auto c = lca2(3, {{1, 1, 7}, {2, 0, 10}});
+        EXPECT_EQ(traverse_static(intersection(nestedExpand(self(a), 1), self(c))),
+                  traverse_dynamic(dyn::intersection(dyn::expand(dyn::self(a), 1), dyn::self(c))));
+    }
+
+    ////////////////////////////////////////////////////////////////////////
+    //// Dynamic-specific behaviour
+    ////////////////////////////////////////////////////////////////////////
+
+    // The number of operands is a runtime vector: the natural entry point for
+    // bindings. Must match the variadic form.
+    TEST(subset_dynamic, runtime_vector_api)
+    {
+        auto a = lca1(0, {{0, 10}});
+        auto b = lca1(0, {{5, 15}});
+        auto c = lca1(0, {{2, 8}});
+
+        using set_t = DynamicSet<1, LevelCellArray<1>::interval_t>;
+        std::vector<set_t> operands{dyn::self(a), dyn::self(b), dyn::self(c)};
+
+        EXPECT_EQ(traverse_dynamic(dyn::intersection(operands)),
+                  traverse_dynamic(dyn::intersection(dyn::self(a), dyn::self(b), dyn::self(c))));
+    }
+
+    // clone() must yield an independent tree giving the same result.
+    TEST(subset_dynamic, clone_is_independent)
+    {
+        auto a = lca1(0, {{0, 10}});
+        auto b = lca1(0, {{5, 15}});
+
+        auto original = dyn::intersection(dyn::self(a), dyn::self(b));
+        auto copy     = original.clone();
+
+        auto expected = traverse_dynamic(original);
+        EXPECT_EQ(expected, traverse_dynamic(copy));
+        EXPECT_EQ(expected, traverse_dynamic(original)); // original still traversable
+    }
+
+    // to_lca() of a dynamic expression equals the static one.
+    TEST(subset_dynamic, to_lca)
+    {
+        auto a = lca1(2, {{0, 5}, {8, 12}});
+        auto b = lca1(2, {{3, 9}, {11, 20}});
+
+        auto static_lca  = intersection(self(a), self(b)).on(1).to_lca();
+        auto dynamic_lca = dyn::intersection(dyn::self(a), dyn::self(b)).on(1).to_lca();
+        EXPECT_EQ(static_lca, dynamic_lca);
+    }
+
+} // namespace samurai


### PR DESCRIPTION
## Description

The set algebra in `include/samurai/subset/` encodes the whole expression tree in the C++ type system. That is great for performance (fully inlined, no virtual calls, no heap), but an expression can then only be built when its structure is known at compile time. Two situations are not covered:

- the structure of a set expression is only known at **runtime** (number of operands, choice of operators, levels);
- **bindings** such as Python cannot instantiate arbitrary template combinations.

This PR adds a **dynamic (runtime) counterpart** that reuses the static algorithms verbatim. Type erasure happens at a **single boundary - the traverser**; everything else (operators, projection, translation, expansion, contraction, `apply`, `to_lca`) is reused unchanged.

- `dynamic/any_traverser.hpp` - `ISetTraverser` (runtime interface) + `AnyTraverser`, a *static* traverser forwarding to it, so it plugs into any static traverser as `traverser_t<d>`.
- `dynamic/dynamic_set.hpp` - `ISet<dim,TInterval>` (runtime interface) + `DynamicSetAdaptor`, a *static* set forwarding to it, so it plugs as a child of any static combinator.
- `dynamic/node.hpp` - `static_switch` (runtime -> compile-time dimension), `ExecNode` (drives a static set behind `ISet`), a generic `Node` (holds the dynamic children it was built from and deep-clones them for thread-safety via a `rebuild` functor), the `DynamicSet` handle, and the `dyn::` DSL.
- `dynamic/small_object.hpp` - a self-contained small-buffer holder used by `AnyTraverser`.

n-ary operators are built at runtime by **left binary fold** (associativity + additive level shifts make it identical to the fused n-ary). Execution reuses the existing `apply` / `to_lca`. Thread-safety is obtained the same way the static side gets it: `clone()` a tree per thread.

The `dyn::` DSL mirrors the static one and covers all of it: `self`, `box`, `on`, `translate`, `expand`, `contract`, and `union_` / `intersection` / `difference` in both a variadic form (reads like the static DSL) and a `std::vector` form (the natural entry point for bindings).

```cpp
// structure decided at runtime
auto s = dyn::intersection(dyn::self(a), dyn::self(b)).on(level);
s(func);          // or s.to_lca(), via the existing static apply
```

**Performance.** The dynamic path is inherently slower than the static one (runtime tree, not fusable/inlinable): roughly 10-40x on the paired benchmark (`benchmark/benchmark_dynamic_set.cpp`), which is the accepted trade-off for the slow path (runtime structure, bindings) - it is not meant for the hot inlined loops the static algebra already serves. A small-buffer optimization keeps leaf traversers (and their copies into parent operators' tuples, the bulk of a traversal's allocations) inline instead of on the heap, isolated in `small_object.hpp`. It uses `std::construct_at` / `std::destroy_at` (no raw `new`/`delete`). A/B measured (same binary, buffer 48 vs forced-heap): **~18-26% faster** dynamic path. A buffer-size sweep confirmed 48 is optimal.

## How has this been tested?

`tests/test_subset_dynamic.cpp` - 23 tests checking static-vs-dynamic equivalence in 1D/2D/3D (intersection/union/difference, nested, mixed levels, projection `.on`, translate, expand, box, contract), disjoint/empty results and empty `to_lca`, the runtime `std::vector` API, `clone()` independence, `to_lca` equality, and the small-buffer move path. All pass; clean under the strict warning set and clang-tidy; `leaks` reports 0 leaks.

## Code of Conduct
By submitting this PR, you agree to follow our [Code of Conduct](https://github.com/hpc-maths/samurai/blob/master/docs/CODE_OF_CONDUCT.md)
- [x] I agree to follow this project's Code of Conduct
