### PR TITLE
feat: exact reconstruction across refinement (LBM stream, FV fluxes, reconstruction())

### DIFF
--- a/demos/LBM/new_D2Q5444_euler_rayleigh_taylor.cpp
+++ b/demos/LBM/new_D2Q5444_euler_rayleigh_taylor.cpp
@@ -53,6 +53,7 @@ int main(int argc, char* argv[])
     std::string filename = "new_D2Q5444_euler_rayleigh_taylor";
     std::size_t nfiles   = 1;
 
+    // The exact-reconstruction stream is enabled through the global --exact-reconstruction option.
     app.add_option("--lambda", lambda, "Lattice velocity")->capture_default_str()->group("Simulation parameters");
     app.add_option("--gamma", gamma, "Ratio of specific heats")->capture_default_str()->group("Simulation parameters");
     app.add_option("--gravity", g, "Gravity")->capture_default_str()->group("Simulation parameters");

--- a/docs/source/reference/figures/reconstruction_cone.svg
+++ b/docs/source/reference/figures/reconstruction_cone.svg
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="680" height="390" viewBox="0 0 680 390" font-family="Helvetica, Arial, sans-serif">
+  <defs>
+    <marker id="a2" markerWidth="9" markerHeight="9" refX="7" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M0,0 L7,3 L0,6 Z" fill="#718096"/>
+    </marker>
+    <marker id="a2b" markerWidth="9" markerHeight="9" refX="7" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M0,0 L7,3 L0,6 Z" fill="#a0aec0"/>
+    </marker>
+  </defs>
+
+  <!-- title -->
+  <text x="340" y="34" font-size="15" fill="#2d3748" text-anchor="middle">
+    t (level L = l0+2) = a fixed linear combination of level-l0 cells
+  </text>
+  <text x="340" y="54" font-size="12.5" fill="#718096" text-anchor="middle">
+    the one-level wavelet composed delta_l = 2 times
+  </text>
+
+  <!-- prediction cone -->
+  <polygon points="328,82 100,300 484,300" fill="#2b6cb0" fill-opacity="0.08" stroke="none"/>
+
+  <!-- ===== level L (fine, on top) : cells of width 24, t highlighted ===== -->
+  <text x="40" y="104" font-size="14" fill="#4a5568" font-style="italic">L</text>
+  <g fill="#eef5fb" stroke="#2b6cb0" stroke-width="1.3">
+    <rect x="268" y="82" width="24" height="34"/>
+    <rect x="292" y="82" width="24" height="34"/>
+    <rect x="340" y="82" width="24" height="34"/>
+    <rect x="364" y="82" width="24" height="34"/>
+    <rect x="388" y="82" width="24" height="34"/>
+  </g>
+  <rect x="316" y="82" width="24" height="34" fill="#cfe0f2" stroke="#2b6cb0" stroke-width="2.2"/>
+  <text x="328" y="105" font-size="12" fill="#1a365d" text-anchor="middle">t</text>
+
+  <!-- ===== level l0+1 (middle) : cells of width 48, cone cells highlighted ===== -->
+  <text x="30" y="218" font-size="14" fill="#4a5568" font-style="italic">l0+1</text>
+  <g fill="#f4f8fc" stroke="#90aecd" stroke-width="1.1">
+    <rect x="100" y="190" width="48" height="46"/>
+    <rect x="148" y="190" width="48" height="46"/>
+    <rect x="196" y="190" width="48" height="46"/>
+    <rect x="388" y="190" width="48" height="46"/>
+    <rect x="436" y="190" width="48" height="46"/>
+    <rect x="484" y="190" width="48" height="46"/>
+    <rect x="532" y="190" width="48" height="46"/>
+  </g>
+  <g fill="#eef5fb" stroke="#2b6cb0" stroke-width="1.7">
+    <rect x="244" y="190" width="48" height="46"/>
+    <rect x="292" y="190" width="48" height="46"/>
+    <rect x="340" y="190" width="48" height="46"/>
+  </g>
+
+  <!-- ===== level l0 (coarse, on bottom) : cells of width 96 ===== -->
+  <text x="30" y="328" font-size="14" fill="#4a5568" font-style="italic">l0</text>
+  <g fill="#dbe9f6" stroke="#2b6cb0" stroke-width="1.7">
+    <rect x="100" y="300" width="96" height="52"/>
+    <rect x="196" y="300" width="96" height="52"/>
+    <rect x="292" y="300" width="96" height="52"/>
+    <rect x="388" y="300" width="96" height="52"/>
+    <rect x="484" y="300" width="96" height="52"/>
+  </g>
+  <text x="532" y="331" font-size="13" fill="#1a365d" text-anchor="middle">f(l0)</text>
+
+  <!-- step 1 : t depends on its three level-(l0+1) parents -->
+  <line x1="324" y1="116" x2="270" y2="188" stroke="#718096" stroke-width="1.4" marker-end="url(#a2)"/>
+  <line x1="328" y1="116" x2="316" y2="188" stroke="#718096" stroke-width="1.4" marker-end="url(#a2)"/>
+  <line x1="332" y1="116" x2="362" y2="188" stroke="#718096" stroke-width="1.4" marker-end="url(#a2)"/>
+
+  <!-- step 2 : each of those recurses to level l0 (shown for the central cell) -->
+  <line x1="312" y1="236" x2="248" y2="298" stroke="#a0aec0" stroke-width="1.2" stroke-dasharray="4 3" marker-end="url(#a2b)"/>
+  <line x1="316" y1="236" x2="340" y2="298" stroke="#a0aec0" stroke-width="1.2" stroke-dasharray="4 3" marker-end="url(#a2b)"/>
+  <line x1="320" y1="236" x2="432" y2="298" stroke="#a0aec0" stroke-width="1.2" stroke-dasharray="4 3" marker-end="url(#a2b)"/>
+</svg>

--- a/docs/source/reference/figures/reconstruction_exact.svg
+++ b/docs/source/reference/figures/reconstruction_exact.svg
@@ -1,0 +1,132 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="700" height="384" viewBox="0 0 700 384" font-family="Helvetica, Arial, sans-serif">
+  <defs>
+    <marker id="a2" markerWidth="9" markerHeight="9" refX="7" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M0,0 L7,3 L0,6 Z" fill="#718096"/>
+    </marker>
+    <marker id="a2b" markerWidth="9" markerHeight="9" refX="7" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M0,0 L7,3 L0,6 Z" fill="#a0aec0"/>
+    </marker>
+    <marker id="ao" markerWidth="9" markerHeight="9" refX="7" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M0,0 L7,3 L0,6 Z" fill="#c05621"/>
+    </marker>
+  </defs>
+
+  <!-- shared level labels -->
+  <text x="12" y="107" font-size="13" fill="#4a5568" font-style="italic">L</text>
+  <text x="12" y="185" font-size="13" fill="#4a5568" font-style="italic">l0+1</text>
+  <text x="12" y="281" font-size="13" fill="#4a5568" font-style="italic">l0</text>
+
+  <!-- panel divider -->
+  <line x1="352" y1="46" x2="352" y2="360" stroke="#e2e8f0" stroke-width="2"/>
+
+  <!-- ============================ PANEL A : FLAT ============================ -->
+  <g>
+    <text x="172" y="30" font-size="15" fill="#2b6cb0" text-anchor="middle" font-weight="bold">flat reconstruction</text>
+
+    <!-- cone -->
+    <polygon points="224,90 150,250 296,250" fill="#2b6cb0" fill-opacity="0.08"/>
+
+    <!-- refinement boundary (right edge of the donor) -->
+    <line x1="232" y1="150" x2="232" y2="306" stroke="#cbd5e0" stroke-width="1.4" stroke-dasharray="3 3"/>
+
+    <!-- L row : t is the right-most fine child of the donor -->
+    <g fill="#eef5fb" stroke="#2b6cb0" stroke-width="1.3">
+      <rect x="168" y="92" width="16" height="22"/>
+      <rect x="184" y="92" width="16" height="22"/>
+      <rect x="200" y="92" width="16" height="22"/>
+    </g>
+    <rect x="216" y="92" width="16" height="22" fill="#cfe0f2" stroke="#2b6cb0" stroke-width="2.2"/>
+    <text x="224" y="108" font-size="11" fill="#1a365d" text-anchor="middle">t</text>
+
+    <!-- l0+1 row : the 3 cells feeding t; the boundary cell is guessed from l0 -->
+    <g fill="#f4f8fc" stroke="#90aecd" stroke-width="1.1">
+      <rect x="104" y="165" width="32" height="32"/>
+      <rect x="136" y="165" width="32" height="32"/>
+      <rect x="264" y="165" width="32" height="32"/>
+    </g>
+    <g fill="#ffffff" stroke="#a0aec0" stroke-width="1.6" stroke-dasharray="4 3">
+      <rect x="168" y="165" width="32" height="32"/>
+      <rect x="200" y="165" width="32" height="32"/>
+      <rect x="232" y="165" width="32" height="32"/>
+    </g>
+    <text x="248" y="185" font-size="8.5" fill="#718096" text-anchor="middle">guess</text>
+
+    <!-- l0 row : coarse cells; the 3rd (donor) is stored, the region to the right is refined -->
+    <g fill="#dbe9f6" stroke="#2b6cb0" stroke-width="1.7">
+      <rect x="40"  y="250" width="64" height="52"/>
+      <rect x="104" y="250" width="64" height="52"/>
+      <rect x="168" y="250" width="64" height="52"/>
+    </g>
+    <text x="200" y="281" font-size="11" fill="#1a365d" text-anchor="middle">stored</text>
+    <rect x="232" y="250" width="64" height="52" fill="#f7fafc" stroke="#cbd5e0" stroke-width="1.3" stroke-dasharray="4 3"/>
+    <text x="264" y="281" font-size="9.5" fill="#a0aec0" text-anchor="middle">refined</text>
+
+    <!-- step 1 : t <- its 3 cells at l0+1 -->
+    <line x1="222" y1="114" x2="188" y2="163" stroke="#718096" stroke-width="1.4" marker-end="url(#a2)"/>
+    <line x1="224" y1="114" x2="216" y2="163" stroke="#718096" stroke-width="1.4" marker-end="url(#a2)"/>
+    <line x1="226" y1="114" x2="246" y2="163" stroke="#718096" stroke-width="1.4" marker-end="url(#a2)"/>
+
+    <!-- step 2 : the boundary cell is guessed from l0 -->
+    <line x1="246" y1="197" x2="206" y2="248" stroke="#a0aec0" stroke-width="1.2" stroke-dasharray="4 3" marker-end="url(#a2b)"/>
+    <line x1="250" y1="197" x2="262" y2="248" stroke="#a0aec0" stroke-width="1.2" stroke-dasharray="4 3" marker-end="url(#a2b)"/>
+
+    <text x="172" y="332" font-size="12" fill="#718096" text-anchor="middle">The boundary cell is guessed from l0,</text>
+    <text x="172" y="348" font-size="12" fill="#718096" text-anchor="middle">so the real finer cell is ignored.</text>
+  </g>
+
+  <!-- ============================ PANEL B : EXACT ============================ -->
+  <g transform="translate(360,0)">
+    <text x="172" y="30" font-size="15" fill="#c05621" text-anchor="middle" font-weight="bold">exact reconstruction</text>
+
+    <!-- cone -->
+    <polygon points="224,90 150,250 296,250" fill="#2b6cb0" fill-opacity="0.08"/>
+
+    <!-- refinement boundary -->
+    <line x1="232" y1="150" x2="232" y2="306" stroke="#cbd5e0" stroke-width="1.4" stroke-dasharray="3 3"/>
+
+    <!-- L row -->
+    <g fill="#eef5fb" stroke="#2b6cb0" stroke-width="1.3">
+      <rect x="168" y="92" width="16" height="22"/>
+      <rect x="184" y="92" width="16" height="22"/>
+      <rect x="200" y="92" width="16" height="22"/>
+    </g>
+    <rect x="216" y="92" width="16" height="22" fill="#cfe0f2" stroke="#2b6cb0" stroke-width="2.2"/>
+    <text x="224" y="108" font-size="11" fill="#1a365d" text-anchor="middle">t</text>
+
+    <!-- l0+1 row : the boundary cell is a real stored leaf -->
+    <g fill="#f4f8fc" stroke="#90aecd" stroke-width="1.1">
+      <rect x="104" y="165" width="32" height="32"/>
+      <rect x="136" y="165" width="32" height="32"/>
+    </g>
+    <g fill="#ffffff" stroke="#a0aec0" stroke-width="1.6" stroke-dasharray="4 3">
+      <rect x="168" y="165" width="32" height="32"/>
+      <rect x="200" y="165" width="32" height="32"/>
+    </g>
+    <rect x="232" y="165" width="32" height="32" fill="#fde3cf" stroke="#dd6b20" stroke-width="2.4"/>
+    <text x="248" y="178" font-size="8.5" fill="#9c4221" text-anchor="middle">real</text>
+    <text x="248" y="190" font-size="8" fill="#9c4221" text-anchor="middle">stored</text>
+    <rect x="264" y="165" width="32" height="32" fill="#fdeee2" stroke="#e0a678" stroke-width="1.3"/>
+
+    <!-- l0 row -->
+    <g fill="#dbe9f6" stroke="#2b6cb0" stroke-width="1.7">
+      <rect x="40"  y="250" width="64" height="52"/>
+      <rect x="104" y="250" width="64" height="52"/>
+      <rect x="168" y="250" width="64" height="52"/>
+    </g>
+    <text x="200" y="281" font-size="11" fill="#1a365d" text-anchor="middle">stored</text>
+    <rect x="232" y="250" width="64" height="52" fill="#f7fafc" stroke="#cbd5e0" stroke-width="1.3" stroke-dasharray="4 3"/>
+    <text x="264" y="281" font-size="9.5" fill="#a0aec0" text-anchor="middle">refined</text>
+
+    <!-- step 1 : t <- 3 cells (orange to the real leaf across the boundary) -->
+    <line x1="222" y1="114" x2="188" y2="163" stroke="#718096" stroke-width="1.4" marker-end="url(#a2)"/>
+    <line x1="224" y1="114" x2="216" y2="163" stroke="#718096" stroke-width="1.4" marker-end="url(#a2)"/>
+    <line x1="226" y1="114" x2="246" y2="163" stroke="#c05621" stroke-width="1.9" marker-end="url(#ao)"/>
+
+    <!-- the real leaf overrides: no prediction from l0 -->
+    <text x="248" y="222" font-size="11" fill="#c05621" text-anchor="middle">override</text>
+
+    <text x="172" y="332" font-size="12" fill="#9c4221" text-anchor="middle">The real finer cell across the boundary</text>
+    <text x="172" y="348" font-size="12" fill="#9c4221" text-anchor="middle">is used as-is and carried up into t.</text>
+  </g>
+</svg>

--- a/docs/source/reference/figures/reconstruction_prediction.svg
+++ b/docs/source/reference/figures/reconstruction_prediction.svg
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="620" height="320" viewBox="0 0 620 320" font-family="Helvetica, Arial, sans-serif">
+  <defs>
+    <marker id="arrow" markerWidth="9" markerHeight="9" refX="7" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M0,0 L7,3 L0,6 Z" fill="#2d3748"/>
+    </marker>
+  </defs>
+
+  <!-- formula on top -->
+  <text x="310" y="34" font-size="15" fill="#2d3748" text-anchor="middle">
+    f(l+1, ii=0) = f(i) + 1/8 ( f(i-1) - f(i+1) )
+  </text>
+
+  <!-- ===== level l+1 (fine, on top): the two children of cell i ===== -->
+  <text x="40" y="102" font-size="14" fill="#4a5568" font-style="italic">level l+1</text>
+  <!-- ii=0 : left (even) child, highlighted -->
+  <rect x="260" y="78" width="60" height="52" fill="#cfe0f2" stroke="#2b6cb0" stroke-width="2.2"/>
+  <text x="290" y="109" font-size="13" fill="#1a365d" text-anchor="middle">ii=0</text>
+  <!-- ii=1 : right (odd) child -->
+  <rect x="320" y="78" width="60" height="52" fill="#eef5fb" stroke="#2b6cb0" stroke-width="1.6"/>
+  <text x="350" y="109" font-size="13" fill="#1a365d" text-anchor="middle">ii=1</text>
+
+  <!-- ===== level l (coarse, on bottom): i-1, i, i+1 ===== -->
+  <text x="40" y="242" font-size="14" fill="#4a5568" font-style="italic">level l</text>
+  <rect x="140" y="212" width="120" height="56" fill="#dbe9f6" stroke="#2b6cb0" stroke-width="2"/>
+  <text x="200" y="246" font-size="15" fill="#1a365d" text-anchor="middle">f(i-1)</text>
+  <rect x="260" y="212" width="120" height="56" fill="#dbe9f6" stroke="#2b6cb0" stroke-width="2"/>
+  <text x="320" y="246" font-size="15" fill="#1a365d" text-anchor="middle">f(i)</text>
+  <rect x="380" y="212" width="120" height="56" fill="#dbe9f6" stroke="#2b6cb0" stroke-width="2"/>
+  <text x="440" y="246" font-size="15" fill="#1a365d" text-anchor="middle">f(i+1)</text>
+
+  <!-- prediction arrows: coarse (bottom) -> child ii=0 (top) -->
+  <line x1="205" y1="212" x2="283" y2="132" stroke="#2d3748" stroke-width="1.6" marker-end="url(#arrow)"/>
+  <line x1="320" y1="212" x2="291" y2="132" stroke="#2d3748" stroke-width="1.6" marker-end="url(#arrow)"/>
+  <line x1="435" y1="212" x2="299" y2="132" stroke="#2d3748" stroke-width="1.6" marker-end="url(#arrow)"/>
+
+  <!-- weights -->
+  <text x="228" y="180" font-size="13" fill="#c05621" text-anchor="middle">+1/8</text>
+  <text x="312" y="176" font-size="13" fill="#2b6cb0" text-anchor="middle">1</text>
+  <text x="404" y="180" font-size="13" fill="#c05621" text-anchor="middle">-1/8</text>
+
+  <!-- nesting guide: the two children span exactly cell i -->
+  <line x1="260" y1="140" x2="260" y2="206" stroke="#a0aec0" stroke-width="0.8" stroke-dasharray="3 3"/>
+  <line x1="380" y1="140" x2="380" y2="206" stroke="#a0aec0" stroke-width="0.8" stroke-dasharray="3 3"/>
+</svg>

--- a/docs/source/reference/index.rst
+++ b/docs/source/reference/index.rst
@@ -7,6 +7,7 @@ Reference manual
 
    Boundary conditions <bc>
    Algebra of set <subset>
+   Prediction and reconstruction <reconstruction>
    Finite Volume schemes <finite_volume_schemes>
    Local schemes <local_schemes>
    Load balancing <load_balancing>

--- a/docs/source/reference/reconstruction.md
+++ b/docs/source/reference/reconstruction.md
@@ -1,0 +1,278 @@
+# Prediction, portions and reconstruction
+
+An adapted samurai mesh stores each region of the domain at the coarsest level
+that resolves it. Many operations nonetheless need the value a field *would*
+take on a finer grid than the one it is stored on: writing a uniform field for
+I/O and post-processing, moving a field from one adapted mesh to another, or
+evaluating a scheme whose stencil crosses a level jump (the LBM stream, a finite
+volume flux at a refinement interface).
+
+samurai recovers those values by *prediction*: a cell at level $l$ splits into
+$2^{\mathrm{dim}}$ children at level $l+1$, and the value of an absent finer cell
+is interpolated from its coarser neighbours with an interpolating wavelet. This
+page describes the three layers built on that idea:
+
+- {ref}`prediction <rec-prediction>` - the interpolation stencil itself, as a
+  sparse linear combination of coarse-cell values;
+- {ref}`portion <rec-portion>` - applying such a stencil to a field to
+  reconstruct the child(ren) of a coarse cell;
+- {ref}`reconstruction <rec-reconstruction>` - projecting a whole adapted field
+  onto a uniform fine mesh, either *flat* or *exact* across refinement
+  boundaries.
+
+Everything lives in {file}`include/samurai/reconstruction.hpp`.
+
+(rec-prediction)=
+## Prediction: the interpolating wavelet
+
+Prediction is **linear**: the predicted value of a finer cell is a fixed linear
+combination of coarse-cell values that depends only on the level gap and on the
+child position inside its coarse cell, never on the field itself. samurai
+represents such a combination with a `prediction_map`: a sparse map
+
+$$
+\texttt{coeff} : k \longmapsto w_k , \qquad
+\text{standing for} \quad \sum_k w_k \, f(\text{reference} + k),
+$$
+
+where $k$ is a `dim`-dimensional integer offset relative to a reference cell.
+Because the maps are linear they form an algebra (`+=`, `-=`, scalar `*=`), which
+is what lets several children be summed into a single stencil later on.
+
+The one-level stencil comes from the wavelet interpolation coefficients
+`interp_coeffs<2*r+1>` of {file}`include/samurai/numeric/prediction.hpp`, where
+`r` is the mesh's `prediction_stencil_radius` (default `1`, a 3-point stencil).
+For `r = 1` the coefficients are $\{\,s/8,\ 1,\ -s/8\,\}$ with a sign $s = +1$ for
+an even child and $s = -1$ for an odd one, so in 1D:
+
+$$
+f(l+1,\ 2i)   = f(i) + \tfrac{1}{8}\bigl(f(i-1) - f(i+1)\bigr), \qquad
+f(l+1,\ 2i+1) = f(i) - \tfrac{1}{8}\bigl(f(i-1) - f(i+1)\bigr).
+$$
+
+```{figure} ./figures/reconstruction_prediction.svg
+:name: fig-rec-prediction
+:width: 560px
+:align: center
+
+One-level prediction in 1D. The left child (`ii=0`) of the coarse cell `i` is
+interpolated from `i` (weight `1`) and its two neighbours (weights `±1/8`). The
+two children average back to `f(i)`, so prediction is conservative.
+```
+
+The function
+
+```cpp
+template <std::size_t order = 1, class... index_t>
+auto& prediction(std::size_t level, index_t... indices);
+```
+
+builds the `prediction_map` of the child `indices`, sitting `level`
+levels below a reference coarse cell placed at the origin (`level` is the level
+*gap* $\Delta l$, not an absolute level; `level = 0` is the identity map). A gap
+of $\Delta l \geq 2$ is obtained by composing the one-level wavelet $\Delta l$
+times: the child's parent is `indices >> 1` one level up, the parity
+`indices & 1` picks the interpolation sign per direction, and the non-central
+neighbours each contribute their own $\Delta l - 1$ stencil. Every intermediate
+map is memoised in a static cache keyed by `(order, level, indices)`, so a stencil
+is built once and reused for the whole run.
+
+```{note}
+Child indices are not restricted to $[0, 2^{\Delta l})$. Outside that box the
+stencil simply reaches into the neighbouring coarse cells, which is exactly how
+the LBM stream expresses a shift by crossing coarse-cell boundaries.
+```
+
+(rec-portion)=
+## `portion`: reconstructing the children of a coarse cell
+
+`portion` applies a prediction stencil to a field. It answers: *what is the value
+of the child(ren) `ii` of the coarse cell(s) `i`, for a field `f` stored `delta_l`
+levels coarser than those children?*
+
+```cpp
+auto portion(const Field& f,
+             std::size_t level, std::size_t delta_l,
+             const std::tuple</*interval*/, index_t...>& i,   // coarse location
+             const std::tuple<cell_index_t...>&          ii); // child selector
+```
+
+The first entry of `i` is an **interval**, so the whole row of coarse cells is
+reconstructed at once (vectorised over `x`); the remaining entries are the
+transverse coarse indices. The result is the flat linear combination of level-`l0`
+cells lifted to the target level through the wavelet, i.e. the prediction cone of
+the figure below.
+
+```{figure} ./figures/reconstruction_cone.svg
+:name: fig-rec-cone
+:width: 620px
+:align: center
+
+Reconstructing a fine cell `t` at level `L = l0 + 2`. Composing the one-level
+wavelet `delta_l` times, `t` becomes a fixed linear combination of the level-`l0`
+cells its prediction cone reaches. `portion` evaluates that combination directly.
+```
+
+The child selector `ii` has two forms, which differ in cost:
+
+- **scalar** (`ii` are plain integers) - the stencil of that single child,
+  `prediction(delta_l, ii)`. A nonlinear consumer, such as a finite volume flux
+  that must apply its flux function separately to each fine cell, uses this form
+  and recomputes every child.
+- **slice** (`ii` are intervals) - a whole box of children at once. Because
+  reconstruction is linear, the box's stencil is the *sum* of its children's
+  stencils; that sum is built once by `accumulate_slice`, cached, and then
+  applied in a single pass over a small, gap-independent stencil. This is what
+  makes the LBM stream cheap (`LBMScheme::portion_column`): a shift over a whole
+  column costs one stencil, not one per fine cell.
+
+```{note}
+`transfer` (moving a field between two adapted meshes) uses a convenience overload
+of `portion` taking plain index arrays for a single coarse cell and one of its
+children.
+```
+
+(rec-reconstruction)=
+## `reconstruction`: projecting onto a uniform fine mesh
+
+```cpp
+template <class Field>
+auto reconstruction(Field& field, bool exact = args::exact_reconstruction);
+```
+
+`reconstruction` creates a new field on a **uniform** grid at the domain's finest
+level and fills every one of its fine cells from the adapted `field`. (It first
+runs `update_ghost_mr` so that all ghost and projection cells hold correct values,
+and it needs at least two boundary ghosts.)
+
+Each fine cell of the uniform grid sits inside exactly one stored cell of the
+adapted mesh. The question is only: *how do we get its value?* There are two
+answers.
+
+### Flat reconstruction (the default)
+
+Every fine cell is filled with the prediction recipe of the previous sections,
+always starting from the level of the coarse cell that contains it. Concretely,
+for each level `l`, on the part of the uniform grid covered by `cells[l]`,
+`reconstruction_op_` writes all $2^{\Delta l\cdot\mathrm{dim}}$ children of each
+coarse cell at once (the fine cells of a row are addressed with a strided interval,
+so a given sub-position is broadcast over the whole row). This is exactly `portion`
+applied over the entire mesh: simple, fast, and almost always what you want.
+
+### Exact reconstruction near a refinement boundary
+
+Prediction is, by definition, a **guess**. Usually the guess is excellent. But
+look at the border between a coarse region and a finely resolved one: there, the
+mesh **already stores** the real, detailed finer values, right next to the coarse
+cell we are reconstructing from. A guess made only from the coarse side cannot
+know that detail, so the flat result is slightly wrong at the interface.
+
+The idea of *exact* reconstruction is simply to stop guessing whenever real data
+is available:
+
+- **flat** always guesses, level by level down to the base level `l0`, even where
+  finer real cells exist just next door;
+- **exact** climbs the levels one at a time and, whenever it lands on a cell that
+  is *actually stored in the mesh*, uses that real value instead of guessing. It
+  only guesses where nothing real exists.
+
+```{figure} ./figures/reconstruction_exact.svg
+:name: fig-rec-exact
+:width: 660px
+:align: center
+
+Reconstructing a fine child `t` of a coarse donor cell (the stored `l0` cell,
+3rd from the left) whose right-hand neighbour is refined, drawn like the
+prediction cone above. `t` is a weighted average of **3** cells at level `l0+1`,
+and the rightmost of them lies just across the refinement boundary. **Left
+(flat):** that boundary cell is guessed from `l0` (dashed), so the real finer cell
+sitting there is ignored. **Right (exact):** it is a real cell actually stored in
+the mesh, so its value is used as-is (orange) and carried up into `t`.
+```
+
+Where the neighbourhood is entirely coarse, no real finer cell is ever met and
+exact reconstruction gives **exactly the same result** as flat - the two differ
+only near refinement boundaries. Exact reconstruction is turned on with the
+`--exact-reconstruction` command-line option, or by calling
+`reconstruction(field, /*exact=*/true)`.
+
+#### In symbols: the capped cascade
+
+Write $A(m, i)$ for the exact reconstructed value at level $m$, index $i$, when
+reconstructing a cell whose own base level is $l_0$. The three bullet points above
+are exactly:
+
+$$
+\begin{aligned}
+A(l_0, i) &= f(l_0, i)
+   && \text{start from the level-}l_0\text{ value (real cell or ghost),}\\
+A(m,   i) &= f(m, i)
+   && \text{if the cell }(m,i)\text{ is really stored (use it, don't guess),}\\
+A(m,   i) &= \sum_k c_k(i)\, A\bigl(m-1,\ \lfloor i/2\rfloor + k\bigr)
+   && \text{otherwise (guess from one level down).}
+\end{aligned}
+$$
+
+Here $c_k(i) = \texttt{prediction<r>(1, i \& 1)}$ is exactly the one-level recipe of
+{ref}`the first section <rec-prediction>` (offsets relative to the parent
+$\lfloor i/2 \rfloor$). "Really stored" means the cell belongs to
+$\texttt{cells} \cup \texttt{proj\_cells}$: either a genuine finer leaf, or a
+projection cell carrying the exact average of its children.
+
+The cascade is **capped at $l_0$**: only *finer* cells (levels $> l_0$) override,
+so a cell is always reconstructed from its own level upward. This handles nested
+refinement without double counting, and reduces to the flat result wherever the
+neighbourhood is not refined.
+
+```{important}
+The cascade reads the field **only** at stored cells - the base level $l_0$ and the
+overriding finer cells - and recurses everywhere else. It therefore never reads a
+cell the adapted mesh does not hold, at any depth. A naive recursion on the *value*
+would instead try to read guessed positions that are not stored.
+```
+
+#### For reference: the building blocks
+
+`make_real_backed_lca(mesh)` builds, per level, the
+$(\texttt{cells} \cup \texttt{proj\_cells})$ set that the cascade tests to decide
+"is this cell really stored?". `update_ghost_mr` must have run first so that the
+projection cells carry the exact child averages.
+
+```cpp
+template <class Mesh>
+auto make_real_backed_lca(const Mesh& mesh)
+{
+    using lca_t     = typename Mesh::lca_type;
+    using mesh_id_t = typename Mesh::mesh_id_t;
+
+    std::vector<lca_t> stored(mesh.max_level() + 1);
+    for (std::size_t level = mesh.min_level(); level <= mesh.max_level(); ++level)
+    {
+        stored[level] = lca_t(union_(mesh[mesh_id_t::cells][level], mesh[mesh_id_t::proj_cells][level]));
+    }
+    return stored;
+}
+```
+
+The cascade is evaluated by:
+
+- `reconstruct_exact(l0, delta_l, coord, read_at, stored, memo)` - the scalar,
+  memoised recursion of $A(m, i)$ for a single value. The memo is shared across the
+  sub-cells of one reconstruction, so the cost stays $O(\text{cone} \times
+  \text{depth})$ rather than exponential.
+- `reconstruct_exact_box(l0, L, lo_L, hi_L, read_at, stored, out)` - the
+  vectorised version used by `reconstruction` and the LBM stream. It fills a whole
+  fine box level by level over dense buffers, using the real value where a cell is
+  stored and guessing otherwise. With the "use the stored value" step disabled it
+  becomes the flat reconstruction, which is why both paths share one
+  `reconstruct_box` core.
+
+## Summary
+
+| Layer | Entry point | Role |
+| --- | --- | --- |
+| Stencil | `prediction`, `prediction_map` | the interpolating-wavelet combination, memoised |
+| Apply | `portion` | reconstruct the child(ren) of a coarse cell (scalar or summed slice) |
+| Project | `reconstruction` | fill a uniform fine field from an adapted one |
+| Exact | `reconstruct_exact` / `reconstruct_exact_box`, `make_real_backed_lca` | use the real finer cells instead of guessing across refinement boundaries |
+```

--- a/docs/source/reference/reconstruction.md
+++ b/docs/source/reference/reconstruction.md
@@ -23,6 +23,7 @@ page describes the three layers built on that idea:
 Everything lives in {file}`include/samurai/reconstruction.hpp`.
 
 (rec-prediction)=
+
 ## Prediction: the interpolating wavelet
 
 Prediction is **linear**: the predicted value of a finer cell is a fixed linear
@@ -84,6 +85,7 @@ the LBM stream expresses a shift by crossing coarse-cell boundaries.
 ```
 
 (rec-portion)=
+
 ## `portion`: reconstructing the children of a coarse cell
 
 `portion` applies a prediction stencil to a field. It answers: *what is the value
@@ -133,6 +135,7 @@ children.
 ```
 
 (rec-reconstruction)=
+
 ## `reconstruction`: projecting onto a uniform fine mesh
 
 ```cpp
@@ -213,9 +216,9 @@ A(m,   i) &= \sum_k c_k(i)\, A\bigl(m-1,\ \lfloor i/2\rfloor + k\bigr)
 \end{aligned}
 $$
 
-Here $c_k(i) = \texttt{prediction<r>(1, i \& 1)}$ is exactly the one-level recipe of
-{ref}`the first section <rec-prediction>` (offsets relative to the parent
-$\lfloor i/2 \rfloor$). "Really stored" means the cell belongs to
+Here $c_k(i) = \texttt{prediction<r>(1, i \& 1)}$ is exactly the one-level
+recipe of {ref}`the first section <rec-prediction>` (offsets relative to
+the parent $\lfloor i/2 \rfloor$). "Really stored" means the cell belongs to
 $\texttt{cells} \cup \texttt{proj\_cells}$: either a genuine finer leaf, or a
 projection cell carrying the exact average of its children.
 
@@ -225,10 +228,11 @@ refinement without double counting, and reduces to the flat result wherever the
 neighbourhood is not refined.
 
 ```{important}
-The cascade reads the field **only** at stored cells - the base level $l_0$ and the
-overriding finer cells - and recurses everywhere else. It therefore never reads a
-cell the adapted mesh does not hold, at any depth. A naive recursion on the *value*
-would instead try to read guessed positions that are not stored.
+The cascade reads the field **only** at stored cells - the base level $l_0$
+and the overriding finer cells - and recurses everywhere else. It therefore
+never reads a cell the adapted mesh does not hold, at any depth. A naive
+recursion on the *value* would instead try to read guessed positions that are
+not stored.
 ```
 
 #### For reference: the building blocks
@@ -257,22 +261,23 @@ auto make_real_backed_lca(const Mesh& mesh)
 The cascade is evaluated by:
 
 - `reconstruct_exact(l0, delta_l, coord, read_at, stored, memo)` - the scalar,
-  memoised recursion of $A(m, i)$ for a single value. The memo is shared across the
-  sub-cells of one reconstruction, so the cost stays $O(\text{cone} \times
+  memoised recursion of $A(m, i)$ for a single value. The memo is shared across
+  the sub-cells of one reconstruction, so the cost stays $O(\text{cone} \times
   \text{depth})$ rather than exponential.
 - `reconstruct_exact_box(l0, L, lo_L, hi_L, read_at, stored, out)` - the
-  vectorised version used by `reconstruction` and the LBM stream. It fills a whole
-  fine box level by level over dense buffers, using the real value where a cell is
-  stored and guessing otherwise. With the "use the stored value" step disabled it
-  becomes the flat reconstruction, which is why both paths share one
+  vectorised version used by `reconstruction` and the LBM stream. It fills a
+  whole fine box level by level over dense buffers, using the real value where a
+  cell is stored and guessing otherwise. With the "use the stored value" step
+  disabled it becomes the flat reconstruction, which is why both paths share one
   `reconstruct_box` core.
 
 ## Summary
 
-| Layer | Entry point | Role |
-| --- | --- | --- |
-| Stencil | `prediction`, `prediction_map` | the interpolating-wavelet combination, memoised |
-| Apply | `portion` | reconstruct the child(ren) of a coarse cell (scalar or summed slice) |
-| Project | `reconstruction` | fill a uniform fine field from an adapted one |
-| Exact | `reconstruct_exact` / `reconstruct_exact_box`, `make_real_backed_lca` | use the real finer cells instead of guessing across refinement boundaries |
-```
+- **Stencil** - `prediction`, `prediction_map`: the interpolating-wavelet
+  combination, memoised.
+- **Apply** - `portion`: reconstruct the child(ren) of a coarse cell, either one
+  scalar child or a whole summed slice.
+- **Project** - `reconstruction`: fill a uniform fine field from an adapted one.
+- **Exact** - `reconstruct_exact` / `reconstruct_exact_box`, backed by
+  `make_real_backed_lca`: use the real finer cells instead of guessing across
+  refinement boundaries.

--- a/include/samurai/algorithm/graduation.hpp
+++ b/include/samurai/algorithm/graduation.hpp
@@ -576,7 +576,7 @@ namespace samurai
                 {
                     return (ll < max_level) ? lca_t(difference(F[ll], self(F[ll + 1]).on(ll))) : F[ll];
                 };
-                const auto exchange_graded_level = [&](const lca_t& graded_l, size_t ll, int phase) -> std::vector<lca_t>
+                const auto exchange_graded_level = [&](const lca_t& graded_l, size_t ll, size_t phase) -> std::vector<lca_t>
                 {
                     if (!has_neighbour)
                     {

--- a/include/samurai/arguments.hpp
+++ b/include/samurai/arguments.hpp
@@ -23,6 +23,7 @@ namespace samurai
         static bool dont_redirect_output = false;
 #endif
         static int finer_level_flux       = 0;
+        static bool exact_reconstruction  = false;
         static bool refine_boundary       = false;
         static bool save_debug_fields     = false;
         static bool print_petsc_numbering = false;
@@ -62,6 +63,12 @@ namespace samurai
                "--finer-level-flux",
                args::finer_level_flux,
                "Computation of fluxes at finer levels (default: 0, i.e. no finer level flux, -1 for max_level flux, > 0 for current level + finer_level_flux)")
+            ->capture_default_str()
+            ->group("SAMURAI");
+        app.add_flag("--exact-reconstruction",
+                     args::exact_reconstruction,
+                     "Reconstruct across refinement boundaries with the real finer cells instead of the flat prediction (LBM stream, FV "
+                     "finer-level fluxes, reconstruction()). Removes the projection error at interfaces; default: off")
             ->capture_default_str()
             ->group("SAMURAI");
         app.add_flag("--refine-boundary", args::refine_boundary, "Keep the boundary refined at max_level")->capture_default_str()->group("SAMURAI");

--- a/include/samurai/bc/apply_field_bc.hpp
+++ b/include/samurai/bc/apply_field_bc.hpp
@@ -595,8 +595,6 @@ namespace samurai
             return; // No outer corners in 1D
         }
 
-        auto domain = self(field.mesh().domain()).on(level);
-
         for_each_diagonal_direction<dim>(
             [&](const auto& direction)
             {

--- a/include/samurai/reconstruction.hpp
+++ b/include/samurai/reconstruction.hpp
@@ -1003,23 +1003,13 @@ namespace samurai
     template <class Mesh>
     auto make_real_backed_lca(const Mesh& mesh)
     {
-        static constexpr std::size_t dim = Mesh::dim;
-        using interval_t                 = typename Mesh::interval_t;
-        using lca_t                      = LevelCellArray<dim, interval_t>;
-        using lcl_t                      = LevelCellList<dim, interval_t>;
-        using mesh_id_t                  = typename Mesh::mesh_id_t;
+        using lca_t     = typename Mesh::lca_type;
+        using mesh_id_t = typename Mesh::mesh_id_t;
 
         std::vector<lca_t> stored(mesh.max_level() + 1);
         for (std::size_t level = mesh.min_level(); level <= mesh.max_level(); ++level)
         {
-            lcl_t lcl{level};
-            auto expr = union_(mesh[mesh_id_t::cells][level], mesh[mesh_id_t::proj_cells][level]);
-            expr(
-                [&](const auto& interval, const auto& index_yz)
-                {
-                    lcl[index_yz].add_interval(interval);
-                });
-            stored[level] = {lcl};
+            stored[level] = lca_t(union_(mesh[mesh_id_t::cells][level], mesh[mesh_id_t::proj_cells][level]));
         }
         return stored;
     }

--- a/include/samurai/reconstruction.hpp
+++ b/include/samurai/reconstruction.hpp
@@ -10,6 +10,7 @@
 #include <unordered_map>
 #include <vector>
 
+#include "arguments.hpp"
 #include "field.hpp"
 #include "numeric/prediction.hpp"
 #include "samurai_config.hpp"
@@ -1103,6 +1104,28 @@ namespace samurai
                 return c;
             }
         };
+    }
+
+    /**
+     * Support of the composed prediction, in cells of the base level: the radius, around the coarse
+     * cell it lives in, of the base-level footprint read by a reconstruction cascade spanning @a j
+     * levels with a prediction stencil of half-width @a r.
+     *
+     * It is the per-level box growth of @ref detail::reconstruct_box unrolled: S_0 = 0,
+     * S_{k+1} = r + ceil(S_k / 2), which saturates at 2r. Note that it is NOT r + j: the widening is
+     * geometric (r + r/2 + r/4 + ...), so it is strictly larger than r + j - 1 as soon as r >= 3.
+     * Used to size the halo of the band of cells a stream/flux has to recompute across a refinement
+     * boundary (see LBMScheme::stream_exact_reconstruction).
+     */
+    template <class value_t = int>
+    constexpr value_t composed_prediction_support(std::size_t r, std::size_t j)
+    {
+        value_t support = 0;
+        for (std::size_t k = 0; k < j; ++k)
+        {
+            support = static_cast<value_t>(r) + (support + 1) / 2;
+        }
+        return support;
     }
 
     namespace detail

--- a/include/samurai/reconstruction.hpp
+++ b/include/samurai/reconstruction.hpp
@@ -4,9 +4,11 @@
 #include <fmt/format.h>
 #include <fmt/ranges.h>
 
+#include <map>
 #include <stdexcept>
 #include <tuple>
 #include <unordered_map>
+#include <vector>
 
 #include "field.hpp"
 #include "numeric/prediction.hpp"
@@ -572,63 +574,6 @@ namespace samurai
                                                                 std::forward<T2>(field));
     }
 
-    /**
-     * Reconstruct an adapted field onto the uniform grid at the domain (finest) level
-     * and return it as a new field on that grid. Every coarse cell is expanded into its
-     * fine children by @ref reconstruction_op_. Mainly for I/O and post-processing, where
-     * a single-resolution image of the solution is wanted.
-     *
-     * Requires at least two boundary ghosts (the prediction stencil reaches two coarse
-     * cells); throws otherwise. Ghosts are refreshed first via @c update_ghost_mr_if_needed.
-     */
-    template <class Field>
-    auto reconstruction(Field& field)
-    {
-        using mesh_t    = typename Field::mesh_t;
-        using mesh_id_t = typename mesh_t::mesh_id_t;
-        using ca_type   = typename mesh_t::ca_type;
-
-        if (field.mesh().max_stencil_radius() < 2)
-        {
-            throw std::runtime_error("The reconstruction function requires at least 2 ghosts on the boundary.\nTo fix this issue, remove "
-                                     "mesh_config.disable_minimal_ghost_width().");
-        }
-
-        update_ghost_mr_if_needed(field);
-
-        auto make_field_like = [](const std::string& name, auto& mesh)
-        {
-            if constexpr (Field::is_scalar)
-            {
-                return make_scalar_field<typename Field::value_type>(name, mesh);
-            }
-            else
-            {
-                return make_vector_field<typename Field::value_type, Field::n_comp>(name, mesh);
-            }
-        };
-
-        auto& mesh = field.mesh();
-        ca_type reconstruct_mesh;
-        std::size_t reconstruct_level       = mesh.domain().level();
-        reconstruct_mesh[reconstruct_level] = mesh.domain();
-        reconstruct_mesh.update_index();
-
-        auto m                 = holder(reconstruct_mesh);
-        auto reconstruct_field = make_field_like(field.name(), m);
-        reconstruct_field.fill(0.);
-
-        std::size_t min_level = mesh[mesh_id_t::cells].min_level();
-        std::size_t max_level = mesh[mesh_id_t::cells].max_level();
-
-        for (std::size_t level = min_level; level <= max_level; ++level)
-        {
-            auto set = intersection(mesh[mesh_id_t::cells][level], reconstruct_mesh[reconstruct_level]).on(level);
-            set.apply_op(make_reconstruction(reconstruct_level, reconstruct_field, field));
-        }
-        return reconstruct_field;
-    }
-
     namespace detail
     {
         /**
@@ -954,6 +899,468 @@ namespace samurai
         auto dst_tuple = detail::extract_dst_tuple<dim>(delta_l, dst_indices);
 
         detail::portion_impl<Field::mesh_t::config_t::prediction_stencil_radius, Field>(result, get_f, level, delta_l, src_tuple, dst_tuple);
+    }
+
+    // =====================================================================================
+    //  "exact-reconstruction" reconstruction on adapted meshes
+    //
+    //  portion() (and hence the LBM stream / finer-level FV flux) reconstructs the value a
+    //  field would take on a finer grid as a *flat* linear combination of level-l0 cells,
+    //  lifted to the target level L via the interpolating-wavelet prediction. When the level
+    //  gap delta_l = L - l0 >= 2 and the prediction cone crosses a refinement boundary, the
+    //  flat stencil skips the intermediate levels and never uses the real detail carried by
+    //  the finer leaves that are actually present, propagating a projection error.
+    //
+    //  reconstruct_exact() computes instead the multiresolution reconstruction *capped
+    //  at the donor's own base level l0*: only finer real cells (levels > l0) override; the
+    //  coarser-neighbour ghosts stay exactly as the flat path sees them (filled by
+    //  update_ghost_mr). This is the correct value when reconstructing a donor cell from its
+    //  own level. Writing it as the capped cascade
+    //
+    //      A(l0, i) = f(l0, i)                                   (base: level-l0 value, real or ghost)
+    //      A(m , i) = f(m , i)                    if (m,i) is a stored finer leaf/proj  (override)
+    //      A(m , i) = sum_k c_k(i) * A(m-1, parent(i)+k)        otherwise (one-level prediction)
+    //
+    //  with c_k(i) = prediction<r>(1, i & 1) (offsets relative to parent i>>1), handles nested
+    //  refinement without double counting, and equals the flat value wherever the cone stays
+    //  clear of refinement. Crucially it reads f ONLY at stored cells (base l0 + overrides) and
+    //  RECURSES at non-stored intermediate cells, so it never reads outside all_cells, at any
+    //  depth (unlike a per-cell recursion on the value, which reads predicted positions that
+    //  the adapted mesh does not store).
+    // =====================================================================================
+
+    namespace detail
+    {
+        // Non-throwing membership test: is `coord` (integer indices at the lca's level) a cell
+        // of `lca`? (get_interval throws when absent; find returns a negative offset instead.)
+        template <std::size_t dim, class TInterval, class value_t>
+        bool lca_contains(const LevelCellArray<dim, TInterval>& lca, const std::array<value_t, dim>& coord)
+        {
+            xt::xtensor_fixed<typename TInterval::coord_index_t, xt::xshape<dim>> c;
+            for (std::size_t d = 0; d < dim; ++d)
+            {
+                c[d] = static_cast<typename TInterval::coord_index_t>(coord[d]);
+            }
+            return find(lca, c) >= 0;
+        }
+
+        // A(m, coord): capped exact-reconstruction reconstruction (see banner above). `read_at(level, coord)`
+        // returns the field value at a single stored cell; `stored[level]` is the level's
+        // (cells U proj_cells) LevelCellArray; `memo` caches A over the cone (shared across the
+        // sub-cells of one reconstruction so the cascade is O(cone x depth), not exponential).
+        template <std::size_t r, std::size_t dim, class value_t, class Reader, class LCA, class Memo>
+        double exact_value(std::size_t l0,
+                           std::size_t m,
+                           const std::array<value_t, dim>& coord,
+                           Reader&& read_at,
+                           const std::vector<LCA>& stored,
+                           Memo& memo)
+        {
+            if (m == l0)
+            {
+                return read_at(l0, coord); // base: level-l0 value (real or ghost), exactly as flat sees it
+            }
+            if (lca_contains(stored[m], coord))
+            {
+                return read_at(m, coord); // finer real leaf / proj => real value overrides
+            }
+
+            auto key = std::make_pair(m, coord);
+            if (auto it = memo.find(key); it != memo.end())
+            {
+                return it->second;
+            }
+
+            std::array<value_t, dim> parent;
+            for (std::size_t d = 0; d < dim; ++d)
+            {
+                parent[d] = coord[d] >> 1;
+            }
+            // one-level prediction map: offsets are relative to the parent cell (coord >> 1)
+            const auto& pred = [&]<std::size_t... D>(std::index_sequence<D...>) -> const prediction_map<dim, value_t>&
+            {
+                return prediction<r, value_t>(1, (coord[D] & value_t{1})...);
+            }(std::make_index_sequence<dim>{});
+
+            double res = 0.;
+            for (const auto& kv : pred.coeff)
+            {
+                std::array<value_t, dim> child;
+                for (std::size_t d = 0; d < dim; ++d)
+                {
+                    child[d] = parent[d] + kv.first[d];
+                }
+                res += kv.second * exact_value<r>(l0, m - 1, child, std::forward<Reader>(read_at), stored, memo);
+            }
+            memo[key] = res;
+            return res;
+        }
+    } // namespace detail
+
+    // Build, per level, the (cells U proj_cells) LevelCellArray used as the "real-backed" set by
+    // the exact-reconstruction reconstruction. Index by level; entries below min_level / above max_level are
+    // empty. update_ghost_mr must have run so proj_cells carry the exact child means.
+    template <class Mesh>
+    auto make_real_backed_lca(const Mesh& mesh)
+    {
+        static constexpr std::size_t dim = Mesh::dim;
+        using interval_t                 = typename Mesh::interval_t;
+        using lca_t                      = LevelCellArray<dim, interval_t>;
+        using lcl_t                      = LevelCellList<dim, interval_t>;
+        using mesh_id_t                  = typename Mesh::mesh_id_t;
+
+        std::vector<lca_t> stored(mesh.max_level() + 1);
+        for (std::size_t level = mesh.min_level(); level <= mesh.max_level(); ++level)
+        {
+            lcl_t lcl{level};
+            auto expr = union_(mesh[mesh_id_t::cells][level], mesh[mesh_id_t::proj_cells][level]);
+            expr(
+                [&](const auto& interval, const auto& index_yz)
+                {
+                    lcl[index_yz].add_interval(interval);
+                });
+            stored[level] = {lcl};
+        }
+        return stored;
+    }
+
+    // Real-aware reconstruction of a single fine cell at level L = l0 + delta_l, whose integer
+    // indices at that level are `coord`. `read_at(level, coord)` reads one stored cell of the field;
+    // `stored` comes from make_real_backed_lca(); `memo` is reused across the sub-cells of one
+    // donor. Returns the flat value wherever the cone stays clear of refinement.
+    template <std::size_t r, std::size_t dim, class value_t, class Reader, class LCA, class Memo>
+    double reconstruct_exact(std::size_t l0,
+                             std::size_t delta_l,
+                             const std::array<value_t, dim>& coord,
+                             Reader&& read_at,
+                             const std::vector<LCA>& stored,
+                             Memo& memo)
+    {
+        return detail::exact_value<r>(l0, l0 + delta_l, coord, std::forward<Reader>(read_at), stored, memo);
+    }
+
+    namespace detail
+    {
+        // Hash for the (level, coord) memo key of reconstruct_exact.
+        template <std::size_t dim, class value_t>
+        struct level_coord_hash
+        {
+            std::size_t operator()(const std::pair<std::size_t, std::array<value_t, dim>>& key) const
+            {
+                std::size_t h = std::hash<std::size_t>{}(key.first);
+                h ^= ArrayHash<value_t, dim>{}(key.second) + 0x9e3779b9 + (h << 6) + (h >> 2);
+                return h;
+            }
+        };
+    }
+
+    // Recommended memo type for the scalar reconstruct_exact: an open-addressing hash map on
+    // (level, coord), faster than a node-based std::map when a whole column is reconstructed at once.
+    // (The LBM stream uses the vectorised reconstruct_exact_box below, which needs no memo.)
+    template <std::size_t dim, class value_t>
+    using exact_reconstruction_memo_t = std::
+        unordered_map<std::pair<std::size_t, std::array<value_t, dim>>, double, detail::level_coord_hash<dim, value_t>>;
+
+    namespace detail
+    {
+        // A half-open integer box [lo, hi) at one level, row-major (dimension 0 slowest).
+        template <std::size_t dim, class value_t>
+        struct ra_box
+        {
+            std::array<value_t, dim> lo, hi;
+
+            std::size_t count() const
+            {
+                std::size_t n = 1;
+                for (std::size_t d = 0; d < dim; ++d)
+                {
+                    n *= static_cast<std::size_t>(hi[d] - lo[d]);
+                }
+                return n;
+            }
+
+            std::size_t offset(const std::array<value_t, dim>& c) const
+            {
+                std::size_t idx = 0;
+                for (std::size_t d = 0; d < dim; ++d)
+                {
+                    idx = idx * static_cast<std::size_t>(hi[d] - lo[d]) + static_cast<std::size_t>(c[d] - lo[d]);
+                }
+                return idx;
+            }
+
+            bool contains(const std::array<value_t, dim>& c) const
+            {
+                for (std::size_t d = 0; d < dim; ++d)
+                {
+                    if (c[d] < lo[d] || c[d] >= hi[d])
+                    {
+                        return false;
+                    }
+                }
+                return true;
+            }
+
+            std::array<value_t, dim> coord(std::size_t flat) const
+            {
+                std::array<value_t, dim> c;
+                for (std::size_t dd = dim; dd-- > 0;)
+                {
+                    auto n = static_cast<std::size_t>(hi[dd] - lo[dd]);
+                    c[dd]  = lo[dd] + static_cast<value_t>(flat % n);
+                    flat /= n;
+                }
+                return c;
+            }
+        };
+    }
+
+    namespace detail
+    {
+        // Reconstruct a whole finest-level box [lo_L, hi_L) (level L) from base level l0, level by
+        // level over dense contiguous buffers with hoisted one-level stencils. At each level a cell
+        // is either overridden by the real value (when `is_stored(m, coord)` is true) or predicted
+        // from the level below. With `is_stored` always false this is the plain flat reconstruction;
+        // with the (cells U proj_cells) membership it is the capped exact-reconstruction cascade. Reads the
+        // field only at the base level and at stored cells - never outside all_cells. Fills `out`
+        // (row-major over the box). This is the fast path shared by the flat and exact-reconstruction streams.
+        template <std::size_t r, std::size_t dim, class value_t, class Reader, class Stored>
+        void reconstruct_box(std::size_t l0,
+                             std::size_t L,
+                             const std::array<value_t, dim>& lo_L,
+                             const std::array<value_t, dim>& hi_L,
+                             Reader&& read_at,
+                             Stored&& is_stored,
+                             std::vector<double>& out)
+        {
+            using box_t             = ra_box<dim, value_t>;
+            const std::size_t depth = L - l0;
+
+            // Per-level boxes (index d: level l0 + d), grown top-down: a cell at level m needs its
+            // parent +-r at level m-1.
+            std::vector<box_t> box(depth + 1);
+            box[depth] = {lo_L, hi_L};
+            for (std::size_t d = depth; d-- > 0;)
+            {
+                for (std::size_t k = 0; k < dim; ++k)
+                {
+                    box[d].lo[k] = (box[d + 1].lo[k] >> 1) - static_cast<value_t>(r);
+                    box[d].hi[k] = ((box[d + 1].hi[k] - 1) >> 1) + static_cast<value_t>(r) + 1;
+                }
+            }
+
+            std::vector<std::vector<double>> buf(depth + 1);
+            for (std::size_t d = 0; d <= depth; ++d)
+            {
+                buf[d].resize(box[d].count());
+            }
+
+            // Base level l0: the field values (real cells + ghosts), exactly as the flat path reads.
+            for (std::size_t f = 0; f < box[0].count(); ++f)
+            {
+                buf[0][f] = read_at(l0, box[0].coord(f));
+            }
+
+            for (std::size_t d = 1; d <= depth; ++d)
+            {
+                const std::size_t m = l0 + d;
+                const auto& below   = box[d - 1];
+                for (std::size_t f = 0; f < box[d].count(); ++f)
+                {
+                    auto i = box[d].coord(f);
+                    if (is_stored(m, i))
+                    {
+                        buf[d][f] = read_at(m, i);
+                        continue;
+                    }
+                    std::array<value_t, dim> parent;
+                    for (std::size_t k = 0; k < dim; ++k)
+                    {
+                        parent[k] = i[k] >> 1;
+                    }
+                    const auto& pred = [&]<std::size_t... D>(std::index_sequence<D...>) -> const prediction_map<dim, value_t>&
+                    {
+                        return prediction<r, value_t>(1, (i[D] & value_t{1})...);
+                    }(std::make_index_sequence<dim>{});
+                    double v = 0.;
+                    for (const auto& kv : pred.coeff)
+                    {
+                        std::array<value_t, dim> pc;
+                        for (std::size_t k = 0; k < dim; ++k)
+                        {
+                            pc[k] = parent[k] + kv.first[k];
+                        }
+                        v += kv.second * buf[d - 1][below.offset(pc)];
+                    }
+                    buf[d][f] = v;
+                }
+            }
+            out.swap(buf[depth]);
+        }
+    }
+
+    // Vectorised exact-reconstruction reconstruction of a whole finest-level box [lo_L, hi_L) (level L), from
+    // base level l0: the capped cascade of reconstruct_exact(), but over dense buffers instead
+    // of a per-cell memoised recursion. `read_at`, `stored` as in reconstruct_exact().
+    template <std::size_t r, std::size_t dim, class value_t, class Reader, class LCA>
+    void reconstruct_exact_box(std::size_t l0,
+                               std::size_t L,
+                               const std::array<value_t, dim>& lo_L,
+                               const std::array<value_t, dim>& hi_L,
+                               Reader&& read_at,
+                               const std::vector<LCA>& stored,
+                               std::vector<double>& out)
+    {
+        detail::reconstruct_box<r>(
+            l0,
+            L,
+            lo_L,
+            hi_L,
+            std::forward<Reader>(read_at),
+            [&](std::size_t m, const std::array<value_t, dim>& c)
+            {
+                return detail::lca_contains(stored[m], c);
+            },
+            out);
+    }
+
+    // Vectorised flat reconstruction of a whole finest-level box [lo_L, hi_L) (level L) from base
+    // level l0 - the same dense cascade with no real-cell override (equivalent to portion() over the
+    // box, up to the rounding of a cascade vs a single flattened stencil).
+    template <std::size_t r, std::size_t dim, class value_t, class Reader>
+    void reconstruct_flat_box(std::size_t l0,
+                              std::size_t L,
+                              const std::array<value_t, dim>& lo_L,
+                              const std::array<value_t, dim>& hi_L,
+                              Reader&& read_at,
+                              std::vector<double>& out)
+    {
+        detail::reconstruct_box<r>(
+            l0,
+            L,
+            lo_L,
+            hi_L,
+            std::forward<Reader>(read_at),
+            [](std::size_t, const std::array<value_t, dim>&)
+            {
+                return false;
+            },
+            out);
+    }
+
+    // Reconstruct `field` onto a uniform mesh at the domain's finest level. By default each leaf is
+    // predicted flat from its own level; with `exact` (defaulting to the --exact-reconstruction
+    // option) the reconstruction instead uses the real finer cells across refinement boundaries (the
+    // capped cascade, see reconstruct_exact_box), removing the projection error at interfaces.
+    template <class Field>
+    auto reconstruction(Field& field, bool exact = args::exact_reconstruction)
+    {
+        using mesh_t     = typename Field::mesh_t;
+        using mesh_id_t  = typename mesh_t::mesh_id_t;
+        using ca_type    = typename mesh_t::ca_type;
+        using interval_t = typename mesh_t::interval_t;
+        using value_t    = typename interval_t::value_t;
+
+        if (field.mesh().max_stencil_radius() < 2)
+        {
+            throw std::runtime_error("The reconstruction function requires at least 2 ghosts on the boundary.\nTo fix this issue, remove "
+                                     "mesh_config.disable_minimal_ghost_width().");
+        }
+
+        update_ghost_mr_if_needed(field);
+
+        auto make_field_like = [](const std::string& name, auto& mesh)
+        {
+            if constexpr (Field::is_scalar)
+            {
+                return make_scalar_field<typename Field::value_type>(name, mesh);
+            }
+            else
+            {
+                return make_vector_field<typename Field::value_type, Field::n_comp>(name, mesh);
+            }
+        };
+
+        auto& mesh = field.mesh();
+        ca_type reconstruct_mesh;
+        std::size_t reconstruct_level       = mesh.domain().level();
+        reconstruct_mesh[reconstruct_level] = mesh.domain();
+        reconstruct_mesh.update_index();
+
+        auto m                 = holder(reconstruct_mesh);
+        auto reconstruct_field = make_field_like(field.name(), m);
+        reconstruct_field.fill(0.);
+
+        std::size_t min_level = mesh[mesh_id_t::cells].min_level();
+        std::size_t max_level = mesh[mesh_id_t::cells].max_level();
+
+        if (!exact)
+        {
+            for (std::size_t level = min_level; level <= max_level; ++level)
+            {
+                auto set = intersection(mesh[mesh_id_t::cells][level], reconstruct_mesh[reconstruct_level]).on(level);
+                set.apply_op(make_reconstruction(reconstruct_level, reconstruct_field, field));
+            }
+            return reconstruct_field;
+        }
+
+        // Exact reconstruction: cascade each leaf's finest sub-region using the real finer cells.
+        static constexpr std::size_t dim = mesh_t::dim;
+        constexpr std::size_t n_comp     = Field::is_scalar ? 1 : Field::n_comp;
+
+        auto cell_access = [&](auto& f, std::size_t comp, std::size_t lvl, const std::array<value_t, dim>& c) -> decltype(auto)
+        {
+            return [&]<std::size_t... K>(std::index_sequence<K...>) -> decltype(auto)
+            {
+                if constexpr (Field::is_scalar)
+                {
+                    (void)comp;
+                    return f(lvl, interval_t{c[0], c[0] + 1}, c[K + 1]...);
+                }
+                else
+                {
+                    return f(comp, lvl, interval_t{c[0], c[0] + 1}, c[K + 1]...);
+                }
+            }(std::make_index_sequence<dim - 1>{});
+        };
+
+        auto stored = make_real_backed_lca(mesh);
+        std::vector<double> box_vals;
+        for (std::size_t level = min_level; level <= max_level; ++level)
+        {
+            const std::size_t delta_l = reconstruct_level - level;
+            for_each_interval(mesh[mesh_id_t::cells][level],
+                              [&](std::size_t, const auto& i, const auto& index)
+                              {
+                                  std::array<value_t, dim> lo, hi;
+                                  [&]<std::size_t... D>(std::index_sequence<D...>)
+                                  {
+                                      ((lo[D] = (D == 0 ? i.start : static_cast<value_t>(index[(D == 0 ? 0 : D - 1)])) << delta_l), ...);
+                                      ((hi[D] = (D == 0 ? i.end : static_cast<value_t>(index[(D == 0 ? 0 : D - 1)]) + 1) << delta_l), ...);
+                                  }(std::make_index_sequence<dim>{});
+                                  const detail::ra_box<dim, value_t> box{lo, hi};
+
+                                  for (std::size_t comp = 0; comp < n_comp; ++comp)
+                                  {
+                                      auto read_at = [&](std::size_t lvl, const std::array<value_t, dim>& c) -> double
+                                      {
+                                          return cell_access(field, comp, lvl, c)[0];
+                                      };
+                                      reconstruct_exact_box<mesh_t::config_t::prediction_stencil_radius>(level,
+                                                                                                         reconstruct_level,
+                                                                                                         lo,
+                                                                                                         hi,
+                                                                                                         read_at,
+                                                                                                         stored,
+                                                                                                         box_vals);
+                                      for (std::size_t f = 0; f < box.count(); ++f)
+                                      {
+                                          cell_access(reconstruct_field, comp, reconstruct_level, box.coord(f)) = box_vals[f];
+                                      }
+                                  }
+                              });
+        }
+        return reconstruct_field;
     }
 
     /**

--- a/include/samurai/schemes/fv/flux_based/flux_based_scheme__nonlin.hpp
+++ b/include/samurai/schemes/fv/flux_based/flux_based_scheme__nonlin.hpp
@@ -313,6 +313,15 @@ namespace samurai
         // The block is the stencil_size fine cells around the interface (flux direction, plus a small
         // margin) times the 2^{delta_l} children in each transverse direction - covering every cell
         // predict_value reads. This replaces the per-cell portion() with one dense cascade.
+        //
+        // Deliberately no interface band here, unlike LBMScheme::stream_exact_reconstruction. Such a
+        // band would be safe - away from any refinement, the exact and flat cascades are the same code
+        // up to the is_stored predicate, so they agree bit-for-bit, and over-inclusion would cost
+        // nothing at all - but it cannot pay for itself. Measured on the 2D WENO5 burgers case
+        // (min_level 2, max_level 8, --finer-level-flux -1): the whole cost of the is_stored lookups
+        // is 0.48 s out of 25.3 s (1.9%), while the finer-level flux machinery itself accounts for
+        // 14.6 s (59%). A band could only reclaim a fraction of that 1.9%, in exchange for a coverage
+        // invariant to keep correct. If this path ever needs to be faster, the 14.6 s is the target.
         void build_recons_box(const FluxParameters<true>& flux_params,
                               const StencilCells<cfg>& cells,
                               const input_field_t& field,

--- a/include/samurai/schemes/fv/flux_based/flux_based_scheme__nonlin.hpp
+++ b/include/samurai/schemes/fv/flux_based/flux_based_scheme__nonlin.hpp
@@ -59,6 +59,7 @@ namespace samurai
         FluxDefinition<cfg> m_flux_definition;
         bool m_include_boundary_fluxes = true;
         int m_finer_level_flux         = args::finer_level_flux;
+        bool m_exact_reconstruction    = args::exact_reconstruction;
 
       public:
 
@@ -100,6 +101,19 @@ namespace samurai
         bool enable_finer_level_flux() const
         {
             return m_finer_level_flux != 0;
+        }
+
+        // When computing fluxes at a finer level, reconstruct the finer stencil values with the real
+        // finer cells across refinement boundaries instead of the flat prediction (see
+        // reconstruct_exact). Default: the global --exact-reconstruction option.
+        void set_exact_reconstruction(bool exact)
+        {
+            m_exact_reconstruction = exact;
+        }
+
+        bool exact_reconstruction() const
+        {
+            return m_exact_reconstruction;
         }
 
         void enable_max_level_flux(bool enable)
@@ -145,21 +159,25 @@ namespace samurai
         /**
          * We store here everything that we compute only once per level
          */
+        using lca_t = LevelCellArray<dim, interval_t>;
+
         template <bool enable_finer_level_flux>
         struct FluxParameters
         {
-            std::size_t flux_direction      = 0;
-            std::size_t max_level           = 0;
-            std::size_t level               = 0;
-            std::size_t delta_l             = 0;
-            double left_factor              = 0;
-            double right_factor             = 0;
-            double cell_length              = 0; // cell length at the level where the flux is computed
-            int finer_level_flux            = 0; // this is the number of levels to go up to compute the flux
-            std::size_t n_fine_fluxes       = 0; // number of fluxes at max_level to sum up together, or 1 if enable_max_finer_flux=false
-            int n_children_at_max_level     = 0; // number of 1D children at max_level of one cell at the current level
-            std::size_t coarse_stencil_size = 0; // number of cells at the current level used to predict the required values at
-                                                 // max_level
+            std::size_t flux_direction       = 0;
+            std::size_t max_level            = 0;
+            std::size_t level                = 0;
+            std::size_t delta_l              = 0;
+            bool exact                       = false;   // exact reconstruction of the finer stencil values
+            const std::vector<lca_t>* stored = nullptr; // (cells U proj_cells) per level, only if exact
+            double left_factor               = 0;
+            double right_factor              = 0;
+            double cell_length               = 0; // cell length at the level where the flux is computed
+            int finer_level_flux             = 0; // this is the number of levels to go up to compute the flux
+            std::size_t n_fine_fluxes        = 0; // number of fluxes at max_level to sum up together, or 1 if enable_max_finer_flux=false
+            int n_children_at_max_level      = 0; // number of 1D children at max_level of one cell at the current level
+            std::size_t coarse_stencil_size  = 0; // number of cells at the current level used to predict the required values at
+                                                  // max_level
 
             void set_level(std::size_t l)
             {
@@ -185,14 +203,159 @@ namespace samurai
             }
         }
 
+        // Read one stored cell f(comp, level, coord) of the (possibly vector) input field, unpacking
+        // the transverse directions - the reader used by the exact reconstruction.
+        template <std::size_t... K>
+        static field_value_type read_field_cell(const input_field_t& field,
+                                                std::size_t comp,
+                                                std::size_t level,
+                                                const std::array<interval_value_t, dim>& c,
+                                                std::index_sequence<K...>)
+        {
+            if constexpr (input_field_t::is_scalar)
+            {
+                (void)comp;
+                return field(level, interval_t{c[0], c[0] + 1}, c[K + 1]...)[0];
+            }
+            else
+            {
+                return field(comp, level, interval_t{c[0], c[0] + 1}, c[K + 1]...)[0];
+            }
+        }
+
+        using exact_memos_t   = std::array<exact_reconstruction_memo_t<dim, interval_value_t>, n_comp>;
+        using recons_box_t    = detail::ra_box<dim, interval_value_t>;
+        using recons_values_t = std::array<std::vector<double>, n_comp>;
+
+        template <bool enable_finer_level_flux>
         SAMURAI_INLINE void predict_value(typename cfg::input_field_t::local_data_type& predicted_value,
                                           const input_field_t& field,
-                                          const std::size_t level,
-                                          const std::size_t delta_l,
                                           const cell_indices_t& coarse_cell_indices,
-                                          const cell_indices_t& fine_cell_indices)
+                                          const cell_indices_t& fine_cell_indices,
+                                          const FluxParameters<enable_finer_level_flux>& flux_params,
+                                          exact_memos_t& memos,
+                                          const recons_box_t& box,
+                                          const recons_values_t& box_values)
         {
-            portion(predicted_value, field, level, delta_l, coarse_cell_indices, fine_cell_indices);
+            const std::size_t level   = flux_params.level;
+            const std::size_t delta_l = flux_params.delta_l;
+
+            if constexpr (!enable_finer_level_flux)
+            {
+                portion(predicted_value, field, level, delta_l, coarse_cell_indices, fine_cell_indices);
+            }
+            else
+            {
+                if (delta_l == 0)
+                {
+                    portion(predicted_value, field, level, delta_l, coarse_cell_indices, fine_cell_indices);
+                    return;
+                }
+
+                // The whole finer stencil block was reconstructed at once into box_values (flat or
+                // exact, per component; see build_recons_box) - just read this cell from it.
+                std::array<interval_value_t, dim> g;
+                for (std::size_t k = 0; k < dim; ++k)
+                {
+                    g[k] = (coarse_cell_indices[k] << delta_l) + fine_cell_indices[k];
+                }
+                if (box.contains(g))
+                {
+                    const std::size_t off = box.offset(g);
+                    if constexpr (input_field_t::is_scalar)
+                    {
+                        predicted_value = box_values[0][off];
+                    }
+                    else
+                    {
+                        for (std::size_t comp = 0; comp < n_comp; ++comp)
+                        {
+                            predicted_value(static_cast<size_type>(comp)) = box_values[comp][off];
+                        }
+                    }
+                    return;
+                }
+
+                // Safety fallback (should not trigger with a correctly-sized box): reconstruct this
+                // single cell, matching the flat / exact choice.
+                if (!flux_params.exact)
+                {
+                    portion(predicted_value, field, level, delta_l, coarse_cell_indices, fine_cell_indices);
+                    return;
+                }
+                static constexpr std::size_t r = mesh_t::config_t::prediction_stencil_radius;
+                constexpr auto tseq            = std::make_index_sequence<dim - 1>{};
+                auto reconstruct_component     = [&](std::size_t comp) -> field_value_type
+                {
+                    auto read = [&](std::size_t l, const std::array<interval_value_t, dim>& c) -> double
+                    {
+                        return read_field_cell(field, comp, l, c, tseq);
+                    };
+                    return reconstruct_exact<r>(level, delta_l, g, read, *flux_params.stored, memos[comp]);
+                };
+                if constexpr (input_field_t::is_scalar)
+                {
+                    predicted_value = reconstruct_component(0);
+                }
+                else
+                {
+                    for (std::size_t comp = 0; comp < n_comp; ++comp)
+                    {
+                        predicted_value(static_cast<size_type>(comp)) = reconstruct_component(comp);
+                    }
+                }
+            }
+        }
+
+        // Reconstruct the whole finer stencil block of one interface at once (flat via
+        // reconstruct_flat_box, or exact via reconstruct_exact_box), per component, into box_values.
+        // The block is the stencil_size fine cells around the interface (flux direction, plus a small
+        // margin) times the 2^{delta_l} children in each transverse direction - covering every cell
+        // predict_value reads. This replaces the per-cell portion() with one dense cascade.
+        void build_recons_box(const FluxParameters<true>& flux_params,
+                              const StencilCells<cfg>& cells,
+                              const input_field_t& field,
+                              recons_box_t& box,
+                              recons_values_t& box_values) const
+        {
+            static constexpr std::size_t r = mesh_t::config_t::prediction_stencil_radius;
+            constexpr auto tseq            = std::make_index_sequence<dim - 1>{};
+            const std::size_t level        = flux_params.level;
+            const std::size_t delta_l      = flux_params.delta_l;
+            const auto flux_dir            = flux_params.flux_direction;
+            const auto half                = static_cast<interval_value_t>(stencil_size / 2);
+            const auto& right              = cells[stencil_size / 2]; // first coarse cell right of the interface
+
+            for (std::size_t k = 0; k < dim; ++k)
+            {
+                if (k == flux_dir)
+                {
+                    const interval_value_t interface = right.indices[k] << delta_l; // fine coord of the interface
+                    box.lo[k]                        = interface - half - static_cast<interval_value_t>(r);
+                    box.hi[k]                        = interface + half + static_cast<interval_value_t>(r);
+                }
+                else
+                {
+                    box.lo[k] = right.indices[k] << delta_l;
+                    box.hi[k] = (right.indices[k] + 1) << delta_l;
+                }
+            }
+
+            for (std::size_t comp = 0; comp < n_comp; ++comp)
+            {
+                auto read = [&](std::size_t l, const std::array<interval_value_t, dim>& c) -> double
+                {
+                    return read_field_cell(field, comp, l, c, tseq);
+                };
+                if (flux_params.exact)
+                {
+                    reconstruct_exact_box<r>(level, level + delta_l, box.lo, box.hi, read, *flux_params.stored, box_values[comp]);
+                }
+                else
+                {
+                    reconstruct_flat_box<r>(level, level + delta_l, box.lo, box.hi, read, box_values[comp]);
+                }
+            }
         }
 
         template <bool enable_finer_level_flux>
@@ -254,6 +417,15 @@ namespace samurai
 
                     std::size_t moving_direction = flux_params.flux_direction == 0 ? 1 : 0; // first other direction
 
+                    // Per-component memos for the safety fallback only (see predict_value).
+                    exact_memos_t memos;
+
+                    // Reconstruct the whole finer stencil block of this interface at once (flat or
+                    // exact), instead of one portion() per fine cell; predict_value just reads it.
+                    recons_box_t box;
+                    recons_values_t box_values;
+                    build_recons_box(flux_params, cells, field, box, box_values);
+
                     for (std::size_t fine_flux_index = 0; fine_flux_index < flux_params.n_fine_fluxes; ++fine_flux_index)
                     {
                         left_coarse_cell_indices  = left.indices;
@@ -276,10 +448,12 @@ namespace samurai
                             {
                                 predict_value(stencil_values_list[fine_flux_index][index_in_stencil - s],
                                               field,
-                                              flux_params.level,
-                                              flux_params.delta_l,
                                               left_coarse_cell_indices,
-                                              left_fine_cell_indices);
+                                              left_fine_cell_indices,
+                                              flux_params,
+                                              memos,
+                                              box,
+                                              box_values);
                                 left_fine_cell_indices[flux_direction]--;
                             }
 
@@ -291,10 +465,12 @@ namespace samurai
                             {
                                 predict_value(stencil_values_list[fine_flux_index][index_in_stencil + s],
                                               field,
-                                              flux_params.level,
-                                              flux_params.delta_l,
                                               right_coarse_cell_indices,
-                                              right_fine_cell_indices);
+                                              right_fine_cell_indices,
+                                              flux_params,
+                                              memos,
+                                              box,
+                                              box_values);
                                 right_fine_cell_indices[flux_direction]++;
                             }
 
@@ -429,6 +605,19 @@ namespace samurai
             flux_params.max_level        = mesh.max_level();
             flux_params.flux_direction   = d;
             flux_params.finer_level_flux = m_finer_level_flux;
+
+            // For the exact reconstruction of the finer stencil values: the (cells U proj_cells) set
+            // per level, built once (only when needed). Outlives the loops below.
+            std::vector<lca_t> stored;
+            if constexpr (enable_finer_level_flux)
+            {
+                flux_params.exact = m_exact_reconstruction;
+                if (m_exact_reconstruction)
+                {
+                    stored             = make_real_backed_lca(mesh);
+                    flux_params.stored = &stored;
+                }
+            }
 
             // Same level
             for (std::size_t level = min_level; level <= max_level; ++level)

--- a/include/samurai/schemes/fv/flux_based/flux_based_scheme__nonlin.hpp
+++ b/include/samurai/schemes/fv/flux_based/flux_based_scheme__nonlin.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include "../../../arguments.hpp"
 #include "flux_based_scheme.hpp"
 
 #include <fmt/format.h>

--- a/include/samurai/schemes/lbm/lbm_scheme.hpp
+++ b/include/samurai/schemes/lbm/lbm_scheme.hpp
@@ -14,6 +14,7 @@
 
 #include "../../algorithm.hpp"
 #include "../../algorithm/update_ghost_mr.hpp"
+#include "../../arguments.hpp"
 #include "../../reconstruction.hpp"
 #include "velocity_scheme.hpp"
 

--- a/include/samurai/schemes/lbm/lbm_scheme.hpp
+++ b/include/samurai/schemes/lbm/lbm_scheme.hpp
@@ -514,18 +514,27 @@ namespace samurai
             const auto maxvel           = static_cast<value_t>(max_abs_velocity());
 
             std::vector<double> box_vals;
-            for (std::size_t level = mesh.min_level(); level <= max_level; ++level)
+            // Only a level with a gap to max_level can differ from the flat stream: at max_level the
+            // cascade has depth 0 (the correction is the identity) and proj_cells is empty anyway.
+            for (std::size_t level = mesh.min_level(); level < max_level; ++level)
             {
                 const std::size_t j  = max_level - level;
                 const std::size_t nc = std::size_t{1} << (j * dim);
                 const double inv_nc  = 1. / static_cast<double>(nc);
 
-                // Halo (in level-l0 cells) covering a donor's cone footprint at this gap j: the flat
-                // prediction support (r one level, saturating at 2r) plus the velocity shift, with a
-                // margin. Level-dependent so the finer levels (small j) get a tighter band; over-
-                // inclusion only redoes a few extra cells, it never changes the result.
-                const auto support = std::min(static_cast<value_t>(2 * r), static_cast<value_t>(r + j - 1));
-                const auto reach   = support + maxvel + 1;
+                // Halo (in level-l cells) covering a donor's cone footprint at this gap j: the
+                // prediction support plus the velocity shift, with a margin. Level-dependent so the
+                // finer levels (small j) get a tighter band. Over-inclusion is harmless but not
+                // without consequence: on an extra cell the cascade agrees with the flat prediction
+                // only up to rounding (see reconstruct_flat_box), so the band size is observable at
+                // machine precision. Under-inclusion, on the other hand, silently drops a correction.
+                //
+                // The velocity shift is applied at max_level (see donor_box), so it is worth
+                // ceil(maxvel / 2^j) cells at this level. `support + shift` is already covering
+                // (pinned by reconstruction.band_covers_the_read_footprint); the +1 is pure margin.
+                const auto support = composed_prediction_support<value_t>(r, j);
+                const auto shift   = (maxvel + (value_t{1} << j) - 1) >> j;
+                const auto reach   = support + shift + 1;
 
                 // Cells whose cone reaches a refined cell of this level; the rest keep the flat value.
                 auto interface_cells = intersection(mesh[mesh_id_t::cells][level], expand(mesh[mesh_id_t::proj_cells][level], reach));

--- a/include/samurai/schemes/lbm/lbm_scheme.hpp
+++ b/include/samurai/schemes/lbm/lbm_scheme.hpp
@@ -177,6 +177,23 @@ namespace samurai
         }
 
         /**
+         * Enable the "exact-reconstruction" stream (default: the global --exact-reconstruction
+         * option). When off, the stream reconstructs each streamed value with the flat prediction
+         * (the fast production path). When on, wherever the prediction cone crosses a refinement
+         * boundary it instead uses the real detail carried by the finer leaves that are actually
+         * present (see @ref reconstruct_exact_box), removing the projection error at interfaces.
+         */
+        void set_exact_reconstruction(bool exact)
+        {
+            m_exact_reconstruction = exact;
+        }
+
+        bool exact_reconstruction() const
+        {
+            return m_exact_reconstruction;
+        }
+
+        /**
          * One LBM time step. Updates both @a f (distributions) and @a m (moments). Wall boundary
          * conditions are the ones attached to @a f (see @ref BounceBack / @ref AntiBounceBack and
          * @c make_bc); they are applied by @c update_ghost_mr before the stream reads the ghosts.
@@ -204,7 +221,14 @@ namespace samurai
 
             {
                 ScopedTimer timer_stream("lbm stream");
-                stream(f, *m_f_stream);
+                if (m_exact_reconstruction)
+                {
+                    stream_exact_reconstruction(f, *m_f_stream);
+                }
+                else
+                {
+                    stream(f, *m_f_stream);
+                }
             }
             std::swap(f.array(), m_f_stream->array());
             {
@@ -387,6 +411,158 @@ namespace samurai
             }
         }
 
+        // Read one stored cell f(comp, level, coord) unpacking the transverse directions (the reader
+        // used by the exact reconstruction).
+        template <std::size_t... K>
+        static double
+        read_cell(const field_t& f, std::size_t comp, std::size_t level, const std::array<value_t, dim>& coord, std::index_sequence<K...>)
+        {
+            return f(comp, level, interval_t{coord[0], coord[0] + 1}, coord[K + 1]...)[0];
+        }
+
+        // Integer indices, at the finest level, of the n-th fine sub-cell of coarse cell (ci, index)
+        // at level gap j, shifted by the donor offset -c.
+        template <std::size_t... D>
+        static std::array<value_t, dim>
+        donor_coord(value_t ci, const auto& index, std::size_t j, std::size_t n, const velocity_t& c, std::index_sequence<D...>)
+        {
+            const value_t width = value_t{1} << j;
+            auto along          = [&](auto dc) -> value_t
+            {
+                constexpr std::size_t d = dc;
+                value_t base;
+                if constexpr (d == 0)
+                {
+                    base = ci;
+                }
+                else
+                {
+                    base = static_cast<value_t>(index[d - 1]);
+                }
+                const value_t local = static_cast<value_t>((n >> (d * j)) & static_cast<std::size_t>(width - 1));
+                return (base << j) + local - static_cast<value_t>(c[d]);
+            };
+            return {along(std::integral_constant<std::size_t, D>{})...};
+        }
+
+        // Finest-level bounding box [lo, hi) of every donor sub-cell of the coarse x-interval i
+        // (transverse index) at level gap j, shifted by -c. Contiguous in x over the interval.
+        template <std::size_t... D>
+        static std::pair<std::array<value_t, dim>, std::array<value_t, dim>>
+        donor_box(const auto& i, const auto& index, std::size_t j, const velocity_t& c, std::index_sequence<D...>)
+        {
+            std::array<value_t, dim> lo, hi;
+            (
+                [&]
+                {
+                    constexpr std::size_t d = D;
+                    value_t start, end;
+                    if constexpr (d == 0)
+                    {
+                        start = i.start;
+                        end   = i.end;
+                    }
+                    else
+                    {
+                        start = static_cast<value_t>(index[d - 1]);
+                        end   = start + 1;
+                    }
+                    lo[d] = (start << j) - static_cast<value_t>(c[d]);
+                    hi[d] = (end << j) - static_cast<value_t>(c[d]);
+                }(),
+                ...);
+            return {lo, hi};
+        }
+
+        // Largest |velocity| component over all blocks (sizes the interface halo).
+        int max_abs_velocity() const
+        {
+            int m = 0;
+            for_each_block(
+                [&](const auto& block, std::size_t)
+                {
+                    constexpr std::size_t q = std::decay_t<decltype(block)>::q;
+                    for (std::size_t a = 0; a < q; ++a)
+                    {
+                        for (std::size_t d = 0; d < dim; ++d)
+                        {
+                            m = std::max(m, std::abs(block.velocities[a][d]));
+                        }
+                    }
+                });
+            return m;
+        }
+
+        // stream_exact_reconstruction: the flat stream() everywhere, then the streamed value is
+        // recomputed with the real finer cells (reconstruct_exact_box) on the sparse band of cells
+        // whose reconstruction cone (possibly shifted by the velocity) reaches a refined (proj) cell.
+        // Diagnostic path (see set_exact_reconstruction); the flat stream is the fast default.
+        void stream_exact_reconstruction(const field_t& f_in, field_t& f_out) const
+        {
+            using mesh_id_t         = typename field_t::mesh_t::mesh_id_t;
+            constexpr std::size_t r = field_t::mesh_t::config_t::prediction_stencil_radius;
+            constexpr auto tseq     = std::make_index_sequence<dim - 1>{};
+            constexpr auto dseq     = std::make_index_sequence<dim>{};
+            const std::array<int, dim> no_shift{};
+
+            // Flat reconstruction everywhere (fast); the interface band is corrected below.
+            stream(f_in, f_out);
+
+            auto& mesh                  = f_in.mesh();
+            const std::size_t max_level = mesh.max_level();
+            auto stored                 = make_real_backed_lca(mesh);
+            const auto maxvel           = static_cast<value_t>(max_abs_velocity());
+
+            std::vector<double> box_vals;
+            for (std::size_t level = mesh.min_level(); level <= max_level; ++level)
+            {
+                const std::size_t j  = max_level - level;
+                const std::size_t nc = std::size_t{1} << (j * dim);
+                const double inv_nc  = 1. / static_cast<double>(nc);
+
+                // Halo (in level-l0 cells) covering a donor's cone footprint at this gap j: the flat
+                // prediction support (r one level, saturating at 2r) plus the velocity shift, with a
+                // margin. Level-dependent so the finer levels (small j) get a tighter band; over-
+                // inclusion only redoes a few extra cells, it never changes the result.
+                const auto support = std::min(static_cast<value_t>(2 * r), static_cast<value_t>(r + j - 1));
+                const auto reach   = support + maxvel + 1;
+
+                // Cells whose cone reaches a refined cell of this level; the rest keep the flat value.
+                auto interface_cells = intersection(mesh[mesh_id_t::cells][level], expand(mesh[mesh_id_t::proj_cells][level], reach));
+
+                for_each_block(
+                    [&](const auto& block, std::size_t offset)
+                    {
+                        constexpr std::size_t q = std::decay_t<decltype(block)>::q;
+                        for (std::size_t a = 0; a < q; ++a)
+                        {
+                            const std::size_t comp = offset + a;
+                            const auto& c          = block.velocities[a];
+                            auto read              = [&](std::size_t rl, const std::array<value_t, dim>& coord) -> double
+                            {
+                                return read_cell(f_in, comp, rl, coord, tseq);
+                            };
+                            interface_cells(
+                                [&](const auto& i, const auto& index)
+                                {
+                                    auto [lo, hi] = donor_box(i, index, j, c, dseq);
+                                    reconstruct_exact_box<r>(level, max_level, lo, hi, read, stored, box_vals);
+                                    const detail::ra_box<dim, value_t> box{lo, hi};
+                                    for (value_t ci = i.start; ci < i.end; ++ci)
+                                    {
+                                        double acc = 0.;
+                                        for (std::size_t n = 0; n < nc; ++n)
+                                        {
+                                            acc += box_vals[box.offset(donor_coord(ci, index, j, n, c, dseq))];
+                                        }
+                                        access(f_out, comp, level, interval_t{ci, ci + 1}, index, no_shift, tseq) = inv_nc * acc;
+                                    }
+                                });
+                        }
+                    });
+            }
+        }
+
         // collide: m = M.f (all blocks) ; equilibrium (sees all moments) ; relax (MRT) ;
         //          optional source (body force) ; f = M^{-1} m.
         template <class MField>
@@ -472,8 +648,9 @@ namespace samurai
         std::string m_name;
         double m_lambda;
         std::tuple<Blocks...> m_blocks;
-        source_t m_source;                         // optional body-force source term (see set_source)
-        mutable std::optional<field_t> m_f_stream; // worker for the streamed distributions (reused across steps)
+        source_t m_source;                                        // optional body-force source term (see set_source)
+        bool m_exact_reconstruction = args::exact_reconstruction; // exact-reconstruction stream (default from --exact-reconstruction)
+        mutable std::optional<field_t> m_f_stream;                // worker for the streamed distributions (reused across steps)
     };
 
     /**

--- a/tests/test_lbm.cpp
+++ b/tests/test_lbm.cpp
@@ -134,7 +134,8 @@ namespace samurai
         // ------------------------------------------------------------------ D2Q4 advection
         // diagonal == false: axial velocities {(1,0),(0,1),(-1,0),(0,-1)}
         // diagonal == true : rotated velocities {(1,1),(-1,1),(-1,-1),(1,-1)}
-        advection_result run_d2q4_advection(std::size_t max_level, double Tf, double ax, double ay, bool diagonal, bool adapt = false)
+        advection_result
+        run_d2q4_advection(std::size_t max_level, double Tf, double ax, double ay, bool diagonal, bool adapt = false, bool exact = false)
         {
             static constexpr std::size_t dim = 2;
             const double lambda = 1., l2 = 1., s1 = 1.5, s2 = 1.;
@@ -192,6 +193,7 @@ namespace samurai
 
             using field_t = decltype(f);
             auto scheme   = make_lbm_scheme<field_t>("D2Q4", lambda, velocity_scheme<dim, 4>(vel, M, invM, {0., s1, s1, s2}, eq));
+            scheme.set_exact_reconstruction(exact);
             scheme.init_equilibrium(f, m);
 
             const double dx = L / static_cast<double>(std::size_t{1} << max_level);
@@ -302,6 +304,37 @@ namespace samurai
         auto r = run_d2q4_advection(7, 0.4, 0.5, 0.5, /*diagonal*/ true, /*adapt*/ true);
         EXPECT_LT(r.mass_drift, 1e-11);
         EXPECT_LT(r.rel_l2_error, 0.1);
+    }
+
+    TEST(lbm_d2q4, exact_reconstruction_matches_flat_without_refinement)
+    {
+        // With no refinement anywhere, the exact-reconstruction reconstruction reduces to the flat one, so
+        // the whole run must match the flat stream (up to the rounding of a cascade vs a single
+        // flattened stencil). This pins down the exact-reconstruction wiring independently of the correction.
+        auto flat = run_d2q4_advection(6, 0.4, 0.5, 0.5, /*diagonal*/ true, /*adapt*/ false, /*exact*/ false);
+        auto ra   = run_d2q4_advection(6, 0.4, 0.5, 0.5, /*diagonal*/ true, /*adapt*/ false, /*exact*/ true);
+
+        EXPECT_LT(ra.mass_drift, 1e-11);
+        EXPECT_NEAR(ra.rel_l2_error, flat.rel_l2_error, 1e-10);
+        EXPECT_NEAR(ra.umin, flat.umin, 1e-10);
+        EXPECT_NEAR(ra.umax, flat.umax, 1e-10);
+    }
+
+    TEST(lbm_d2q4, exact_reconstruction_stays_accurate_and_changes_result)
+    {
+        // On an adaptive run the exact-reconstruction stream reconstructs across refinement boundaries with
+        // the real finer leaves: it stays accurate (mass bounded, error small) and produces a
+        // result that actually differs from the flat stream. This periodic pure-advection flat
+        // stream is already exactly mass-conserving by symmetry, so the exact-reconstruction variant only
+        // adds a little arithmetic round-off here (a mild drift bound is asserted); its conservation
+        // gain shows on interface-dominated cases (see the Rayleigh-Taylor demo, --exact-reconstruction).
+        auto flat = run_d2q4_advection(7, 0.4, 0.5, 0.5, /*diagonal*/ true, /*adapt*/ true, /*exact*/ false);
+        auto ra   = run_d2q4_advection(7, 0.4, 0.5, 0.5, /*diagonal*/ true, /*adapt*/ true, /*exact*/ true);
+
+        EXPECT_LT(ra.mass_drift, 1e-6);
+        EXPECT_LT(ra.rel_l2_error, 0.1);
+        // The correction is active at the refinement interfaces => a measurable difference.
+        EXPECT_GT(std::abs(ra.rel_l2_error - flat.rel_l2_error), 1e-9);
     }
 
     // ==================================================================== D1Q5 |c| > 1 stream

--- a/tests/test_lbm.cpp
+++ b/tests/test_lbm.cpp
@@ -940,7 +940,6 @@ namespace samurai
             const double lambda = 5., gamma = 1.4, gm1 = gamma - 1., g = 2.;
             const double rho_down = 1., rho_up = uniform_density ? 1. : 2.;
             const double l = lambda, l2 = l * l;
-            constexpr double pi = 3.14159265358979323846;
 
             Box<double, dim> box({0., 0.}, {1., 1.});
             auto cfg = mesh_config<dim>().min_level(max_level).max_level(max_level).periodic(false).max_stencil_size(4).graduation_width(2);

--- a/tests/test_portion.cpp
+++ b/tests/test_portion.cpp
@@ -683,4 +683,125 @@ namespace samurai
         }
         EXPECT_GT(checked, 0u);
     }
+
+    // The composed prediction support is the geometric series r + r/2 + r/4 + ..., NOT r + j.
+    TEST(reconstruction, composed_prediction_support_saturates_at_twice_the_radius)
+    {
+        const std::map<std::size_t, std::vector<int>> expected{
+            {0, {0, 0, 0, 0, 0, 0, 0}   },
+            {1, {0, 1, 2, 2, 2, 2, 2}   },
+            {2, {0, 2, 3, 4, 4, 4, 4}   },
+            {3, {0, 3, 5, 6, 6, 6, 6}   },
+            {4, {0, 4, 6, 7, 8, 8, 8}   },
+            {5, {0, 5, 8, 9, 10, 10, 10}},
+        };
+        for (const auto& [r, support] : expected)
+        {
+            for (std::size_t j = 0; j < support.size(); ++j)
+            {
+                EXPECT_EQ(composed_prediction_support(r, j), support[j]) << "r=" << r << " j=" << j;
+            }
+        }
+        // The trap: a linear r + j - 1 under-estimates the support as soon as r >= 3, which would
+        // silently shrink the band of cells the exact-reconstruction stream recomputes.
+        EXPECT_GT(composed_prediction_support(3, 2), 3 + 2 - 1);
+        EXPECT_GT(composed_prediction_support(5, 3), 5 + 3 - 1);
+    }
+
+    // Every base-level cell the cascade reads must lie inside the halo that the exact-reconstruction
+    // stream uses to select the cells to recompute: composed_prediction_support(r, j) cells for the
+    // prediction, plus ceil(maxvel / 2^j) for the velocity shift applied at the finest level (see
+    // LBMScheme::stream_exact_reconstruction, which adds one more cell of margin on top of that).
+    // A halo too small would leave cells whose cone crosses a refinement boundary with the flat
+    // value, with no error and no warning.
+    template <std::size_t r, std::size_t dim>
+    void check_band_covers_read_footprint(std::size_t max_j, int max_vel, int nx)
+    {
+        using value_t            = default_config::value_t;
+        constexpr std::size_t l0 = 3;
+        constexpr value_t base   = 5; // donor cell, away from the origin so no shift is ambiguous
+
+        std::size_t checked = 0;
+        for (std::size_t j = 0; j <= max_j; ++j)
+        {
+            const value_t support = composed_prediction_support<value_t>(r, j);
+            for (int m = 0; m <= max_vel; ++m)
+            {
+                const value_t shift = static_cast<value_t>((m + (1 << j) - 1) >> j);
+                const value_t reach = support + shift;
+
+                // Every velocity with max_d |c_d| <= m must fit in that same halo, since the stream
+                // sizes the band once for all the velocities of all the blocks.
+                const auto ncomb = static_cast<std::size_t>(std::pow(2 * m + 1, dim));
+                for (std::size_t s = 0; s < ncomb; ++s)
+                {
+                    std::array<value_t, dim> c{};
+                    std::size_t t = s;
+                    for (std::size_t d = 0; d < dim; ++d)
+                    {
+                        c[d] = static_cast<value_t>(t % static_cast<std::size_t>(2 * m + 1)) - m;
+                        t /= static_cast<std::size_t>(2 * m + 1);
+                    }
+
+                    // The donor box of LBMScheme::donor_box: an x-interval of nx cells, a single cell
+                    // in the transverse directions, taken at the finest level and shifted by -c.
+                    std::array<value_t, dim> lo, hi, start, end;
+                    for (std::size_t d = 0; d < dim; ++d)
+                    {
+                        start[d] = base;
+                        end[d]   = base + static_cast<value_t>((d == 0) ? nx : 1);
+                        lo[d]    = (start[d] << j) - c[d];
+                        hi[d]    = (end[d] << j) - c[d];
+                    }
+
+                    std::size_t nread = 0;
+                    auto read         = [&](std::size_t l, const std::array<value_t, dim>& g) -> double
+                    {
+                        EXPECT_EQ(l, l0) << "the flat cascade must only read the base level";
+                        for (std::size_t d = 0; d < dim; ++d)
+                        {
+                            EXPECT_GE(g[d], start[d] - reach) << "r=" << r << " j=" << j << " m=" << m << " c=" << c[0] << " d=" << d;
+                            EXPECT_LE(g[d], end[d] - 1 + reach) << "r=" << r << " j=" << j << " m=" << m << " c=" << c[0] << " d=" << d;
+                        }
+                        ++nread;
+                        return 0.;
+                    };
+
+                    std::vector<double> out;
+                    reconstruct_flat_box<r>(l0, l0 + j, lo, hi, read, out);
+                    EXPECT_GT(nread, 0u);
+                    ++checked;
+                }
+            }
+        }
+        EXPECT_GT(checked, 0u);
+    }
+
+    TEST(reconstruction, band_covers_the_read_footprint_1D)
+    {
+        check_band_covers_read_footprint<0, 1>(6, 4, 1);
+        check_band_covers_read_footprint<1, 1>(6, 4, 1);
+        check_band_covers_read_footprint<2, 1>(6, 4, 1);
+        check_band_covers_read_footprint<3, 1>(6, 4, 1);
+        check_band_covers_read_footprint<4, 1>(6, 4, 1);
+        check_band_covers_read_footprint<5, 1>(6, 4, 1);
+        // A multi-cell x-interval: the halo is measured from the interval bounds.
+        check_band_covers_read_footprint<1, 1>(5, 3, 4);
+        check_band_covers_read_footprint<3, 1>(5, 3, 4);
+    }
+
+    TEST(reconstruction, band_covers_the_read_footprint_2D)
+    {
+        check_band_covers_read_footprint<0, 2>(4, 2, 1);
+        check_band_covers_read_footprint<1, 2>(4, 2, 1);
+        check_band_covers_read_footprint<2, 2>(4, 2, 1);
+        check_band_covers_read_footprint<3, 2>(4, 2, 1);
+        check_band_covers_read_footprint<1, 2>(3, 2, 3);
+    }
+
+    TEST(reconstruction, band_covers_the_read_footprint_3D)
+    {
+        check_band_covers_read_footprint<1, 3>(2, 2, 1);
+        check_band_covers_read_footprint<2, 3>(2, 1, 1);
+    }
 }

--- a/tests/test_portion.cpp
+++ b/tests/test_portion.cpp
@@ -1,13 +1,21 @@
-#include <cmath>
-
 #include <gtest/gtest.h>
+
+#include <cmath>
+#include <functional>
+#include <map>
+#include <set>
+#include <utility>
+
 #include <samurai/algorithm.hpp>
 #include <samurai/algorithm/update_ghost_mr.hpp>
 #include <samurai/box.hpp>
 #include <samurai/cell_list.hpp>
 #include <samurai/field.hpp>
+#include <samurai/mesh_config.hpp>
+#include <samurai/mr/adapt.hpp>
 #include <samurai/mr/mesh.hpp>
 #include <samurai/reconstruction.hpp>
+#include <samurai/samurai.hpp>
 #include <samurai/uniform_mesh.hpp>
 
 // Tests for portion() (include/samurai/reconstruction.hpp): the reconstructed value a field would
@@ -354,5 +362,325 @@ namespace samurai
         // truncation error, but the flat one adds the projection error on top).
         const double truth = std::cos(3. * (15 + 0.5) / (1 << 3));
         EXPECT_LT(std::abs(descending - truth), std::abs(flat - truth));
+    }
+
+    // ------------------------------------------------------------------------------------
+    //  exact-reconstruction reconstruction (reconstruct_exact): on an adapted mesh it must equal
+    //  the multiresolution reconstruction capped at the donor's base level (finer real cells
+    //  override, coarser-neighbour ghosts kept as the flat path sees them), reduce to the flat
+    //  portion() when the cone stays clear of refinement, and actually differ from flat at a
+    //  refinement interface.
+    // ------------------------------------------------------------------------------------
+
+    // Deterministic graded staircase L1..L5 (wide base) so a delta_l = 4 cone spans the L2, L3
+    // and L4 real cells at once (nested-refinement / double-count case).
+    TEST(portion_exact, graded_staircase_1D)
+    {
+        constexpr std::size_t dim = 1;
+        CellList<dim> cl;
+        cl[1][{}].add_interval({0, 8});     // [0,128)   in level-5 units
+        cl[2][{}].add_interval({16, 18});   // [128,144)
+        cl[3][{}].add_interval({36, 38});   // [144,152)
+        cl[4][{}].add_interval({76, 78});   // [152,156)
+        cl[5][{}].add_interval({156, 160}); // [156,160)
+
+        auto cfg                = mesh_config<dim>().min_level(1).max_level(5).max_stencil_radius(2);
+        auto mesh               = mra::make_mesh(cl, cfg);
+        using mesh_t            = decltype(mesh);
+        using mesh_id_t         = mesh_t::mesh_id_t;
+        using interval_t        = mesh_t::interval_t;
+        using value_t           = interval_t::value_t;
+        constexpr std::size_t r = mesh_t::config_t::prediction_stencil_radius;
+
+        auto u = make_scalar_field<double>("u", mesh);
+        for_each_cell(mesh[mesh_id_t::cells],
+                      [&](const auto& c)
+                      {
+                          u[c] = std::cos(3. * c.center()[0]);
+                      });
+        update_ghost_mr(u);
+
+        auto stored = make_real_backed_lca(mesh);
+        auto read   = [&](std::size_t l, const std::array<value_t, dim>& c) -> double
+        {
+            return u(l, interval_t{c[0], c[0] + 1})[0];
+        };
+
+        // Independent reference: capped recursion using a std::set membership (a different
+        // mechanism than the find()-based test inside reconstruct_exact).
+        std::vector<std::set<value_t>> in_set(mesh.max_level() + 1);
+        for (std::size_t l = mesh.min_level(); l <= mesh.max_level(); ++l)
+        {
+            for (auto id : {mesh_id_t::cells, mesh_id_t::proj_cells})
+            {
+                for_each_interval(mesh[id][l],
+                                  [&](std::size_t, const auto& i, const auto&)
+                                  {
+                                      for (value_t k = i.start; k < i.end; ++k)
+                                      {
+                                          in_set[l].insert(k);
+                                      }
+                                  });
+            }
+        }
+        std::function<double(std::size_t, std::size_t, value_t)> ref = [&](std::size_t l0, std::size_t m, value_t i) -> double
+        {
+            if (m == l0 || in_set[m].count(i))
+            {
+                return u(m, interval_t{i, i + 1})[0];
+            }
+            double res = 0.;
+            for (const auto& kv : prediction<r, value_t>(1, i & 1).coeff)
+            {
+                res += kv.second * ref(l0, m - 1, (i >> 1) + kv.first[0]);
+            }
+            return res;
+        };
+
+        auto flat_portion = [&](std::size_t l0, std::size_t delta_l, value_t g) -> double
+        {
+            value_t coarse = g >> delta_l;
+            value_t local  = g - (coarse << delta_l);
+            return portion<r>(u, l0, delta_l, std::make_tuple(interval_t{coarse, coarse + 1}), std::make_tuple(local))[0];
+        };
+
+        std::size_t checked       = 0;
+        std::size_t nb_nontrivial = 0;
+        for (std::size_t l0 = mesh.min_level(); l0 < mesh.max_level(); ++l0)
+        {
+            std::size_t delta_l = mesh.max_level() - l0;
+            for (value_t g = 0; g < 160; ++g)
+            {
+                double flat = std::numeric_limits<double>::quiet_NaN();
+                double expected;
+                double got;
+                try
+                {
+                    flat     = flat_portion(l0, delta_l, g);
+                    expected = ref(l0, mesh.max_level(), g);
+                    std::map<std::pair<std::size_t, std::array<value_t, dim>>, double> memo;
+                    got = reconstruct_exact<r>(l0, delta_l, std::array<value_t, dim>{g}, read, stored, memo);
+                }
+                catch (...)
+                {
+                    continue; // g whose flat stencil leaves all_cells: not a case the stream hits
+                }
+                ++checked;
+                // main property: the capped multiresolution reconstruction, to machine precision
+                EXPECT_NEAR(got, expected, 1e-13) << "l0=" << l0 << " g=" << g;
+                if (std::abs(expected - flat) > 1e-9)
+                {
+                    ++nb_nontrivial; // correction active (cone crosses a refinement)
+                }
+                else
+                {
+                    // no refinement in the cone => reduces to the flat prediction (up to the
+                    // rounding of a cascade vs a single flattened stencil)
+                    EXPECT_NEAR(got, flat, 1e-12) << "l0=" << l0 << " g=" << g;
+                }
+            }
+        }
+        EXPECT_GT(checked, 0u);
+        EXPECT_GT(nb_nontrivial, 0u); // the correction is actually active at the interfaces
+    }
+
+    // Adapted 2D mesh (sharp front => graded refinement): exercises the dim-generic machinery
+    // and nested refinement in 2D against the same capped-recursion reference.
+    TEST(portion_exact, adapted_mesh_2D)
+    {
+        ::samurai::initialize();
+        constexpr std::size_t dim = 2;
+        using box_t               = Box<double, dim>;
+
+        auto fill = [](auto& field)
+        {
+            auto& mesh = field.mesh();
+            using mid  = std::decay_t<decltype(mesh)>::mesh_id_t;
+            for_each_cell(mesh[mid::cells],
+                          [&](const auto& c)
+                          {
+                              auto x   = c.center()[0];
+                              auto y   = c.center()[1];
+                              field[c] = std::tanh(20. * (x - 0.5)) + std::cos(4. * y);
+                          });
+        };
+
+        auto cfg  = mesh_config<dim>().min_level(2).max_level(6);
+        auto mesh = mra::make_mesh(
+            box_t{
+                {0., 0.},
+                {1., 1.}
+        },
+            cfg);
+        auto u = make_scalar_field<double>("u", mesh);
+        fill(u);
+        make_MRAdapt(u)(mra_config().epsilon(1e-3).regularity(2.));
+        fill(u); // re-fill on the adapted topology
+        update_ghost_mr(u);
+
+        using mesh_t            = decltype(mesh);
+        using mesh_id_t         = mesh_t::mesh_id_t;
+        using interval_t        = mesh_t::interval_t;
+        using value_t           = interval_t::value_t;
+        constexpr std::size_t r = mesh_t::config_t::prediction_stencil_radius;
+        const std::size_t L     = mesh.max_level();
+
+        auto stored = make_real_backed_lca(mesh);
+        auto read   = [&](std::size_t l, const std::array<value_t, dim>& c) -> double
+        {
+            return u(l, interval_t{c[0], c[0] + 1}, c[1])[0];
+        };
+
+        std::vector<std::set<std::pair<value_t, value_t>>> in_set(L + 1);
+        for (std::size_t l = mesh.min_level(); l <= L; ++l)
+        {
+            for (auto id : {mesh_id_t::cells, mesh_id_t::proj_cells})
+            {
+                for_each_interval(mesh[id][l],
+                                  [&](std::size_t, const auto& i, const auto& index)
+                                  {
+                                      for (value_t k = i.start; k < i.end; ++k)
+                                      {
+                                          in_set[l].insert({k, index[0]});
+                                      }
+                                  });
+            }
+        }
+        std::function<double(std::size_t, std::size_t, value_t, value_t)> ref = [&](std::size_t l0, std::size_t m, value_t i, value_t j) -> double
+        {
+            if (m == l0 || in_set[m].count({i, j}))
+            {
+                return u(m, interval_t{i, i + 1}, j)[0];
+            }
+            double res = 0.;
+            for (const auto& kv : prediction<r, value_t>(1, i & 1, j & 1).coeff)
+            {
+                res += kv.second * ref(l0, m - 1, (i >> 1) + kv.first[0], (j >> 1) + kv.first[1]);
+            }
+            return res;
+        };
+
+        std::size_t checked = 0, nb_nontrivial = 0;
+        for (std::size_t l0 = mesh.min_level(); l0 < L; ++l0)
+        {
+            std::size_t delta_l = L - l0;
+            value_t nsub        = value_t{1} << delta_l;
+            for_each_interval(
+                mesh[mesh_id_t::cells][l0],
+                [&](std::size_t, const auto& ii, const auto& idx)
+                {
+                    for (value_t ci = ii.start; ci < ii.end; ++ci)
+                    {
+                        for (value_t sy = 0; sy < nsub; ++sy)
+                        {
+                            for (value_t sx = 0; sx < nsub; ++sx)
+                            {
+                                value_t gx = (ci << delta_l) + sx;
+                                value_t gy = (idx[0] << delta_l) + sy;
+                                double expected, got, flat;
+                                try
+                                {
+                                    expected = ref(l0, L, gx, gy);
+                                    std::map<std::pair<std::size_t, std::array<value_t, dim>>, double> memo;
+                                    got  = reconstruct_exact<r>(l0, delta_l, std::array<value_t, dim>{gx, gy}, read, stored, memo);
+                                    flat = portion<r>(u,
+                                                      l0,
+                                                      delta_l,
+                                                      std::make_tuple(interval_t{ci, ci + 1}, idx[0]),
+                                                      std::make_tuple(sx, sy))[0];
+                                }
+                                catch (...)
+                                {
+                                    continue;
+                                }
+                                ++checked;
+                                EXPECT_NEAR(got, expected, 1e-12) << "l0=" << l0 << " g=(" << gx << "," << gy << ")";
+                                if (std::abs(expected - flat) > 1e-9)
+                                {
+                                    ++nb_nontrivial;
+                                }
+                            }
+                        }
+                    }
+                });
+        }
+        EXPECT_GT(checked, 0u);
+        EXPECT_GT(nb_nontrivial, 0u);
+        ::samurai::finalize();
+    }
+
+    // The vectorised reconstruct_exact_box (the fast path used by the LBM stream) must be
+    // bit-identical to the scalar reconstruct_exact, cell for cell, over a whole sub-cell box.
+    TEST(portion_exact, box_matches_scalar_1D)
+    {
+        constexpr std::size_t dim = 1;
+        CellList<dim> cl;
+        cl[1][{}].add_interval({0, 8});
+        cl[2][{}].add_interval({16, 18});
+        cl[3][{}].add_interval({36, 38});
+        cl[4][{}].add_interval({76, 78});
+        cl[5][{}].add_interval({156, 160});
+
+        auto cfg                = mesh_config<dim>().min_level(1).max_level(5).max_stencil_radius(2);
+        auto mesh               = mra::make_mesh(cl, cfg);
+        using mesh_t            = decltype(mesh);
+        using mesh_id_t         = mesh_t::mesh_id_t;
+        using interval_t        = mesh_t::interval_t;
+        using value_t           = interval_t::value_t;
+        constexpr std::size_t r = mesh_t::config_t::prediction_stencil_radius;
+        const std::size_t L     = mesh.max_level();
+
+        auto u = make_scalar_field<double>("u", mesh);
+        for_each_cell(mesh[mesh_id_t::cells],
+                      [&](const auto& c)
+                      {
+                          u[c] = std::cos(3. * c.center()[0]);
+                      });
+        update_ghost_mr(u);
+
+        auto stored = make_real_backed_lca(mesh);
+        auto read   = [&](std::size_t l, const std::array<value_t, dim>& c) -> double
+        {
+            return u(l, interval_t{c[0], c[0] + 1})[0];
+        };
+
+        std::size_t checked = 0;
+        for (std::size_t l0 = mesh.min_level(); l0 < L; ++l0)
+        {
+            std::size_t delta_l = L - l0;
+            for_each_interval(mesh[mesh_id_t::cells][l0],
+                              [&](std::size_t, const auto& i, const auto&)
+                              {
+                                  std::array<value_t, dim> lo{i.start << delta_l};
+                                  std::array<value_t, dim> hi{i.end << delta_l};
+                                  detail::ra_box<dim, value_t> box{lo, hi};
+                                  std::vector<double> out;
+                                  try
+                                  {
+                                      reconstruct_exact_box<r>(l0, L, lo, hi, read, stored, out);
+                                  }
+                                  catch (...)
+                                  {
+                                      return;
+                                  }
+                                  for (std::size_t f = 0; f < box.count(); ++f)
+                                  {
+                                      auto g = box.coord(f);
+                                      exact_reconstruction_memo_t<dim, value_t> memo;
+                                      double scalar;
+                                      try
+                                      {
+                                          scalar = reconstruct_exact<r>(l0, delta_l, g, read, stored, memo);
+                                      }
+                                      catch (...)
+                                      {
+                                          continue;
+                                      }
+                                      EXPECT_DOUBLE_EQ(out[f], scalar) << "l0=" << l0 << " g=" << g[0];
+                                      ++checked;
+                                  }
+                              });
+        }
+        EXPECT_GT(checked, 0u);
     }
 }


### PR DESCRIPTION
## Description

On an adapted mesh, reconstructing a value across a refinement boundary (the LBM stream,
the FV finer-level fluxes, `reconstruction()`) uses a flat prediction from the donor's own
level: when the level gap is >= 2 and the prediction cone crosses the boundary, it ignores
the real detail carried by the finer leaves that are actually present, propagating a
projection error.

This PR adds an opt-in **exact reconstruction** that uses those real finer cells, behind a
global `--exact-reconstruction` option (`args::exact_reconstruction`), which is the default
for the LBM and FV schemes; a per-scheme `set_exact_reconstruction()` still overrides it.
Built on the flat stream (kept as the fast default), the exact path only corrects the
sparse band of cells whose prediction cone reaches a refinement.

- **`reconstruction.hpp`**: `make_real_backed_lca`, `reconstruct_exact` (scalar reference)
  and the vectorised dense cascade `detail::reconstruct_box` (`reconstruct_flat_box` /
  `reconstruct_exact_box` share it via an `is_stored` predicate). `reconstruction(field,
  exact)` reconstructs each leaf region with the cascade when `exact`.
- **`lbm_scheme.hpp`**: `stream_exact_reconstruction` runs the flat stream then recomputes
  the interface band with `reconstruct_exact_box`; the halo is level-dependent (reach
  scales with the prediction support at the level gap).
- **`flux_based_scheme__nonlin.hpp`**: the finer-level flux reconstructs the whole stencil
  block of an interface in one dense cascade (`reconstruct_flat_box` for flat,
  `reconstruct_exact_box` for exact) instead of one `portion()` per fine cell, and reads
  each stencil value from it (scalar fallback for safety). Both linear and non-linear flux
  functions benefit; only when `--finer-level-flux` is active. ~20% faster on a 2D WENO5
  max-level-flux case, more at larger level gaps.
- **Documentation**: a new reference page `docs/source/reference/reconstruction.md`
  ("Prediction and reconstruction") covering the three layers - the prediction stencil and
  its memoisation, `portion` in its scalar and summed-slice forms, and `reconstruction()`
  flat vs exact, with the capped cascade `A(m, i)` written out. Three figures illustrate
  the one-level stencil, the prediction cone, and the flat/exact difference at a
  refinement boundary.

On Rayleigh-Taylor the correction restores discrete mass conservation that the flat
multi-level stream violates (drift `1.9e-7` -> `4.9e-15`); the flat default is unchanged.

## How has this been tested?

- `tests/test_portion.cpp`: `portion_exact.graded_staircase_1D`,
  `portion_exact.adapted_mesh_2D`, `portion_exact.box_matches_scalar_1D`.
- `tests/test_lbm.cpp`: `lbm_d2q4` exact-reconstruction consistency.
- Demos: `demos/LBM/new_D2Q5444_euler_rayleigh_taylor.cpp` (mass-drift measurement),
  `demos/FiniteVolume/burgers_mra.cpp` (FV finer-level flux, exact active).

## Code of Conduct

By submitting this PR, I agree to follow this project's Code of Conduct.

- [x] I agree to follow this project's Code of Conduct

