### PR TITLE
fix(lbm): apply the wall reflection on the domain corners

### DIFF
--- a/include/samurai/algorithm/update_outer_ghost.hpp
+++ b/include/samurai/algorithm/update_outer_ghost.hpp
@@ -366,6 +366,11 @@ namespace samurai
                         if (!any_periodic)
                         {
                             update_outer_corners_by_polynomial_extrapolation(level, direction, field);
+                            // A boundary condition that owns the diagonal directions overwrites the
+                            // extrapolation just applied (no FV condition does; an LBM reflection with
+                            // diagonal velocities does). It runs BEFORE project_corner_below so that the
+                            // value carried down to the coarser levels is the corrected one.
+                            apply_field_bc_diagonal(level, direction, field);
                             project_corner_below(level, direction, field); // project to level-1 and level-2
                         }
                     });

--- a/include/samurai/bc/apply_field_bc.hpp
+++ b/include/samurai/bc/apply_field_bc.hpp
@@ -6,6 +6,7 @@
 #include "../boundary.hpp"
 #include "../field/concepts.hpp"
 #include "polynomial_extrapolation.hpp"
+#include <algorithm>
 
 #include <stdexcept>
 
@@ -127,14 +128,12 @@ namespace samurai
     {
         auto declared = [&](const DirectionVector<dim>& d)
         {
-            for (const auto& rd : region_directions)
-            {
-                if (rd == d)
-                {
-                    return true;
-                }
-            }
-            return false;
+            return std::any_of(region_directions.begin(),
+                               region_directions.end(),
+                               [&](const auto& rd)
+                               {
+                                   return rd == d;
+                               });
         };
 
         if (declared(direction))

--- a/include/samurai/bc/apply_field_bc.hpp
+++ b/include/samurai/bc/apply_field_bc.hpp
@@ -114,6 +114,148 @@ namespace samurai
     }
 
     /**
+     * Is the diagonal @a direction covered by a boundary region declaring @a region_directions?
+     *
+     * Either the diagonal itself is declared (the default @c Everywhere region enumerates every one
+     * of the 3^dim - 1 directions), or every Cartesian component of it is declared - so a wall put
+     * on {left, top, bottom} owns the top-left and bottom-left corners, which are corners *of that
+     * wall*, but not the bottom-right one, where the neighbouring face carries another condition.
+     * A corner between two different boundary conditions is deliberately left alone.
+     */
+    template <std::size_t dim, class Directions>
+    bool diagonal_direction_is_declared(const Directions& region_directions, const DirectionVector<dim>& direction)
+    {
+        auto declared = [&](const DirectionVector<dim>& d)
+        {
+            for (const auto& rd : region_directions)
+            {
+                if (rd == d)
+                {
+                    return true;
+                }
+            }
+            return false;
+        };
+
+        if (declared(direction))
+        {
+            return true;
+        }
+
+        for (std::size_t d = 0; d < dim; ++d)
+        {
+            if (direction[d] != 0)
+            {
+                DirectionVector<dim> component;
+                component.fill(0);
+                component[d] = direction[d];
+                if (!declared(component))
+                {
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Apply a boundary condition on the outer ghosts in a DIAGONAL (non-Cartesian) direction: the
+     * domain corners in 2D, the domain edges and vertices in 3D.
+     *
+     * Only the boundary conditions that ask for it are applied here - see
+     * @c Bc::fills_diagonal_directions(). No finite-volume condition does: an FV flux stencil never
+     * reads a diagonal ghost, so those ghosts keep being filled by
+     * @c update_outer_corners_by_polynomial_extrapolation, unchanged. A lattice-Boltzmann reflection
+     * whose velocity set contains a diagonal velocity does: such a scheme streams across the corner,
+     * so the corner ghost must carry the wall reflection and not an extrapolation of a distribution
+     * function, which is meaningless there.
+     *
+     * The stencil needs no rotation. A reflection has @c stencil_size == 2, so the diagonal stencil is
+     * just {inner, inner + direction}, exact for any direction - unlike @c convert_for_direction(),
+     * which builds the rotation taking e1 to @a direction and hence only works for a Cartesian one.
+     */
+    template <class Field, std::size_t stencil_size>
+    void apply_diagonal_bc_impl(Bc<Field>& bc, std::size_t level, const DirectionVector<Field::dim>& direction, Field& field)
+    {
+        using mesh_id_t = typename Field::mesh_t::mesh_id_t;
+
+        static constexpr std::size_t dim = Field::dim;
+
+        if constexpr (dim == 1 || stencil_size != 2)
+        {
+            // 1D has no diagonal direction, and only the 2-point stencil of a reflection is
+            // implemented: a wider diagonal stencil would need the general lattice-symmetry
+            // machinery, which this does not add.
+            return;
+        }
+        else
+        {
+            auto& mesh = field.mesh();
+
+            if (level < mesh.min_level() || level > mesh.max_level())
+            {
+                return;
+            }
+
+            for (std::size_t d = 0; d < dim; ++d)
+            {
+                if (direction[d] != 0 && mesh.is_periodic(d))
+                {
+                    return; // a periodic axis has no real boundary in that direction
+                }
+            }
+
+            if (!diagonal_direction_is_declared<dim>(bc.get_region().first, direction))
+            {
+                return;
+            }
+
+            Stencil<2, dim> stencil;
+            xt::view(stencil, 0)  = 0;
+            xt::view(stencil, 1)  = direction;
+            auto stencil_analyzer = make_stencil_analyzer(stencil);
+
+            // mesh.corner(direction) holds the inner corner cells of that diagonal, precomputed on
+            // the mesh (the corner extrapolation uses it too). Restricted to the cells that exist at
+            // this level: on an adapted mesh the corner is not covered at every level, and iterating
+            // ghosts that do not exist is an out-of-bounds access.
+            auto corner_cells = intersection(self(mesh.corner(direction)).on(level), mesh[mesh_id_t::cells][level]).on(level);
+
+            apply_bc_on_subset(bc, field, corner_cells, stencil_analyzer, direction);
+        }
+    }
+
+    /**
+     * Apply, in the diagonal @a direction, those boundary conditions of @a field that fill diagonal
+     * directions. A no-op for every finite-volume condition.
+     */
+    template <class Field>
+        requires field_like<Field>
+    void apply_field_bc_diagonal(std::size_t level, const DirectionVector<Field::dim>& direction, Field& field)
+    {
+        static constexpr std::size_t max_stencil_size_implemented_BC = Bc<Field>::max_stencil_size_implemented;
+
+        for (auto& bc : field.get_bc())
+        {
+            if (!bc->fills_diagonal_directions())
+            {
+                continue;
+            }
+
+            static_for<1, max_stencil_size_implemented_BC + 1>::apply(
+                [&](auto integral_constant_i)
+                {
+                    static constexpr std::size_t i = decltype(integral_constant_i)::value;
+
+                    if (bc->stencil_size() == i)
+                    {
+                        apply_diagonal_bc_impl<Field, i>(*bc.get(), level, direction, field);
+                    }
+                });
+        }
+    }
+
+    /**
      * Apply polynomial extrapolation on the outside ghosts close to boundary cells
      * @param bc The PolynomialExtrapolation boundary condition
      * @param level Level where to apply the polynomial extrapolation

--- a/include/samurai/bc/bc.hpp
+++ b/include/samurai/bc/bc.hpp
@@ -594,6 +594,28 @@ namespace samurai
         virtual std::unique_ptr<Bc> clone() const = 0;
         virtual int stencil_size() const          = 0;
 
+        /**
+         * Does this boundary condition also fill the outer ghosts in the DIAGONAL (non-Cartesian)
+         * directions, i.e. the domain corners (and, in 3D, the domain edges)?
+         *
+         * False for every finite-volume boundary condition: an FV flux stencil is built from
+         * @c star_stencil / @c line_stencil / @c directional_stencils and never reads a diagonal
+         * ghost, and "the Dirichlet extension along {-1,-1}" has no meaning. Those corners are
+         * filled by @c update_outer_corners_by_polynomial_extrapolation instead.
+         *
+         * True for a lattice-Boltzmann reflection whose velocity set contains a diagonal velocity
+         * (D2Q9, D2Q4diag, ...): such a scheme streams across the corner, so the corner ghost must
+         * carry the wall reflection, and a polynomial extrapolation of a distribution function is
+         * meaningless there.
+         *
+         * Only implemented for @c stencil_size() == 2, which is what a reflection needs: the
+         * diagonal stencil is then simply {inner, inner + direction} and requires no rotation.
+         */
+        virtual bool fills_diagonal_directions() const
+        {
+            return false;
+        }
+
         static constexpr int max_stencil_size_implemented = 10; // cppcheck-suppress unusedStructMember
         APPLY_AND_STENCIL_FUNCTIONS(1)
         APPLY_AND_STENCIL_FUNCTIONS(2)

--- a/include/samurai/schemes/lbm/boundary.hpp
+++ b/include/samurai/schemes/lbm/boundary.hpp
@@ -168,12 +168,48 @@ namespace samurai
         std::array<double, n_comp> m_add{};   // constant rhs (empty m_feq); all zero => homogeneous
         feq_fn m_feq{};                       // velocity-consistent rhs: inner distribution -> f^eq to reflect around
 
+        // Set when the velocity set contains a diagonal velocity (more than one non-zero
+        // component, e.g. D2Q9's {1,1} or D2Q4diag). Such a scheme streams across the domain
+        // corners, so those ghosts must carry the reflection too: see fills_diagonal_directions().
+        bool m_diagonal_velocities = false;
+
+        bool fills_diagonal_directions() const override
+        {
+            return m_diagonal_velocities;
+        }
+
+      private:
+
+        template <class Vel>
+        static bool has_diagonal_velocity(const Vel& velocities)
+        {
+            for (const auto& c : velocities)
+            {
+                std::size_t nnz = 0;
+                for (std::size_t d = 0; d < dim; ++d)
+                {
+                    if (c[d] != 0)
+                    {
+                        ++nnz;
+                    }
+                }
+                if (nnz > 1)
+                {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+      public:
+
         // Single block, homogeneous (no-slip wall for BounceBack, zero even moment for AntiBounceBack).
         template <class Vel>
         LbmReflectionImpl(const typename base_t::lca_t& domain, const BcValue<Field>& bcv, const Vel& velocities)
             : base_t(domain, bcv)
             , m_opposite(detail::lbm_opposite_velocities<n_comp, dim>(velocities))
         {
+            m_diagonal_velocities = has_diagonal_velocity(velocities);
             m_odd_axis.fill(-1);
             m_add.fill(0.);
         }
@@ -186,6 +222,7 @@ namespace samurai
             : base_t(domain, bcv)
             , m_opposite(detail::lbm_opposite_velocities<n_comp, dim>(velocities))
         {
+            m_diagonal_velocities = has_diagonal_velocity(velocities);
             m_odd_axis.fill(-1);
             set_wall(wall);
         }
@@ -202,6 +239,7 @@ namespace samurai
             , m_opposite(detail::lbm_opposite_velocities<n_comp, dim>(velocities, block_sizes))
             , m_odd_axis(detail::lbm_expand_odd_axis<n_comp>(block_sizes, block_odd_axis))
         {
+            m_diagonal_velocities = has_diagonal_velocity(velocities);
             m_add.fill(0.);
         }
 
@@ -218,6 +256,7 @@ namespace samurai
             , m_opposite(detail::lbm_opposite_velocities<n_comp, dim>(velocities, block_sizes))
             , m_odd_axis(detail::lbm_expand_odd_axis<n_comp>(block_sizes, block_odd_axis))
         {
+            m_diagonal_velocities = has_diagonal_velocity(velocities);
             set_wall(wall);
         }
 

--- a/include/samurai/schemes/lbm/boundary.hpp
+++ b/include/samurai/schemes/lbm/boundary.hpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier:  BSD-3-Clause
 #pragma once
 
+#include <algorithm>
 #include <array>
 #include <cstddef>
 #include <functional>
@@ -183,22 +184,18 @@ namespace samurai
         template <class Vel>
         static bool has_diagonal_velocity(const Vel& velocities)
         {
-            for (const auto& c : velocities)
-            {
-                std::size_t nnz = 0;
-                for (std::size_t d = 0; d < dim; ++d)
-                {
-                    if (c[d] != 0)
-                    {
-                        ++nnz;
-                    }
-                }
-                if (nnz > 1)
-                {
-                    return true;
-                }
-            }
-            return false;
+            return std::any_of(velocities.begin(),
+                               velocities.end(),
+                               [](const auto& c)
+                               {
+                                   return std::count_if(c.begin(),
+                                                        c.end(),
+                                                        [](int v)
+                                                        {
+                                                            return v != 0;
+                                                        })
+                                        > 1;
+                               });
         }
 
       public:

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -47,6 +47,7 @@ set(SAMURAI_TESTS
     test_hdf5.cpp
     test_interval.cpp
     test_lbm.cpp
+    test_lbm_corner_bc.cpp
     test_level_cell_list.cpp
     test_list_of_intervals.cpp
     test_load_balancing_weight.cpp

--- a/tests/test_lbm_corner_bc.cpp
+++ b/tests/test_lbm_corner_bc.cpp
@@ -1,0 +1,227 @@
+// Copyright 2018-2025 the samurai's authors
+// SPDX-License-Identifier:  BSD-3-Clause
+
+#include <array>
+#include <cstddef>
+
+#include <gtest/gtest.h>
+
+#include <samurai/algorithm/update.hpp>
+#include <samurai/bc.hpp>
+#include <samurai/field.hpp>
+#include <samurai/mr/mesh.hpp>
+#include <samurai/schemes/lbm.hpp>
+
+namespace samurai
+{
+    namespace
+    {
+        constexpr std::size_t dim   = 2;
+        constexpr std::size_t q9    = 9;
+        constexpr std::size_t level = 4;
+
+        // D2Q9, same order as demos/lbm/new_D2Q9_von_karman.cpp
+        auto d2q9_velocities()
+        {
+            return std::array<std::array<int, dim>, q9>{
+                {{0, 0}, {1, 0}, {0, 1}, {-1, 0}, {0, -1}, {1, 1}, {-1, 1}, {-1, -1}, {1, -1}}
+            };
+        }
+
+        // D2Q4, axial only: no diagonal velocity, so no corner is claimed
+        auto d2q4_velocities()
+        {
+            return std::array<std::array<int, dim>, 4>{
+                {{1, 0}, {0, 1}, {-1, 0}, {0, -1}}
+            };
+        }
+
+        template <class Vel>
+        auto opposite_of(const Vel& velocities)
+        {
+            std::array<std::size_t, std::tuple_size_v<Vel>> opposite{};
+            for (std::size_t a = 0; a < opposite.size(); ++a)
+            {
+                opposite[a] = a;
+                for (std::size_t b = 0; b < opposite.size(); ++b)
+                {
+                    if (velocities[b][0] == -velocities[a][0] && velocities[b][1] == -velocities[a][1])
+                    {
+                        opposite[a] = b;
+                    }
+                }
+            }
+            return opposite;
+        }
+
+        auto make_test_mesh()
+        {
+            const Box<double, dim> box({0., 0.}, {1., 1.});
+            auto config = mesh_config<dim>().min_level(level).max_level(level).periodic(false);
+            return mra::make_mesh(box, config);
+        }
+
+        // Interior filled with f(a) = a, uniform in space: the reflection then gives
+        // ghost(a) = opposite[a] and a plain copy gives ghost(a) = a, whatever the
+        // extrapolation order, so the two are trivially distinguishable.
+        template <class Field>
+        void fill_by_component(Field& f)
+        {
+            f.fill(0.);
+            for_each_cell(f.mesh(),
+                          [&](const auto& cell)
+                          {
+                              for (std::size_t a = 0; a < Field::n_comp; ++a)
+                              {
+                                  f[cell](a) = static_cast<double>(a);
+                              }
+                          });
+        }
+    }
+
+    // A D2Q9 wall streams across the domain corners, so the corner ghost must carry the
+    // reflection. Before the fix it held a polynomial extrapolation, i.e. a plain copy of the
+    // diagonal inner cell, and the stream consumed it.
+    TEST(lbm_corner_bc, d2q9_corner_ghost_holds_the_reflection)
+    {
+        auto mesh           = make_test_mesh();
+        auto velocities     = d2q9_velocities();
+        const auto opposite = opposite_of(velocities);
+
+        auto f = make_vector_field<double, q9>("f", mesh);
+        fill_by_component(f);
+        make_bc<BounceBack>(f, velocities);
+        update_ghost_mr(f);
+
+        const int n = 1 << level;
+
+        // Control: a face ghost must show the reflection (it always did)
+        for (std::size_t a = 0; a < q9; ++a)
+        {
+            EXPECT_DOUBLE_EQ(f(level, {-1, 0}, n / 2)(0, a), static_cast<double>(opposite[a])) << "face ghost, component " << a;
+        }
+
+        // The four domain corners must show the reflection too
+        const std::array<std::array<int, dim>, 4> corners{
+            {{-1, -1}, {n, -1}, {-1, n}, {n, n}}
+        };
+        for (const auto& c : corners)
+        {
+            for (std::size_t a = 0; a < q9; ++a)
+            {
+                EXPECT_DOUBLE_EQ(f(level, {c[0], c[0] + 1}, c[1])(0, a), static_cast<double>(opposite[a]))
+                    << "corner ghost (" << c[0] << "," << c[1] << "), component " << a;
+            }
+        }
+    }
+
+    // The corner value is consumed by the stream, so getting it wrong reaches the solution.
+    //
+    // The assertion has to be on the concrete expected value, not on "cell (0,0) equals the corner
+    // ghost": the buggy corner fill is a plain COPY of the diagonal inner cell, so that comparison
+    // holds whatever the ghost contains and discriminates nothing (verified - it passes with the fix
+    // disabled). With the reflection in place the ghost holds opposite[a], so after a pure stream
+    // cell (0,0) must hold opposite[5] = 7, where the buggy fill would deliver 5.
+    TEST(lbm_corner_bc, d2q9_corner_ghost_is_read_by_the_stream)
+    {
+        auto mesh                       = make_test_mesh();
+        auto velocities                 = d2q9_velocities();
+        const auto opposite             = opposite_of(velocities);
+        constexpr std::size_t diag_comp = 5; // velocity {1,1}: cell (0,0) reads ghost (-1,-1)
+
+        auto f = make_vector_field<double, q9>("f", mesh);
+        auto m = make_vector_field<double, q9>("m", mesh);
+        fill_by_component(f);
+        m.fill(0.);
+        make_bc<BounceBack>(f, velocities);
+
+        // M = invM = I and every relaxation rate zero, so the MRT collision is the identity and one
+        // step is a pure stream. operator() updates the ghosts itself first, which is what we want:
+        // the corner value under test must be the one the boundary condition produces.
+        std::array<std::array<double, q9>, q9> M{};
+        std::array<std::array<double, q9>, q9> invM{};
+        for (std::size_t a = 0; a < q9; ++a)
+        {
+            M[a][a]    = 1.;
+            invM[a][a] = 1.;
+        }
+        std::array<double, q9> s{};
+        s.fill(0.);
+        auto eq = [](std::array<double, q9>& meq, std::span<const double> mm)
+        {
+            for (std::size_t a = 0; a < q9; ++a)
+            {
+                meq[a] = mm[a];
+            }
+        };
+
+        using field_t = decltype(f);
+        auto scheme   = make_lbm_scheme<field_t>("d2q9_identity_collision", 1., velocity_scheme<dim, q9>(velocities, M, invM, s, eq));
+
+        update_ghost_mr(f);
+        // Guard against the whole test becoming vacuous: the reflection and the copy must differ
+        // for this component, otherwise the assertion below cannot discriminate.
+        ASSERT_NE(opposite[diag_comp], diag_comp);
+        EXPECT_DOUBLE_EQ(f(level, {-1, 0}, -1)(0, diag_comp), static_cast<double>(opposite[diag_comp]));
+
+        scheme(f, m);
+
+        // After a pure stream, cell (0,0) must hold the corner ghost's value: the reflection
+        // (opposite[5] = 7), where the buggy corner fill would deliver a copy (5).
+        EXPECT_DOUBLE_EQ(f(level, {0, 1}, 0)(0, diag_comp), static_cast<double>(opposite[diag_comp]));
+    }
+
+    // A scheme with no diagonal velocity must not claim the corners: those ghosts keep the
+    // polynomial extrapolation, i.e. a copy of the diagonal inner cell (ghost(a) == a here).
+    TEST(lbm_corner_bc, axial_scheme_leaves_the_corner_to_the_extrapolation)
+    {
+        auto mesh       = make_test_mesh();
+        auto velocities = d2q4_velocities();
+
+        auto f = make_vector_field<double, 4>("f", mesh);
+        fill_by_component(f);
+        make_bc<BounceBack>(f, velocities);
+        update_ghost_mr(f);
+
+        for (std::size_t a = 0; a < 4; ++a)
+        {
+            EXPECT_DOUBLE_EQ(f(level, {-1, 0}, -1)(0, a), static_cast<double>(a)) << "corner ghost, component " << a;
+        }
+    }
+
+    // A corner between two DIFFERENT boundary conditions is deliberately left alone: neither wall
+    // declares both of its Cartesian components, so the extrapolation keeps it.
+    TEST(lbm_corner_bc, corner_between_two_different_bcs_is_left_to_the_extrapolation)
+    {
+        auto mesh           = make_test_mesh();
+        auto velocities     = d2q9_velocities();
+        const auto opposite = opposite_of(velocities);
+
+        auto f = make_vector_field<double, q9>("f", mesh);
+        fill_by_component(f);
+
+        const DirectionVector<dim> left{-1, 0};
+        const DirectionVector<dim> right{1, 0};
+        const DirectionVector<dim> top{0, 1};
+        const DirectionVector<dim> bottom{0, -1};
+        make_bc<BounceBack>(f, velocities)->on(left, top, bottom);
+        make_bc<Neumann<1>>(f)->on(right);
+
+        update_ghost_mr(f);
+
+        const int n = 1 << level;
+
+        // top-left and bottom-left: both components belong to the BounceBack wall -> reflection
+        for (std::size_t a = 0; a < q9; ++a)
+        {
+            EXPECT_DOUBLE_EQ(f(level, {-1, 0}, -1)(0, a), static_cast<double>(opposite[a])) << "bottom-left, component " << a;
+            EXPECT_DOUBLE_EQ(f(level, {-1, 0}, n)(0, a), static_cast<double>(opposite[a])) << "top-left, component " << a;
+        }
+
+        // bottom-right: 'right' carries a different condition -> extrapolation (a plain copy)
+        for (std::size_t a = 0; a < q9; ++a)
+        {
+            EXPECT_DOUBLE_EQ(f(level, {n, n + 1}, -1)(0, a), static_cast<double>(a)) << "bottom-right, component " << a;
+        }
+    }
+}


### PR DESCRIPTION
## Description

For a lattice-Boltzmann scheme with **diagonal** lattice velocities (D2Q9, D2Q4diag), the domain-corner outer ghost held a polynomial extrapolation of the distribution function - in practice a plain copy of the diagonal inner cell - instead of the wall reflection, and the stream consumed it.

The region of a boundary condition already declared the diagonal directions and built their corner cell arrays: `Everywhere::get_region` enumerates all `3^dim - 1` directions and computes a corner LCA for each one with more than one non-zero component. But `apply_bc_impl` discarded them, because `is_cartesian(direction)` keeps only the directions with a single non-zero component. The region and the apply path therefore disagreed about where the condition acts, and nothing ever overwrote the corner extrapolation. Extrapolating a distribution function has no physical meaning for a bounce-back wall.

In 3D the same code path fills the 12 **edge** ghost lines as well as the 8 vertices, so the affected set is `O(N)` cells there, not `O(1)`.

### The fix is opt-in, so finite volume is unaffected

* `Bc::fills_diagonal_directions()` returns `false` by default. An FV flux stencil is built from `star_stencil` / `line_stencil` / `directional_stencils` and never reads a diagonal ghost, and "the Dirichlet extension along `{-1,-1}`" has no meaning, so those corners keep their polynomial extrapolation unchanged.
* `LbmReflectionImpl` overrides it, **derived from the velocity set** rather than declared by hand: true iff some velocity has more than one non-zero component. D2Q9 and D2Q4diag opt in; D2Q4 and D1Q\* do not.
* The diagonal stencil needs **no rotation**. A reflection has `stencil_size == 2`, so it is simply `{inner, inner + direction}`, exact for any direction - unlike `convert_for_direction()`, which builds the rotation taking `e1` to the direction and is not an integer lattice transformation for a diagonal. That is the reason the `is_cartesian` guard existed in the first place. Wider diagonal stencils are not implemented and return early.
* It runs between `update_outer_corners_by_polynomial_extrapolation` and `project_corner_below`, so the corrected value is the one carried down to the coarser levels.
* `mesh.corner(direction)` is precomputed on the mesh, so no cell array is built per call.

### Which corners a condition owns

`OnDirection::get_region` only declares the directions the user passed, so `->on(left, top, bottom)` declares no diagonal at all. A diagonal therefore counts as declared when **either** the diagonal itself is declared (the default `Everywhere` region) **or every Cartesian component of it is**. A wall on `{left, top, bottom}` thus owns the top-left and bottom-left corners - corners *of that wall* - but not the bottom-right one, where the neighbouring face carries another condition.

**A corner between two different boundary conditions is deliberately left to the extrapolation.** What it should be is a genuine open question rather than something to pick silently.

### Not covered by this PR

`ImposedDistribution` carries no velocity set, so its opt-in cannot be derived the same way; someone has to decide whether imposing a distribution owns the corner. Its corner ghost still holds the extrapolation, which affects the `new_D2Q9_von_karman` demo (the other diagonal-velocity demos are periodic, hence unaffected). Likewise, `LbmReflectionImpl::get_apply_function` derives `wall_axis` from the last non-zero component of the direction, which is arbitrary for a diagonal; it is unused for a single-block homogeneous reflection, but a multi-block **slip** wall would read it.

## Related issue

None - found while auditing the boundary-condition machinery.

## How has this been tested?

New file `tests/test_lbm_corner_bc.cpp`, 4 cases. The full suite is green: **408/408** (`build-tests/tests/test_samurai_lib`).

Each test was checked against a **negative control** - the override forced to `false`, rebuilt and rerun - because a test that passes either way proves nothing:

| test | without the fix |
| --- | --- |
| `d2q9_corner_ghost_holds_the_reflection` (with a face ghost as control) | fails |
| `d2q9_corner_ghost_is_read_by_the_stream` | fails |
| `corner_between_two_different_bcs_is_left_to_the_extrapolation` | fails |
| `axial_scheme_leaves_the_corner_to_the_extrapolation` | passes (no-change guard, as intended) |

The tests fill the interior with `f(a) = a`, uniform in space and varying in component, so the reflection gives `ghost(a) = opposite[a]` and a plain copy gives `ghost(a) = a` whatever the extrapolation order.

The stream test asserts the concrete expected value, not "cell `(0,0)` equals the corner ghost": the buggy fill is a copy of that very cell, so such a comparison holds whatever the ghost contains and discriminates nothing. It uses `M = invM = I` with every relaxation rate zero, which makes the MRT collision the identity so one step is a pure stream, and an `ASSERT_NE` guards against the comparison degenerating again.

## Code of Conduct

- [x] I agree to follow this project's Code of Conduct
