### PR TITLE
refactor(mr): remove dead code around detail computation and refine_ghost

### DIFF
--- a/include/samurai/mr/adapt.hpp
+++ b/include/samurai/mr/adapt.hpp
@@ -295,16 +295,9 @@ namespace samurai
         // Detail computation //
         //--------------------//
 
-        // We compute the detail in the cells and ghosts below the cells, except near the (non-periodic) boundaries, where we compute
-        // the detail only in the cells (justification in the comments below).
-
-        bool periodic_in_all_directions = true;
-        std::array<bool, dim> contract_directions;
-        for (std::size_t d = 0; d < dim; ++d)
-        {
-            periodic_in_all_directions = periodic_in_all_directions && mesh.is_periodic(d);
-            contract_directions[d]     = !mesh.is_periodic(d);
-        }
+        // The detail is computed at every position of all_cells[level] lying below a leaf cell (at
+        // level+1 or level+2). The set is not contracted near non-periodic boundaries: there, the
+        // prediction stencil reads the outer ghosts filled by the boundary conditions.
 
         times::timers.start("detail computation");
         for (std::size_t level = ((min_level > 0) ? min_level - 1 : 0); level < max_level - ite; ++level)

--- a/include/samurai/mr/operators.hpp
+++ b/include/samurai/mr/operators.hpp
@@ -849,60 +849,6 @@ namespace samurai
         return make_field_operator_function<to_coarsen_op>(std::forward<CT>(e)...);
     }
 
-    /*************************
-     * refine_ghost operator *
-     *************************/
-
-    template <std::size_t dim, class TInterval>
-    class refine_ghost_op : public field_operator_base<dim, TInterval>
-    {
-      public:
-
-        INIT_OPERATOR(refine_ghost_op)
-
-        template <class T>
-        SAMURAI_INLINE void operator()(Dim<1>, T& flag) const
-        {
-            auto mask = flag(level + 1, i) & static_cast<std::uint8_t>(CellFlag::keep);
-            apply_on_masked(flag(level, i / 2),
-                            mask,
-                            [](auto& e)
-                            {
-                                e = static_cast<std::uint8_t>(CellFlag::refine);
-                            });
-        }
-
-        template <class T>
-        SAMURAI_INLINE void operator()(Dim<2>, T& flag) const
-        {
-            auto mask = flag(level + 1, i, j) & static_cast<std::uint8_t>(CellFlag::keep);
-            apply_on_masked(flag(level, i / 2, j / 2),
-                            mask,
-                            [](auto& e)
-                            {
-                                e = static_cast<std::uint8_t>(CellFlag::refine);
-                            });
-        }
-
-        template <class T>
-        SAMURAI_INLINE void operator()(Dim<3>, T& flag) const
-        {
-            auto mask = flag(level + 1, i, j, k) & static_cast<std::uint8_t>(CellFlag::keep);
-            apply_on_masked(flag(level, i / 2, j / 2, k / 2),
-                            mask,
-                            [](auto& e)
-                            {
-                                e = static_cast<std::uint8_t>(CellFlag::refine);
-                            });
-        }
-    };
-
-    template <class... CT>
-    SAMURAI_INLINE auto refine_ghost(CT&&... e)
-    {
-        return make_field_operator_function<refine_ghost_op>(std::forward<CT>(e)...);
-    }
-
     /********************
      * enlarge operator *
      ********************/


### PR DESCRIPTION
## Description

Two inert items, removed independently of any behaviour change. Both were found while
charting a rewrite of the boundary machinery, and neither is worth carrying into it.

**`refine_ghost_op` and its `refine_ghost` factory** (`mr/operators.hpp`) have no call site
anywhere in the tree: `include/`, `demos/`, `tests/` and `benchmark/` only ever reference the
definition itself. They also carried a latent bug, dividing signed cell indices with `/`
rather than `>>` (`i / 2` truncates toward zero, so an index of `-1` maps to `0` instead of
`-1`) - inconsequential while the operator is never instantiated, but not worth keeping.

**`periodic_in_all_directions` and `contract_directions`** in `Adapt::operator()` were
computed and never read. The comment above them described a contraction of the detail set
near non-periodic boundaries that no longer happens, and referred to a justification "in the
comments below" that no longer exists - `ghosts_below_cells` is not contracted. It is
replaced by a comment describing what the code actually does, which matters because that
comment is actively misleading about where details are computed near boundaries.

## Code of Conduct

- [x] I agree to follow this project's Code of Conduct