### PR TITLE
test(bc): assert boundary reproduction order in the cell-average convention

### DIFF
--- a/tests/test_bc_ghost_values.cpp
+++ b/tests/test_bc_ghost_values.cpp
@@ -12,6 +12,24 @@
 //   domain corner, the off-diagonal ghosts copy the diagonal value.
 // - Far ghost layers (ghost_width > 1): filled by polynomial extrapolation.
 // - SetRegion: a B.C. restricted to a user subset via ->on(subset).
+//
+// TWO CONVENTIONS, and the distinction is load-bearing. bc/ is written in the
+// point-value convention: bc/dirichlet.hpp fits a polynomial through the cell
+// values placed at cell *centres* ("If we set the abscissa 0 at the center of
+// cells[0], this system reads p(0) = u[cells[0]] ..."). A finite-volume field
+// stores cell *averages*. The two disagree, and the disagreement is not
+// cosmetic: for a relation carrying a boundary datum, the reproduction order in
+// the cell-average sense is capped at m + 1, where m is the differential order
+// of the datum (0 for a Dirichlet value, 1 for a Neumann derivative). So every
+// Dirichlet<k> reproduces only degree 1 on cell averages, whatever k is.
+//
+// Both conventions are therefore asserted here, via @ref Sampling:
+//   - point:   exactness up to degree `order`, which is what the construction
+//              intends and what pins the coefficients (full coverage of them).
+//   - average: exactness up to the cap, and NON-exactness one degree above,
+//              which pins the real order from both sides.
+// A test written only in the point-value convention passes by making the same
+// convention error as the code, and cannot see the cap at all.
 
 #include <cmath>
 #include <map>
@@ -24,6 +42,7 @@
 #include <samurai/field.hpp>
 #include <samurai/mr/adapt.hpp>
 #include <samurai/mr/mesh.hpp>
+#include <samurai/numeric/gauss_legendre.hpp>
 #include <samurai/samurai.hpp>
 #include <samurai/subset/node.hpp>
 
@@ -31,6 +50,36 @@ namespace samurai
 {
     namespace
     {
+        // How a field value is taken from the analytical function f: a point sample at
+        // the cell centre (the convention bc/ is written in) or the exact average of f
+        // over the cell (what a finite-volume field stores). See the file header.
+        enum class Sampling
+        {
+            point,
+            average
+        };
+
+        inline const char* name_of(Sampling s)
+        {
+            return s == Sampling::point ? "point" : "average";
+        }
+
+        // Exact average of f over the cell. Degree 10 is well above every polynomial
+        // used in this file, so the quadrature is exact and introduces no error of its
+        // own; the division by |cell| turns the integral into the average.
+        template <std::size_t dim, class TInterval, class F>
+        double cell_average(const Cell<dim, TInterval>& cell, F&& f)
+        {
+            static GaussLegendre<10> gl;
+            return gl.template quadrature<1>(cell, f) / std::pow(cell.length, static_cast<double>(dim));
+        }
+
+        template <std::size_t dim, class TInterval, class F>
+        double sample(Sampling s, const Cell<dim, TInterval>& cell, F&& f)
+        {
+            return s == Sampling::point ? f(cell.center()) : cell_average(cell, f);
+        }
+
         // Non-zero axis and its sign for a Cartesian direction.
         template <std::size_t dim>
         std::pair<std::size_t, int> axis_and_sign(const DirectionVector<dim>& direction)
@@ -94,17 +143,27 @@ namespace samurai
             return n;
         }
 
-        // Iterate over the `h` filled ghost layers on the +/-direction side, at
-        // every level, and check that each ghost holds f(ghost center). Works on
-        // both uniform and adapted meshes (domain_boundary gives the boundary
-        // cells per level). Returns the number of ghosts checked.
+        // Result of sweeping the filled ghosts: how many were seen, and the largest
+        // deviation from the oracle. Returned rather than asserted, so a caller can
+        // demand exactness (error ~ 0) or demand NON-exactness (error above a floor),
+        // which is what pins a reproduction order from both sides.
+        struct GhostSweep
+        {
+            std::size_t nb    = 0;
+            double max_err    = 0.;
+            double worst_at_h = 0.;
+        };
+
+        // Sweep the `h` filled ghost layers on the +/-direction side, at every level,
+        // comparing each ghost to `f` taken in the requested convention. Works on both
+        // uniform and adapted meshes (domain_boundary gives the boundary cells per level).
         template <class Field, class F>
-        std::size_t check_ghosts(Field& u, const DirectionVector<Field::dim>& direction, int h, F&& f)
+        GhostSweep sweep_ghosts(Field& u, const DirectionVector<Field::dim>& direction, int h, Sampling sampling, F&& f)
         {
             using mesh_id_t = typename Field::mesh_t::mesh_id_t;
             auto& mesh      = u.mesh();
 
-            std::size_t nb = 0;
+            GhostSweep out;
             for (std::size_t level = mesh.min_level(); level <= mesh.max_level(); ++level)
             {
                 auto inner  = domain_boundary(mesh, level, direction);
@@ -116,13 +175,27 @@ namespace samurai
                                   ghosts,
                                   [&](auto& cell)
                                   {
-                                      ++nb;
-                                      EXPECT_NEAR(u[cell], f(cell.center()), 1e-11)
-                                          << "dim=" << Field::dim << " direction=" << direction << " level=" << level << " layer=" << k;
+                                      ++out.nb;
+                                      const double e = std::abs(u[cell] - sample(sampling, cell, f));
+                                      if (e > out.max_err)
+                                      {
+                                          out.max_err    = e;
+                                          out.worst_at_h = cell.length;
+                                      }
                                   });
                 }
             }
-            return nb;
+            return out;
+        }
+
+        // Point-value convention with exactness demanded, i.e. the original behaviour of
+        // this helper. Kept so the existing tests read unchanged.
+        template <class Field, class F>
+        std::size_t check_ghosts(Field& u, const DirectionVector<Field::dim>& direction, int h, F&& f)
+        {
+            auto s = sweep_ghosts(u, direction, h, Sampling::point, f);
+            EXPECT_NEAR(s.max_err, 0., 1e-11) << "dim=" << Field::dim << " direction=" << direction;
+            return s.nb;
         }
 
         // Dirichlet of the given order. `functional` selects the FunctionBc path
@@ -258,6 +331,128 @@ namespace samurai
 
                     EXPECT_GT(check_ghosts(u, direction, h, f), 0u);
                 });
+        }
+
+        // ------------------------------------------------------------------------
+        // Reproduction order, probed from both sides and in both conventions.
+        // ------------------------------------------------------------------------
+
+        // Coefficients of the probe polynomial. Arbitrary but fixed and all nonzero, so
+        // that no term is accidentally annihilated by a symmetry of the relation - a
+        // polynomial that happens to be (anti)symmetric about the boundary would make
+        // the probe vacuous.
+        inline constexpr double probe_coeff[6] = {1., 3., -2., 0.7, -0.4, 0.25};
+
+        // Polynomial of degree `deg` in the normal coordinate alone, so its restriction
+        // to a boundary face is constant and the Dirichlet/Neumann datum is a scalar.
+        template <class Coords>
+        double normal_polynomial(const Coords& coords, std::size_t normal_axis, std::size_t deg)
+        {
+            const double x = coords[normal_axis];
+            double p       = 0.;
+            double xk      = 1.;
+            for (std::size_t k = 0; k <= deg; ++k, xk *= x)
+            {
+                p += probe_coeff[k] * xk;
+            }
+            return p;
+        }
+
+        template <class Coords>
+        double normal_polynomial_derivative(const Coords& coords, std::size_t normal_axis, std::size_t deg)
+        {
+            const double x = coords[normal_axis];
+            double p       = 0.;
+            double xk      = 1.;
+            for (std::size_t k = 1; k <= deg; ++k, xk *= x)
+            {
+                p += probe_coeff[k] * static_cast<double>(k) * xk;
+            }
+            return p;
+        }
+
+        // Fill the field with the degree-`deg` probe in the given convention, apply a
+        // Dirichlet<order>, and sweep every filled ghost in that same convention. The
+        // boundary datum stays a POINT value of f at the face in both conventions,
+        // because that is what the BC consumes - and that asymmetry is precisely what
+        // caps the cell-average order.
+        template <std::size_t dim, std::size_t order, class Mesh>
+        GhostSweep dirichlet_sweep(Mesh& mesh, Sampling sampling, std::size_t deg)
+        {
+            GhostSweep worst;
+            for_each_cartesian_direction<dim>(
+                [&](const auto& direction)
+                {
+                    auto [normal_axis, s] = axis_and_sign<dim>(direction);
+
+                    auto f = [normal_axis, deg](const auto& coords)
+                    {
+                        return normal_polynomial(coords, normal_axis, deg);
+                    };
+
+                    auto u = make_scalar_field<double>("u", mesh);
+                    for_each_cell(mesh,
+                                  [&](auto& cell)
+                                  {
+                                      u[cell] = sample(sampling, cell, f);
+                                  });
+
+                    xt::xtensor_fixed<double, xt::xshape<dim>> face;
+                    face.fill(0.);
+                    face[normal_axis] = (s > 0) ? 1. : 0.;
+                    make_bc<Dirichlet<order>>(u, f(face));
+                    apply_field_bc(u, DirectionVector<dim>(direction));
+
+                    auto sw = sweep_ghosts(u, direction, static_cast<int>(order), sampling, f);
+                    worst.nb += sw.nb;
+                    if (sw.max_err > worst.max_err)
+                    {
+                        worst.max_err    = sw.max_err;
+                        worst.worst_at_h = sw.worst_at_h;
+                    }
+                });
+            return worst;
+        }
+
+        // Same, for Neumann<1>. Its datum is the outward normal derivative at the face,
+        // again a point quantity.
+        template <std::size_t dim, class Mesh>
+        GhostSweep neumann_sweep(Mesh& mesh, Sampling sampling, std::size_t deg)
+        {
+            GhostSweep worst;
+            for_each_cartesian_direction<dim>(
+                [&](const auto& direction)
+                {
+                    auto [normal_axis, s] = axis_and_sign<dim>(direction);
+
+                    auto f = [normal_axis, deg](const auto& coords)
+                    {
+                        return normal_polynomial(coords, normal_axis, deg);
+                    };
+
+                    auto u = make_scalar_field<double>("u", mesh);
+                    for_each_cell(mesh,
+                                  [&](auto& cell)
+                                  {
+                                      u[cell] = sample(sampling, cell, f);
+                                  });
+
+                    xt::xtensor_fixed<double, xt::xshape<dim>> face;
+                    face.fill(0.);
+                    face[normal_axis] = (s > 0) ? 1. : 0.;
+                    // outward normal derivative: d/dx along the outward normal
+                    make_bc<Neumann<1>>(u, static_cast<double>(s) * normal_polynomial_derivative(face, normal_axis, deg));
+                    apply_field_bc(u, DirectionVector<dim>(direction));
+
+                    auto sw = sweep_ghosts(u, direction, 1, sampling, f);
+                    worst.nb += sw.nb;
+                    if (sw.max_err > worst.max_err)
+                    {
+                        worst.max_err    = sw.max_err;
+                        worst.worst_at_h = sw.worst_at_h;
+                    }
+                });
+            return worst;
         }
 
         // Number of axes along which the point lies outside the unit box.
@@ -665,6 +860,109 @@ namespace samurai
     {
         auto mesh = uniform_mesh<3>(4, 1);
         run_neumann<3>(mesh, true);
+    }
+
+    //-------------------------------------------------------------------------
+    // Reproduction order in both conventions, pinned from both sides.
+    //
+    // Exactness alone does not pin an order: it must also FAIL one degree above,
+    // otherwise a relation of higher order than claimed passes silently. Each test
+    // below asserts both.
+    //
+    // The point-value column is what bc/ is written for and what pins the
+    // coefficients. The cell-average column is what a finite-volume field gets, and
+    // it is capped at m + 1 with m the differential order of the boundary datum:
+    //   Dirichlet (m = 0) -> 1, for EVERY order;
+    //   Neumann   (m = 1) -> 2, one higher than the class name suggests.
+    //-------------------------------------------------------------------------
+
+    namespace
+    {
+        // A residual is "not exact" only if it is far above roundoff. The probe values
+        // are O(1), so 1e-6 is a wide margin either way.
+        constexpr double exact_tol     = 1e-11;
+        constexpr double not_exact_tol = 1e-6;
+
+        template <std::size_t dim, std::size_t order>
+        void check_dirichlet_orders(std::size_t expected_point, std::size_t expected_average)
+        {
+            auto mesh = uniform_mesh<dim>(4, static_cast<int>(order));
+
+            for (auto sampling : {Sampling::point, Sampling::average})
+            {
+                const std::size_t expected = (sampling == Sampling::point) ? expected_point : expected_average;
+
+                auto at_order = dirichlet_sweep<dim, order>(mesh, sampling, expected);
+                EXPECT_GT(at_order.nb, 0u);
+                EXPECT_NEAR(at_order.max_err, 0., exact_tol) << "Dirichlet<" << order << "> dim=" << dim << " " << name_of(sampling)
+                                                             << ": expected exactness on degree " << expected;
+
+                auto above = dirichlet_sweep<dim, order>(mesh, sampling, expected + 1);
+                EXPECT_GT(above.max_err, not_exact_tol)
+                    << "Dirichlet<" << order << "> dim=" << dim << " " << name_of(sampling) << ": degree " << (expected + 1)
+                    << " must NOT be reproduced, else the order is higher than claimed";
+            }
+        }
+
+        template <std::size_t dim>
+        void check_neumann_orders(std::size_t expected_point, std::size_t expected_average)
+        {
+            auto mesh = uniform_mesh<dim>(4, 1);
+
+            for (auto sampling : {Sampling::point, Sampling::average})
+            {
+                const std::size_t expected = (sampling == Sampling::point) ? expected_point : expected_average;
+
+                auto at_order = neumann_sweep<dim>(mesh, sampling, expected);
+                EXPECT_GT(at_order.nb, 0u);
+                EXPECT_NEAR(at_order.max_err, 0., exact_tol)
+                    << "Neumann<1> dim=" << dim << " " << name_of(sampling) << ": expected exactness on degree " << expected;
+
+                auto above = neumann_sweep<dim>(mesh, sampling, expected + 1);
+                EXPECT_GT(above.max_err, not_exact_tol)
+                    << "Neumann<1> dim=" << dim << " " << name_of(sampling) << ": degree " << (expected + 1) << " must NOT be reproduced";
+            }
+        }
+    }
+
+    TEST(bc_ghost_values, order_dirichlet1_1d)
+    {
+        check_dirichlet_orders<1, 1>(/*point=*/1, /*average=*/1);
+    }
+
+    TEST(bc_ghost_values, order_dirichlet2_1d)
+    {
+        check_dirichlet_orders<1, 2>(/*point=*/2, /*average=*/1);
+    }
+
+    TEST(bc_ghost_values, order_dirichlet3_1d)
+    {
+        check_dirichlet_orders<1, 3>(/*point=*/3, /*average=*/1);
+    }
+
+    TEST(bc_ghost_values, order_dirichlet4_1d)
+    {
+        check_dirichlet_orders<1, 4>(/*point=*/4, /*average=*/1);
+    }
+
+    TEST(bc_ghost_values, order_dirichlet2_2d)
+    {
+        check_dirichlet_orders<2, 2>(/*point=*/2, /*average=*/1);
+    }
+
+    TEST(bc_ghost_values, order_dirichlet2_3d)
+    {
+        check_dirichlet_orders<3, 2>(/*point=*/2, /*average=*/1);
+    }
+
+    TEST(bc_ghost_values, order_neumann_1d)
+    {
+        check_neumann_orders<1>(/*point=*/2, /*average=*/2);
+    }
+
+    TEST(bc_ghost_values, order_neumann_2d)
+    {
+        check_neumann_orders<2>(/*point=*/2, /*average=*/2);
     }
 
     //-------------------------------------------------------------------------

--- a/tests/test_fv_operators.cpp
+++ b/tests/test_fv_operators.cpp
@@ -911,10 +911,16 @@ namespace samurai
     //
     //  2. With a solution EVEN about the faces (prod cos(2 pi x)), the boundary
     //     truncation error does not converge: O(1), flat from level 4 to 7. That is
-    //     not a bug. The ghost value is correct only to O(h^2) - Dirichlet reproduces
-    //     degree 1 in the cell-average sense, whatever order is requested - and the
-    //     operator divides by h^2, so the local truncation error at a boundary cell
-    //     is O(1) for any closure one order below the interior.
+    //     not a bug. This test samples u at cell centres, and Dirichlet<1> reproduces
+    //     only degree 1 on point values, so the ghost carries an O(h^2) error
+    //     (2(1 - cos(pi h)) ~ pi^2 h^2, hence the plateau at pi^2 in 1D and 2 pi^2
+    //     at the 2D corners, where both directions contribute); the operator divides
+    //     by h^2, so the local truncation error at a boundary cell is O(1) for any
+    //     closure one order below the interior. With point sampling, a higher-order
+    //     Dirichlet would converge here; on the cell AVERAGES a finite-volume field
+    //     actually stores, the cap asserted in test_bc_ghost_values.cpp keeps the
+    //     ghost error at O(h^2) - and this plateau in place - for EVERY Dirichlet
+    //     order.
     //
     // Consequence for the acceptance bar: the max-norm operator truncation error is
     // the WRONG functional to extend to the boundary. A mesh-independent boundary
@@ -944,8 +950,10 @@ namespace samurai
         }
 
         // Max truncation error of -Laplacian over boundary-touching cells only, for a
-        // manufactured solution that is even about every face (so the Dirichlet odd
-        // reflection is maximally wrong rather than accidentally exact).
+        // manufactured solution that is even about every face. The ghost relation
+        // u_ghost = 2g - u_0 reproduces the odd part of u - g about the face exactly
+        // and errs by twice its even part at the first cell centre; an even solution
+        // makes that error leading-order instead of accidentally zero.
         template <std::size_t dim>
         double boundary_diffusion_error(std::size_t level)
         {
@@ -1026,11 +1034,14 @@ namespace samurai
     }
 
     // The same measurement with the antisymmetric solution of the convergence tests
-    // above, kept as an executable warning: the boundary appears to be order 3 there,
-    // purely because Dirichlet<1> is an odd reflection and prod sin is antisymmetric
-    // about every face. This is what a naively lifted interior restriction would
-    // report. If this test ever fails, the odd-reflection coincidence has gone, and
-    // the trap it documents is no longer a trap.
+    // above, kept as an executable warning: the boundary appears to be order 3 there.
+    // Antisymmetry pays twice: Dirichlet<1> is an odd reflection, so the ghost is
+    // EXACT and the boundary cell is left with the plain interior truncation
+    // -(h^2/12) u'''' + O(h^4); and u'''' ~ sin(2 pi x) vanishes at the faces, so
+    // that term is O(h) on a boundary cell - h^2 * h = order 3. This is what a
+    // naively lifted interior restriction would report. If this test ever fails, the
+    // odd-reflection coincidence has gone, and the trap it documents is no longer a
+    // trap.
     namespace
     {
         template <std::size_t dim>

--- a/tests/test_fv_operators.cpp
+++ b/tests/test_fv_operators.cpp
@@ -895,6 +895,199 @@ namespace samurai
         check_diffusion_convergence<2>();
     }
 
+    // ---------------------------------------------------------------------------
+    // Boundary truncation error: the baseline, and a guard against a vacuous test.
+    //
+    // The convergence tests above deliberately exclude boundary cells, so they say
+    // nothing about the boundary closure. Extending them to the boundary does NOT
+    // work by dropping the exclusion, for two reasons, both measured here:
+    //
+    //  1. Their manufactured solution, prod sin(2 pi x), is zero and ANTISYMMETRIC
+    //     about every face - and Dirichlet<1> (u_ghost = 2g - u_0) is exactly an odd
+    //     reflection, hence exact on it. Including boundary cells then reports order
+    //     3 at the boundary, BETTER than the interior's 2, and proves nothing at all.
+    //     A vacuous test that looks like a triumph. Do not "fix" the test below by
+    //     switching it back to sines.
+    //
+    //  2. With a solution EVEN about the faces (prod cos(2 pi x)), the boundary
+    //     truncation error does not converge: O(1), flat from level 4 to 7. That is
+    //     not a bug. The ghost value is correct only to O(h^2) - Dirichlet reproduces
+    //     degree 1 in the cell-average sense, whatever order is requested - and the
+    //     operator divides by h^2, so the local truncation error at a boundary cell
+    //     is O(1) for any closure one order below the interior.
+    //
+    // Consequence for the acceptance bar: the max-norm operator truncation error is
+    // the WRONG functional to extend to the boundary. A mesh-independent boundary
+    // convergence statement needs a SOLUTION error (solve, then measure
+    // ||u_h - u||), where an O(1) truncation confined to O(N^(d-1)) cells still
+    // leaves the solution convergent. That needs an elliptic solve and is not
+    // covered here.
+    //
+    // What is asserted below is today's baseline. When the boundary closure improves,
+    // this test must be updated, and that update is the evidence of the improvement.
+    // ---------------------------------------------------------------------------
+    namespace
+    {
+        template <class Cell>
+        bool touches_boundary(const Cell& cell, std::size_t nb_cells_per_dir)
+        {
+            const auto nx = static_cast<long long>(nb_cells_per_dir);
+            for (std::size_t d = 0; d < Cell::dim; ++d)
+            {
+                const auto i = static_cast<long long>(cell.indices[d]);
+                if (i == 0 || i == nx - 1)
+                {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        // Max truncation error of -Laplacian over boundary-touching cells only, for a
+        // manufactured solution that is even about every face (so the Dirichlet odd
+        // reflection is maximally wrong rather than accidentally exact).
+        template <std::size_t dim>
+        double boundary_diffusion_error(std::size_t level)
+        {
+            const std::size_t nx = 1u << level;
+            auto mesh            = uniform_mesh<dim>(level);
+            auto u               = make_scalar_field<double>("u", mesh);
+
+            constexpr double k = 2 * M_PI;
+            auto exact         = [&](const auto& x)
+            {
+                double v = 1.;
+                for (std::size_t d = 0; d < dim; ++d)
+                {
+                    v *= std::cos(k * x(d));
+                }
+                return v;
+            };
+            for_each_cell(mesh,
+                          [&](const auto& cell)
+                          {
+                              u[cell] = exact(cell.center());
+                          });
+
+            // cos is nonzero on the faces and varies along them, so the Dirichlet datum
+            // is a function of position, not a constant.
+            using cell_t   = typename decltype(u)::cell_t;
+            using coords_t = typename cell_t::coords_t;
+            make_bc<Dirichlet<1>>(u,
+                                  [exact](const auto&, const cell_t&, const coords_t& c)
+                                  {
+                                      return exact(c);
+                                  });
+
+            DiffCoeff<dim> K;
+            K.fill(1.);
+            auto diff   = make_diffusion_order2<decltype(u)>(K);
+            auto result = diff(u);
+
+            double err = 0.;
+            for_each_cell(mesh,
+                          [&](const auto& cell)
+                          {
+                              if (touches_boundary(cell, nx))
+                              {
+                                  const double expected = dim * k * k * exact(cell.center());
+                                  err                   = std::max(err, std::abs(result[cell] - expected));
+                              }
+                          });
+            return err;
+        }
+
+        template <std::size_t dim>
+        void check_boundary_truncation_does_not_converge()
+        {
+            const double e5 = boundary_diffusion_error<dim>(5);
+            const double e6 = boundary_diffusion_error<dim>(6);
+            const double e7 = boundary_diffusion_error<dim>(7);
+
+            // O(1): the error must not be shrinking towards zero.
+            EXPECT_GT(e7, 1.0) << "dim=" << dim << " errors: " << e5 << " " << e6 << " " << e7;
+
+            // And it must be flat: an observed order well below the interior's 2. If this
+            // ever exceeds 0.5, the boundary closure has changed and the comment block
+            // above, plus the acceptance bar it describes, need revisiting.
+            EXPECT_LT(observed_order(e5, e6), 0.5) << "dim=" << dim << " errors: " << e5 << " " << e6 << " " << e7;
+            EXPECT_LT(observed_order(e6, e7), 0.5) << "dim=" << dim << " errors: " << e5 << " " << e6 << " " << e7;
+        }
+    }
+
+    TEST(fv_operators, boundary_truncation_baseline_1d)
+    {
+        check_boundary_truncation_does_not_converge<1>();
+    }
+
+    TEST(fv_operators, boundary_truncation_baseline_2d)
+    {
+        check_boundary_truncation_does_not_converge<2>();
+    }
+
+    // The same measurement with the antisymmetric solution of the convergence tests
+    // above, kept as an executable warning: the boundary appears to be order 3 there,
+    // purely because Dirichlet<1> is an odd reflection and prod sin is antisymmetric
+    // about every face. This is what a naively lifted interior restriction would
+    // report. If this test ever fails, the odd-reflection coincidence has gone, and
+    // the trap it documents is no longer a trap.
+    namespace
+    {
+        template <std::size_t dim>
+        double boundary_diffusion_error_antisymmetric(std::size_t level)
+        {
+            const std::size_t nx = 1u << level;
+            auto mesh            = uniform_mesh<dim>(level);
+            auto u               = make_scalar_field<double>("u", mesh);
+
+            constexpr double k = 2 * M_PI;
+            auto exact         = [&](const auto& x)
+            {
+                double v = 1.;
+                for (std::size_t d = 0; d < dim; ++d)
+                {
+                    v *= std::sin(k * x(d));
+                }
+                return v;
+            };
+            for_each_cell(mesh,
+                          [&](const auto& cell)
+                          {
+                              u[cell] = exact(cell.center());
+                          });
+            make_bc<Dirichlet<1>>(u, 0.);
+
+            DiffCoeff<dim> K;
+            K.fill(1.);
+            auto diff   = make_diffusion_order2<decltype(u)>(K);
+            auto result = diff(u);
+
+            double err = 0.;
+            for_each_cell(mesh,
+                          [&](const auto& cell)
+                          {
+                              if (touches_boundary(cell, nx))
+                              {
+                                  const double expected = dim * k * k * exact(cell.center());
+                                  err                   = std::max(err, std::abs(result[cell] - expected));
+                              }
+                          });
+            return err;
+        }
+    }
+
+    TEST(fv_operators, boundary_truncation_antisymmetric_solution_is_vacuous)
+    {
+        const double e5 = boundary_diffusion_error_antisymmetric<1>(5);
+        const double e6 = boundary_diffusion_error_antisymmetric<1>(6);
+        const double e7 = boundary_diffusion_error_antisymmetric<1>(7);
+
+        // Order 3 at the boundary, above the interior's 2, on a solution the boundary
+        // condition happens to be exact on. Measuring the closure this way is vacuous.
+        EXPECT_NEAR(observed_order(e5, e6), 3.0, 0.3) << "errors: " << e5 << " " << e6 << " " << e7;
+        EXPECT_NEAR(observed_order(e6, e7), 3.0, 0.3) << "errors: " << e5 << " " << e6 << " " << e7;
+    }
+
     // WENO5 convection is 5th-order accurate on a smooth solution. We advect a
     // sine wave with a constant positive velocity and check the slope of the
     // error on interior cells (stencil half-width 3).


### PR DESCRIPTION
## Description

The boundary tests were written entirely in the point-value convention: they filled the field
with `f(cell.center())` and compared each ghost to `f(ghost.center())`. `bc/` is written the
same way - `bc/dirichlet.hpp` fits a polynomial through cell values placed at cell *centres* -
so the tests passed by making the same convention error as the code, and could not see the
consequence of it.

A finite-volume field stores cell **averages**. For a relation carrying a boundary datum, the
reproduction order in the cell-average sense is capped at `m + 1`, with `m` the differential
order of the datum, because the cells carry averages while the datum carries a point quantity:
filling with averages of `P` is the same as filling with point values of `Q = A[P]` (`A` the
cell-average operator, `A[P] = P + (h²/24) P'' + …`), and the supplied datum then differs from
the one that would reproduce `Q` by a term proportional to `h² D^{m+2}[P](x_b)`, which vanishes
exactly on degrees `≤ m + 1`. The residual is relation-specific: for `Dirichlet<k≥2>` on a
degree-2 probe it is exactly `-(h²/24) L_b(x_g) P''(x_b)`, with `L_b` the Lagrange basis of the
boundary node - nonzero at every ghost centre, since its roots are the cell centres; for
`Dirichlet<1>` the relation's own point-value error at degree 2 adds to it with the same sign;
for `Neumann<1>` the factor is `h²/12`, the averaging and the centred difference contributing
`h²/24` each. Measured here, in the library:

| BC | point-value order | cell-average order |
|---|---|---|
| `Dirichlet<1..4>` | `k` | **1**, for every `k` |
| `Neumann<1>` | 2 | 2 |

So every `Dirichlet` reproduces only degree 1 on cell averages whatever order is requested, and
`Neumann<1>` is order 2 - one above what its name suggests.

Both conventions are now asserted, and each order is pinned from **both** sides: exact at the
expected degree, and **not** exact one degree above. Exactness alone does not pin an order, it
only bounds it from below. Cell averages come from samurai's own `GaussLegendre` at a degree
well above the probe polynomials, so the quadrature contributes no error of its own.

This PR changes only what the suite certifies. No library code is touched.

### Boundary truncation baseline, and two traps

Also adds the diffusion boundary truncation baseline, with two findings that make the obvious
version of that test unsafe:

- The convergence tests deliberately exclude boundary cells. Dropping that exclusion with their
  manufactured solution `Π sin(2πx)` reports order **3** at the boundary - *better* than the
  interior's 2. Antisymmetry pays twice: `Dirichlet<1>` is an odd reflection, so the ghost is
  exact and the boundary cell is left with the plain interior truncation `-(h²/12) u''''`; and
  `u'''' ∝ sin` vanishes at the faces, so that term is `O(h)` on a boundary cell, which is what
  lifts 2 to 3. A vacuous test that looks like a triumph. It is kept here as an executable
  warning so it cannot be reintroduced.
- With a solution even about the faces (`Π cos(2πx)`), the boundary truncation error does not
  converge at all: `O(1)`, flat from level 4 to 7 (9.88 in 1D, 19.75 in 2D - the plateaux are
  `π²` and `2π²`, the ghost error `2(1 − cos(πh)) ≈ π²h²` divided by `h²`, doubled at the 2D
  corners). That is not a bug - the ghost is correct to `O(h²)` and the operator divides by
  `h²`, so any closure one order below the interior does this. The test samples point values,
  so this plateau is `Dirichlet<1>`'s point-value order at work; on the cell averages a
  finite-volume field actually stores, the cap above keeps it in place for every `Dirichlet`
  order. It does mean the max-norm *operator truncation* error is the wrong functional to
  extend to the boundary; a mesh-independent boundary convergence statement needs a *solution*
  error, hence an elliptic solve, which is not attempted here.

What is asserted is today's baseline, so that any improvement to the closure forces the
assertion to be updated - and the update is the evidence of the improvement.

## How has this been tested?

`tests/test_bc_ghost_values.cpp` and `tests/test_fv_operators.cpp` are the changed files.

## Code of Conduct

- [x] I agree to follow this project's Code of Conduct
