### PR TITLE
feat(numeric): shared 1D prediction coefficients and the boundary shift

### DIFF
--- a/include/samurai/numeric/prediction_coefficients.hpp
+++ b/include/samurai/numeric/prediction_coefficients.hpp
@@ -72,7 +72,7 @@ namespace samurai
 
             constexpr Rational() = default;
 
-            constexpr Rational(std::int64_t num, std::int64_t den = 1)
+            constexpr explicit Rational(std::int64_t num, std::int64_t den = 1)
                 : n(num)
                 , d(den)
             {
@@ -100,22 +100,22 @@ namespace samurai
 
             constexpr Rational operator+(const Rational& o) const
             {
-                return {n * o.d + o.n * d, d * o.d};
+                return Rational{n * o.d + o.n * d, d * o.d};
             }
 
             constexpr Rational operator-(const Rational& o) const
             {
-                return {n * o.d - o.n * d, d * o.d};
+                return Rational{n * o.d - o.n * d, d * o.d};
             }
 
             constexpr Rational operator*(const Rational& o) const
             {
-                return {n * o.n, d * o.d};
+                return Rational{n * o.n, d * o.d};
             }
 
             constexpr Rational operator/(const Rational& o) const
             {
-                return {n * o.d, d * o.n};
+                return Rational{n * o.d, d * o.n};
             }
 
             constexpr bool is_zero() const

--- a/include/samurai/numeric/prediction_coefficients.hpp
+++ b/include/samurai/numeric/prediction_coefficients.hpp
@@ -174,35 +174,37 @@ namespace samurai
                 rhs[q] = monomial_average(q, child_lo, child_hi);
             }
 
-            for (std::size_t col = 0; col < n; ++col)
+            // `col` and `row` would shadow samurai::col() / samurai::row()
+            // (storage/xtensor/xtensor_static.hpp), so the indices are named for what they are.
+            for (std::size_t pivot_col = 0; pivot_col < n; ++pivot_col)
             {
-                std::size_t pivot = col;
-                while (pivot < n && a[pivot][col].is_zero())
+                std::size_t pivot_row = pivot_col;
+                while (pivot_row < n && a[pivot_row][pivot_col].is_zero())
                 {
-                    ++pivot;
+                    ++pivot_row;
                 }
-                std::swap(a[col], a[pivot]);
-                std::swap(rhs[col], rhs[pivot]);
+                std::swap(a[pivot_col], a[pivot_row]);
+                std::swap(rhs[pivot_col], rhs[pivot_row]);
 
-                const Rational p = a[col][col];
+                const Rational p = a[pivot_col][pivot_col];
                 for (std::size_t k = 0; k < n; ++k)
                 {
-                    a[col][k] = a[col][k] / p;
+                    a[pivot_col][k] = a[pivot_col][k] / p;
                 }
-                rhs[col] = rhs[col] / p;
+                rhs[pivot_col] = rhs[pivot_col] / p;
 
-                for (std::size_t row = 0; row < n; ++row)
+                for (std::size_t other = 0; other < n; ++other)
                 {
-                    if (row == col || a[row][col].is_zero())
+                    if (other == pivot_col || a[other][pivot_col].is_zero())
                     {
                         continue;
                     }
-                    const Rational f = a[row][col];
+                    const Rational f = a[other][pivot_col];
                     for (std::size_t k = 0; k < n; ++k)
                     {
-                        a[row][k] = a[row][k] - f * a[col][k];
+                        a[other][k] = a[other][k] - f * a[pivot_col][k];
                     }
-                    rhs[row] = rhs[row] - f * rhs[col];
+                    rhs[other] = rhs[other] - f * rhs[pivot_col];
                 }
             }
 

--- a/include/samurai/numeric/prediction_coefficients.hpp
+++ b/include/samurai/numeric/prediction_coefficients.hpp
@@ -1,0 +1,301 @@
+// Copyright 2018-2025 the samurai's authors
+// SPDX-License-Identifier:  BSD-3-Clause
+
+#pragma once
+
+#include <array>
+#include <cassert>
+#include <cstdint>
+#include <cstdlib>
+#include <numeric>
+#include <unordered_map>
+
+#include "../utils.hpp"
+
+/**
+ * @file prediction_coefficients.hpp
+ *
+ * The 1D prediction coefficients, and the shift a stencil takes near a boundary.
+ *
+ * Prediction interpolates a coarse cell's value onto its children. In dim > 1 it is a
+ * tensor product of this 1D family, one factor per direction, so this file holds the
+ * whole of what its consumers share: each of them builds its own product from it and
+ * keeps its own loop structure.
+ *
+ * A stencil of prediction stencil radius @c r reads @c 2r+1 consecutive coarse cells.
+ * Away from a boundary it is centred on the parent. Near one it is **shifted inward**
+ * so that it reads only cells that exist, and the coefficients are re-solved for that
+ * shift. @c shift == 0 is the centred family and reproduces
+ * @c interp_coeffs<2r+1> (numeric/prediction.hpp) bit-exactly.
+ *
+ * Coefficients come from the **cell-average** moment conditions: for every monomial of
+ * degree <= @c 2r, the combination of the stencil cells' averages must equal the
+ * child's average. That is a @c (2r+1)x(2r+1) system, solved here in exact rational
+ * arithmetic and rounded to double once at the end, so a dyadic value - which is every
+ * value of the centred family - comes out bit-exact rather than merely close.
+ *
+ * Two things are deliberately kept apart, because conflating them is what would make a
+ * distributed run depend on its partition:
+ *   - @ref prediction_shift decides *which* stencil to use, from the geometry of the
+ *     domain alone;
+ *   - whether the cells that stencil names are present locally is a separate, halo
+ *     question, and not this file's business.
+ */
+
+namespace samurai
+{
+    /**
+     * The 1D prediction coefficients of one child, as a stencil start plus @c 2r+1
+     * weights: the child's value is @c sum_k c[k] * u(parent + start + k).
+     */
+    template <std::size_t radius>
+    struct PredictionCoefficients
+    {
+        static constexpr std::size_t size = 2 * radius + 1;
+
+        int start = -static_cast<int>(radius); ///< offset of @c c[0] from the parent cell
+        std::array<double, size> c{};
+    };
+
+    namespace detail
+    {
+        /**
+         * Minimal exact rational, enough to solve the moment system. Normalised after
+         * every operation so the magnitudes stay small: for @c radius <= 5 they remain
+         * far inside @c std::int64_t, which the bit-exactness tests against
+         * @c interp_coeffs would catch if it ever stopped being true.
+         */
+        struct Rational
+        {
+            std::int64_t n = 0;
+            std::int64_t d = 1;
+
+            constexpr Rational() = default;
+
+            constexpr Rational(std::int64_t num, std::int64_t den = 1)
+                : n(num)
+                , d(den)
+            {
+                normalise();
+            }
+
+            constexpr void normalise()
+            {
+                if (d < 0)
+                {
+                    n = -n;
+                    d = -d;
+                }
+                const std::int64_t g = std::gcd(n < 0 ? -n : n, d);
+                if (g > 1)
+                {
+                    n /= g;
+                    d /= g;
+                }
+                if (n == 0)
+                {
+                    d = 1;
+                }
+            }
+
+            constexpr Rational operator+(const Rational& o) const
+            {
+                return {n * o.d + o.n * d, d * o.d};
+            }
+
+            constexpr Rational operator-(const Rational& o) const
+            {
+                return {n * o.d - o.n * d, d * o.d};
+            }
+
+            constexpr Rational operator*(const Rational& o) const
+            {
+                return {n * o.n, d * o.d};
+            }
+
+            constexpr Rational operator/(const Rational& o) const
+            {
+                return {n * o.d, d * o.n};
+            }
+
+            constexpr bool is_zero() const
+            {
+                return n == 0;
+            }
+
+            constexpr double to_double() const
+            {
+                return static_cast<double>(n) / static_cast<double>(d);
+            }
+        };
+
+        constexpr Rational pow(Rational x, std::size_t e)
+        {
+            Rational r{1};
+            for (std::size_t k = 0; k < e; ++k)
+            {
+                r = r * x;
+            }
+            return r;
+        }
+
+        /// Average of @c x^q over @c [lo, hi]. The moment the system is posed on.
+        constexpr Rational monomial_average(std::size_t q, Rational lo, Rational hi)
+        {
+            const Rational num = pow(hi, q + 1) - pow(lo, q + 1);
+            return num / (Rational{static_cast<std::int64_t>(q) + 1} * (hi - lo));
+        }
+
+        /**
+         * Solve the moment system for one child. The parent cell is @c [0,1], the
+         * stencil cell at offset @c s is @c [s, s+1], and the child is the low or high
+         * half of the parent. Gauss-Jordan with partial pivoting on exact rationals, so
+         * the result is the exact solution of an exactly-posed system.
+         */
+        template <std::size_t radius>
+        std::array<double, 2 * radius + 1> solve_moment_system(std::size_t parity, int shift)
+        {
+            constexpr std::size_t n = 2 * radius + 1;
+            const int start         = -static_cast<int>(radius) + shift;
+
+            const Rational child_lo = (parity == 0) ? Rational{0} : Rational{1, 2};
+            const Rational child_hi = (parity == 0) ? Rational{1, 2} : Rational{1};
+
+            // row q: sum_k a[k] * avg(x^q over stencil cell k) = avg(x^q over the child)
+            std::array<std::array<Rational, n>, n> a{};
+            std::array<Rational, n> rhs{};
+            for (std::size_t q = 0; q < n; ++q)
+            {
+                for (std::size_t k = 0; k < n; ++k)
+                {
+                    const auto s = Rational{start + static_cast<int>(k)};
+                    a[q][k]      = monomial_average(q, s, s + Rational{1});
+                }
+                rhs[q] = monomial_average(q, child_lo, child_hi);
+            }
+
+            for (std::size_t col = 0; col < n; ++col)
+            {
+                std::size_t pivot = col;
+                while (pivot < n && a[pivot][col].is_zero())
+                {
+                    ++pivot;
+                }
+                std::swap(a[col], a[pivot]);
+                std::swap(rhs[col], rhs[pivot]);
+
+                const Rational p = a[col][col];
+                for (std::size_t k = 0; k < n; ++k)
+                {
+                    a[col][k] = a[col][k] / p;
+                }
+                rhs[col] = rhs[col] / p;
+
+                for (std::size_t row = 0; row < n; ++row)
+                {
+                    if (row == col || a[row][col].is_zero())
+                    {
+                        continue;
+                    }
+                    const Rational f = a[row][col];
+                    for (std::size_t k = 0; k < n; ++k)
+                    {
+                        a[row][k] = a[row][k] - f * a[col][k];
+                    }
+                    rhs[row] = rhs[row] - f * rhs[col];
+                }
+            }
+
+            std::array<double, n> out{};
+            for (std::size_t k = 0; k < n; ++k)
+            {
+                out[k] = rhs[k].to_double();
+            }
+            return out;
+        }
+    }
+
+    /**
+     * The 1D prediction coefficients of the child of parity @a parity, for a stencil
+     * shifted inward by @a shift cells.
+     *
+     * @param parity 0 for the child on the low side of the parent, 1 for the high side.
+     *               Matches the low bit of the child's index.
+     * @param shift  inward displacement of the stencil, in cells: positive moves it away
+     *               from a low-side boundary, negative away from a high-side one, and 0
+     *               is the centred stencil. @c |shift| <= radius.
+     *
+     * Memoised: the solve happens once per @c (radius, parity, shift), and there are at
+     * most @c 2*(2*radius+1) of those.
+     */
+    template <std::size_t radius>
+    const PredictionCoefficients<radius>& prediction_coefficients(std::size_t parity, int shift)
+    {
+        assert(parity < 2 && "prediction_coefficients: parity is 0 or 1");
+        assert(std::abs(shift) <= static_cast<int>(radius) && "prediction_coefficients: |shift| must not exceed the stencil radius");
+
+        static std::unordered_map<int, PredictionCoefficients<radius>> cache;
+
+        const int key = 2 * shift + static_cast<int>(parity);
+        auto it       = cache.find(key);
+        if (it != cache.end())
+        {
+            return it->second;
+        }
+
+        PredictionCoefficients<radius> out;
+        out.start = -static_cast<int>(radius) + shift;
+        out.c     = detail::solve_moment_system<radius>(parity, shift);
+        return cache.emplace(key, out).first->second;
+    }
+
+    /// What @ref prediction_shift concluded about a position.
+    struct PredictionShift
+    {
+        int shift = 0;    ///< pass to @ref prediction_coefficients
+        bool fits = true; ///< false when no shift makes the stencil fit
+    };
+
+    /**
+     * The shift a prediction stencil must take at a given position.
+     *
+     * @param radius     prediction stencil radius
+     * @param avail_low  how many cells are available below the parent, at its level
+     * @param avail_high how many are available above it
+     *
+     * @c fits is false exactly when @c avail_low + avail_high < 2 * radius, i.e. when the
+     * band available at that level is too narrow to hold @c 2r+1 cells however it is
+     * shifted. That is the constructibility condition the mesh must guarantee, and a
+     * caller is expected to report it loudly rather than silently degrade the order.
+     *
+     * @warning Either count may be **capped at @c 2 * radius**, never lower. A deficit on
+     * one side is at most @c radius and is made up from the other side, so @c 2 * radius
+     * is all the information the answer can use - but capping at @c radius instead would
+     * make @c fits report false at a boundary where the stencil does fit, since a side
+     * short by @c radius needs @c 2 * radius available opposite it.
+     */
+    constexpr PredictionShift prediction_shift(std::size_t radius, int avail_low, int avail_high)
+    {
+        const int r = static_cast<int>(radius);
+
+        if (avail_low + avail_high < 2 * r)
+        {
+            return {0, false};
+        }
+
+        // A deficit on one side is made up by shifting towards the other, and at most one
+        // of the two deficits can be positive once the stencil fits at all.
+        const int deficit_low  = r - avail_low;
+        const int deficit_high = r - avail_high;
+
+        if (deficit_low > 0)
+        {
+            return {deficit_low, true};
+        }
+        if (deficit_high > 0)
+        {
+            return {-deficit_high, true};
+        }
+        return {0, true};
+    }
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -53,6 +53,7 @@ set(SAMURAI_TESTS
     test_mra.cpp
     test_periodic.cpp
     test_portion.cpp
+    test_prediction_coefficients.cpp
     test_projection_prediction_roundtrip.cpp
     test_restart.cpp
     test_scaling.cpp

--- a/tests/test_prediction_coefficients.cpp
+++ b/tests/test_prediction_coefficients.cpp
@@ -1,0 +1,354 @@
+// Copyright 2018-2025 the samurai's authors
+// SPDX-License-Identifier:  BSD-3-Clause
+
+// The invariants of the prediction coefficients, asserted on the coefficients
+// themselves rather than through a mesh.
+//
+// Prediction is a property of the coefficients, so its invariants are checkable without
+// building anything: no mesh, no field, no adaptation. That is why these tests are cheap
+// enough to assert at every position class and every stencil shift, which a mesh-based
+// test could only sample.
+//
+// Asserted here:
+//   1. Reproduction   - the coefficients are exact on every monomial of degree <= 2r, in
+//                       the cell-average sense, at every shift.
+//   2. Conservativity - the two children's values average back to the parent exactly, at
+//                       every shift.
+//   3. Amplification  - sum |c| is bounded per shift, and the bound of the COMPOSED map
+//                       does not grow with the level gap. The second half is the load
+//                       bearing one: a bound that grew with the gap would mean the
+//                       multiscale transform is not stable at the boundary.
+//   4. Compatibility  - at shift 0 the coefficients reproduce interp_coeffs bit-exactly,
+//                       so switching a consumer over cannot change an interior value.
+
+#include <cmath>
+#include <map>
+
+#include <gtest/gtest.h>
+
+#include <samurai/numeric/prediction.hpp>
+#include <samurai/numeric/prediction_coefficients.hpp>
+
+namespace samurai
+{
+    namespace
+    {
+        // Average of x^q over [lo, hi], in double. The tests below only ever compare it
+        // against a combination of the same quantities, so the shared rounding cancels to
+        // well within the tolerances used.
+        double monomial_average(std::size_t q, double lo, double hi)
+        {
+            const double qq = static_cast<double>(q) + 1.;
+            return (std::pow(hi, qq) - std::pow(lo, qq)) / (qq * (hi - lo));
+        }
+
+        // The parent cell is [0,1]; the stencil cell at offset s is [s, s+1]; the children
+        // are the two halves of the parent.
+        template <std::size_t radius>
+        double reproduction_residual(std::size_t parity, int shift, std::size_t q)
+        {
+            const auto& p = prediction_coefficients<radius>(parity, shift);
+
+            double lhs = 0.;
+            for (std::size_t k = 0; k < p.size; ++k)
+            {
+                const double s = static_cast<double>(p.start + static_cast<int>(k));
+                lhs += p.c[k] * monomial_average(q, s, s + 1.);
+            }
+
+            const double child_lo = (parity == 0) ? 0.0 : 0.5;
+            const double rhs      = monomial_average(q, child_lo, child_lo + 0.5);
+            return lhs - rhs;
+        }
+
+        template <std::size_t radius>
+        double l1_mass(std::size_t parity, int shift)
+        {
+            const auto& p = prediction_coefficients<radius>(parity, shift);
+            double s      = 0.;
+            for (std::size_t k = 0; k < p.size; ++k)
+            {
+                s += std::abs(p.c[k]);
+            }
+            return s;
+        }
+
+        // ------------------------------------------------------------------
+        // The composed map: prediction applied `gap` times in a row, expressed back in
+        // the units of the coarsest level. Built exactly as reconstruction.hpp builds its
+        // prediction maps, by recursion on the gap, so the bound measured here is the one
+        // an actual multi-level reconstruction pays.
+        //
+        // `shift_of` decides the stencil at an absolute index, which is what makes this a
+        // boundary measurement rather than an interior one: with a boundary at index 0 the
+        // stencil clamps inward exactly where it has to.
+        // ------------------------------------------------------------------
+        using Map = std::map<long, double>;
+
+        template <std::size_t radius, class ShiftOf>
+        const Map& composed_map(long gap, long index, ShiftOf&& shift_of, std::map<std::pair<long, long>, Map>& cache)
+        {
+            auto key = std::make_pair(gap, index);
+            auto it  = cache.find(key);
+            if (it != cache.end())
+            {
+                return it->second;
+            }
+
+            if (gap == 0)
+            {
+                return cache[key] = Map{
+                           {index, 1.}
+                };
+            }
+
+            const long parent     = index >> 1; // arithmetic shift: floors, including for negatives
+            const std::size_t par = static_cast<std::size_t>(index & 1);
+            const auto& p         = prediction_coefficients<radius>(par, shift_of(parent));
+
+            Map out;
+            for (std::size_t k = 0; k < p.size; ++k)
+            {
+                if (p.c[k] == 0.)
+                {
+                    continue;
+                }
+                const long src = parent + p.start + static_cast<int>(k);
+                for (const auto& kv : composed_map<radius>(gap - 1, src, shift_of, cache))
+                {
+                    out[kv.first] += p.c[k] * kv.second;
+                }
+            }
+            return cache[key] = out;
+        }
+
+        // Worst sum |c| over the children of the coarse cell `p`, at level gap `gap`.
+        template <std::size_t radius, class ShiftOf>
+        double composed_l1(long gap, long p, ShiftOf&& shift_of)
+        {
+            std::map<std::pair<long, long>, Map> cache;
+            const long nb = 1L << gap;
+            double worst  = 0.;
+            for (long ii = 0; ii < nb; ++ii)
+            {
+                double s = 0.;
+                for (const auto& kv : composed_map<radius>(gap, p * nb + ii, shift_of, cache))
+                {
+                    s += std::abs(kv.second);
+                }
+                worst = std::max(worst, s);
+            }
+            return worst;
+        }
+
+        // Interior: never clamp.
+        auto interior_shift()
+        {
+            return [](long)
+            {
+                return 0;
+            };
+        }
+
+        // A boundary at index 0: cells below it do not exist at any level, so the stencil
+        // clamps inward for the first `radius` cells. Nothing bounds the domain above, so
+        // avail_high is passed at the cap of 2 * radius - passing `radius` there would make
+        // prediction_shift report that the stencil does not fit, since a side short by
+        // `radius` needs 2 * radius available opposite it.
+        template <std::size_t radius>
+        auto left_boundary_shift()
+        {
+            return [](long parent)
+            {
+                const int r         = static_cast<int>(radius);
+                const int avail_low = (parent >= static_cast<long>(radius)) ? r : static_cast<int>(parent);
+                const auto s        = prediction_shift(radius, avail_low, 2 * r);
+                EXPECT_TRUE(s.fits) << "the stencil must fit at every position of this probe, parent=" << parent;
+                return s.shift;
+            };
+        }
+
+        template <std::size_t radius>
+        void check_reproduction_and_conservativity()
+        {
+            const int r = static_cast<int>(radius);
+            for (int shift = -r; shift <= r; ++shift)
+            {
+                for (std::size_t parity = 0; parity < 2; ++parity)
+                {
+                    // 1. exact on every monomial of degree <= 2r
+                    for (std::size_t q = 0; q <= 2 * radius; ++q)
+                    {
+                        EXPECT_NEAR(reproduction_residual<radius>(parity, shift, q), 0., 1e-10)
+                            << "radius=" << radius << " shift=" << shift << " parity=" << parity << " degree=" << q;
+                    }
+                }
+
+                // 2. the children average back to the parent, as an identity between
+                // coefficient vectors and not merely for particular data
+                const auto& lo = prediction_coefficients<radius>(0, shift);
+                const auto& hi = prediction_coefficients<radius>(1, shift);
+                for (std::size_t k = 0; k < lo.size; ++k)
+                {
+                    const double mean     = 0.5 * (lo.c[k] + hi.c[k]);
+                    const double expected = (lo.start + static_cast<int>(k) == 0) ? 1. : 0.;
+                    EXPECT_NEAR(mean, expected, 1e-12) << "radius=" << radius << " shift=" << shift << " k=" << k;
+                }
+            }
+        }
+    }
+
+    //-------------------------------------------------------------------------
+    // 4. Bit-exact agreement with interp_coeffs at shift 0.
+    //
+    // This is what lets a consumer be switched over without changing any interior value,
+    // so the acceptance bar for the boundary work can be "interior bit-identical" rather
+    // than "interior within tolerance". Note EXPECT_DOUBLE_EQ, not EXPECT_NEAR.
+    //-------------------------------------------------------------------------
+    template <std::size_t radius>
+    void check_matches_interp_coeffs()
+    {
+        constexpr std::size_t order = 2 * radius + 1;
+
+        // interp_coeffs takes the sign of the child: +1 for the low child, -1 for the high.
+        const auto legacy_lo = interp_coeffs<order>(1.);
+        const auto legacy_hi = interp_coeffs<order>(-1.);
+
+        const auto& lo = prediction_coefficients<radius>(0, 0);
+        const auto& hi = prediction_coefficients<radius>(1, 0);
+
+        EXPECT_EQ(lo.start, -static_cast<int>(radius));
+        EXPECT_EQ(hi.start, -static_cast<int>(radius));
+
+        for (std::size_t k = 0; k < order; ++k)
+        {
+            EXPECT_DOUBLE_EQ(lo.c[k], legacy_lo[k]) << "radius=" << radius << " low child, k=" << k;
+            EXPECT_DOUBLE_EQ(hi.c[k], legacy_hi[k]) << "radius=" << radius << " high child, k=" << k;
+        }
+    }
+
+    TEST(prediction_coefficients, matches_interp_coeffs_bit_exactly)
+    {
+        check_matches_interp_coeffs<1>();
+        check_matches_interp_coeffs<2>();
+        check_matches_interp_coeffs<3>();
+        check_matches_interp_coeffs<4>();
+        check_matches_interp_coeffs<5>();
+    }
+
+    //-------------------------------------------------------------------------
+    // 1 and 2. Reproduction and conservativity, at every shift.
+    //-------------------------------------------------------------------------
+    TEST(prediction_coefficients, reproduction_and_conservativity_radius1)
+    {
+        check_reproduction_and_conservativity<1>();
+    }
+
+    TEST(prediction_coefficients, reproduction_and_conservativity_radius2)
+    {
+        check_reproduction_and_conservativity<2>();
+    }
+
+    TEST(prediction_coefficients, reproduction_and_conservativity_radius3)
+    {
+        check_reproduction_and_conservativity<3>();
+    }
+
+    // A negative control: the coefficients must NOT be exact one degree above 2r, else the
+    // order is higher than claimed and the tests above are not pinning anything.
+    TEST(prediction_coefficients, not_exact_above_2r)
+    {
+        EXPECT_GT(std::abs(reproduction_residual<1>(0, 0, 3)), 1e-6);
+        EXPECT_GT(std::abs(reproduction_residual<1>(0, 1, 3)), 1e-6);
+        EXPECT_GT(std::abs(reproduction_residual<2>(0, 0, 5)), 1e-6);
+        EXPECT_GT(std::abs(reproduction_residual<2>(0, 2, 5)), 1e-6);
+    }
+
+    //-------------------------------------------------------------------------
+    // 3. Amplification: bounded per shift, and NOT growing with the level gap.
+    //-------------------------------------------------------------------------
+    TEST(prediction_coefficients, one_step_l1_mass)
+    {
+        // Centred, and the fully one-sided stencil at each radius. The one-sided family
+        // legitimately carries more l1 mass than the centred one; what matters is that it
+        // is bounded, and that the composed bound below does not grow.
+        EXPECT_NEAR(l1_mass<1>(0, 0), 1.25, 1e-12);
+        EXPECT_NEAR(l1_mass<1>(0, 1), 2.0, 1e-12);
+        EXPECT_NEAR(l1_mass<2>(0, 0), 89. / 64., 1e-12);
+        EXPECT_NEAR(l1_mass<2>(0, 2), 3.5, 1e-12);
+        EXPECT_NEAR(l1_mass<3>(0, 0), 381. / 256., 1e-12);
+        EXPECT_NEAR(l1_mass<3>(0, 3), 55. / 8., 1e-12);
+    }
+
+    TEST(prediction_coefficients, composed_amplification_does_not_grow_with_the_level_gap)
+    {
+        // Interior: saturates at 4/3 in 1D.
+        double prev_interior = 0.;
+        for (long gap = 1; gap <= 12; ++gap)
+        {
+            const double v = composed_l1<1>(gap, 8, interior_shift());
+            EXPECT_LT(v, 1.4) << "interior, gap=" << gap;
+            EXPECT_GE(v, prev_interior - 1e-12) << "interior, gap=" << gap; // monotone up to roundoff
+            prev_interior = v;
+        }
+        EXPECT_NEAR(composed_l1<1>(12, 8, interior_shift()), 4. / 3., 1e-3);
+
+        // At the boundary: saturates at 10/3, i.e. 2.5x the interior. Bounded, and flat in
+        // the gap, which is the property the multiscale stability argument needs and the
+        // one the literature does not establish for cell averages.
+        double prev_boundary = 0.;
+        for (long gap = 1; gap <= 12; ++gap)
+        {
+            const double v = composed_l1<1>(gap, 0, left_boundary_shift<1>());
+            EXPECT_LT(v, 3.4) << "boundary, gap=" << gap;
+            EXPECT_GE(v, prev_boundary - 1e-12) << "boundary, gap=" << gap;
+            prev_boundary = v;
+        }
+        EXPECT_NEAR(composed_l1<1>(12, 0, left_boundary_shift<1>()), 10. / 3., 1e-2);
+
+        // And a cell 2r away from the boundary is already indistinguishable from the
+        // interior: the clamping never reaches it, so only the first 2r cells deviate.
+        EXPECT_DOUBLE_EQ(composed_l1<1>(10, 2, left_boundary_shift<1>()), composed_l1<1>(10, 8, interior_shift()));
+    }
+
+    //-------------------------------------------------------------------------
+    // The shift classifier, which decides WHICH stencil to use. Pure integer arithmetic on
+    // the geometry of the domain, so it is partition independent by construction: it never
+    // looks at what a rank happens to hold.
+    //-------------------------------------------------------------------------
+    TEST(prediction_shift, centred_when_the_stencil_fits)
+    {
+        for (std::size_t r = 1; r <= 4; ++r)
+        {
+            const auto s = prediction_shift(r, static_cast<int>(r), static_cast<int>(r));
+            EXPECT_TRUE(s.fits);
+            EXPECT_EQ(s.shift, 0) << "radius=" << r;
+        }
+    }
+
+    TEST(prediction_shift, clamps_inward_by_the_deficit)
+    {
+        // radius 2, low side short by 1 then by 2: shift up by exactly the deficit.
+        EXPECT_EQ(prediction_shift(2, 1, 5).shift, 1);
+        EXPECT_EQ(prediction_shift(2, 0, 5).shift, 2);
+        // high side, mirrored
+        EXPECT_EQ(prediction_shift(2, 5, 1).shift, -1);
+        EXPECT_EQ(prediction_shift(2, 5, 0).shift, -2);
+        // never more than the radius
+        EXPECT_LE(std::abs(prediction_shift(3, 0, 9).shift), 3);
+    }
+
+    TEST(prediction_shift, reports_when_no_shift_fits)
+    {
+        // The band must hold 2r+1 cells: avail_low + avail_high >= 2r.
+        EXPECT_TRUE(prediction_shift(2, 0, 4).fits);
+        EXPECT_FALSE(prediction_shift(2, 0, 3).fits);
+        EXPECT_FALSE(prediction_shift(3, 2, 3).fits);
+        EXPECT_TRUE(prediction_shift(3, 3, 3).fits);
+
+        // radius 1 needs only 2 cells beyond the parent, which is why it is the radius
+        // that fits everywhere in practice today.
+        EXPECT_TRUE(prediction_shift(1, 0, 2).fits);
+        EXPECT_FALSE(prediction_shift(1, 0, 1).fits);
+    }
+}


### PR DESCRIPTION
## Description

Adds the object that the four consumers of prediction are meant to share, plus its invariants.
**No consumer is switched over yet, so this PR changes no behaviour** - it adds a header and a
test file.

Today `interp_coeffs` is consumed independently by `numeric/prediction.hpp` (the definition and
`prediction_op`), `mr/operators.hpp` (`compute_detail_op`), `reconstruction.hpp` (the
`prediction_map` machinery, and through it the adapted LBM stream) and
`petsc/fv/FV_scheme_assembly.hpp` (prediction as a matrix row). They must share one object, for a
correctness reason rather than tidiness: adaptation's contract is "if `|detail| < eps_l` the fine
cell can be removed, because prediction recovers it to within `eps_l`", so if the detail uses one
operator near a boundary and refine uses another, the error committed is not the one the
threshold measured.

`numeric/prediction_coefficients.hpp` provides:

- **`prediction_coefficients<radius>(parity, shift)`** - the `2r+1` weights and the stencil start
  for one child, for a stencil shifted inward by `shift` cells. In dim > 1 prediction is a tensor
  product of this 1D family, so this is the whole of what the consumers share; each keeps its own
  loop structure.
- **`prediction_shift(radius, avail_low, avail_high)`** - which stencil to use, from the geometry
  alone, plus whether any shift makes it fit. Deliberately kept apart from whether those cells are
  present locally: that is a halo question, and conflating the two is what would make a distributed
  run depend on its partition.

### Why the coefficients are solved rather than tabulated

They come from the **cell-average moment conditions** - for every monomial of degree `<= 2r`, the
combination of the stencil cells' averages must equal the child's average - solved in exact
rational arithmetic and rounded to double once at the end.

That matters more than it sounds. At `shift = 0` the result is **bit-exactly** equal to the
hand-written `interp_coeffs<2r+1>` for radius 1 to 5, asserted with `EXPECT_DOUBLE_EQ` rather
than a tolerance. So a consumer can later be switched over without moving any interior value,
which is what lets the acceptance bar for the boundary work be "interior bit-identical" rather
than "interior within tolerance". It also removes the order ceiling the hand-written tables
impose.

### The invariants need no mesh

Prediction is a property of the coefficients, so its invariants are checkable without building a
mesh, a field or an adaptation - which is what makes it cheap enough to assert at *every* shift
instead of sampling a few:

- **reproduction**: exact on every monomial of degree `<= 2r` in the cell-average sense, at every
  shift, radius 1 to 3 - and **not** exact at `2r+1`, so the order is pinned from both sides;
- **conservativity**: the two children average back to the parent exactly, as an identity between
  coefficient vectors rather than for particular data, at every shift;
- **amplification**: one-step `sum|c|` reproduces the known `5/4, 89/64, 381/256` centred and
  `2, 7/2, 55/8` one-sided values; and the **composed** map's bound does not grow with the level
  gap, saturating at `4/3` in the interior and `10/3` at a clamped boundary. That flatness in the
  gap is the property multiscale stability needs, and the one the literature establishes only for
  the point-value transform in 1D, never for cell averages. A cell `2r` from the boundary comes
  out bit-identical to the interior, confirming that only the first `2r` positions deviate.

## How has this been tested?

New: `tests/test_prediction_coefficients.cpp` (10 tests), registered in `tests/CMakeLists.txt`.

## Code of Conduct

- [x] I agree to follow this project's Code of Conduct