### PR TITLE
refactor: route the four prediction consumers through the shared coefficients

### DIFF
--- a/include/samurai/mr/operators.hpp
+++ b/include/samurai/mr/operators.hpp
@@ -153,10 +153,10 @@ namespace samurai
             }
             else
             {
-                using value_t    = typename TInterval::value_t;
-                auto sorder      = static_cast<value_t>(order);
-                auto interp_even = interp_coeffs<2 * order + 1>(1.);
-                auto interp_odd  = interp_coeffs<2 * order + 1>(-1.);
+                using value_t           = typename TInterval::value_t;
+                auto sorder             = static_cast<value_t>(order);
+                const auto& interp_even = prediction_coefficients<order>(0, 0).c;
+                const auto& interp_odd  = prediction_coefficients<order>(1, 0).c;
 
                 detail(level + 1, 2 * i)     = field(level + 1, 2 * i);
                 detail(level + 1, 2 * i + 1) = field(level + 1, 2 * i + 1);
@@ -235,8 +235,8 @@ namespace samurai
             }
             else
             {
-                auto interp_even = interp_coeffs<2 * order + 1>(1.);
-                auto interp_odd  = interp_coeffs<2 * order + 1>(-1.);
+                const auto& interp_even = prediction_coefficients<order>(0, 0).c;
+                const auto& interp_odd  = prediction_coefficients<order>(1, 0).c;
 
                 constexpr std::size_t interp_size = 2 * order + 1;
 
@@ -374,8 +374,8 @@ namespace samurai
             }
             else
             {
-                auto interp_even = interp_coeffs<2 * order + 1>(1.);
-                auto interp_odd  = interp_coeffs<2 * order + 1>(-1.);
+                const auto& interp_even = prediction_coefficients<order>(0, 0).c;
+                const auto& interp_odd  = prediction_coefficients<order>(1, 0).c;
 
                 constexpr std::size_t interp_size = 2 * order + 1;
 

--- a/include/samurai/numeric/prediction.hpp
+++ b/include/samurai/numeric/prediction.hpp
@@ -16,9 +16,16 @@
 #include "../operators_base.hpp"
 #include "../static_algorithm.hpp"
 #include "../utils.hpp"
+#include "prediction_coefficients.hpp"
 
 namespace samurai
 {
+    // Superseded by @ref prediction_coefficients (numeric/prediction_coefficients.hpp), which
+    // solves these same values from the cell-average moment conditions instead of tabulating
+    // them, and generalises them to the boundary-shifted stencils. Nothing in the library calls
+    // interp_coeffs any more; it is kept as the independent reference that the generated family
+    // is checked against, bit for bit, in tests/test_prediction_coefficients.cpp. It goes away
+    // with the public API break of the boundary rewrite, along with the order ceiling it imposes.
     template <std::size_t s>
     SAMURAI_INLINE std::array<double, s> interp_coeffs(double sign);
 
@@ -159,8 +166,8 @@ namespace samurai
         constexpr std::size_t order = 2 * pred_stencil_size + 1;
 
         // (even index coefficients, odd index coefficients)
-        std::array<std::array<double, order>, 2> interp_coeff_pair = {
-            {interp_coeffs<order>(1.), interp_coeffs<order>(-1.)}
+        const std::array<std::array<double, order>, 2> interp_coeff_pair = {
+            {prediction_coefficients<pred_stencil_size>(0, 0).c, prediction_coefficients<pred_stencil_size>(1, 0).c}
         };
 
         // Compute the memory accessors for the source data
@@ -297,8 +304,8 @@ namespace samurai
         using value_t               = typename TInterval::value_t;
 
         // (even index coefficients, odd index coefficients)
-        std::array<std::array<double, order>, 2> interp_coeff_pair = {
-            {interp_coeffs<order>(1.), interp_coeffs<order>(-1.)}
+        const std::array<std::array<double, order>, 2> interp_coeff_pair = {
+            {prediction_coefficients<pred_stencil_size>(0, 0).c, prediction_coefficients<pred_stencil_size>(1, 0).c}
         };
 
         const auto* src_data = src.data();

--- a/include/samurai/petsc/fv/FV_scheme_assembly.hpp
+++ b/include/samurai/petsc/fv/FV_scheme_assembly.hpp
@@ -1384,11 +1384,11 @@ namespace samurai
                             PetscInt ghost_index = this->local_row_index(ghost, field_i);
                             MatSetValueLocal(A, ghost_index, ghost_index, scaling, current_insert_mode());
 
-                            auto ii      = ghost.indices(0);
-                            auto ig      = ii >> 1;
-                            double isign = (ii & 1) ? -1 : 1;
+                            auto ii                   = ghost.indices(0);
+                            auto ig                   = ii >> 1;
+                            const std::size_t iparity = static_cast<std::size_t>(ii & 1);
 
-                            auto interpx = samurai::interp_coeffs<2 * prediction_stencil_radius + 1>(isign);
+                            const auto& interpx = samurai::prediction_coefficients<prediction_stencil_radius>(iparity, 0).c;
 
                             auto parent_index = this->local_col_index(static_cast<PetscInt>(this->mesh().get_index(ghost.level - 1, ig)),
                                                                       field_i);
@@ -1417,11 +1417,11 @@ namespace samurai
             {
                 std::vector<cell_coeff_pair_t> linear_comb;
 
-                auto ii      = ghost.indices(0);
-                auto ig      = ii >> 1;
-                double isign = (ii & 1) ? -1 : 1;
+                auto ii                   = ghost.indices(0);
+                auto ig                   = ii >> 1;
+                const std::size_t iparity = static_cast<std::size_t>(ii & 1);
 
-                auto interpx = samurai::interp_coeffs<2 * prediction_stencil_radius + 1>(isign);
+                const auto& interpx = samurai::prediction_coefficients<prediction_stencil_radius>(iparity, 0).c;
 
                 auto parent_index = this->mesh().get_index(ghost.level - 1, ig);
                 linear_comb.emplace_back(parent_index, 1.);
@@ -1456,15 +1456,15 @@ namespace samurai
                             PetscInt ghost_index = this->local_row_index(ghost, field_i);
                             MatSetValueLocal(A, ghost_index, ghost_index, scaling, current_insert_mode());
 
-                            auto ii      = ghost.indices(0);
-                            auto ig      = ii >> 1;
-                            auto j       = ghost.indices(1);
-                            auto jg      = j >> 1;
-                            double isign = (ii & 1) ? -1 : 1;
-                            double jsign = (j & 1) ? -1 : 1;
+                            auto ii                   = ghost.indices(0);
+                            auto ig                   = ii >> 1;
+                            auto j                    = ghost.indices(1);
+                            auto jg                   = j >> 1;
+                            const std::size_t iparity = static_cast<std::size_t>(ii & 1);
+                            const std::size_t jparity = static_cast<std::size_t>(j & 1);
 
-                            auto interpx = samurai::interp_coeffs<2 * prediction_stencil_radius + 1>(isign);
-                            auto interpy = samurai::interp_coeffs<2 * prediction_stencil_radius + 1>(jsign);
+                            const auto& interpx = samurai::prediction_coefficients<prediction_stencil_radius>(iparity, 0).c;
+                            const auto& interpy = samurai::prediction_coefficients<prediction_stencil_radius>(jparity, 0).c;
 
                             auto parent_index = this->local_col_index(static_cast<PetscInt>(this->mesh().get_index(ghost.level - 1, ig, jg)),
                                                                       field_i);
@@ -1497,15 +1497,15 @@ namespace samurai
             {
                 std::vector<cell_coeff_pair_t> linear_comb;
 
-                auto ii      = ghost.indices(0);
-                auto ig      = ii >> 1;
-                auto j       = ghost.indices(1);
-                auto jg      = j >> 1;
-                double isign = (ii & 1) ? -1 : 1;
-                double jsign = (j & 1) ? -1 : 1;
+                auto ii                   = ghost.indices(0);
+                auto ig                   = ii >> 1;
+                auto j                    = ghost.indices(1);
+                auto jg                   = j >> 1;
+                const std::size_t iparity = static_cast<std::size_t>(ii & 1);
+                const std::size_t jparity = static_cast<std::size_t>(j & 1);
 
-                auto interpx = samurai::interp_coeffs<2 * prediction_stencil_radius + 1>(isign);
-                auto interpy = samurai::interp_coeffs<2 * prediction_stencil_radius + 1>(jsign);
+                const auto& interpx = samurai::prediction_coefficients<prediction_stencil_radius>(iparity, 0).c;
+                const auto& interpy = samurai::prediction_coefficients<prediction_stencil_radius>(jparity, 0).c;
 
                 auto parent_index = this->mesh().get_index(ghost.level - 1, ig, jg);
                 linear_comb.emplace_back(parent_index, 1.);
@@ -1544,19 +1544,19 @@ namespace samurai
                             PetscInt ghost_index = this->local_row_index(ghost, field_i);
                             MatSetValueLocal(A, ghost_index, ghost_index, scaling, current_insert_mode());
 
-                            auto ii      = ghost.indices(0);
-                            auto ig      = ii >> 1;
-                            auto j       = ghost.indices(1);
-                            auto jg      = j >> 1;
-                            auto k       = ghost.indices(2);
-                            auto kg      = k >> 1;
-                            double isign = (ii & 1) ? -1 : 1;
-                            double jsign = (j & 1) ? -1 : 1;
-                            double ksign = (k & 1) ? -1 : 1;
+                            auto ii                   = ghost.indices(0);
+                            auto ig                   = ii >> 1;
+                            auto j                    = ghost.indices(1);
+                            auto jg                   = j >> 1;
+                            auto k                    = ghost.indices(2);
+                            auto kg                   = k >> 1;
+                            const std::size_t iparity = static_cast<std::size_t>(ii & 1);
+                            const std::size_t jparity = static_cast<std::size_t>(j & 1);
+                            const std::size_t kparity = static_cast<std::size_t>(k & 1);
 
-                            auto interpx = samurai::interp_coeffs<2 * prediction_stencil_radius + 1>(isign);
-                            auto interpy = samurai::interp_coeffs<2 * prediction_stencil_radius + 1>(jsign);
-                            auto interpz = samurai::interp_coeffs<2 * prediction_stencil_radius + 1>(ksign);
+                            const auto& interpx = samurai::prediction_coefficients<prediction_stencil_radius>(iparity, 0).c;
+                            const auto& interpy = samurai::prediction_coefficients<prediction_stencil_radius>(jparity, 0).c;
+                            const auto& interpz = samurai::prediction_coefficients<prediction_stencil_radius>(kparity, 0).c;
 
                             auto parent_index = this->local_col_index(
                                 static_cast<PetscInt>(this->mesh().get_index(ghost.level - 1, ig, jg, kg)),
@@ -1595,19 +1595,19 @@ namespace samurai
             {
                 std::vector<cell_coeff_pair_t> linear_comb;
 
-                auto ii      = ghost.indices(0);
-                auto ig      = ii >> 1;
-                auto j       = ghost.indices(1);
-                auto jg      = j >> 1;
-                auto k       = ghost.indices(2);
-                auto kg      = k >> 1;
-                double isign = (ii & 1) ? -1 : 1;
-                double jsign = (j & 1) ? -1 : 1;
-                double ksign = (k & 1) ? -1 : 1;
+                auto ii                   = ghost.indices(0);
+                auto ig                   = ii >> 1;
+                auto j                    = ghost.indices(1);
+                auto jg                   = j >> 1;
+                auto k                    = ghost.indices(2);
+                auto kg                   = k >> 1;
+                const std::size_t iparity = static_cast<std::size_t>(ii & 1);
+                const std::size_t jparity = static_cast<std::size_t>(j & 1);
+                const std::size_t kparity = static_cast<std::size_t>(k & 1);
 
-                auto interpx = samurai::interp_coeffs<2 * prediction_stencil_radius + 1>(isign);
-                auto interpy = samurai::interp_coeffs<2 * prediction_stencil_radius + 1>(jsign);
-                auto interpz = samurai::interp_coeffs<2 * prediction_stencil_radius + 1>(ksign);
+                const auto& interpx = samurai::prediction_coefficients<prediction_stencil_radius>(iparity, 0).c;
+                const auto& interpy = samurai::prediction_coefficients<prediction_stencil_radius>(jparity, 0).c;
+                const auto& interpz = samurai::prediction_coefficients<prediction_stencil_radius>(kparity, 0).c;
 
                 auto parent_index = this->mesh().get_index(ghost.level - 1, ig, jg, kg);
                 linear_comb.emplace_back(parent_index, 1.);

--- a/include/samurai/reconstruction.hpp
+++ b/include/samurai/reconstruction.hpp
@@ -24,7 +24,7 @@
  * keeps only the cells actually present in the adapted mesh; the value of an
  * absent finer cell is @e predicted from its coarser neighbours through the
  * wavelet interpolation of half-width @c prediction_stencil_radius (the
- * @c interp_coeffs<2*radius+1> of numeric/prediction.hpp). Prediction is linear,
+ * @ref prediction_coefficients of numeric/prediction_coefficients.hpp). Prediction is linear,
  * so the predicted value is a fixed linear combination of coarse-cell values
  * that depends only on the level gap and on the child position inside its coarse
  * cell, never on the field. Three layers build on that fact:
@@ -376,7 +376,7 @@ namespace samurai
      * crossing coarse-cell boundaries).
      *
      * @tparam order  half-width of the wavelet interpolation, i.e.
-     *                @c prediction_stencil_radius (uses @c interp_coeffs<2*order+1>).
+     *                @c prediction_stencil_radius (uses @ref prediction_coefficients).
      * @param  level  the level gap @c delta_l (NOT an absolute level). @c 0 is the
      *                identity map @c {indices: 1} (the cell itself).
      *
@@ -409,7 +409,7 @@ namespace samurai
         }
 
         auto parent_indices = std::make_tuple((indices >> 1)...);
-        auto signs          = std::make_tuple(((indices & 1) ? -1. : 1.)...);
+        auto parities       = std::make_tuple(static_cast<std::size_t>(indices & 1)...);
 
         std::apply(
             [&](auto... parent_values)
@@ -418,12 +418,16 @@ namespace samurai
             },
             parent_indices);
 
+        // Shift 0: this map is built in coarse-cell units around a reference cell placed at
+        // the origin, with no notion of where the domain boundary is, so it can only be the
+        // centred family. A boundary-aware caller passes the position class in (see
+        // prediction_coefficients.hpp); the cache key would then have to carry it.
         auto interp_coeff_values = std::apply(
-            [&](auto... sign_values)
+            [&](auto... parity_values)
             {
-                return std::make_tuple(interp_coeffs<2 * order + 1>(sign_values)...);
+                return std::make_tuple(prediction_coefficients<order>(parity_values, 0).c...);
             },
-            signs);
+            parities);
 
         detail::multi_dim_loop(interp_coeff_values,
                                [&](auto... loop_indices)


### PR DESCRIPTION
## Description

`interp_coeffs` is currently called independently by four sites. They need to share one object,
for a correctness reason rather than tidiness: adaptation's contract is *"if `|detail| < eps_l`
the fine cell can be removed, because prediction recovers it to within `eps_l`"*, so if the
detail uses one operator near a boundary and refine uses another, the error committed is not the
one the threshold measured. The same argument extends to `reconstruction.hpp` (the LBM stream
reads reconstructed values across level jumps) and to petsc (the assembled matrix must match the
explicit operator).

All four now go through `prediction_coefficients`, **at shift 0**:

| site | what it does |
|---|---|
| `numeric/prediction.hpp` | `prediction_op`, both `dest_on_level` arms |
| `mr/operators.hpp` | `compute_detail_op`, 1d/2d/3d |
| `reconstruction.hpp` | the `prediction_map` recursion |
| `petsc/fv/FV_scheme_assembly.hpp` | prediction as a matrix row, 12 sites |

Shift 0 only, so this is a **pure refactor**: no position dependence is introduced and no value
moves. `reconstruction.hpp` switches from a sign tuple to a parity tuple, which is what the shared
family is keyed on; its map is built in coarse-cell units around a reference cell at the origin
and has no notion of where a boundary is, so it can only be the centred family until the cache key
carries the position class.

Nothing in the library calls `interp_coeffs` any more. It stays as the independent reference the
generated family is checked against bit for bit (see #490), and goes away with the public API
break of the boundary rewrite along with the order ceiling it imposes. Its doc comment says so,
and two stale references to it in `reconstruction.hpp` now point at the new header.

## Related issue

None. Part of the boundary-machinery rewrite; follows #490.

## Code of Conduct

- [x] I agree to follow this project's Code of Conduct