### PR TITLE
fix(mr): give the coarse levels the inward reach a clamped prediction stencil needs

### DIFF
--- a/include/samurai/amr/mesh.hpp
+++ b/include/samurai/amr/mesh.hpp
@@ -252,6 +252,19 @@ namespace samurai
                                                          interval.end + config_t::prediction_stencil_radius});
                             });
                     });
+
+                // The inward band, for the same reason as in mr/mesh.hpp: near a boundary the
+                // prediction stencil shifts inward so that it reads only cells the domain has,
+                // and it then reaches 2r on one side instead of r. Clipped to the domain, so it
+                // adds no outer ghost that nothing would write.
+                auto inward = intersection(
+                    nestedExpand(self(this->cells()[mesh_id_t::pred_cells][level]).on(level - 1), 2 * config_t::prediction_stencil_radius),
+                    this->domain(level - 1));
+                inward(
+                    [&](const auto& interval, const auto& index_yz)
+                    {
+                        lcl[index_yz].add_interval(interval);
+                    });
             }
             this->cells()[mesh_id_t::cells_and_ghosts] = {cl, false};
 

--- a/include/samurai/mesh.hpp
+++ b/include/samurai/mesh.hpp
@@ -635,8 +635,12 @@ namespace samurai
         {
             return 0.;
         }
-        const int radius          = max_stencil_radius();
-        const int prediction_size = (min_level() != max_level()) ? config_t::prediction_stencil_radius : 0;
+        const int radius = max_stencil_radius();
+        // 2r, not r: near a boundary the prediction stencil shifts inward and reaches twice as
+        // far, and the coarse levels carry that margin (see update_sub_mesh_impl). A rank whose
+        // ghosts now reach further has to be discovered as a neighbour, or two ranks end up
+        // holding intersecting ghosts without being registered with each other.
+        const int prediction_size = (min_level() != max_level()) ? 2 * config_t::prediction_stencil_radius : 0;
         const int reach           = (2 * radius) + (4 * prediction_size) + 4;
         return reach * cell_length(my_cells.min_level());
     }

--- a/include/samurai/mesh.hpp
+++ b/include/samurai/mesh.hpp
@@ -895,6 +895,11 @@ namespace samurai
         swap(m_mpi_neighbourhood, mesh.m_mpi_neighbourhood);
         swap(m_union, mesh.m_union);
         swap(m_config, mesh.m_config);
+        // The gravity centre is a property of the cells and must follow them: left behind, a
+        // rank that adapted would keep the centre of its previous mesh while its neighbours
+        // hold the centre of its current one, and the petsc ownership rule that compares the
+        // two would no longer agree from one rank to the next.
+        swap(m_gravity_center, mesh.m_gravity_center);
     }
 
     template <class D, class Config>

--- a/include/samurai/mr/mesh.hpp
+++ b/include/samurai/mr/mesh.hpp
@@ -327,9 +327,90 @@ namespace samurai
         }
 
         // Add cells for the MRA to be able to compute the details at one and two levels below each cells.
-        // The prediction operator gives the number of ghost cells to add in each direction.
+        //
+        // The margin is r outward and 2r inward, r being the prediction stencil radius.
+        //
+        // Outward, r is all there is to read: a centred stencil reaches r, and past the
+        // domain those cells are the outer ghosts the boundary conditions write. Adding more
+        // there would add cells nobody writes and nobody reads - and a cell the mesh holds
+        // but nothing writes is worse than one it does not hold, because it is read as a
+        // value.
+        //
+        // Inward, r is not enough. Near a boundary - the domain's own, or a hole's - the
+        // stencil cannot stay centred: it shifts inward so that it reads only cells the
+        // domain has, and it then reaches 2r on one side. With only r of margin it names
+        // cells the mesh does not hold, and the alternative - reading whatever a centred
+        // stencil finds outside - is what feeds boundary-condition values to the wavelet.
+        //
+        // 2r is also where the composed prediction map's support saturates, independently of
+        // the level gap, and it is the same 2 already hardcoded in the max_stencil_radius
+        // floor and in reconstruction()'s and transfer()'s "the prediction stencil reaches
+        // two coarse cells".
         if (this->max_level() != this->min_level())
         {
+            constexpr int prediction_reach        = config_t::prediction_stencil_radius;
+            constexpr int prediction_inward_reach = 2 * config_t::prediction_stencil_radius;
+
+            // Where the inward band is allowed to put cells, at a level.
+            //
+            // Inside the domain, everywhere. Only cells within 2r of a boundary can be named by
+            // a clamped stencil, so restricting the band to that shell was tried - and it is a
+            // trap: a stencil at distance 0 is shifted by r and reads distance 2r *inclusive*,
+            // so the shell has to be 2r + 1 wide, and getting it wrong loses exactly one cell
+            // and aborts eight demos. It bought 1.5 % of update_sub_mesh. Not worth the edge.
+            //
+            // Outside, the band extends beyond a *periodic* boundary, where the cells exist and
+            // the periodic exchange fills them, and where a stencil clamped in one direction
+            // reads further along the others. It does not extend beyond a non-periodic one:
+            // there the outer ghosts stop at r, the boundary conditions fill exactly those, and
+            // a cell the mesh holds but nothing writes is worse than one it does not hold.
+            //
+            // The level is clamped because the callers build both arms of
+            // add_prediction_ghosts unconditionally and let it drop the `level - 2` one at
+            // level 1: the set expressions are lazy, so an underflowed level costs nothing
+            // there, but this is not lazy.
+            std::vector<lca_type> band(this->max_level() + 1);
+            std::vector<bool> band_known(this->max_level() + 1, false);
+
+            auto band_at = [&](std::size_t target_level) -> const lca_type&
+            {
+                const std::size_t l = std::min(target_level, this->max_level());
+                if (!band_known[l])
+                {
+                    if (this->is_periodic())
+                    {
+                        lcl_type lcl{l, this->origin_point(), this->scaling_factor()};
+                        auto add = [&](const auto& set)
+                        {
+                            set(
+                                [&](const auto& i, const auto& idx)
+                                {
+                                    lcl[idx].add_interval(i);
+                                });
+                        };
+                        add(self(this->domain(l)));
+                        for (std::size_t d = 0; d < dim; ++d)
+                        {
+                            if (!this->is_periodic(d))
+                            {
+                                continue;
+                            }
+                            DirectionVector<dim> shift = xt::zeros<int>({dim});
+                            shift[d]                   = prediction_inward_reach;
+                            add(translate(this->domain(l), shift));
+                            add(translate(this->domain(l), -shift));
+                        }
+                        band[l] = lca_type{lcl};
+                    }
+                    else
+                    {
+                        band[l] = this->domain(l);
+                    }
+                    band_known[l] = true;
+                }
+                return band[l];
+            };
+
             auto add_prediction_ghosts = [&](auto&& subset_cells, auto&& subset_cells_and_ghosts, auto level)
             {
                 lcl_type& lcl_m1 = cell_list[level - 1];
@@ -357,10 +438,21 @@ namespace samurai
                 {
                     // own part
                     add_prediction_ghosts(
-                        nestedExpand(self(this->cells()[mesh_id_t::cells][level]).on(level - 2), config_t::prediction_stencil_radius),
-                        intersection(nestedExpand(self(this->cells()[mesh_id_t::cells_and_ghosts][level]).on(level - 1),
-                                                  config_t::prediction_stencil_radius),
-                                     nestedExpand(self(this->subdomain()).on(level - 1), config_t::prediction_stencil_radius)),
+                        nestedExpand(self(this->cells()[mesh_id_t::cells][level]).on(level - 2), prediction_reach),
+                        intersection(nestedExpand(self(this->cells()[mesh_id_t::cells_and_ghosts][level]).on(level - 1), prediction_reach),
+                                     nestedExpand(self(this->subdomain()).on(level - 1), prediction_reach)),
+                        level);
+
+                    // The inward band, added on top of the r margin rather than folded into
+                    // it: same shape as the arms above, so the set expressions resolve at the
+                    // same level, and the cell list merges the two contributions.
+                    add_prediction_ghosts(
+                        intersection(nestedExpand(self(this->cells()[mesh_id_t::cells][level]).on(level - 2), prediction_inward_reach),
+                                     band_at(level - 2)),
+                        intersection(
+                            nestedExpand(self(this->cells()[mesh_id_t::cells_and_ghosts][level]).on(level - 1), prediction_inward_reach),
+                            band_at(level - 1),
+                            nestedExpand(self(this->subdomain()).on(level - 1), prediction_inward_reach)),
                         level);
 
                     // periodic part
@@ -369,10 +461,21 @@ namespace samurai
                     {
                         add_prediction_ghosts(
                             intersection(nestedExpand(translate(this->cells()[mesh_id_t::cells][level], d >> delta_l).on(level - 2),
-                                                      config_t::prediction_stencil_radius),
+                                                      prediction_reach),
                                          self(this->subdomain()).on(level - 2)),
                             intersection(nestedExpand(translate(this->cells()[mesh_id_t::cells_and_ghosts][level], d >> delta_l).on(level - 1),
-                                                      config_t::prediction_stencil_radius),
+                                                      prediction_reach),
+                                         self(this->subdomain()).on(level - 1)),
+                            level);
+
+                        add_prediction_ghosts(
+                            intersection(nestedExpand(translate(this->cells()[mesh_id_t::cells][level], d >> delta_l).on(level - 2),
+                                                      prediction_inward_reach),
+                                         band_at(level - 2),
+                                         self(this->subdomain()).on(level - 2)),
+                            intersection(nestedExpand(translate(this->cells()[mesh_id_t::cells_and_ghosts][level], d >> delta_l).on(level - 1),
+                                                      prediction_inward_reach),
+                                         band_at(level - 1),
                                          self(this->subdomain()).on(level - 1)),
                             level);
                     }
@@ -387,11 +490,20 @@ namespace samurai
                     [&](std::size_t level)
                     {
                         add_prediction_ghosts(
-                            intersection(nestedExpand(self(neighbour.mesh[mesh_id_t::cells][level]).on(level - 2),
-                                                      config_t::prediction_stencil_radius),
+                            intersection(nestedExpand(self(neighbour.mesh[mesh_id_t::cells][level]).on(level - 2), prediction_reach),
+                                         self(this->subdomain()).on(level - 2)),
+                            intersection(
+                                nestedExpand(self(neighbour.mesh[mesh_id_t::cells_and_ghosts][level]).on(level - 1), prediction_reach),
+                                self(this->subdomain()).on(level - 1)),
+                            level);
+
+                        add_prediction_ghosts(
+                            intersection(nestedExpand(self(neighbour.mesh[mesh_id_t::cells][level]).on(level - 2), prediction_inward_reach),
+                                         band_at(level - 2),
                                          self(this->subdomain()).on(level - 2)),
                             intersection(nestedExpand(self(neighbour.mesh[mesh_id_t::cells_and_ghosts][level]).on(level - 1),
-                                                      config_t::prediction_stencil_radius),
+                                                      prediction_inward_reach),
+                                         band_at(level - 1),
                                          self(this->subdomain()).on(level - 1)),
                             level);
 
@@ -401,11 +513,23 @@ namespace samurai
                         {
                             add_prediction_ghosts(
                                 intersection(nestedExpand(translate(neighbour.mesh[mesh_id_t::cells][level], d >> delta_l).on(level - 2),
-                                                          config_t::prediction_stencil_radius),
+                                                          prediction_reach),
                                              self(this->subdomain()).on(level - 2)),
                                 intersection(
                                     nestedExpand(translate(neighbour.mesh[mesh_id_t::cells_and_ghosts][level], d >> delta_l).on(level - 1),
-                                                 config_t::prediction_stencil_radius),
+                                                 prediction_reach),
+                                    self(this->subdomain()).on(level - 1)),
+                                level);
+
+                            add_prediction_ghosts(
+                                intersection(nestedExpand(translate(neighbour.mesh[mesh_id_t::cells][level], d >> delta_l).on(level - 2),
+                                                          prediction_inward_reach),
+                                             band_at(level - 2),
+                                             self(this->subdomain()).on(level - 2)),
+                                intersection(
+                                    nestedExpand(translate(neighbour.mesh[mesh_id_t::cells_and_ghosts][level], d >> delta_l).on(level - 1),
+                                                 prediction_inward_reach),
+                                    band_at(level - 1),
                                     self(this->subdomain()).on(level - 1)),
                                 level);
                         }

--- a/include/samurai/mr/mesh.hpp
+++ b/include/samurai/mr/mesh.hpp
@@ -436,24 +436,42 @@ namespace samurai
                 this->cells()[mesh_id_t::cells],
                 [&](std::size_t level)
                 {
-                    // own part
-                    add_prediction_ghosts(
-                        nestedExpand(self(this->cells()[mesh_id_t::cells][level]).on(level - 2), prediction_reach),
-                        intersection(nestedExpand(self(this->cells()[mesh_id_t::cells_and_ghosts][level]).on(level - 1), prediction_reach),
-                                     nestedExpand(self(this->subdomain()).on(level - 1), prediction_reach)),
-                        level);
+                    if (!this->is_periodic())
+                    {
+                        // Without a periodic direction the two contributions below - the r
+                        // margin, and the 2r band clipped to the domain - are one set: the 2r
+                        // expansion clipped to the domain expanded by r. One traversal of two
+                        // operands per arm instead of two traversals of one and three.
+                        add_prediction_ghosts(
+                            intersection(nestedExpand(self(this->cells()[mesh_id_t::cells][level]).on(level - 2), prediction_inward_reach),
+                                         nestedExpand(self(this->domain(std::min(level - 2, this->max_level()))), prediction_reach)),
+                            intersection(
+                                nestedExpand(self(this->cells()[mesh_id_t::cells_and_ghosts][level]).on(level - 1), prediction_inward_reach),
+                                nestedExpand(self(this->domain(level - 1)), prediction_reach),
+                                nestedExpand(self(this->subdomain()).on(level - 1), prediction_inward_reach)),
+                            level);
+                    }
+                    else
+                    {
+                        // own part
+                        add_prediction_ghosts(
+                            nestedExpand(self(this->cells()[mesh_id_t::cells][level]).on(level - 2), prediction_reach),
+                            intersection(nestedExpand(self(this->cells()[mesh_id_t::cells_and_ghosts][level]).on(level - 1), prediction_reach),
+                                         nestedExpand(self(this->subdomain()).on(level - 1), prediction_reach)),
+                            level);
 
-                    // The inward band, added on top of the r margin rather than folded into
-                    // it: same shape as the arms above, so the set expressions resolve at the
-                    // same level, and the cell list merges the two contributions.
-                    add_prediction_ghosts(
-                        intersection(nestedExpand(self(this->cells()[mesh_id_t::cells][level]).on(level - 2), prediction_inward_reach),
-                                     band_at(level - 2)),
-                        intersection(
-                            nestedExpand(self(this->cells()[mesh_id_t::cells_and_ghosts][level]).on(level - 1), prediction_inward_reach),
-                            band_at(level - 1),
-                            nestedExpand(self(this->subdomain()).on(level - 1), prediction_inward_reach)),
-                        level);
+                        // The inward band, added on top of the r margin rather than folded into
+                        // it: same shape as the arms above, so the set expressions resolve at the
+                        // same level, and the cell list merges the two contributions.
+                        add_prediction_ghosts(
+                            intersection(nestedExpand(self(this->cells()[mesh_id_t::cells][level]).on(level - 2), prediction_inward_reach),
+                                         band_at(level - 2)),
+                            intersection(
+                                nestedExpand(self(this->cells()[mesh_id_t::cells_and_ghosts][level]).on(level - 1), prediction_inward_reach),
+                                band_at(level - 1),
+                                nestedExpand(self(this->subdomain()).on(level - 1), prediction_inward_reach)),
+                            level);
+                    }
 
                     // periodic part
                     const int delta_l = int(this->domain().level() - level);

--- a/include/samurai/petsc/compute_cell_ownership.hpp
+++ b/include/samurai/petsc/compute_cell_ownership.hpp
@@ -4,6 +4,7 @@
 #include "../field.hpp"
 #include "../io/hdf5.hpp"
 
+#include <limits>
 #include <stdexcept>
 
 namespace samurai
@@ -15,21 +16,23 @@ namespace samurai
         {
             std::size_t cell_index;
             std::size_t level;
-            std::vector<int> possible_owners;
             int owner_rank;
+            int rule; ///< which ownership rule decided, here
 
             std::size_t cell_index_on_neighbour;
             int owner_rank_on_neighbour;
+            int rule_on_neighbour;
 
             template <class Archive>
             void serialize(Archive& ar, const unsigned int /*version*/)
             {
                 ar & cell_index;
                 ar & level;
-                ar & possible_owners;
                 ar & owner_rank;
+                ar & rule;
                 ar & cell_index_on_neighbour;
                 ar & owner_rank_on_neighbour;
+                ar & rule_on_neighbour;
             }
         };
 
@@ -58,6 +61,53 @@ namespace samurai
             std::cout << "PETSc numbering saved to 'petsc_indices.xdmf'." << std::endl;
         }
 
+        /**
+         * Decide, for every cell this rank holds, which rank owns its unknown.
+         *
+         * The unknowns of the petsc system are the cells of the reference mesh of every rank, and
+         * a cell held by several ranks must have exactly one owner: the rank that assembles its
+         * row and in whose index range it lives. The exchange that gives a ghost its global index
+         * is positional, so every rank holding a cell has to reach the **same** owner **without
+         * asking anyone**: the rule below is a function of data every holder has, and it is
+         * evaluated identically everywhere. A single check pass then verifies that neighbours
+         * agree, and a disagreement is an error, not something to negotiate - it means two ranks
+         * hold a common cell without being registered as neighbours, which is the one situation
+         * in which they cannot have the same data.
+         *
+         * The rules, in increasing order of precedence. The principle behind them: a row is
+         * assembled by the rank that *classifies* the cell - as a real cell, a projection ghost,
+         * a prediction ghost or a boundary ghost - in its **own** mesh, because that
+         * classification is what the assembly visits (`for_each_projection_ghost`,
+         * `for_each_prediction_ghost`, the boundary stencils of the real boundary cells) and
+         * what guarantees that the rank holds every cell the row reads. So the owner has to be
+         * one of the ranks that classify the cell, and among them the lowest rank.
+         *
+         *   4. **Any other cell** - one no rank's real cells give a meaning to, such as a coarse
+         *      prediction margin far from every cell, or an outer corner - gets an identity row
+         *      from its owner, so any consistent choice does: the holder whose subdomain's
+         *      gravity centre is the closest, the tie going to the lowest rank. The holders are
+         *      this rank and every neighbour whose reference mesh contains the cell.
+         *   3. **A projection ghost** - a scheme ghost of some rank whose children are real cells
+         *      of that rank - is owned by the lowest such rank; **a prediction ghost** - a scheme
+         *      ghost of some rank whose parent is a real cell of that rank - likewise. The two
+         *      cannot overlap: a cell with a real parent has no real children.
+         *   2. **A real cell** is owned by the rank it belongs to.
+         *   1. **An outer ghost the boundary conditions fill** - a cell outside the domain within
+         *      @c ghost_width of a real boundary cell, in one Cartesian direction - is owned by the
+         *      lowest rank owning such a boundary cell. The boundary-condition row of such a
+         *      ghost is assembled while visiting the real boundary cells of the owning rank, so
+         *      any other owner would leave the row empty and the condition silently dropped.
+         *
+         * Every input to these rules - the neighbours' cells, scheme ghosts, domain and gravity
+         * centre - travels with the neighbourhood exchange, so every holder evaluates the same
+         * function on the same data. What was here before decided ownership from local
+         * heuristics - "the minimum rank of the children *this rank* holds", "the closer of the
+         * two gravity centres, pairwise" - whose answers differ from rank to rank, and then
+         * tried to repair the disagreements over a bounded number of correction passes. Pairwise
+         * closeness is not transitive, so three ranks sharing a coarse cell could each name a
+         * different owner and the passes never converged; the failure appeared as soon as the
+         * coarse levels carried a wider prediction margin and more cells were shared.
+         */
         template <class Mesh>
         void compute_cell_ownership(Mesh& mesh)
         {
@@ -77,316 +127,275 @@ namespace samurai
             std::vector<int>& owner_rank   = ownership.owner_rank;
             std::vector<int>& cell_indices = ownership.cell_indices;
 
-            using mesh_id_t  = typename Mesh::mesh_id_t;
-            using lca_t      = typename Mesh::lca_type;
-            using interval_t = typename Mesh::interval_t;
-            using index_t    = xt::xtensor_fixed<typename interval_t::value_t, xt::xshape<Mesh::dim - 1>>;
+            using mesh_id_t = typename Mesh::mesh_id_t;
 
             mpi::communicator world;
-            int rank = world.rank();
+            const int rank = world.rank();
 
-            std::size_t min_level = mesh[mesh_id_t::reference].min_level();
-            std::size_t max_level = mesh[mesh_id_t::reference].max_level();
+            const std::size_t min_level = mesh[mesh_id_t::reference].min_level();
+            const std::size_t max_level = mesh[mesh_id_t::reference].max_level();
 
             constexpr int UNSET = std::numeric_limits<int>::max();
 
-            // Stores the owner rank of each cell
-            owner_rank.resize(n_local_cells);
-            std::fill(owner_rank.begin(), owner_rank.end(), UNSET);
+            auto squared_distance = [](const auto& cell, const auto& centre)
+            {
+                auto diff = cell.center() - centre;
+                return samurai::math::sum(diff * diff);
+            };
 
-            // Local cells are locally owned.
-            for_each_cell(mesh,
-                          [&](auto& cell)
+            //---------------------------------------------------------//
+            // Rule 4: the closest gravity centre among the holders    //
+            //---------------------------------------------------------//
+            // Evaluated first, on every cell, so that the other rules can simply overwrite it.
+            // The comparison is a total order on (distance, rank), so the answer does not depend
+            // on the order in which the holders are visited.
+
+            owner_rank.assign(n_local_cells, rank);
+            std::vector<int> rule(n_local_cells, 4); // the rule that decided each cell, for the mismatch report
+            std::vector<double> best_distance(n_local_cells, std::numeric_limits<double>::infinity());
+
+            for_each_cell(mesh[mesh_id_t::reference],
+                          [&](const auto& cell)
                           {
-                              owner_rank[static_cast<std::size_t>(cell.index)] = rank;
+                              best_distance[static_cast<std::size_t>(cell.index)] = squared_distance(cell, mesh.gravity_center());
                           });
 
             for (std::size_t level = min_level; level <= max_level; ++level)
             {
-                // All the boundary ghosts of locally owned boundary cells are also locally owned.
-                auto domain_bdry_outer_layer = domain_boundary_outer_layer(mesh, level, mesh.ghost_width());
-                auto boundary_ghosts         = intersection(domain_bdry_outer_layer, mesh[mesh_id_t::reference][level]);
-                for_each_cell(mesh,
-                              boundary_ghosts,
-                              [&](auto& ghost)
-                              {
-                                  owner_rank[static_cast<std::size_t>(ghost.index)] = rank;
-                              });
-
-                for (auto& neighbour : mesh.mpi_neighbourhood())
+                for (const auto& neighbour : mesh.mpi_neighbourhood())
                 {
-                    // Ghosts that corresponds to neighbour's cells are owned by that neighbour.
+                    auto shared = intersection(mesh[mesh_id_t::reference][level], neighbour.mesh[mesh_id_t::reference][level]);
+                    for_each_cell(mesh,
+                                  shared,
+                                  [&](const auto& cell)
+                                  {
+                                      const auto cell_index = static_cast<std::size_t>(cell.index);
+                                      const double distance = squared_distance(cell, neighbour.mesh.gravity_center());
+                                      if (distance < best_distance[cell_index]
+                                          || (distance == best_distance[cell_index] && neighbour.rank < owner_rank[cell_index]))
+                                      {
+                                          best_distance[cell_index] = distance;
+                                          owner_rank[cell_index]    = neighbour.rank;
+                                      }
+                                  });
+                }
+            }
+
+            //-----------------------------------------------------------------//
+            // Rule 3: projection and prediction ghosts follow the rank that   //
+            // classifies them, the lowest one when several do                 //
+            //-----------------------------------------------------------------//
+
+            std::vector<int> classifier(n_local_cells, UNSET);
+
+            auto claim_classified_ghosts = [&](const auto& holder_mesh, int holder_rank)
+            {
+                const auto& holder_cells  = holder_mesh[mesh_id_t::cells];
+                const auto& holder_ghosts = holder_mesh[mesh_id_t::cells_and_ghosts];
+
+                auto claim = [&](auto&& set)
+                {
+                    for_each_cell(mesh,
+                                  set,
+                                  [&](const auto& ghost)
+                                  {
+                                      auto& owner = classifier[static_cast<std::size_t>(ghost.index)];
+                                      owner       = std::min(owner, holder_rank);
+                                  });
+                };
+
+                for (std::size_t level = min_level; level <= max_level; ++level)
+                {
+                    if (level < max_level)
+                    {
+                        auto projection_ghosts = intersection(mesh[mesh_id_t::reference][level], holder_ghosts[level], holder_cells[level + 1])
+                                                     .on(level);
+                        claim(projection_ghosts);
+                    }
+                    if (level > min_level)
+                    {
+                        auto prediction_ghosts = intersection(mesh[mesh_id_t::reference][level], holder_ghosts[level], holder_cells[level - 1])
+                                                     .on(level);
+                        claim(prediction_ghosts);
+                    }
+                }
+            };
+
+            claim_classified_ghosts(mesh, rank);
+            for (const auto& neighbour : mesh.mpi_neighbourhood())
+            {
+                claim_classified_ghosts(neighbour.mesh, neighbour.rank);
+            }
+
+            for (std::size_t cell_index = 0; cell_index < n_local_cells; ++cell_index)
+            {
+                if (classifier[cell_index] != UNSET)
+                {
+                    owner_rank[cell_index] = classifier[cell_index];
+                    rule[cell_index]       = 3;
+                }
+            }
+
+            //--------------------//
+            // Rule 2: real cells //
+            //--------------------//
+
+            for_each_cell(mesh,
+                          [&](const auto& cell)
+                          {
+                              owner_rank[static_cast<std::size_t>(cell.index)] = rank;
+                              rule[static_cast<std::size_t>(cell.index)]       = 2;
+                          });
+
+            for (std::size_t level = min_level; level <= max_level; ++level)
+            {
+                for (const auto& neighbour : mesh.mpi_neighbourhood())
+                {
                     auto neighbour_cells = intersection(neighbour.mesh[mesh_id_t::cells][level], mesh[mesh_id_t::reference][level]);
                     for_each_cell(mesh,
                                   neighbour_cells,
-                                  [&](auto& cell)
+                                  [&](const auto& cell)
                                   {
                                       owner_rank[static_cast<std::size_t>(cell.index)] = neighbour.rank;
+                                      rule[static_cast<std::size_t>(cell.index)]       = 2;
                                   });
+                }
+            }
 
-                    // Boundary ghosts associated with neighbour's boundary cells are also owned by that neighbour
-                    auto nghb_domain_bdry_outer_layer = domain_boundary_outer_layer(neighbour.mesh, level, neighbour.mesh.ghost_width());
-                    auto nghb_boundary_ghosts         = intersection(nghb_domain_bdry_outer_layer, mesh[mesh_id_t::reference][level]);
+            //--------------------------------------------------------------//
+            // Rule 1: the outer ghosts of a real boundary cell follow it   //
+            //--------------------------------------------------------------//
+
+            std::vector<int> boundary_owner(n_local_cells, UNSET);
+
+            auto claim_boundary_ghosts = [&](const auto& holder_mesh, int holder_rank)
+            {
+                for (std::size_t level = min_level; level <= max_level; ++level)
+                {
+                    auto outer_layer     = domain_boundary_outer_layer(holder_mesh, level, holder_mesh.ghost_width());
+                    auto boundary_ghosts = intersection(outer_layer, mesh[mesh_id_t::reference][level]);
                     for_each_cell(mesh,
-                                  nghb_boundary_ghosts,
-                                  [&](auto& ghost)
+                                  boundary_ghosts,
+                                  [&](const auto& ghost)
                                   {
-                                      owner_rank[static_cast<std::size_t>(ghost.index)] = neighbour.rank;
+                                      auto& owner = boundary_owner[static_cast<std::size_t>(ghost.index)];
+                                      owner       = std::min(owner, holder_rank);
                                   });
                 }
-            }
+            };
 
-            // Boundary ghosts at lower levels might still be unset (if they have no children in this rank).
-            // This can happen if a coarse ghost is outside the boundary owned by another subdomain.
-            // I think this can't happen unless the resolution is sufficiently small, so that coarse ghosts of one subdomain
-            // goes all the way to the domain boundary of the other subdomain without having its boundary cells as ghosts.
-            for (std::size_t level = min_level; level <= max_level - 1; ++level)
+            claim_boundary_ghosts(mesh, rank);
+            for (const auto& neighbour : mesh.mpi_neighbourhood())
             {
-                for (auto& neighbour : mesh.mpi_neighbourhood())
-                {
-                    auto nghb_domain_bdry_outer_layer = domain_boundary_outer_layer(neighbour.mesh, level + 1, neighbour.mesh.ghost_width());
-                    auto nghb_domain_bdry_outer_layer_no_children = difference(nghb_domain_bdry_outer_layer,
-                                                                               mesh[mesh_id_t::reference][level + 1]);
-                    auto nghb_boundary_ghosts = intersection(nghb_domain_bdry_outer_layer_no_children, mesh[mesh_id_t::reference][level])
-                                                    .on(level);
-                    for_each_cell(mesh,
-                                  nghb_boundary_ghosts,
-                                  [&](auto& ghost)
-                                  {
-                                      assert(owner_rank[static_cast<std::size_t>(ghost.index)] == UNSET);
-                                      if (owner_rank[static_cast<std::size_t>(ghost.index)] == UNSET)
-                                      {
-                                          owner_rank[static_cast<std::size_t>(ghost.index)] = neighbour.rank;
-                                      }
-                                  });
-                }
+                claim_boundary_ghosts(neighbour.mesh, neighbour.rank);
             }
-
-            // The projection ghosts are owned by the minimum rank of their children
-            for (std::size_t level = max_level - 1; level >= min_level; --level)
-            {
-                lca_t proj_ghost_lca(level, mesh.origin_point(), mesh.scaling_factor());
-                index_t index_ghost;
-
-                auto projection_ghosts = intersection(mesh[mesh_id_t::reference][level], mesh[mesh_id_t::reference][level + 1]).on(level);
-                for_each_cell(mesh,
-                              projection_ghosts,
-                              [&](auto& ghost)
-                              {
-                                  assert(static_cast<std::size_t>(ghost.index) < owner_rank.size());
-                                  auto& ghost_owner_rank = owner_rank[static_cast<std::size_t>(ghost.index)];
-                                  if (ghost_owner_rank == UNSET)
-                                  {
-                                      index_ghost = xt::view(ghost.indices, xt::range(1, Mesh::dim));
-                                      proj_ghost_lca.add_point_back(ghost.indices[0], index_ghost);
-                                      auto children = intersection(self(proj_ghost_lca).on(level + 1), mesh[mesh_id_t::reference][level + 1]);
-                                      for_each_cell(mesh,
-                                                    children,
-                                                    [&](auto& child)
-                                                    {
-                                                        ghost_owner_rank = std::min(ghost_owner_rank,
-                                                                                    owner_rank[static_cast<std::size_t>(child.index)]);
-                                                    });
-                                      proj_ghost_lca.clear();
-                                  }
-                              });
-
-                // For the projection ghosts that have no children in this rank, we look for children in neighbour ranks
-                for (auto& neighbour : mesh.mpi_neighbourhood())
-                {
-                    auto projection_ghosts_nghb = intersection(mesh[mesh_id_t::reference][level],
-                                                               difference(neighbour.mesh[mesh_id_t::reference][level + 1],
-                                                                          mesh[mesh_id_t::reference][level + 1]))
-                                                      .on(level);
-                    for_each_cell(mesh,
-                                  projection_ghosts_nghb,
-                                  [&](auto& ghost)
-                                  {
-                                      auto& ghost_owner_rank = owner_rank[static_cast<std::size_t>(ghost.index)];
-                                      if (ghost_owner_rank == UNSET)
-                                      {
-                                          ghost_owner_rank = neighbour.rank;
-                                      }
-                                  });
-                }
-
-                if (level == 0)
-                {
-                    break;
-                }
-            }
-
-            // The prediction ghosts are owned by the rank of their parent
-            for (std::size_t level = min_level + 1; level <= max_level; ++level)
-            {
-                lca_t pred_ghost_lca(level, mesh.origin_point(), mesh.scaling_factor());
-                index_t index_ghost;
-
-                auto prediction_ghosts = intersection(mesh[mesh_id_t::reference][level], mesh[mesh_id_t::reference][level - 1]).on(level);
-                for_each_cell(
-                    mesh,
-                    prediction_ghosts,
-                    [&](auto& ghost)
-                    {
-                        auto& ghost_owner_rank = owner_rank[static_cast<std::size_t>(ghost.index)];
-                        if (ghost_owner_rank == UNSET)
-                        {
-                            index_ghost = xt::view(ghost.indices, xt::range(1, Mesh::dim));
-                            pred_ghost_lca.add_point_back(ghost.indices[0], index_ghost);
-                            auto parent_set = intersection(self(pred_ghost_lca).on(level - 1), mesh[mesh_id_t::reference][level - 1]);
-                            for_each_cell(mesh,
-                                          parent_set,
-                                          [&](auto& parent)
-                                          {
-                                              assert(ghost_owner_rank == UNSET && "there must be only one parent");
-                                              ghost_owner_rank = owner_rank[static_cast<std::size_t>(parent.index)];
-                                          });
-                            pred_ghost_lca.clear();
-                        }
-                    });
-            }
-
-            // The remaining shared ghosts are owned by the rank whose subdomain's gravity center is the closest.
-            // It can typpically handle the outer corners and other remaining boundary ghosts.
-            for (std::size_t level = min_level; level <= max_level; ++level)
-            {
-                for (auto& neighbour : mesh.mpi_neighbourhood())
-                {
-                    auto intersecting_cells_and_ghosts = intersection(mesh[mesh_id_t::reference][level],
-                                                                      neighbour.mesh[mesh_id_t::reference][level]);
-                    for_each_cell(mesh,
-                                  intersecting_cells_and_ghosts,
-                                  [&](auto& cell)
-                                  {
-                                      if (owner_rank[static_cast<std::size_t>(cell.index)] == UNSET)
-                                      {
-                                          auto diff     = cell.center() - mesh.gravity_center();
-                                          auto distance = std::sqrt(samurai::math::sum(diff * diff));
-
-                                          auto nghb_diff     = cell.center() - neighbour.mesh.gravity_center();
-                                          auto nghb_distance = std::sqrt(samurai::math::sum(nghb_diff * nghb_diff));
-
-                                          owner_rank[static_cast<std::size_t>(cell.index)] = distance < nghb_distance ? rank : neighbour.rank;
-                                      }
-                                  });
-                }
-            }
-
-            // Finally, the ghosts that are not owned by any rank at this point are owned by the current rank.
-            for (std::size_t cell_index = 0; cell_index < n_local_cells; ++cell_index)
-            {
-                if (owner_rank[cell_index] == UNSET)
-                {
-                    owner_rank[cell_index] = rank;
-                }
-            }
-
-            //--------------------------------------------//
-            // Look for owner mismatches and correct them //
-            //--------------------------------------------//
-            // An owner mismatch is when two neighbouring ranks disagree on the owner of a cell.
-            // Mismatches can happen when two neighbouring ranks have intersecting ghosts although they are not registered in the
-            // neighbourhood of each other.
-
-            // We register, for all cells, the possible owners (neighbour ranks that also have this cell).
-            // This will be used to choose another owner in case of mismatch.
-            std::vector<std::vector<int>> possible_owners(n_local_cells);
 
             for (std::size_t cell_index = 0; cell_index < n_local_cells; ++cell_index)
             {
-                possible_owners[cell_index].push_back(rank);
-            }
-            for (std::size_t level = min_level; level <= max_level; ++level)
-            {
-                for (auto& neighbour : mesh.mpi_neighbourhood())
+                if (boundary_owner[cell_index] != UNSET)
                 {
-                    auto intersecting_cells_and_ghosts = intersection(mesh[mesh_id_t::reference][level],
-                                                                      neighbour.mesh[mesh_id_t::reference][level]);
-                    for_each_cell(mesh,
-                                  intersecting_cells_and_ghosts,
-                                  [&](auto& cell)
-                                  {
-                                      possible_owners[static_cast<std::size_t>(cell.index)].push_back(neighbour.rank);
-                                  });
+                    owner_rank[cell_index] = boundary_owner[cell_index];
+                    rule[cell_index]       = 1;
                 }
             }
 
-            // The process of checking for mismatches and correcting them is repeated until no mismatch is found.
-            int n_mismatch_checks         = 0;
-            const int max_mismatch_checks = world.size() + 2; // arbitrary limit
-            bool owner_mismatch           = false;
+            //-----------------------------------//
+            // Check that the neighbours agree   //
+            //-----------------------------------//
+            // The exchange is positional, so both sides must walk the same cells in the same
+            // order: the same levels, and the intersection built with its operands in the same
+            // order - derived from the rank numbers, not from which side is sending.
+
+            auto shared_cells = [&](const auto& neighbour, std::size_t level)
+            {
+                const auto& mine  = mesh[mesh_id_t::reference][level];
+                const auto& other = neighbour.mesh[mesh_id_t::reference][level];
+                return rank < neighbour.rank ? intersection(mine, other) : intersection(other, mine);
+            };
+
+            // The level range comes from both meshes, not from this rank's: a rank whose
+            // reference mesh starts at a coarser level than its neighbour's would otherwise
+            // walk more levels than the neighbour does and read the values off by a level.
+            auto shared_max_level = [&](const auto& neighbour)
+            {
+                return std::max(max_level, neighbour.mesh[mesh_id_t::reference].max_level());
+            };
+
             std::vector<std::vector<MismatchInfo>> mismatches(mesh.mpi_neighbourhood().size());
-            bool unsolvable_mismatch_found = false;
+            bool owner_mismatch = false;
 
-            while (n_mismatch_checks < max_mismatch_checks && !unsolvable_mismatch_found)
             {
-                for (auto& m : mismatches)
-                {
-                    m.clear();
-                }
-                owner_mismatch = false;
-                n_mismatch_checks++;
-
-                // SEND
                 std::vector<mpi::request> req;
                 std::vector<std::vector<PetscInt>> to_send_by_neighbour(mesh.mpi_neighbourhood().size());
-                std::size_t i_neigh = 0;
-                for (auto& neighbour : mesh.mpi_neighbourhood())
+                std::size_t i_neighbour = 0;
+                for (const auto& neighbour : mesh.mpi_neighbourhood())
                 {
-                    auto& to_send = to_send_by_neighbour[i_neigh];
-
-                    for (std::size_t level = min_level; level <= max_level; ++level)
+                    auto& to_send = to_send_by_neighbour[i_neighbour];
+                    for (std::size_t level = 0; level <= shared_max_level(neighbour); ++level)
                     {
-                        auto intersecting_cells_and_ghosts = intersection(mesh[mesh_id_t::reference][level],
-                                                                          neighbour.mesh[mesh_id_t::reference][level]);
+                        auto shared = shared_cells(neighbour, level);
                         for_each_cell(mesh,
-                                      intersecting_cells_and_ghosts,
-                                      [&](auto& cell)
+                                      shared,
+                                      [&](const auto& cell)
                                       {
                                           to_send.push_back(owner_rank[static_cast<std::size_t>(cell.index)]);
                                           to_send.push_back(static_cast<PetscInt>(cell.index));
+                                          to_send.push_back(rule[static_cast<std::size_t>(cell.index)]);
+                                          for (std::size_t d = 0; d < Mesh::dim; ++d)
+                                          {
+                                              to_send.push_back(static_cast<PetscInt>(cell.indices[d]));
+                                          }
                                       });
                     }
                     req.push_back(world.isend(neighbour.rank /* dest */, neighbour.rank /* tag */, to_send));
-                    i_neigh++;
+                    i_neighbour++;
                 }
 
-                // RECEIVE
-                std::size_t i_neighbour = 0;
-                for (auto& neighbour : mesh.mpi_neighbourhood())
+                i_neighbour = 0;
+                for (const auto& neighbour : mesh.mpi_neighbourhood())
                 {
                     std::vector<PetscInt> to_recv;
                     std::size_t read = 0;
                     world.recv(neighbour.rank /* source */, rank /* tag */, to_recv);
-                    for (std::size_t level = 0; level <= max_level; ++level)
+                    for (std::size_t level = 0; level <= shared_max_level(neighbour); ++level)
                     {
-                        auto intersecting_cells_and_ghosts = intersection(neighbour.mesh[mesh_id_t::reference][level],
-                                                                          mesh[mesh_id_t::reference][level]);
+                        auto shared = shared_cells(neighbour, level);
                         for_each_cell(mesh,
-                                      intersecting_cells_and_ghosts,
-                                      [&](auto& cell)
+                                      shared,
+                                      [&](const auto& cell)
                                       {
-                                          auto neighbour_owner_rank    = to_recv[read++];
-                                          auto cell_index_on_neighbour = to_recv[read++];
-                                          // MISMATCH DETECTED!!!
-                                          if (owner_rank[static_cast<std::size_t>(cell.index)] != neighbour_owner_rank)
+                                          const auto neighbour_owner_rank    = static_cast<int>(to_recv[read++]);
+                                          const auto cell_index_on_neighbour = static_cast<std::size_t>(to_recv[read++]);
+                                          const auto rule_on_neighbour       = static_cast<int>(to_recv[read++]);
+                                          const auto cell_index              = static_cast<std::size_t>(cell.index);
+                                          for (std::size_t d = 0; d < Mesh::dim; ++d)
+                                          {
+                                              const auto coord = to_recv[read++];
+                                              if (coord != static_cast<PetscInt>(cell.indices[d]))
+                                              {
+                                                  throw std::runtime_error(fmt::format(
+                                                      "[{}] compute_cell_ownership: the ownership exchange with rank {} is misaligned at "
+                                                      "level {}: this rank walks the cell at ({}) where the neighbour sent its cell {} at "
+                                                      "coordinate {} = {}. The two ranks do not walk the same shared cells.",
+                                                      rank,
+                                                      neighbour.rank,
+                                                      level,
+                                                      fmt::join(cell.indices, ", "),
+                                                      cell_index_on_neighbour,
+                                                      d,
+                                                      coord));
+                                              }
+                                          }
+                                          if (owner_rank[cell_index] != neighbour_owner_rank)
                                           {
                                               owner_mismatch = true;
-                                              mismatches[i_neighbour].emplace_back(static_cast<std::size_t>(cell.index),
-                                                                                   level,
-                                                                                   possible_owners[static_cast<std::size_t>(cell.index)],
-                                                                                   owner_rank[static_cast<std::size_t>(cell.index)],
-                                                                                   cell_index_on_neighbour,
-                                                                                   neighbour_owner_rank);
-
-                                              // std::cout << fmt::format(
-                                              //     "[{}] Error: owner mismatch in cell {} on level {} (owned here by {} != {} on [{}] with
-                                              //     cell_index {})\n", rank, cell.index, level,
-                                              //     owner_rank[static_cast<std::size_t>(cell.index)],
-                                              //     neighbour_owner_rank,
-                                              //     neighbour.rank,
-                                              //     cell_index_on_neighbour);
-                                              // owner_rank[static_cast<std::size_t>(cell.index)] = world.size() * 2; // mark error
+                                              mismatches[i_neighbour].push_back({cell_index,
+                                                                                 level,
+                                                                                 owner_rank[cell_index],
+                                                                                 rule[cell_index],
+                                                                                 cell_index_on_neighbour,
+                                                                                 neighbour_owner_rank,
+                                                                                 rule_on_neighbour});
                                           }
                                       });
                     }
@@ -394,124 +403,37 @@ namespace samurai
                 }
 
                 mpi::wait_all(req.begin(), req.end());
-
-                owner_mismatch = mpi::all_reduce(world, owner_mismatch, std::logical_or());
-                if (!owner_mismatch)
-                {
-                    // No more mismatches, get out
-                    break;
-                }
-                // else // export for analysis
-                // {
-                //     auto owner_rank_field = make_scalar_field<int>("owner_rank", mesh);
-                //     for (std::size_t cell_index = 0; cell_index < mesh.nb_cells(); ++cell_index)
-                //     {
-                //         owner_rank_field[cell_index] = owner_rank[cell_index];
-                //     }
-                //     auto samurai_cell_indices_field = make_scalar_field<std::size_t>("samurai_cell_index", mesh);
-                //     for (std::size_t cell_index = 0; cell_index < mesh.nb_cells(); ++cell_index)
-                //     {
-                //         samurai_cell_indices_field[cell_index] = static_cast<std::size_t>(cell_index);
-                //     }
-                //     save(fs::current_path(), "owner_mismatch", {true, true}, mesh, owner_rank_field, samurai_cell_indices_field);
-
-                //     std::cerr << "Cell ownership mismatch detected. Exiting." << std::endl;
-                //     exit(EXIT_FAILURE);
-                // }
-
-                // Send mismatches to neighbours
-                req.clear();
-                i_neighbour = 0;
-                for (auto& neighbour : mesh.mpi_neighbourhood())
-                {
-                    req.push_back(world.isend(neighbour.rank /* dest */, neighbour.rank /* tag */, mismatches[i_neighbour]));
-                    i_neighbour++;
-                }
-
-                // Receive mismatches from neighbours and change owner ranks if needed
-                i_neighbour = 0;
-                for (auto& neighbour : mesh.mpi_neighbourhood())
-                {
-                    std::vector<MismatchInfo> neighbour_mismatches;
-                    world.recv(neighbour.rank /* source */, rank /* tag */, neighbour_mismatches);
-                    for (auto& neighbour_mismatch : neighbour_mismatches)
-                    {
-                        // If the owner_rank I have chosen is not in the possible_owners of the neighbour, we must choose another one that
-                        // is possible for both.
-                        auto& my_cell_index = neighbour_mismatch.cell_index_on_neighbour;
-                        if (std::find(neighbour_mismatch.possible_owners.begin(),
-                                      neighbour_mismatch.possible_owners.end(),
-                                      owner_rank[my_cell_index])
-                            == neighbour_mismatch.possible_owners.end())
-                        {
-                            // Find the intersection between the neighbour's possible_owners and my possible_owners
-                            std::vector<int> intersection;
-                            for (auto& neighbour_possible_owner : neighbour_mismatch.possible_owners)
-                            {
-                                if (std::find(possible_owners[my_cell_index].begin(),
-                                              possible_owners[my_cell_index].end(),
-                                              neighbour_possible_owner)
-                                    != possible_owners[my_cell_index].end())
-                                {
-                                    intersection.push_back(neighbour_possible_owner);
-                                }
-                            }
-                            if (intersection.empty())
-                            {
-                                std::cerr << fmt::format(
-                                    "[{}] Error: cannot resolve ownership mismatch for cell {} (cell_index {} in rank [{}]). ",
-                                    rank,
-                                    my_cell_index,
-                                    neighbour_mismatch.cell_index,
-                                    neighbour.rank);
-                                std::cerr << fmt::format("[{}] Possible owners: [{}] --> ({}), [{}] --> ({}).\n",
-                                                         rank,
-                                                         rank,
-                                                         fmt::join(possible_owners[my_cell_index], ", "),
-                                                         neighbour.rank,
-                                                         fmt::join(neighbour_mismatch.possible_owners, ", "));
-                                unsolvable_mismatch_found = true;
-                                break;
-                            }
-                            // Update possible_owners to the intersection
-                            possible_owners[my_cell_index] = intersection;
-                            // Choose the minimum rank in the intersection as the new owner
-                            owner_rank[my_cell_index] = *std::min_element(possible_owners[my_cell_index].begin(),
-                                                                          possible_owners[my_cell_index].end());
-                        }
-                        // else, the owner rank is acceptable for both ranks, we don't change it
-                    }
-                    neighbour_mismatches.clear();
-                    i_neighbour++;
-                }
-                mpi::wait_all(req.begin(), req.end());
             }
 
-            // Print the mismatches
-            if ((n_mismatch_checks == max_mismatch_checks || unsolvable_mismatch_found) && owner_mismatch)
+            owner_mismatch = mpi::all_reduce(world, owner_mismatch, std::logical_or());
+
+            if (owner_mismatch)
             {
                 auto owner_rank_field = make_scalar_field<int>("owner_rank", mesh);
                 for (std::size_t cell_index = 0; cell_index < mesh.nb_cells(); ++cell_index)
                 {
                     owner_rank_field[cell_index] = owner_rank[cell_index];
                 }
-                std::size_t i_neigh = 0;
-                for (auto& neighbour : mesh.mpi_neighbourhood())
+                std::size_t i_neighbour = 0;
+                for (const auto& neighbour : mesh.mpi_neighbourhood())
                 {
-                    for (auto& mismatch : mismatches[i_neigh])
+                    for (const auto& mismatch : mismatches[i_neighbour])
                     {
-                        std::cout << fmt::format(
-                            "[{}] Mismatch for cell {} at level {} (owned here by {} and owned by {} on [{}] with cell_index {})\n",
+                        std::cerr << fmt::format(
+                            "[{}] Mismatch for cell {} at level {} (owned here by {} by rule {}, and owned by {} by rule {} "
+                            "on [{}] with cell_index {})\n",
                             rank,
                             mismatch.cell_index,
                             mismatch.level,
-                            owner_rank[mismatch.cell_index],
+                            mismatch.owner_rank,
+                            mismatch.rule,
                             mismatch.owner_rank_on_neighbour,
+                            mismatch.rule_on_neighbour,
                             neighbour.rank,
                             mismatch.cell_index_on_neighbour);
                         owner_rank_field[mismatch.cell_index] = 2 * world.size(); // mark error
                     }
-                    i_neigh++;
+                    i_neighbour++;
                 }
 
                 auto samurai_cell_indices_field = make_scalar_field<std::size_t>("samurai_cell_index", mesh);
@@ -520,15 +442,13 @@ namespace samurai
                     samurai_cell_indices_field[cell_index] = static_cast<std::size_t>(cell_index);
                 }
                 save(fs::current_path(), "owner_mismatch", {true, true}, mesh, owner_rank_field, samurai_cell_indices_field);
-                std::cerr << fmt::format("[{}] Error: cell ownership mismatch detected. ", rank);
-                if (!unsolvable_mismatch_found)
-                {
-                    std::cerr << fmt::format("Maximum number of correction passes reached ({}). ", max_mismatch_checks);
-                }
-                std::cerr << fmt::format("See 'owner_mismatch.xdmf' for details.\n", rank);
-                std::cerr << fmt::format(
-                    "[{}] This usually happens when low level ghosts are shared between subdomains that are not in each other's direct neighbourhood. To solve this issue, try increasing the min level.\n",
-                    rank);
+                std::cout.flush();
+                std::cerr << fmt::format("[{}] Error: cell ownership mismatch detected. See 'owner_mismatch.xdmf' for details.\n", rank);
+                std::cerr << fmt::format("[{}] The ownership rule is the same on every rank, so two ranks can only disagree when they hold "
+                                         "a common cell without being registered as neighbours of each other. This usually happens when "
+                                         "low level ghosts are shared between subdomains that are not in each other's direct "
+                                         "neighbourhood. To solve this issue, try increasing the min level.\n",
+                                         rank);
                 throw std::runtime_error(fmt::format("[{}] Cell ownership mismatch detected. See 'owner_mismatch.xdmf' for details.", rank));
             }
 
@@ -563,11 +483,11 @@ namespace samurai
             if (args::print_petsc_numbering)
             {
                 sleep(static_cast<unsigned int>(rank));
-                std::cout << fmt::format("[{}]: Cell ownership: owned: {}, total: {}\n", world.rank(), n_owned_cells, n_local_cells);
+                std::cerr << fmt::format("[{}]: Cell ownership: owned: {}, total: {}\n", world.rank(), n_owned_cells, n_local_cells);
                 for_each_cell(mesh[mesh_id_t::reference],
                               [&](auto& cell)
                               {
-                                  std::cout << fmt::format("[{}]:          cell_index {} level {} (owned by {}): CI{}\n",
+                                  std::cerr << fmt::format("[{}]:          cell_index {} level {} (owned by {}): CI{}\n",
                                                            world.rank(),
                                                            cell.index,
                                                            cell.level,

--- a/include/samurai/petsc/fv/FV_scheme_assembly.hpp
+++ b/include/samurai/petsc/fv/FV_scheme_assembly.hpp
@@ -1182,8 +1182,10 @@ namespace samurai
                 //                           1+4=5 in 2D
                 static constexpr std::size_t proj_stencil_size = 1 + (1 << dim);
 #ifdef SAMURAI_WITH_MPI
-                // assume that half the stencil can be on other processes
-                PetscInt o_nnz_value = mpi::communicator().size() == 1 ? 0 : proj_stencil_size / 2;
+                // The owner of a projection ghost is the lowest rank holding one of its children as
+                // a real cell (compute_cell_ownership), so every other child may be on another
+                // process: allocate for all of them.
+                PetscInt o_nnz_value = mpi::communicator().size() == 1 ? 0 : (1 << dim);
 #endif
 
                 for_each_projection_ghost(mesh(),

--- a/include/samurai/petsc/global_numbering.hpp
+++ b/include/samurai/petsc/global_numbering.hpp
@@ -119,8 +119,8 @@ namespace samurai
             if (args::print_petsc_numbering)
             {
                 sleep(static_cast<unsigned int>(rank));
-                std::cout << fmt::format("[{}]: n_owned_unknowns = {}, n_ghost_unknowns = {}\n", rank, n_owned_unknowns, n_ghost_unknowns);
-                std::cout << fmt::format("[{}]: OWNED local_index = [{},{}], global_index = [{},{}]\n",
+                std::cerr << fmt::format("[{}]: n_owned_unknowns = {}, n_ghost_unknowns = {}\n", rank, n_owned_unknowns, n_ghost_unknowns);
+                std::cerr << fmt::format("[{}]: OWNED local_index = [{},{}], global_index = [{},{}]\n",
                                          rank,
                                          local_index,
                                          local_index + static_cast<PetscInt>(n_owned_unknowns) - 1,
@@ -148,7 +148,7 @@ namespace samurai
 
             if (args::print_petsc_numbering)
             {
-                std::cout << fmt::format("rank {}: GHOSTS local_index = [{},{}]\n",
+                std::cerr << fmt::format("rank {}: GHOSTS local_index = [{},{}]\n",
                                          rank,
                                          local_index,
                                          local_index + static_cast<PetscInt>(n_ghost_unknowns) - 1);
@@ -275,7 +275,7 @@ namespace samurai
                     {
                         if (ownership.owner_rank[cell_index] == rank)
                         {
-                            std::cout << fmt::format("[{}]:          cell_index {} (owned by {}): CI{} L{} G{}\n",
+                            std::cerr << fmt::format("[{}]:          cell_index {} (owned by {}): CI{} L{} G{}\n",
                                                      world.rank(),
                                                      cell_index,
                                                      ownership.owner_rank[cell_index],
@@ -285,7 +285,7 @@ namespace samurai
                         }
                         else
                         {
-                            std::cout << fmt::format("[{}]:          cell_index {} (owned by {}): CI{} L{} G{}\n",
+                            std::cerr << fmt::format("[{}]:          cell_index {} (owned by {}): CI{} L{} G{}\n",
                                                      world.rank(),
                                                      cell_index,
                                                      ownership.owner_rank[cell_index],

--- a/include/samurai/petsc/global_numbering.hpp
+++ b/include/samurai/petsc/global_numbering.hpp
@@ -1,4 +1,6 @@
 #pragma once
+#include <algorithm>
+
 #include "../arguments.hpp"
 #include "cell_ownership.hpp"
 #include <petsc.h>
@@ -163,7 +165,35 @@ namespace samurai
                 }
             }
 
-            // Exchange global indices of the local cells/ghosts with neighbouring MPI processes
+            // Exchange global indices of the local cells/ghosts with neighbouring MPI processes.
+            //
+            // The exchange is positional: the n-th value received is the n-th value the
+            // neighbour sent. That only holds if both sides walk the same cells in the same
+            // order, and the two conditions below are what make them:
+            //
+            //   - **one value per shared unknown, owned or not.** Filtering on ownership while
+            //     sending and on the *other* rank's ownership while receiving compares two
+            //     ranks' opinions, and where those disagree - which is what the ownership
+            //     correction passes exist to repair, and cannot always - the sequences drift
+            //     and every later ghost gets another cell's global index. The corruption is
+            //     silent: it produces a valid-looking index in another rank's range, and the
+            //     only symptom is petsc refusing an unexpected column much later. Sending
+            //     UNSET for what I do not own costs one integer per shared cell and removes
+            //     the possibility;
+            //   - **the same level range and the same operand order on both sides.** Both are
+            //     derived from the pair, not from one side's mesh: the levels from both
+            //     meshes' extent, the operand order from the rank numbers.
+            auto shared_cells = [&](const auto& neighbour, std::size_t level)
+            {
+                const auto& mine  = mesh[mesh_id_t::reference][level];
+                const auto& other = neighbour.mesh[mesh_id_t::reference][level];
+                return rank < neighbour.rank ? intersection(mine, other) : intersection(other, mine);
+            };
+
+            auto shared_max_level = [&](const auto& neighbour)
+            {
+                return std::max(max_level, neighbour.mesh[mesh_id_t::reference].max_level());
+            };
 
             // SEND
             std::vector<mpi::request> req;
@@ -173,21 +203,18 @@ namespace samurai
             {
                 auto& to_send = to_send_by_neighbour[i_neigh];
 
-                for (std::size_t level = min_level; level <= max_level; ++level)
+                for (std::size_t level = 0; level <= shared_max_level(neighbour); ++level)
                 {
-                    auto intersecting_cells_and_ghosts = intersection(mesh[mesh_id_t::reference][level],
-                                                                      neighbour.mesh[mesh_id_t::reference][level]);
+                    auto shared = shared_cells(neighbour, level);
                     for_each_cell(mesh,
-                                  intersecting_cells_and_ghosts,
+                                  shared,
                                   [&](auto& cell)
                                   {
-                                      auto cell_index = static_cast<std::size_t>(cell.index);
-                                      if (ownership.owner_rank[cell_index] == rank)
+                                      auto cell_index  = static_cast<std::size_t>(cell.index);
+                                      const bool owned = ownership.owner_rank[cell_index] == rank;
+                                      for (int i = 0; i < n_unknowns_per_cell; ++i)
                                       {
-                                          for (int i = 0; i < n_unknowns_per_cell; ++i)
-                                          {
-                                              to_send.push_back(global_indices[owned_unknown_index(cell_index, i)]);
-                                          }
+                                          to_send.push_back(owned ? global_indices[owned_unknown_index(cell_index, i)] : UNSET);
                                       }
                                   });
                 }
@@ -201,29 +228,43 @@ namespace samurai
                 std::vector<PetscInt> to_recv;
                 std::size_t read = 0;
                 world.recv(neighbour.rank /* source */, rank /* tag */, to_recv);
-                for (std::size_t level = 0; level <= max_level; ++level)
+                for (std::size_t level = 0; level <= shared_max_level(neighbour); ++level)
                 {
-                    auto intersecting_cells_and_ghosts = intersection(neighbour.mesh[mesh_id_t::reference][level],
-                                                                      mesh[mesh_id_t::reference][level]);
+                    auto shared = shared_cells(neighbour, level);
                     for_each_cell(mesh,
-                                  intersecting_cells_and_ghosts,
+                                  shared,
                                   [&](auto& cell)
                                   {
                                       auto cell_index = static_cast<std::size_t>(cell.index);
-                                      if (ownership.owner_rank[cell_index] == neighbour.rank)
+                                      for (int i = 0; i < n_unknowns_per_cell; ++i)
                                       {
-                                          for (int i = 0; i < n_unknowns_per_cell; ++i)
+                                          const PetscInt sent = to_recv[read++];
+                                          if (ownership.owner_rank[cell_index] != neighbour.rank)
                                           {
-                                              assert(global_indices[ghost_unknown_index(cell_index, i)] == UNSET);
-                                              global_indices[ghost_unknown_index(cell_index, i)] = to_recv[read++];
+                                              continue;
                                           }
+                                          // The neighbour says it does not own a cell this rank
+                                          // considers its ghost. That is an ownership
+                                          // disagreement, and it used to become a wrong global
+                                          // index; say so instead.
+                                          if (sent == UNSET)
+                                          {
+                                              std::cerr << fmt::format(
+                                                  "[{}] rank {} does not own the cell at level {} that this rank holds as its ghost: "
+                                                  "the two disagree on ownership, so no global index exists for it.\n",
+                                                  rank,
+                                                  neighbour.rank,
+                                                  level);
+                                              continue;
+                                          }
+                                          assert(global_indices[ghost_unknown_index(cell_index, i)] == UNSET);
+                                          global_indices[ghost_unknown_index(cell_index, i)] = sent;
                                       }
                                   });
                 }
             }
 
             mpi::wait_all(req.begin(), req.end());
-
             if (args::print_petsc_numbering)
             {
                 sleep(static_cast<unsigned int>(rank));
@@ -258,25 +299,16 @@ namespace samurai
         }
 #endif
 
+        // Two local unknowns mapping to the same global index is silent corruption: petsc
+        // accepts the mapping and the only symptom is a refused column much later, in another
+        // rank's range. Sorting a copy makes the check O(n log n) instead of O(n^2), which is
+        // what it costs to be affordable at all - the quadratic version could only ever live
+        // inside an assert, and asserts are compiled out of the builds that run in CI.
         inline bool has_duplicates(const std::vector<PetscInt>& local_to_global_mapping)
         {
-            bool duplicate_found = false;
-            for (std::size_t i = 0; i < local_to_global_mapping.size(); ++i)
-            {
-                for (std::size_t j = i + 1; j < local_to_global_mapping.size(); ++j)
-                {
-                    if (local_to_global_mapping[i] == local_to_global_mapping[j])
-                    {
-                        duplicate_found = true;
-                        break;
-                    }
-                }
-                if (duplicate_found)
-                {
-                    break;
-                }
-            }
-            return duplicate_found;
+            std::vector<PetscInt> sorted(local_to_global_mapping);
+            std::sort(sorted.begin(), sorted.end());
+            return std::adjacent_find(sorted.begin(), sorted.end()) != sorted.end();
         }
     }
 }

--- a/include/samurai/prediction_shifts.hpp
+++ b/include/samurai/prediction_shifts.hpp
@@ -5,6 +5,7 @@
 
 #include <algorithm>
 #include <array>
+#include <bit>
 #include <cassert>
 #include <cstddef>
 #include <cstdlib>
@@ -42,11 +43,17 @@
  *      the domain happens to be stored.
  *
  * Asking the box, rather than each direction separately, is what a **re-entrant corner**
- * needs. Per-direction availability cannot see a cell that is missing only diagonally: at
- * the cell diagonally off the corner of a hole, every direction reads cells the domain has,
- * yet the corner of the box is inside the hole. The two rules agree everywhere else - on a
- * box domain they agree at every cell, corners included - so this is a statement about
- * re-entrant corners only, whether they belong to a hole or to an L-shaped domain.
+ * needs. Per-direction availability cannot see a cell that is missing only diagonally:
+ *
+ *         # # # . .        # a cell of the domain, . a cell of a hole
+ *         # # # . .
+ *         # # c # #        every cell c reads along an axis is there, yet the
+ *         # # # # #        top-right corner of the radius-1 box around c is in
+ *                          the hole - only the box rule sees it and shifts
+ *
+ * The two rules agree everywhere else - on a box domain they agree at every cell, corners
+ * included - so this is a statement about re-entrant corners only, whether they belong to a
+ * hole or to an L-shaped domain.
  *
  * That also makes @c fits a joint condition: it is false when *no* shift makes the box fit,
  * which is strictly stronger than each direction being wide enough on its own. It is the
@@ -72,7 +79,13 @@
  * The decomposition is exact on a holed domain, and that is the reason it is a run
  * decomposition rather than one class per interval: an interval passing over the edge of a
  * hole has cells whose stencil must be shifted and cells whose stencil must not, and
- * classifying the whole interval by its worst cell would move interior values.
+ * classifying the whole interval by its worst cell would move interior values:
+ *
+ *         the interval:      # # # # # # # # # # # #
+ *         a hole below it:           . . . .
+ *         its shift along y: 0 0 0 ^ ^ ^ ^ ^ ^ 0 0 0     ^ shifted away from the
+ *                                                          hole, one cell past it
+ *                                                          each side at radius 1
  *
  * **A periodic direction has no boundary.** Stepping off the end of one reaches the cells
  * the periodic ghost exchange fills from, so the stencil stays centred there and nothing is
@@ -117,8 +130,7 @@ namespace samurai
 
         /**
          * The @a n-th vector of the box `[-half, half]^len`, direction 0 varying fastest.
-         * The inverse is the mixed-radix digit sum, which is how the tables below index
-         * rows.
+         * For the transverse row tables, @ref TransverseRows::index_of is its inverse.
          */
         template <std::size_t len>
         constexpr std::array<int, len> nth_offset(std::size_t n, int half)
@@ -254,16 +266,18 @@ namespace samurai
          * wrapped where the displacement has stepped off the end of a periodic direction.
          *
          * A row that exists is never wrapped, so a hole inside the domain still clamps:
-         * only stepping off the *end* of the domain wraps. Two transverse directions can
-         * step off at once - the corner of a doubly periodic 3D domain - and wrapping one
-         * of them alone leaves the row still empty, so the combinations are tried fewest
-         * wraps first and the first non-empty one wins.
+         * only stepping off the *end* of the domain wraps, and a hole's image one wrap
+         * away is outside the domain. Only a direction the displacement stepped in, and
+         * that is periodic, can have stepped off the end; when two of them have at once -
+         * the corner of a doubly periodic 3D domain - wrapping one of them alone leaves
+         * the row still empty, so the combinations are tried fewest wraps first and the
+         * first non-empty one wins.
          */
         template <std::size_t dim, class TInterval>
-        RowScan<TInterval> wrapped_row_scan(const LevelCellArray<dim, TInterval>& domain,
-                                            const xt::xtensor_fixed<typename TInterval::value_t, xt::xshape<dim - 1>>& index,
-                                            const std::array<int, dim - 1>& offset,
-                                            const std::array<typename TInterval::value_t, dim>& period)
+        RowScan<TInterval> displaced_row(const LevelCellArray<dim, TInterval>& domain,
+                                         const xt::xtensor_fixed<typename TInterval::value_t, xt::xshape<dim - 1>>& index,
+                                         const std::array<int, dim - 1>& offset,
+                                         const std::array<typename TInterval::value_t, dim>& period)
         {
             using value_t               = typename TInterval::value_t;
             constexpr std::size_t cross = dim - 1;
@@ -280,39 +294,35 @@ namespace samurai
                 return row;
             }
 
-            for (std::size_t wraps = 1; wraps <= cross; ++wraps)
+            // The directions that can have stepped off the end.
+            std::array<std::size_t, cross> wrappable{};
+            std::size_t n = 0;
+            for (std::size_t d = 0; d < cross; ++d)
             {
-                for (std::size_t mask = 0; mask < (std::size_t{1} << cross); ++mask)
+                if (offset[d] != 0 && period[d + 1] != 0)
                 {
-                    std::size_t bits = 0;
-                    for (std::size_t d = 0; d < cross; ++d)
-                    {
-                        bits += (mask >> d) & std::size_t{1};
-                    }
-                    if (bits != wraps)
+                    wrappable[n++] = d;
+                }
+            }
+
+            // Each subset of them, as a mask over the wrappable list.
+            for (int wraps = 1; wraps <= static_cast<int>(n); ++wraps)
+            {
+                for (std::size_t mask = 1; mask < (std::size_t{1} << n); ++mask)
+                {
+                    if (std::popcount(mask) != wraps)
                     {
                         continue;
                     }
 
                     auto wrapped = base;
-                    bool usable  = true;
-                    for (std::size_t d = 0; d < cross && usable; ++d)
+                    for (std::size_t b = 0; b < n; ++b)
                     {
-                        if (((mask >> d) & std::size_t{1}) == 0)
+                        if ((mask >> b) & std::size_t{1})
                         {
-                            continue;
-                        }
-                        // Only a direction the displacement stepped in can have stepped off
-                        // the end, and only a periodic one wraps.
-                        usable = offset[d] != 0 && period[d + 1] != 0;
-                        if (usable)
-                        {
+                            const auto d = wrappable[b];
                             wrapped[d] -= static_cast<value_t>(offset[d] > 0 ? 1 : -1) * period[d + 1];
                         }
-                    }
-                    if (!usable)
-                    {
-                        continue;
                     }
 
                     auto candidate = row_scan(domain, wrapped);
@@ -324,6 +334,107 @@ namespace samurai
             }
             return row;
         }
+
+        /**
+         * How far one row covers around a cell:
+         *
+         *                            x
+         *             [ = = = = = = # = = = = = = = = = ]    the run the row holds x in
+         *               <-- low --> ^ <----- high ----->     both capped at the reach
+         *
+         * @c holds is false when the row does not hold the cell itself, and the counts
+         * include the cells a periodic wrap reads off either end of the row. @c until is
+         * the first coordinate above the cell at which any of this may change, so a
+         * caller sweeping a range knows how far the answer it just got remains valid.
+         */
+        template <class value_t>
+        struct RowCover
+        {
+            bool holds    = false;
+            int low       = 0;
+            int high      = 0;
+            value_t until = 0;
+        };
+
+        /**
+         * One row of the periodically extended domain. Which row of the domain that is
+         * was settled by @ref displaced_row - the transverse half of the wrap; this class
+         * adds the wrap *along* the row, so that off either end of a periodic direction
+         * the cover keeps counting through the cells the periodic ghost exchange fills
+         * the stencil from.
+         */
+        template <class TInterval>
+        class DomainRow
+        {
+          public:
+
+            using value_t = typename TInterval::value_t;
+
+            DomainRow() = default;
+
+            DomainRow(RowScan<TInterval> scan, value_t wrap, int reach)
+                : m_scan(scan)
+                , m_wrap(wrap)
+                , m_reach(reach)
+            {
+            }
+
+            /**
+             * The cover around @a x - queried at increasing @a x, as @ref RowScan
+             * requires.
+             *
+             * @c until is read off the geometry alone, *before* the wrap below tops the
+             * counts back up: within the reach of either end of a run the cover changes
+             * cell by cell, and in between it is constant - the bulk, where the consumers
+             * keep their current kernel:
+             *
+             *        [ + + + + | = = = = = = = = = = = | + + + + ]
+             *          2r cells:   the bulk: constant    2r cells:
+             *          changes     until run.end - 2r    changes
+             *          each cell                         each cell
+             *
+             * A wrap makes the two ends read the same as the bulk; it does not make them
+             * one run with it.
+             */
+            RowCover<value_t> around(value_t x)
+            {
+                RowCover<value_t> cover;
+                cover.holds = m_scan.covers(x, cover.until);
+                if (!cover.holds)
+                {
+                    return cover;
+                }
+
+                const auto& run = m_scan.current();
+                cover.low       = static_cast<int>(std::min(x - run.start, static_cast<value_t>(m_reach)));
+                cover.high      = static_cast<int>(std::min(run.end - 1 - x, static_cast<value_t>(m_reach)));
+                cover.until     = (cover.low < m_reach || cover.high < m_reach) ? x + 1 : run.end - static_cast<value_t>(m_reach);
+
+                // Off the end of a periodic direction the stencil reads the cells the
+                // periodic exchange fills it from, one wrap away. One cell at a time,
+                // because along the row the count varies from cell to cell. A cell
+                // missing because of a hole is not restored by this: its image one wrap
+                // away is outside the domain, so the test fails.
+                if (m_wrap != 0)
+                {
+                    while (cover.low < m_reach && m_scan.contains(x - cover.low - 1 + m_wrap))
+                    {
+                        ++cover.low;
+                    }
+                    while (cover.high < m_reach && m_scan.contains(x + cover.high + 1 - m_wrap))
+                    {
+                        ++cover.high;
+                    }
+                }
+                return cover;
+            }
+
+          private:
+
+            RowScan<TInterval> m_scan;
+            value_t m_wrap = 0;
+            int m_reach    = 0;
+        };
 
         /// Is @a a the more centred of the two shifts? The order is the file comment's.
         template <std::size_t dim>
@@ -357,35 +468,66 @@ namespace samurai
             return false;
         }
 
-        /// How many transverse offsets a radius-@c radius stencil can reach: `[-2r, 2r]` per
-        /// transverse direction, a shift of at most r reading at most r further out.
-        template <std::size_t radius>
-        constexpr std::size_t row_extent = 4 * radius + 1;
-
-        /// The `[-2r, 2r]^(dim-1)` transverse offsets, flattened.
+        /**
+         * The transverse rows a radius-@c radius stencil can reach. Availability is only
+         * ever needed up to `2r` from the cell: a stencil short by r on one side needs 2r
+         * available opposite it, and nothing beyond that changes the answer. The same 2r
+         * bounds the transverse reach, a shift of at most r reading at most r further out:
+         *
+         *        -2r        -r         0         +r        +2r
+         *         [==========(=========c=========)==========]
+         *                     the centred stencil            [ ] everything any
+         *                                                        shift can reach
+         *
+         * The type owns both the enumeration of the `[-2r, 2r]^(dim-1)` transverse
+         * offsets and the index of an offset in that enumeration, so a table built with
+         * @ref index_of points into a row array built with @ref offset by construction
+         * rather than by convention.
+         */
         template <std::size_t radius, std::size_t dim>
-        constexpr std::size_t row_count = ipow(row_extent<radius>, dim - 1);
+        struct TransverseRows
+        {
+            static constexpr int reach         = 2 * static_cast<int>(radius);
+            static constexpr std::size_t width = 4 * radius + 1;
+            static constexpr std::size_t count = ipow(width, dim - 1);
 
-        /// The transverse rows one stencil box covers: `[-r, r]^(dim-1)` around its shift.
-        template <std::size_t radius, std::size_t dim>
-        constexpr std::size_t band_size = ipow(2 * radius + 1, dim - 1);
+            /// The @a k-th transverse offset, `k < count`.
+            static constexpr std::array<int, dim - 1> offset(std::size_t k)
+            {
+                return nth_offset<dim - 1>(k, reach);
+            }
 
-        /// The shifts a stencil can take: `[-r, r]^dim`.
-        template <std::size_t radius, std::size_t dim>
-        constexpr std::size_t shift_count = ipow(2 * radius + 1, dim);
+            /// Where a transverse offset sits in the enumeration - @ref offset 's inverse.
+            static constexpr std::size_t index_of(const std::array<int, dim - 1>& o)
+            {
+                std::size_t flat   = 0;
+                std::size_t stride = 1;
+                for (std::size_t d = 0; d + 1 < dim; ++d)
+                {
+                    flat += static_cast<std::size_t>(o[d] + reach) * stride;
+                    stride *= width;
+                }
+                return flat;
+            }
+        };
 
         /**
          * The candidate shifts in the order they are preferred, with the rows each one
          * reads. Both depend on nothing but @c radius and @c dim, so they are tabulated
-         * once: taking the first admissible entry of @c shift is the rule, and @c rows[c]
-         * holds the indices - into the caller's `[-2r, 2r]^(dim-1)` row table - of the
-         * `(2r+1)^(dim-1)` rows the c-th stencil box covers.
+         * once: taking the first admissible entry of @c shift is the whole selection
+         * rule, and @c rows[c] holds the @ref TransverseRows indices of the rows the c-th
+         * stencil box covers.
          */
         template <std::size_t radius, std::size_t dim>
         struct ShiftSearch
         {
-            std::array<std::array<int, dim>, shift_count<radius, dim>> shift{};
-            std::array<std::array<std::size_t, band_size<radius, dim>>, shift_count<radius, dim>> rows{};
+            /// The shifts a stencil can take: `[-r, r]^dim`.
+            static constexpr std::size_t count = ipow(2 * radius + 1, dim);
+            /// The rows one stencil box covers: `[-r, r]^(dim-1)` around its shift.
+            static constexpr std::size_t band = ipow(2 * radius + 1, dim - 1);
+
+            std::array<std::array<int, dim>, count> shift{};
+            std::array<std::array<std::size_t, band>, count> rows{};
         };
 
         template <std::size_t radius, std::size_t dim>
@@ -393,37 +535,67 @@ namespace samurai
         {
             constexpr int r             = static_cast<int>(radius);
             constexpr std::size_t cross = dim - 1;
+            using search_t              = ShiftSearch<radius, dim>;
 
-            static const ShiftSearch<radius, dim> table = []
+            static const search_t table = []
             {
-                ShiftSearch<radius, dim> out;
-                for (std::size_t c = 0; c < shift_count<radius, dim>; ++c)
+                search_t out;
+                for (std::size_t c = 0; c < search_t::count; ++c)
                 {
                     out.shift[c] = nth_offset<dim>(c, r);
                 }
                 std::sort(out.shift.begin(), out.shift.end(), more_centred<dim>);
 
-                for (std::size_t c = 0; c < shift_count<radius, dim>; ++c)
+                for (std::size_t c = 0; c < search_t::count; ++c)
                 {
-                    for (std::size_t k = 0; k < band_size<radius, dim>; ++k)
+                    for (std::size_t k = 0; k < search_t::band; ++k)
                     {
                         const auto within = nth_offset<cross>(k, r);
 
-                        std::size_t flat   = 0;
-                        std::size_t stride = 1;
+                        std::array<int, cross> transverse{};
                         for (std::size_t d = 0; d < cross; ++d)
                         {
-                            const auto transverse = out.shift[c][d + 1] + within[d] + 2 * r;
-                            flat += static_cast<std::size_t>(transverse) * stride;
-                            stride *= row_extent<radius>;
+                            transverse[d] = out.shift[c][d + 1] + within[d];
                         }
-                        out.rows[c][k] = flat;
+                        out.rows[c][k] = TransverseRows<radius, dim>::index_of(transverse);
                     }
                 }
                 return out;
             }();
 
             return table;
+        }
+
+        /**
+         * The most centred shift whose whole stencil box the domain holds, read off the
+         * cover of every row the stencil can reach: shifted by @c s, the box reads
+         * `[s_0 - r, s_0 + r]` along each of the rows it covers, so @c s is admissible
+         * exactly when each of those rows holds the cell and covers at least that far.
+         */
+        template <std::size_t radius, std::size_t dim, class value_t>
+        PredictionStencilShift<dim> most_centred_fit(const std::array<RowCover<value_t>, TransverseRows<radius, dim>::count>& covers)
+        {
+            constexpr int r   = static_cast<int>(radius);
+            using search_t    = ShiftSearch<radius, dim>;
+            const auto& order = shift_search<radius, dim>();
+
+            PredictionStencilShift<dim> best;
+            best.fits = false;
+            for (std::size_t c = 0; c < search_t::count && !best.fits; ++c)
+            {
+                bool admissible = true;
+                for (std::size_t k = 0; k < search_t::band && admissible; ++k)
+                {
+                    const auto& cover = covers[order.rows[c][k]];
+                    admissible        = cover.holds && order.shift[c][0] - r >= -cover.low && order.shift[c][0] + r <= cover.high;
+                }
+                if (admissible)
+                {
+                    best.shift = order.shift[c];
+                    best.fits  = true;
+                }
+            }
+            return best;
         }
     }
 
@@ -461,22 +633,14 @@ namespace samurai
                                        Func&& f)
     {
         using value_t = typename TInterval::value_t;
+        using rows_t  = detail::TransverseRows<radius, dim>;
 
-        constexpr int r = static_cast<int>(radius);
-
-        // Availability is only ever needed up to 2r: a stencil short by r on one side needs
-        // 2r available opposite it, and nothing beyond that changes the answer. The
-        // transverse rows the stencil can reach are the same 2r out, a shift of at most r
-        // reading at most r further.
-        constexpr int reach                = 2 * r;
-        constexpr std::size_t rows_reached = detail::row_count<radius, dim>;
-
-        const auto& order = detail::shift_search<radius, dim>();
-
-        std::array<detail::RowScan<TInterval>, rows_reached> rows;
-        for (std::size_t k = 0; k < rows_reached; ++k)
+        // One cursor per transverse row the stencil can reach, over the periodically
+        // extended domain.
+        std::array<detail::DomainRow<TInterval>, rows_t::count> rows;
+        for (std::size_t k = 0; k < rows_t::count; ++k)
         {
-            rows[k] = detail::wrapped_row_scan(domain, index, detail::nth_offset<dim - 1>(k, reach), period);
+            rows[k] = detail::DomainRow<TInterval>(detail::displaced_row(domain, index, rows_t::offset(k), period), period[0], rows_t::reach);
         }
 
         // The run being accumulated. Runs are emitted only when the shift changes, so two
@@ -493,82 +657,21 @@ namespace samurai
             }
         };
 
-        // How far each row reaches either side of x, capped at the reach, and where the
-        // answer it gives stops holding.
-        std::array<bool, rows_reached> covered{};
-        std::array<int, rows_reached> low{};
-        std::array<int, rows_reached> high{};
+        std::array<detail::RowCover<value_t>, rows_t::count> covers;
 
         value_t x = i.start;
         while (x < i.end)
         {
+            // The cover of every row around x, and the first coordinate at which any of
+            // those covers may change - before which the shift cannot change either.
             value_t next = i.end;
-
-            for (std::size_t k = 0; k < rows_reached; ++k)
+            for (std::size_t k = 0; k < rows_t::count; ++k)
             {
-                value_t change = 0;
-                covered[k]     = rows[k].covers(x, change);
-                if (!covered[k])
-                {
-                    next = std::min(next, change);
-                    continue;
-                }
-
-                const auto& run = rows[k].current();
-                low[k]          = static_cast<int>(std::min(x - run.start, static_cast<value_t>(reach)));
-                high[k]         = static_cast<int>(std::min(run.end - 1 - x, static_cast<value_t>(reach)));
-
-                // The class changes cell by cell within 2r of each end of the run of cells
-                // the row holds, and is constant in between - the bulk the consumers keep
-                // their current kernel on. This reads the geometry, before the periodic
-                // wrap below tops the counts back up: a wrap makes the two ends read the
-                // same as the bulk, it does not make them one run with it.
-                if (low[k] < reach || high[k] < reach)
-                {
-                    next = std::min(next, x + 1);
-                }
-                else
-                {
-                    next = std::min(next, run.end - static_cast<value_t>(reach));
-                }
-
-                // Off the end of a periodic direction the stencil reads the cells the
-                // periodic exchange fills it from, one wrap away. One cell at a time,
-                // because in x the count varies from cell to cell. A cell missing because
-                // of a hole is not restored by this: its image one wrap away is outside the
-                // domain, so the test fails.
-                if (period[0] != 0)
-                {
-                    for (auto k_low = low[k]; k_low < reach && rows[k].contains(x - k_low - 1 + period[0]); ++k_low)
-                    {
-                        low[k] = k_low + 1;
-                    }
-                    for (auto k_high = high[k]; k_high < reach && rows[k].contains(x + k_high + 1 - period[0]); ++k_high)
-                    {
-                        high[k] = k_high + 1;
-                    }
-                }
+                covers[k] = rows[k].around(x);
+                next      = std::min(next, covers[k].until);
             }
 
-            // The most centred shift whose whole stencil box the domain holds. The x extent
-            // is read off the rows the box covers: shifted by s, it reads [s - r, s + r]
-            // around x, which each of those rows must hold.
-            PredictionStencilShift<dim> shift;
-            shift.fits = false;
-            for (std::size_t c = 0; c < detail::shift_count<radius, dim> && !shift.fits; ++c)
-            {
-                bool admissible = true;
-                for (std::size_t k = 0; k < detail::band_size<radius, dim> && admissible; ++k)
-                {
-                    const auto row = order.rows[c][k];
-                    admissible     = covered[row] && order.shift[c][0] - r >= -low[row] && order.shift[c][0] + r <= high[row];
-                }
-                if (admissible)
-                {
-                    shift.shift = order.shift[c];
-                    shift.fits  = true;
-                }
-            }
+            const auto shift = detail::most_centred_fit<radius, dim>(covers);
 
             // A breakpoint that failed to move would spin here rather than fail, so it is
             // asserted instead of being clamped away.

--- a/include/samurai/prediction_shifts.hpp
+++ b/include/samurai/prediction_shifts.hpp
@@ -1,0 +1,369 @@
+// Copyright 2018-2025 the samurai's authors
+// SPDX-License-Identifier:  BSD-3-Clause
+
+#pragma once
+
+#include <algorithm>
+#include <array>
+#include <cassert>
+#include <cstddef>
+#include <limits>
+
+#include <xtensor/containers/xfixed.hpp>
+
+#include "algorithm.hpp"
+#include "level_cell_array.hpp"
+#include "numeric/prediction_coefficients.hpp"
+
+/**
+ * @file prediction_shifts.hpp
+ *
+ * Where a prediction stencil sits, read off the domain.
+ *
+ * numeric/prediction_coefficients.hpp holds the numeric half of the question - given a
+ * shift, what are the coefficients - and knows nothing about a mesh. This file holds the
+ * geometric half: given a cell, what shift must the stencil take so that it reads only
+ * cells the domain has. The two are kept apart on purpose, because the numeric half is a
+ * global memo that must stay mesh-free.
+ *
+ * **The domain, never the subdomain.** The shift is classified against the *global,
+ * replicated* domain at the level in question, and never against the cells one MPI rank
+ * happens to hold. That is what makes the operator partition independent with no
+ * communication: every rank asks the same question of the same object and gets the same
+ * answer. Whether the cells the chosen stencil names are present *locally* is a separate,
+ * halo question, answered by the ghost width, and it is not this file's business.
+ * Conflating the two - "clamp to what I can see" - is the one way to make results depend
+ * on the rank count.
+ *
+ * **One query per interval, not per cell.** @ref for_each_prediction_shift_run walks an
+ * interval once and hands back the maximal runs over which the shift is constant, so the
+ * consumer keeps its hoists: it selects a coefficient table per run and leaves its inner
+ * loop untouched. On a box domain an interval away from the boundary yields exactly one
+ * run with all shifts zero, which is what keeps interior values bit-identical.
+ *
+ * The decomposition is exact on a holed domain, and that is the reason it is a run
+ * decomposition rather than one class per interval: an interval passing over the edge of a
+ * hole has cells whose stencil must be shifted and cells whose stencil must not, and
+ * classifying the whole interval by its worst cell would move interior values.
+ *
+ * **A periodic direction has no boundary.** Stepping off the end of one reaches the cells
+ * the periodic ghost exchange fills from, so the stencil stays centred there and nothing is
+ * clamped; the caller says which directions those are by passing their wrap. Holes are
+ * unaffected by this, in a periodic direction as in any other, because only stepping off
+ * the end of the domain wraps.
+ */
+
+namespace samurai
+{
+    /**
+     * The prediction stencil shifts holding over a run of cells: one shift per direction.
+     */
+    template <std::size_t dim>
+    struct PredictionShifts
+    {
+        std::array<int, dim> shift{}; ///< @c shift[d] is what @ref prediction_coefficients takes along @c d
+        bool fits = true;             ///< false where no shift makes the stencil fit (see @ref prediction_shift)
+    };
+
+    namespace detail
+    {
+        /**
+         * A cursor over the x-intervals of one row of a level cell array - the cells at a
+         * fixed transverse index. Rows are queried at increasing x, so the cursor only
+         * moves forward and scanning a whole interval costs one pass over the intervals it
+         * meets rather than a search per cell.
+         */
+        template <class TInterval>
+        class RowScan
+        {
+          public:
+
+            using value_t = typename TInterval::value_t;
+
+            RowScan() = default;
+
+            RowScan(const TInterval* first, std::size_t size)
+                : m_first(first)
+                , m_size(size)
+            {
+            }
+
+            /**
+             * Does this row hold the cell at @a x? @a next_change is set to the smallest
+             * coordinate above @a x at which the answer changes, so a caller scanning a
+             * range knows how far the answer it just got remains valid.
+             */
+            bool covers(value_t x, value_t& next_change)
+            {
+                while (m_cursor < m_size && m_first[m_cursor].end <= x)
+                {
+                    ++m_cursor;
+                }
+
+                if (m_cursor == m_size)
+                {
+                    next_change = std::numeric_limits<value_t>::max();
+                    return false;
+                }
+                if (m_first[m_cursor].start <= x)
+                {
+                    next_change = m_first[m_cursor].end;
+                    return true;
+                }
+                next_change = m_first[m_cursor].start;
+                return false;
+            }
+
+            /// True when the domain has no cell at this transverse index at all.
+            bool empty() const
+            {
+                return m_size == 0;
+            }
+
+            /// The interval holding the last @c x that @ref covers accepted.
+            const TInterval& current() const
+            {
+                return m_first[m_cursor];
+            }
+
+            /**
+             * Does this row hold the cell at @a x, asked out of order? The cursor above is
+             * for scanning; this is for the handful of cells a periodic wrap reaches at the
+             * far end of the row.
+             */
+            bool contains(value_t x) const
+            {
+                const auto* it = std::upper_bound(m_first,
+                                                  m_first + m_size,
+                                                  x,
+                                                  [](value_t v, const TInterval& itv)
+                                                  {
+                                                      return v < itv.start;
+                                                  });
+                return it != m_first && (it - 1)->end > x;
+            }
+
+          private:
+
+            const TInterval* m_first = nullptr;
+            std::size_t m_size       = 0;
+            std::size_t m_cursor     = 0;
+        };
+
+        /**
+         * The row of @a lca at transverse index @a index, as a cursor. Empty when the
+         * domain has no cell at that index at all.
+         */
+        template <std::size_t dim, class TInterval>
+        RowScan<TInterval>
+        row_scan(const LevelCellArray<dim, TInterval>& lca, const xt::xtensor_fixed<typename TInterval::value_t, xt::xshape<dim - 1>>& index)
+        {
+            std::size_t start = 0;
+            std::size_t end   = lca[dim - 1].size();
+
+            // The transverse dimensions are nested outermost first, so the range of
+            // x-intervals is narrowed one dimension at a time, as find() does.
+            for (std::size_t d = dim - 1; d >= 1; --d)
+            {
+                const auto pos = find_on_dim(lca, d, start, end, index[d - 1]);
+                if (pos == std::numeric_limits<std::size_t>::max())
+                {
+                    return {};
+                }
+                const auto offset = static_cast<std::size_t>(lca[d][pos].index + index[d - 1]);
+                start             = lca.offsets(d)[offset];
+                end               = lca.offsets(d)[offset + 1];
+            }
+
+            if (start == end)
+            {
+                return {};
+            }
+            return {lca[0].data() + start, end - start};
+        }
+    }
+
+    /**
+     * Split @a i into the maximal runs over which the prediction stencil shift is
+     * constant, and call @a f on each as @c f(run, shifts).
+     *
+     * @tparam radius prediction stencil radius
+     * @param domain  the domain at the level @a i lives at - global and replicated, see
+     *                the file comment
+     * @param period  the periodic wrap of each direction, at that level, and @c 0 where the
+     *                direction is not periodic. It is the same quantity the periodic ghost
+     *                exchange shifts by, @c (max_indices[d] - min_indices[d]) >> delta_l,
+     *                and it must agree with it: a periodic direction has no boundary, so
+     *                clamping a stencil against one would move values for nothing.
+     * @param i       an interval of cells, at that same level
+     * @param index   its transverse index
+     *
+     * Each run carries the storage index of @a i, so a consumer can index a field with it
+     * exactly as it indexes @a i.
+     *
+     * Cells of @a i that the domain does not hold are reported as their own runs with
+     * @c fits false, whether or not the direction is periodic: prediction has nothing to
+     * reach into there. The query reports it rather than deciding what to do about it.
+     */
+    template <std::size_t radius, std::size_t dim, class TInterval, class Func>
+    void for_each_prediction_shift_run(const LevelCellArray<dim, TInterval>& domain,
+                                       const std::array<typename TInterval::value_t, dim>& period,
+                                       const TInterval& i,
+                                       const xt::xtensor_fixed<typename TInterval::value_t, xt::xshape<dim - 1>>& index,
+                                       Func&& f)
+    {
+        using value_t = typename TInterval::value_t;
+
+        // Availability is only ever needed up to 2r: a stencil short by r on one side needs
+        // 2r available opposite it, and nothing beyond that changes the answer.
+        constexpr auto reach = static_cast<value_t>(2 * radius);
+
+        auto own = detail::row_scan(domain, index);
+
+        // The rows the transverse directions read, indexed [direction][side][distance - 1].
+        std::array<std::array<std::array<detail::RowScan<TInterval>, 2 * radius>, 2>, dim - 1> rows;
+        for (std::size_t d = 0; d + 1 < dim; ++d)
+        {
+            for (std::size_t side = 0; side < 2; ++side)
+            {
+                for (std::size_t k = 1; k <= 2 * radius; ++k)
+                {
+                    auto neighbour = index;
+                    neighbour[d] += (side == 0 ? -1 : 1) * static_cast<value_t>(k);
+                    auto row = detail::row_scan(domain, neighbour);
+
+                    // Off the end of a periodic direction, the cells the stencil reads are
+                    // the ones the periodic exchange fills it from, one wrap away. A row
+                    // that exists is never wrapped, so a hole inside the domain still
+                    // clamps: only stepping off the end wraps.
+                    if (row.empty() && period[d + 1] != 0)
+                    {
+                        neighbour[d] -= (side == 0 ? -1 : 1) * period[d + 1];
+                        row = detail::row_scan(domain, neighbour);
+                    }
+                    rows[d][side][k - 1] = row;
+                }
+            }
+        }
+
+        value_t x = i.start;
+        while (x < i.end)
+        {
+            value_t next   = i.end;
+            value_t change = 0;
+
+            const bool inside = own.covers(x, change);
+            next              = std::min(next, change);
+
+            if (!inside)
+            {
+                f(TInterval{x, next, i.index}, PredictionShifts<dim>{{}, false});
+                x = next;
+                continue;
+            }
+
+            std::array<int, dim> avail_low{};
+            std::array<int, dim> avail_high{};
+
+            const auto& own_interval = own.current();
+            avail_low[0]             = static_cast<int>(std::min(x - own_interval.start, reach));
+            avail_high[0]            = static_cast<int>(std::min(own_interval.end - 1 - x, reach));
+
+            // In x the class changes cell by cell within 2r of each end of the run of cells
+            // the domain holds, and is constant in between - the bulk the consumers keep
+            // their current kernel on. This reads the geometry, before any periodic wrap
+            // below tops the counts back up: a wrap makes the two ends read the same as the
+            // bulk, it does not make them one run with it.
+            if (avail_low[0] < reach || avail_high[0] < reach)
+            {
+                next = std::min(next, x + 1);
+            }
+            else
+            {
+                next = std::min(next, own_interval.end - reach);
+            }
+
+            // Same wrap as the transverse rows, one cell at a time because in x the count
+            // varies from cell to cell. A cell missing because of a hole is not restored by
+            // this: its image one wrap away is outside the domain, so the test fails.
+            if (period[0] != 0)
+            {
+                for (auto k = avail_low[0]; k < reach && own.contains(x - k - 1 + period[0]); ++k)
+                {
+                    avail_low[0] = k + 1;
+                }
+                for (auto k = avail_high[0]; k < reach && own.contains(x + k + 1 - period[0]); ++k)
+                {
+                    avail_high[0] = k + 1;
+                }
+            }
+
+            for (std::size_t d = 0; d + 1 < dim; ++d)
+            {
+                for (std::size_t side = 0; side < 2; ++side)
+                {
+                    int available = 0;
+                    for (std::size_t k = 0; k < 2 * radius; ++k)
+                    {
+                        value_t row_change = 0;
+                        const bool covered = rows[d][side][k].covers(x, row_change);
+                        next               = std::min(next, row_change);
+                        if (!covered)
+                        {
+                            // Rows further out cannot restore what this one denies, and
+                            // they cannot change the count while this one is missing.
+                            break;
+                        }
+                        ++available;
+                    }
+                    (side == 0 ? avail_low : avail_high)[d + 1] = available;
+                }
+            }
+
+            PredictionShifts<dim> shifts;
+            for (std::size_t d = 0; d < dim; ++d)
+            {
+                const auto shift = prediction_shift(radius, avail_low[d], avail_high[d]);
+                shifts.shift[d]  = shift.shift;
+                shifts.fits      = shifts.fits && shift.fits;
+            }
+
+            // A breakpoint that failed to move would spin here rather than fail, so it is
+            // asserted instead of being clamped away.
+            assert(next > x && "for_each_prediction_shift_run: the run decomposition did not advance");
+
+            f(TInterval{x, next, i.index}, shifts);
+            x = next;
+        }
+    }
+
+    /**
+     * The prediction stencil shifts at one cell. The per-interval form above is what the
+     * hot kernels use; this is for consumers that already visit cells one at a time, and
+     * for saying in one line what a test means.
+     */
+    template <std::size_t radius, std::size_t dim, class TInterval>
+    PredictionShifts<dim> prediction_shifts_at(const LevelCellArray<dim, TInterval>& domain,
+                                               const std::array<typename TInterval::value_t, dim>& period,
+                                               const xt::xtensor_fixed<typename TInterval::value_t, xt::xshape<dim>>& coord)
+    {
+        using value_t = typename TInterval::value_t;
+
+        xt::xtensor_fixed<value_t, xt::xshape<dim - 1>> index;
+        for (std::size_t d = 0; d + 1 < dim; ++d)
+        {
+            index[d] = coord[d + 1];
+        }
+
+        PredictionShifts<dim> shifts;
+        for_each_prediction_shift_run<radius>(domain,
+                                              period,
+                                              TInterval{coord[0], coord[0] + 1},
+                                              index,
+                                              [&](const auto&, const auto& run_shifts)
+                                              {
+                                                  shifts = run_shifts;
+                                              });
+        return shifts;
+    }
+}

--- a/include/samurai/prediction_shifts.hpp
+++ b/include/samurai/prediction_shifts.hpp
@@ -7,13 +7,13 @@
 #include <array>
 #include <cassert>
 #include <cstddef>
+#include <cstdlib>
 #include <limits>
 
 #include <xtensor/containers/xfixed.hpp>
 
 #include "algorithm.hpp"
 #include "level_cell_array.hpp"
-#include "numeric/prediction_coefficients.hpp"
 
 /**
  * @file prediction_shifts.hpp
@@ -26,6 +26,33 @@
  * cells the domain has. The two are kept apart on purpose, because the numeric half is a
  * global memo that must stay mesh-free.
  *
+ * **The stencil is a box, so the question is asked of the box.** The consumers apply the 1D
+ * family as a tensor product, so the cells a stencil reads at a cell @c c with shift @c s
+ * are the whole box `prod_d [c_d + s_d - r, c_d + s_d + r]` - the mixed terms included. A
+ * shift is admissible exactly when the domain holds that entire box, and the answer is the
+ * *most centred* admissible shift:
+ *
+ *   1. the least shifted overall, i.e. the smallest `sum_d |s_d|` - a shift is what makes a
+ *      stencil one-sided, so the fewer cells it moves in total the better;
+ *   2. among those, the one shifting @c x least, then @c y, and so on: a shift along @c x
+ *      moves the innermost loop's reads, while a transverse shift only picks a different
+ *      row, so a deficit is better absorbed transversally;
+ *   3. among those, the negative shift. Nothing distinguishes the two, so the tie is broken
+ *      by fiat rather than left to the traversal order - the answer must not depend on how
+ *      the domain happens to be stored.
+ *
+ * Asking the box, rather than each direction separately, is what a **re-entrant corner**
+ * needs. Per-direction availability cannot see a cell that is missing only diagonally: at
+ * the cell diagonally off the corner of a hole, every direction reads cells the domain has,
+ * yet the corner of the box is inside the hole. The two rules agree everywhere else - on a
+ * box domain they agree at every cell, corners included - so this is a statement about
+ * re-entrant corners only, whether they belong to a hole or to an L-shaped domain.
+ *
+ * That also makes @c fits a joint condition: it is false when *no* shift makes the box fit,
+ * which is strictly stronger than each direction being wide enough on its own. It is the
+ * constructibility condition the mesh has to guarantee, and a caller is expected to report
+ * it loudly rather than silently degrade the order.
+ *
  * **The domain, never the subdomain.** The shift is classified against the *global,
  * replicated* domain at the level in question, and never against the cells one MPI rank
  * happens to hold. That is what makes the operator partition independent with no
@@ -36,10 +63,11 @@
  * on the rank count.
  *
  * **One query per interval, not per cell.** @ref for_each_prediction_shift_run walks an
- * interval once and hands back the maximal runs over which the shift is constant, so the
+ * interval once and hands back the maximal runs over which the shift is constant - maximal
+ * in the strict sense that no two runs it emits are adjacent with the same shift - so the
  * consumer keeps its hoists: it selects a coefficient table per run and leaves its inner
- * loop untouched. On a box domain an interval away from the boundary yields exactly one
- * run with all shifts zero, which is what keeps interior values bit-identical.
+ * loop untouched. On a box domain an interval away from the boundary yields exactly one run
+ * with all shifts zero, which is what keeps interior values bit-identical.
  *
  * The decomposition is exact on a holed domain, and that is the reason it is a run
  * decomposition rather than one class per interval: an interval passing over the edge of a
@@ -51,22 +79,61 @@
  * clamped; the caller says which directions those are by passing their wrap. Holes are
  * unaffected by this, in a periodic direction as in any other, because only stepping off
  * the end of the domain wraps.
+ *
+ * **Cost.** One query rescans the `(4r+1)^(dim-1)` transverse rows the stencil can reach,
+ * so a consumer sweeping row by row repeats the transverse searches of its neighbours. That
+ * is the first thing to look at should this appear in a profile; the fix would be a cache
+ * keyed on the transverse index, not a change of rule.
  */
 
 namespace samurai
 {
     /**
-     * The prediction stencil shifts holding over a run of cells: one shift per direction.
+     * Where the prediction stencil sits over a run of cells: one shift per direction.
      */
     template <std::size_t dim>
-    struct PredictionShifts
+    struct PredictionStencilShift
     {
-        std::array<int, dim> shift{}; ///< @c shift[d] is what @ref prediction_coefficients takes along @c d
-        bool fits = true;             ///< false where no shift makes the stencil fit (see @ref prediction_shift)
+        std::array<int, dim> shift{}; ///< @c shift[d] is what @c prediction_coefficients takes along @c d
+        bool fits = true;             ///< false where no shift makes the stencil box fit (see the file comment)
+
+        bool operator==(const PredictionStencilShift& o) const
+        {
+            return shift == o.shift && fits == o.fits;
+        }
     };
 
     namespace detail
     {
+        constexpr std::size_t ipow(std::size_t base, std::size_t exponent)
+        {
+            std::size_t out = 1;
+            for (std::size_t k = 0; k < exponent; ++k)
+            {
+                out *= base;
+            }
+            return out;
+        }
+
+        /**
+         * The @a n-th vector of the box `[-half, half]^len`, direction 0 varying fastest.
+         * The inverse is the mixed-radix digit sum, which is how the tables below index
+         * rows.
+         */
+        template <std::size_t len>
+        constexpr std::array<int, len> nth_offset(std::size_t n, int half)
+        {
+            const auto extent = static_cast<std::size_t>(2 * half + 1);
+
+            std::array<int, len> out{};
+            for (std::size_t d = 0; d < len; ++d)
+            {
+                out[d] = static_cast<int>(n % extent) - half;
+                n /= extent;
+            }
+            return out;
+        }
+
         /**
          * A cursor over the x-intervals of one row of a level cell array - the cells at a
          * fixed transverse index. Rows are queried at increasing x, so the cursor only
@@ -181,11 +248,188 @@ namespace samurai
             }
             return {lca[0].data() + start, end - start};
         }
+
+        /**
+         * The row of @a domain at the transverse index @a index displaced by @a offset,
+         * wrapped where the displacement has stepped off the end of a periodic direction.
+         *
+         * A row that exists is never wrapped, so a hole inside the domain still clamps:
+         * only stepping off the *end* of the domain wraps. Two transverse directions can
+         * step off at once - the corner of a doubly periodic 3D domain - and wrapping one
+         * of them alone leaves the row still empty, so the combinations are tried fewest
+         * wraps first and the first non-empty one wins.
+         */
+        template <std::size_t dim, class TInterval>
+        RowScan<TInterval> wrapped_row_scan(const LevelCellArray<dim, TInterval>& domain,
+                                            const xt::xtensor_fixed<typename TInterval::value_t, xt::xshape<dim - 1>>& index,
+                                            const std::array<int, dim - 1>& offset,
+                                            const std::array<typename TInterval::value_t, dim>& period)
+        {
+            using value_t               = typename TInterval::value_t;
+            constexpr std::size_t cross = dim - 1;
+
+            auto base = index;
+            for (std::size_t d = 0; d < cross; ++d)
+            {
+                base[d] += static_cast<value_t>(offset[d]);
+            }
+
+            auto row = row_scan(domain, base);
+            if (!row.empty())
+            {
+                return row;
+            }
+
+            for (std::size_t wraps = 1; wraps <= cross; ++wraps)
+            {
+                for (std::size_t mask = 0; mask < (std::size_t{1} << cross); ++mask)
+                {
+                    std::size_t bits = 0;
+                    for (std::size_t d = 0; d < cross; ++d)
+                    {
+                        bits += (mask >> d) & std::size_t{1};
+                    }
+                    if (bits != wraps)
+                    {
+                        continue;
+                    }
+
+                    auto wrapped = base;
+                    bool usable  = true;
+                    for (std::size_t d = 0; d < cross && usable; ++d)
+                    {
+                        if (((mask >> d) & std::size_t{1}) == 0)
+                        {
+                            continue;
+                        }
+                        // Only a direction the displacement stepped in can have stepped off
+                        // the end, and only a periodic one wraps.
+                        usable = offset[d] != 0 && period[d + 1] != 0;
+                        if (usable)
+                        {
+                            wrapped[d] -= static_cast<value_t>(offset[d] > 0 ? 1 : -1) * period[d + 1];
+                        }
+                    }
+                    if (!usable)
+                    {
+                        continue;
+                    }
+
+                    auto candidate = row_scan(domain, wrapped);
+                    if (!candidate.empty())
+                    {
+                        return candidate;
+                    }
+                }
+            }
+            return row;
+        }
+
+        /// Is @a a the more centred of the two shifts? The order is the file comment's.
+        template <std::size_t dim>
+        bool more_centred(const std::array<int, dim>& a, const std::array<int, dim>& b)
+        {
+            int total_a = 0;
+            int total_b = 0;
+            for (std::size_t d = 0; d < dim; ++d)
+            {
+                total_a += std::abs(a[d]);
+                total_b += std::abs(b[d]);
+            }
+            if (total_a != total_b)
+            {
+                return total_a < total_b;
+            }
+            for (std::size_t d = 0; d < dim; ++d)
+            {
+                if (std::abs(a[d]) != std::abs(b[d]))
+                {
+                    return std::abs(a[d]) < std::abs(b[d]);
+                }
+            }
+            for (std::size_t d = 0; d < dim; ++d)
+            {
+                if (a[d] != b[d])
+                {
+                    return a[d] < b[d];
+                }
+            }
+            return false;
+        }
+
+        /// How many transverse offsets a radius-@c radius stencil can reach: `[-2r, 2r]` per
+        /// transverse direction, a shift of at most r reading at most r further out.
+        template <std::size_t radius>
+        constexpr std::size_t row_extent = 4 * radius + 1;
+
+        /// The `[-2r, 2r]^(dim-1)` transverse offsets, flattened.
+        template <std::size_t radius, std::size_t dim>
+        constexpr std::size_t row_count = ipow(row_extent<radius>, dim - 1);
+
+        /// The transverse rows one stencil box covers: `[-r, r]^(dim-1)` around its shift.
+        template <std::size_t radius, std::size_t dim>
+        constexpr std::size_t band_size = ipow(2 * radius + 1, dim - 1);
+
+        /// The shifts a stencil can take: `[-r, r]^dim`.
+        template <std::size_t radius, std::size_t dim>
+        constexpr std::size_t shift_count = ipow(2 * radius + 1, dim);
+
+        /**
+         * The candidate shifts in the order they are preferred, with the rows each one
+         * reads. Both depend on nothing but @c radius and @c dim, so they are tabulated
+         * once: taking the first admissible entry of @c shift is the rule, and @c rows[c]
+         * holds the indices - into the caller's `[-2r, 2r]^(dim-1)` row table - of the
+         * `(2r+1)^(dim-1)` rows the c-th stencil box covers.
+         */
+        template <std::size_t radius, std::size_t dim>
+        struct ShiftSearch
+        {
+            std::array<std::array<int, dim>, shift_count<radius, dim>> shift{};
+            std::array<std::array<std::size_t, band_size<radius, dim>>, shift_count<radius, dim>> rows{};
+        };
+
+        template <std::size_t radius, std::size_t dim>
+        const ShiftSearch<radius, dim>& shift_search()
+        {
+            constexpr int r             = static_cast<int>(radius);
+            constexpr std::size_t cross = dim - 1;
+
+            static const ShiftSearch<radius, dim> table = []
+            {
+                ShiftSearch<radius, dim> out;
+                for (std::size_t c = 0; c < shift_count<radius, dim>; ++c)
+                {
+                    out.shift[c] = nth_offset<dim>(c, r);
+                }
+                std::sort(out.shift.begin(), out.shift.end(), more_centred<dim>);
+
+                for (std::size_t c = 0; c < shift_count<radius, dim>; ++c)
+                {
+                    for (std::size_t k = 0; k < band_size<radius, dim>; ++k)
+                    {
+                        const auto within = nth_offset<cross>(k, r);
+
+                        std::size_t flat   = 0;
+                        std::size_t stride = 1;
+                        for (std::size_t d = 0; d < cross; ++d)
+                        {
+                            const auto transverse = out.shift[c][d + 1] + within[d] + 2 * r;
+                            flat += static_cast<std::size_t>(transverse) * stride;
+                            stride *= row_extent<radius>;
+                        }
+                        out.rows[c][k] = flat;
+                    }
+                }
+                return out;
+            }();
+
+            return table;
+        }
     }
 
     /**
      * Split @a i into the maximal runs over which the prediction stencil shift is
-     * constant, and call @a f on each as @c f(run, shifts).
+     * constant, and call @a f on each as @c f(run, shift).
      *
      * @tparam radius prediction stencil radius
      * @param domain  the domain at the level @a i lives at - global and replicated, see
@@ -194,16 +438,20 @@ namespace samurai
      *                direction is not periodic. It is the same quantity the periodic ghost
      *                exchange shifts by, @c (max_indices[d] - min_indices[d]) >> delta_l,
      *                and it must agree with it: a periodic direction has no boundary, so
-     *                clamping a stencil against one would move values for nothing.
+     *                clamping a stencil against one would move values for nothing. A wrap
+     *                is applied at most once per direction, which is exact as long as the
+     *                domain is at least @c 2*radius cells wide there - narrower than that,
+     *                a stencil would read the same cell twice and the question is moot.
      * @param i       an interval of cells, at that same level
      * @param index   its transverse index
      *
      * Each run carries the storage index of @a i, so a consumer can index a field with it
      * exactly as it indexes @a i.
      *
-     * Cells of @a i that the domain does not hold are reported as their own runs with
-     * @c fits false, whether or not the direction is periodic: prediction has nothing to
-     * reach into there. The query reports it rather than deciding what to do about it.
+     * Cells of @a i that the domain does not hold are reported with @c fits false, whether
+     * or not the direction is periodic: prediction has nothing to reach into there. So are
+     * cells the domain holds but around which no shift makes the stencil box fit. The query
+     * reports it rather than deciding what to do about it.
      */
     template <std::size_t radius, std::size_t dim, class TInterval, class Func>
     void for_each_prediction_shift_run(const LevelCellArray<dim, TInterval>& domain,
@@ -214,138 +462,140 @@ namespace samurai
     {
         using value_t = typename TInterval::value_t;
 
+        constexpr int r = static_cast<int>(radius);
+
         // Availability is only ever needed up to 2r: a stencil short by r on one side needs
-        // 2r available opposite it, and nothing beyond that changes the answer.
-        constexpr auto reach = static_cast<value_t>(2 * radius);
+        // 2r available opposite it, and nothing beyond that changes the answer. The
+        // transverse rows the stencil can reach are the same 2r out, a shift of at most r
+        // reading at most r further.
+        constexpr int reach                = 2 * r;
+        constexpr std::size_t rows_reached = detail::row_count<radius, dim>;
 
-        auto own = detail::row_scan(domain, index);
+        const auto& order = detail::shift_search<radius, dim>();
 
-        // The rows the transverse directions read, indexed [direction][side][distance - 1].
-        std::array<std::array<std::array<detail::RowScan<TInterval>, 2 * radius>, 2>, dim - 1> rows;
-        for (std::size_t d = 0; d + 1 < dim; ++d)
+        std::array<detail::RowScan<TInterval>, rows_reached> rows;
+        for (std::size_t k = 0; k < rows_reached; ++k)
         {
-            for (std::size_t side = 0; side < 2; ++side)
-            {
-                for (std::size_t k = 1; k <= 2 * radius; ++k)
-                {
-                    auto neighbour = index;
-                    neighbour[d] += (side == 0 ? -1 : 1) * static_cast<value_t>(k);
-                    auto row = detail::row_scan(domain, neighbour);
-
-                    // Off the end of a periodic direction, the cells the stencil reads are
-                    // the ones the periodic exchange fills it from, one wrap away. A row
-                    // that exists is never wrapped, so a hole inside the domain still
-                    // clamps: only stepping off the end wraps.
-                    if (row.empty() && period[d + 1] != 0)
-                    {
-                        neighbour[d] -= (side == 0 ? -1 : 1) * period[d + 1];
-                        row = detail::row_scan(domain, neighbour);
-                    }
-                    rows[d][side][k - 1] = row;
-                }
-            }
+            rows[k] = detail::wrapped_row_scan(domain, index, detail::nth_offset<dim - 1>(k, reach), period);
         }
+
+        // The run being accumulated. Runs are emitted only when the shift changes, so two
+        // neighbouring runs never carry the same one.
+        bool pending = false;
+        value_t run_start{};
+        PredictionStencilShift<dim> run_shift;
+
+        const auto flush = [&](value_t end)
+        {
+            if (pending)
+            {
+                f(TInterval{run_start, end, i.index}, run_shift);
+            }
+        };
+
+        // How far each row reaches either side of x, capped at the reach, and where the
+        // answer it gives stops holding.
+        std::array<bool, rows_reached> covered{};
+        std::array<int, rows_reached> low{};
+        std::array<int, rows_reached> high{};
 
         value_t x = i.start;
         while (x < i.end)
         {
-            value_t next   = i.end;
-            value_t change = 0;
+            value_t next = i.end;
 
-            const bool inside = own.covers(x, change);
-            next              = std::min(next, change);
-
-            if (!inside)
+            for (std::size_t k = 0; k < rows_reached; ++k)
             {
-                f(TInterval{x, next, i.index}, PredictionShifts<dim>{{}, false});
-                x = next;
-                continue;
-            }
-
-            std::array<int, dim> avail_low{};
-            std::array<int, dim> avail_high{};
-
-            const auto& own_interval = own.current();
-            avail_low[0]             = static_cast<int>(std::min(x - own_interval.start, reach));
-            avail_high[0]            = static_cast<int>(std::min(own_interval.end - 1 - x, reach));
-
-            // In x the class changes cell by cell within 2r of each end of the run of cells
-            // the domain holds, and is constant in between - the bulk the consumers keep
-            // their current kernel on. This reads the geometry, before any periodic wrap
-            // below tops the counts back up: a wrap makes the two ends read the same as the
-            // bulk, it does not make them one run with it.
-            if (avail_low[0] < reach || avail_high[0] < reach)
-            {
-                next = std::min(next, x + 1);
-            }
-            else
-            {
-                next = std::min(next, own_interval.end - reach);
-            }
-
-            // Same wrap as the transverse rows, one cell at a time because in x the count
-            // varies from cell to cell. A cell missing because of a hole is not restored by
-            // this: its image one wrap away is outside the domain, so the test fails.
-            if (period[0] != 0)
-            {
-                for (auto k = avail_low[0]; k < reach && own.contains(x - k - 1 + period[0]); ++k)
+                value_t change = 0;
+                covered[k]     = rows[k].covers(x, change);
+                if (!covered[k])
                 {
-                    avail_low[0] = k + 1;
+                    next = std::min(next, change);
+                    continue;
                 }
-                for (auto k = avail_high[0]; k < reach && own.contains(x + k + 1 - period[0]); ++k)
-                {
-                    avail_high[0] = k + 1;
-                }
-            }
 
-            for (std::size_t d = 0; d + 1 < dim; ++d)
-            {
-                for (std::size_t side = 0; side < 2; ++side)
+                const auto& run = rows[k].current();
+                low[k]          = static_cast<int>(std::min(x - run.start, static_cast<value_t>(reach)));
+                high[k]         = static_cast<int>(std::min(run.end - 1 - x, static_cast<value_t>(reach)));
+
+                // The class changes cell by cell within 2r of each end of the run of cells
+                // the row holds, and is constant in between - the bulk the consumers keep
+                // their current kernel on. This reads the geometry, before the periodic
+                // wrap below tops the counts back up: a wrap makes the two ends read the
+                // same as the bulk, it does not make them one run with it.
+                if (low[k] < reach || high[k] < reach)
                 {
-                    int available = 0;
-                    for (std::size_t k = 0; k < 2 * radius; ++k)
+                    next = std::min(next, x + 1);
+                }
+                else
+                {
+                    next = std::min(next, run.end - static_cast<value_t>(reach));
+                }
+
+                // Off the end of a periodic direction the stencil reads the cells the
+                // periodic exchange fills it from, one wrap away. One cell at a time,
+                // because in x the count varies from cell to cell. A cell missing because
+                // of a hole is not restored by this: its image one wrap away is outside the
+                // domain, so the test fails.
+                if (period[0] != 0)
+                {
+                    for (auto k_low = low[k]; k_low < reach && rows[k].contains(x - k_low - 1 + period[0]); ++k_low)
                     {
-                        value_t row_change = 0;
-                        const bool covered = rows[d][side][k].covers(x, row_change);
-                        next               = std::min(next, row_change);
-                        if (!covered)
-                        {
-                            // Rows further out cannot restore what this one denies, and
-                            // they cannot change the count while this one is missing.
-                            break;
-                        }
-                        ++available;
+                        low[k] = k_low + 1;
                     }
-                    (side == 0 ? avail_low : avail_high)[d + 1] = available;
+                    for (auto k_high = high[k]; k_high < reach && rows[k].contains(x + k_high + 1 - period[0]); ++k_high)
+                    {
+                        high[k] = k_high + 1;
+                    }
                 }
             }
 
-            PredictionShifts<dim> shifts;
-            for (std::size_t d = 0; d < dim; ++d)
+            // The most centred shift whose whole stencil box the domain holds. The x extent
+            // is read off the rows the box covers: shifted by s, it reads [s - r, s + r]
+            // around x, which each of those rows must hold.
+            PredictionStencilShift<dim> shift;
+            shift.fits = false;
+            for (std::size_t c = 0; c < detail::shift_count<radius, dim> && !shift.fits; ++c)
             {
-                const auto shift = prediction_shift(radius, avail_low[d], avail_high[d]);
-                shifts.shift[d]  = shift.shift;
-                shifts.fits      = shifts.fits && shift.fits;
+                bool admissible = true;
+                for (std::size_t k = 0; k < detail::band_size<radius, dim> && admissible; ++k)
+                {
+                    const auto row = order.rows[c][k];
+                    admissible     = covered[row] && order.shift[c][0] - r >= -low[row] && order.shift[c][0] + r <= high[row];
+                }
+                if (admissible)
+                {
+                    shift.shift = order.shift[c];
+                    shift.fits  = true;
+                }
             }
 
             // A breakpoint that failed to move would spin here rather than fail, so it is
             // asserted instead of being clamped away.
             assert(next > x && "for_each_prediction_shift_run: the run decomposition did not advance");
 
-            f(TInterval{x, next, i.index}, shifts);
+            if (!pending || !(shift == run_shift))
+            {
+                flush(x);
+                pending   = true;
+                run_start = x;
+                run_shift = shift;
+            }
             x = next;
         }
+
+        flush(i.end);
     }
 
     /**
-     * The prediction stencil shifts at one cell. The per-interval form above is what the
+     * The prediction stencil shift at one cell. The per-interval form above is what the
      * hot kernels use; this is for consumers that already visit cells one at a time, and
      * for saying in one line what a test means.
      */
     template <std::size_t radius, std::size_t dim, class TInterval>
-    PredictionShifts<dim> prediction_shifts_at(const LevelCellArray<dim, TInterval>& domain,
-                                               const std::array<typename TInterval::value_t, dim>& period,
-                                               const xt::xtensor_fixed<typename TInterval::value_t, xt::xshape<dim>>& coord)
+    PredictionStencilShift<dim> prediction_shifts_at(const LevelCellArray<dim, TInterval>& domain,
+                                                     const std::array<typename TInterval::value_t, dim>& period,
+                                                     const xt::xtensor_fixed<typename TInterval::value_t, xt::xshape<dim>>& coord)
     {
         using value_t = typename TInterval::value_t;
 
@@ -355,15 +605,15 @@ namespace samurai
             index[d] = coord[d + 1];
         }
 
-        PredictionShifts<dim> shifts;
+        PredictionStencilShift<dim> shift;
         for_each_prediction_shift_run<radius>(domain,
                                               period,
                                               TInterval{coord[0], coord[0] + 1},
                                               index,
-                                              [&](const auto&, const auto& run_shifts)
+                                              [&](const auto&, const auto& run_shift)
                                               {
-                                                  shifts = run_shifts;
+                                                  shift = run_shift;
                                               });
-        return shifts;
+        return shift;
     }
 }

--- a/include/samurai/prediction_shifts.hpp
+++ b/include/samurai/prediction_shifts.hpp
@@ -10,6 +10,8 @@
 #include <cstddef>
 #include <cstdlib>
 #include <limits>
+#include <type_traits>
+#include <vector>
 
 #include <xtensor/containers/xfixed.hpp>
 
@@ -288,10 +290,10 @@ namespace samurai
                 base[d] += static_cast<value_t>(offset[d]);
             }
 
-            auto row = row_scan(domain, base);
-            if (!row.empty())
+            auto scan = row_scan(domain, base);
+            if (!scan.empty())
             {
-                return row;
+                return scan;
             }
 
             // The directions that can have stepped off the end.
@@ -332,7 +334,7 @@ namespace samurai
                     }
                 }
             }
-            return row;
+            return scan;
         }
 
         /**
@@ -372,7 +374,7 @@ namespace samurai
 
             DomainRow() = default;
 
-            DomainRow(RowScan<TInterval> scan, value_t wrap, int reach)
+            DomainRow(const RowScan<TInterval>& scan, value_t wrap, int reach)
                 : m_scan(scan)
                 , m_wrap(wrap)
                 , m_reach(reach)
@@ -469,26 +471,27 @@ namespace samurai
         }
 
         /**
-         * The transverse rows a radius-@c radius stencil can reach. Availability is only
-         * ever needed up to `2r` from the cell: a stencil short by r on one side needs 2r
-         * available opposite it, and nothing beyond that changes the answer. The same 2r
-         * bounds the transverse reach, a shift of at most r reading at most r further out:
+         * The transverse rows within @c reach_ of a cell. For the shift query the reach is
+         * `2r`: availability is only ever needed up to `2r` from the cell, since a stencil
+         * short by r on one side needs 2r available opposite it, and nothing beyond that
+         * changes the answer. The same 2r bounds the transverse reach, a shift of at most r
+         * reading at most r further out:
          *
          *        -2r        -r         0         +r        +2r
          *         [==========(=========c=========)==========]
          *                     the centred stencil            [ ] everything any
          *                                                        shift can reach
          *
-         * The type owns both the enumeration of the `[-2r, 2r]^(dim-1)` transverse
-         * offsets and the index of an offset in that enumeration, so a table built with
+         * The type owns both the enumeration of the `[-reach, reach]^(dim-1)` transverse
+         * offsets and the index of an offset in that enumeration, so an index computed with
          * @ref index_of points into a row array built with @ref offset by construction
          * rather than by convention.
          */
-        template <std::size_t radius, std::size_t dim>
+        template <int reach_, std::size_t dim>
         struct TransverseRows
         {
-            static constexpr int reach         = 2 * static_cast<int>(radius);
-            static constexpr std::size_t width = 4 * radius + 1;
+            static constexpr int reach         = reach_;
+            static constexpr std::size_t width = 2 * static_cast<std::size_t>(reach) + 1;
             static constexpr std::size_t count = ipow(width, dim - 1);
 
             /// The @a k-th transverse offset, `k < count`.
@@ -512,11 +515,15 @@ namespace samurai
         };
 
         /**
-         * The candidate shifts in the order they are preferred, with the rows each one
-         * reads. Both depend on nothing but @c radius and @c dim, so they are tabulated
-         * once: taking the first admissible entry of @c shift is the whole selection
-         * rule, and @c rows[c] holds the @ref TransverseRows indices of the rows the c-th
-         * stencil box covers.
+         * The candidate shifts in the order they are preferred: `[-r, r]^dim`, sorted by
+         * @ref more_centred. It depends on nothing but @c radius and @c dim, so it is built
+         * once, and taking the first admissible entry is the whole selection rule.
+         *
+         * On the heap, and holding the candidates only. The rows each candidate reads were
+         * tabulated too, as `count x band` indices, and that table is `(2r+1)^(2 dim - 1)`
+         * entries: 16 GB of static storage at radius 3 in six dimensions, which is what the
+         * prediction roundtrip test instantiates. The rows are cheap to recompute where they
+         * are needed, so they are.
          */
         template <std::size_t radius, std::size_t dim>
         struct ShiftSearch
@@ -525,45 +532,26 @@ namespace samurai
             static constexpr std::size_t count = ipow(2 * radius + 1, dim);
             /// The rows one stencil box covers: `[-r, r]^(dim-1)` around its shift.
             static constexpr std::size_t band = ipow(2 * radius + 1, dim - 1);
-
-            std::array<std::array<int, dim>, count> shift{};
-            std::array<std::array<std::size_t, band>, count> rows{};
         };
 
         template <std::size_t radius, std::size_t dim>
-        const ShiftSearch<radius, dim>& shift_search()
+        const std::vector<std::array<int, dim>>& shift_search()
         {
-            constexpr int r             = static_cast<int>(radius);
-            constexpr std::size_t cross = dim - 1;
-            using search_t              = ShiftSearch<radius, dim>;
+            constexpr int r = static_cast<int>(radius);
+            using search_t  = ShiftSearch<radius, dim>;
 
-            static const search_t table = []
+            static const std::vector<std::array<int, dim>> order = []
             {
-                search_t out;
+                std::vector<std::array<int, dim>> out(search_t::count);
                 for (std::size_t c = 0; c < search_t::count; ++c)
                 {
-                    out.shift[c] = nth_offset<dim>(c, r);
+                    out[c] = nth_offset<dim>(c, r);
                 }
-                std::sort(out.shift.begin(), out.shift.end(), more_centred<dim>);
-
-                for (std::size_t c = 0; c < search_t::count; ++c)
-                {
-                    for (std::size_t k = 0; k < search_t::band; ++k)
-                    {
-                        const auto within = nth_offset<cross>(k, r);
-
-                        std::array<int, cross> transverse{};
-                        for (std::size_t d = 0; d < cross; ++d)
-                        {
-                            transverse[d] = out.shift[c][d + 1] + within[d];
-                        }
-                        out.rows[c][k] = TransverseRows<radius, dim>::index_of(transverse);
-                    }
-                }
+                std::sort(out.begin(), out.end(), more_centred<dim>);
                 return out;
             }();
 
-            return table;
+            return order;
         }
 
         /**
@@ -571,32 +559,78 @@ namespace samurai
          * cover of every row the stencil can reach: shifted by @c s, the box reads
          * `[s_0 - r, s_0 + r]` along each of the rows it covers, so @c s is admissible
          * exactly when each of those rows holds the cell and covers at least that far.
+         *
+         * @param covers one cover per row of `TransverseRows<2r, dim>`, in that enumeration
          */
         template <std::size_t radius, std::size_t dim, class value_t>
-        PredictionStencilShift<dim> most_centred_fit(const std::array<RowCover<value_t>, TransverseRows<radius, dim>::count>& covers)
+        PredictionStencilShift<dim> most_centred_fit(const RowCover<value_t>* covers)
         {
-            constexpr int r   = static_cast<int>(radius);
-            using search_t    = ShiftSearch<radius, dim>;
-            const auto& order = shift_search<radius, dim>();
+            constexpr int r             = static_cast<int>(radius);
+            constexpr std::size_t cross = dim - 1;
+            using search_t              = ShiftSearch<radius, dim>;
+            using rows_t                = TransverseRows<2 * r, dim>;
+            const auto& order           = shift_search<radius, dim>();
 
             PredictionStencilShift<dim> best;
             best.fits = false;
             for (std::size_t c = 0; c < search_t::count && !best.fits; ++c)
             {
-                bool admissible = true;
+                const auto& shift = order[c];
+                bool admissible   = true;
                 for (std::size_t k = 0; k < search_t::band && admissible; ++k)
                 {
-                    const auto& cover = covers[order.rows[c][k]];
-                    admissible        = cover.holds && order.shift[c][0] - r >= -cover.low && order.shift[c][0] + r <= cover.high;
+                    const auto within = nth_offset<cross>(k, r);
+                    std::array<int, cross> transverse{};
+                    for (std::size_t d = 0; d < cross; ++d)
+                    {
+                        transverse[d] = shift[d + 1] + within[d];
+                    }
+                    const auto& cover = covers[rows_t::index_of(transverse)];
+                    admissible        = cover.holds && shift[0] - r >= -cover.low && shift[0] + r <= cover.high;
                 }
                 if (admissible)
                 {
-                    best.shift = order.shift[c];
+                    best.shift = shift;
                     best.fits  = true;
                 }
             }
             return best;
         }
+
+        /**
+         * A fixed-size buffer for one query: on the stack while it is small, on the heap
+         * once it is not. The row arrays are `(4r+1)^(dim-1)` entries, five in 2D at radius
+         * 1 and 371293 at radius 3 in six dimensions, and the second is not a stack object.
+         */
+        template <class T, std::size_t count>
+        class QueryScratch
+        {
+          public:
+
+            static constexpr bool on_stack = count * sizeof(T) <= 4096;
+
+            QueryScratch()
+            {
+                if constexpr (!on_stack)
+                {
+                    m_data.resize(count);
+                }
+            }
+
+            T& operator[](std::size_t k)
+            {
+                return m_data[k];
+            }
+
+            const T* data() const
+            {
+                return m_data.data();
+            }
+
+          private:
+
+            std::conditional_t<on_stack, std::array<T, count>, std::vector<T>> m_data{};
+        };
     }
 
     /**
@@ -633,11 +667,11 @@ namespace samurai
                                        Func&& f)
     {
         using value_t = typename TInterval::value_t;
-        using rows_t  = detail::TransverseRows<radius, dim>;
+        using rows_t  = detail::TransverseRows<2 * static_cast<int>(radius), dim>;
 
         // One cursor per transverse row the stencil can reach, over the periodically
         // extended domain.
-        std::array<detail::DomainRow<TInterval>, rows_t::count> rows;
+        detail::QueryScratch<detail::DomainRow<TInterval>, rows_t::count> rows;
         for (std::size_t k = 0; k < rows_t::count; ++k)
         {
             rows[k] = detail::DomainRow<TInterval>(detail::displaced_row(domain, index, rows_t::offset(k), period), period[0], rows_t::reach);
@@ -657,7 +691,7 @@ namespace samurai
             }
         };
 
-        std::array<detail::RowCover<value_t>, rows_t::count> covers;
+        detail::QueryScratch<detail::RowCover<value_t>, rows_t::count> covers;
 
         value_t x = i.start;
         while (x < i.end)
@@ -671,7 +705,7 @@ namespace samurai
                 next      = std::min(next, covers[k].until);
             }
 
-            const auto shift = detail::most_centred_fit<radius, dim>(covers);
+            const auto shift = detail::most_centred_fit<radius, dim>(covers.data());
 
             // A breakpoint that failed to move would spin here rather than fail, so it is
             // asserted instead of being clamped away.

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -55,6 +55,7 @@ set(SAMURAI_TESTS
     test_periodic.cpp
     test_portion.cpp
     test_prediction_coefficients.cpp
+    test_prediction_shifts.cpp
     test_projection_prediction_roundtrip.cpp
     test_restart.cpp
     test_scaling.cpp

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -55,6 +55,7 @@ set(SAMURAI_TESTS
     test_periodic.cpp
     test_portion.cpp
     test_prediction_coefficients.cpp
+    test_prediction_inward_reach.cpp
     test_prediction_shifts.cpp
     test_projection_prediction_roundtrip.cpp
     test_restart.cpp

--- a/tests/test_prediction_inward_reach.cpp
+++ b/tests/test_prediction_inward_reach.cpp
@@ -1,0 +1,297 @@
+// Copyright 2018-2025 the samurai's authors
+// SPDX-License-Identifier:  BSD-3-Clause
+
+// The mesh holds what a prediction stencil reads, wherever prediction is used.
+//
+// Away from a boundary a stencil of radius r reads r cells each side, and the coarse levels
+// carry exactly that margin. Near a boundary the stencil cannot stay centred - it shifts
+// inward so that it reads only cells the domain has - and it then reaches 2r on one side.
+// The margin the mesh carries has to be the larger of the two, or the shifted stencil names
+// cells that are not there. That is a property of the mesh, checked here without computing
+// anything: walk the positions where a detail is computed, ask where the stencil sits, and
+// look up every cell it names.
+//
+// The second test is the other half of the same requirement, in the opposite direction: a
+// cell the mesh holds but that nothing fills is worse than a cell it does not hold, because
+// it is read as a value. Both must hold at once - a margin wide enough to be read, and
+// narrow enough to be filled.
+
+#include <array>
+#include <cmath>
+#include <string>
+
+#include <gtest/gtest.h>
+
+#include <samurai/algorithm/update.hpp>
+#include <samurai/bc.hpp>
+#include <samurai/box.hpp>
+#include <samurai/field.hpp>
+#include <samurai/mr/adapt.hpp>
+#include <samurai/mr/mesh.hpp>
+#include <samurai/prediction_shifts.hpp>
+#include <samurai/samurai.hpp>
+#include <samurai/static_algorithm.hpp>
+#include <samurai/subset/node.hpp>
+
+namespace samurai
+{
+    namespace
+    {
+        // A mesh whose coarse levels are ragged, which is the situation that matters: a level
+        // exists only where the projection chain needs it, so the margin around a position
+        // where a detail is computed is not uniform. A ball sitting one coarse cell away from
+        // the boundary, refined over a wide range of levels, produces exactly that - it is
+        // the configuration of tests/test_mra.cpp, where a clamped stencil first named a cell
+        // the mesh did not hold.
+        template <std::size_t dim>
+        auto ragged_mesh(std::size_t max_level, const std::array<bool, dim>& periodic = {})
+        {
+            auto cfg  = mesh_config<dim>().min_level(2).max_level(max_level).periodic(periodic);
+            auto mesh = mra::make_mesh(Box<double, dim>{xt::zeros<double>({dim}), xt::ones<double>({dim})}, cfg);
+
+            auto phi = make_scalar_field<double>("phi", mesh);
+            for_each_cell(mesh,
+                          [&](auto& cell)
+                          {
+                              const auto c = cell.center();
+                              double r     = 0.;
+                              for (std::size_t d = 0; d < dim; ++d)
+                              {
+                                  r += (c[d] - 0.3) * (c[d] - 0.3);
+                              }
+                              phi[cell] = (std::sqrt(r) < 0.2) ? 1. : 0.;
+                          });
+            make_bc<Dirichlet<1>>(phi, 0.);
+            auto cfg_mra = mra_config().epsilon(1e-4);
+            make_MRAdapt(phi)(cfg_mra);
+            return mesh;
+        }
+
+        // How many stencil cells were looked up, and how many of them the mesh did not hold.
+        struct ReachSweep
+        {
+            std::size_t looked_up = 0;
+            std::size_t missing   = 0;
+        };
+
+        // Every cell named by the stencil of one run, at `level`, in the mesh's own storage.
+        template <std::size_t radius, class Mesh, class Run, class Index, class Shifts>
+        void check_run(const Mesh& mesh, std::size_t level, const Run& run, const Index& index, const Shifts& shifts, ReachSweep& sweep)
+        {
+            static constexpr std::size_t dim  = Mesh::dim;
+            static constexpr std::size_t size = 2 * radius + 1;
+            using mesh_id_t                   = typename Mesh::mesh_id_t;
+            using value_t                     = typename Mesh::interval_t::value_t;
+
+            std::array<value_t, dim> start;
+            for (std::size_t d = 0; d < dim; ++d)
+            {
+                // Where nothing fits the stencil stays centred, which is what the consumers
+                // do: outside the domain it reads the outer ghosts the boundary conditions
+                // write, and the mesh has those.
+                const int shift = shifts.fits ? shifts.shift[d] : 0;
+                start[d]        = static_cast<value_t>(-static_cast<int>(radius) + shift);
+            }
+
+            for (auto x = run.start; x < run.end; ++x)
+            {
+                static_nested_loop<dim, 0, size>(
+                    [&](const auto& k)
+                    {
+                        xt::xtensor_fixed<value_t, xt::xshape<dim>> c;
+                        c[0] = x + start[0] + static_cast<value_t>(k[0]);
+                        for (std::size_t d = 1; d < dim; ++d)
+                        {
+                            c[d] = index[d - 1] + start[d] + static_cast<value_t>(k[d]);
+                        }
+
+                        ++sweep.looked_up;
+                        if (find(mesh[mesh_id_t::reference][level], c) < 0)
+                        {
+                            if (sweep.missing < 5)
+                            {
+                                std::string at = "(";
+                                for (std::size_t d = 0; d < dim; ++d)
+                                {
+                                    at += (d == 0 ? "" : ",") + std::to_string(c[d]);
+                                }
+                                ADD_FAILURE() << "level " << level << ": the cell at x = " << x << " names " << at << ")"
+                                              << " which the mesh does not hold; shifts fit=" << shifts.fits
+                                              << " shift0=" << shifts.shift[0] << " shift1=" << shifts.shift[1];
+                            }
+                            ++sweep.missing;
+                        }
+                    });
+            }
+        }
+
+        // The positions where the detail is computed are the ones adapt visits: every cell of
+        // all_cells lying below a leaf. Same set, so the same stencils.
+        template <class Mesh>
+        ReachSweep sweep_detail_positions(const Mesh& mesh)
+        {
+            static constexpr std::size_t radius = Mesh::config_t::prediction_stencil_radius;
+            using mesh_id_t                     = typename Mesh::mesh_id_t;
+
+            using value_t = typename Mesh::interval_t::value_t;
+
+            // The wrap the periodic ghost exchange copies by, seen at this level, and 0 where
+            // the direction is not periodic. Spelled out here rather than shared: a test that
+            // computed it the same way as the code under test would not be checking it.
+            const auto period_at = [&](std::size_t level)
+            {
+                std::array<value_t, Mesh::dim> period{};
+                const auto minmax  = mesh.domain().minmax_indices();
+                const auto delta_l = mesh.domain().level() - level;
+                for (std::size_t d = 0; d < Mesh::dim; ++d)
+                {
+                    period[d] = mesh.is_periodic(d) ? static_cast<value_t>((minmax[d].second - minmax[d].first) >> delta_l) : 0;
+                }
+                return period;
+            };
+
+            ReachSweep sweep;
+            for (std::size_t level = mesh.min_level() > 0 ? mesh.min_level() - 1 : 0; level < mesh.max_level(); ++level)
+            {
+                const auto period = period_at(level);
+
+                auto ghosts_below_cells = intersection(mesh[mesh_id_t::all_cells][level],
+                                                       union_(mesh[mesh_id_t::cells][level + 1], mesh[mesh_id_t::cells][level + 2]))
+                                              .on(level);
+                ghosts_below_cells(
+                    [&](const auto& i, const auto& index)
+                    {
+                        for_each_prediction_shift_run<radius>(mesh.domain(level),
+                                                              period,
+                                                              i,
+                                                              index,
+                                                              [&](const auto& run, const auto& shifts)
+                                                              {
+                                                                  check_run<radius>(mesh, level, run, index, shifts, sweep);
+                                                              });
+                    });
+            }
+            return sweep;
+        }
+    }
+
+    TEST(prediction_inward_reach, the_mesh_holds_what_a_clamped_stencil_reads_2d)
+    {
+        const auto mesh = ragged_mesh<2>(10);
+
+        const auto sweep = sweep_detail_positions(mesh);
+        EXPECT_GT(sweep.looked_up, 0u);
+        EXPECT_EQ(sweep.missing, 0u);
+    }
+
+    TEST(prediction_inward_reach, the_mesh_holds_what_a_clamped_stencil_reads_1d)
+    {
+        const auto mesh = ragged_mesh<1>(8);
+
+        const auto sweep = sweep_detail_positions(mesh);
+        EXPECT_GT(sweep.looked_up, 0u);
+        EXPECT_EQ(sweep.missing, 0u);
+    }
+
+    TEST(prediction_inward_reach, the_mesh_holds_what_a_clamped_stencil_reads_3d)
+    {
+        const auto mesh = ragged_mesh<3>(7);
+
+        const auto sweep = sweep_detail_positions(mesh);
+        EXPECT_GT(sweep.looked_up, 0u);
+        EXPECT_EQ(sweep.missing, 0u);
+    }
+
+    TEST(prediction_inward_reach, the_mesh_holds_what_a_clamped_stencil_reads_when_periodic)
+    {
+        // A periodic direction has no boundary, so nothing is clamped there; the other one
+        // still is, and the two must coexist on one mesh.
+        const auto mesh = ragged_mesh<2>(10, {true, false});
+
+        const auto sweep = sweep_detail_positions(mesh);
+        EXPECT_GT(sweep.looked_up, 0u);
+        EXPECT_EQ(sweep.missing, 0u);
+    }
+
+    TEST(prediction_inward_reach, the_mesh_holds_what_a_clamped_stencil_reads_while_adapting)
+    {
+        // The invariant has to hold on every mesh adaptation builds, not only on the one it
+        // settles on: the first cell a clamped stencil named and the mesh did not hold showed
+        // up on an intermediate mesh, inside adapt. A moving front is what produces those.
+        constexpr std::size_t dim = 2;
+
+        auto cfg  = mesh_config<dim>().min_level(2).max_level(8);
+        auto mesh = mra::make_mesh(Box<double, dim>{xt::zeros<double>({dim}), xt::ones<double>({dim})}, cfg);
+
+        auto phi = make_scalar_field<double>("phi", mesh);
+        make_bc<Dirichlet<1>>(phi, 0.);
+        auto adapt = make_MRAdapt(phi);
+
+        std::size_t looked_up = 0;
+        for (std::size_t step = 0; step < 6; ++step)
+        {
+            const double centre = 0.2 + 0.1 * static_cast<double>(step);
+            for_each_cell(mesh,
+                          [&](auto& cell)
+                          {
+                              const auto c = cell.center();
+                              double r     = 0.;
+                              for (std::size_t d = 0; d < dim; ++d)
+                              {
+                                  r += (c[d] - centre) * (c[d] - centre);
+                              }
+                              phi[cell] = (std::sqrt(r) < 0.2) ? 1. : 0.;
+                          });
+
+            auto cfg_mra = mra_config().epsilon(1e-4);
+            adapt(cfg_mra);
+
+            const auto sweep = sweep_detail_positions(mesh);
+            EXPECT_EQ(sweep.missing, 0u) << "at step " << step;
+            looked_up += sweep.looked_up;
+        }
+        EXPECT_GT(looked_up, 0u);
+    }
+
+    TEST(prediction_inward_reach, every_cell_the_mesh_holds_is_filled)
+    {
+        // The margin must not outrun what projection, prediction and the boundary conditions
+        // between them write: a cell that is held but never written is read as a value.
+        constexpr std::size_t dim = 2;
+        using mesh_id_t           = MRMeshId;
+
+        auto mesh = ragged_mesh<dim>(10);
+
+        auto u = make_scalar_field<double>("u", mesh);
+        u.fill(std::nan(""));
+        for_each_cell(mesh[mesh_id_t::cells],
+                      [&](const auto& cell)
+                      {
+                          const auto c = cell.center();
+                          u[cell]      = c[0] + 2. * c[1];
+                      });
+        make_bc<Dirichlet<1>>(u, 0.);
+        update_ghost_mr(u);
+
+        std::size_t unfilled = 0;
+        std::size_t total    = 0;
+        for_each_cell(mesh[mesh_id_t::reference],
+                      [&](const auto& cell)
+                      {
+                          ++total;
+                          if (std::isnan(u[cell]))
+                          {
+                              if (unfilled < 5)
+                              {
+                                  const auto& idx = cell.indices;
+                                  ADD_FAILURE() << "level " << cell.level << ": the cell at (" << idx[0] << "," << idx[1] << ") is held by"
+                                                << " the mesh and was never written";
+                              }
+                              ++unfilled;
+                          }
+                      });
+
+        EXPECT_GT(total, 0u);
+        EXPECT_EQ(unfilled, 0u);
+    }
+}

--- a/tests/test_prediction_shifts.cpp
+++ b/tests/test_prediction_shifts.cpp
@@ -1,0 +1,640 @@
+// Copyright 2018-2025 the samurai's authors
+// SPDX-License-Identifier:  BSD-3-Clause
+
+// Where a prediction stencil sits, asserted on the domain alone.
+//
+// The query answers "what shift must the stencil take here" from the domain and nothing
+// else, so these tests need no mesh, no field and no adaptation - they build a level cell
+// array and ask.
+//
+// Asserted here:
+//   1. The shift is the one the geometry forces, at every distance from a boundary, for
+//      radius 1 and 2, in 1D, 2D and 3D.
+//   2. The bulk of an interval comes back as ONE run with every shift zero. That is the
+//      form of the interior bit-identity requirement: a consumer running its current
+//      kernel on that run cannot move an interior value.
+//   3. A holed domain is decomposed exactly, cell for cell, including an interval that
+//      passes over the edge of a hole. Classifying such an interval by its worst cell
+//      would move interior values, which is why the query returns runs at all.
+//   4. Classifying against the cells one rank holds gives a DIFFERENT answer from
+//      classifying against the whole domain. This is the executable form of the
+//      partition-independence invariant: it says what going wrong would look like.
+//   5. The runs tile the queried interval exactly, in order, with none empty.
+
+#include <map>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include <samurai/box.hpp>
+#include <samurai/level_cell_array.hpp>
+#include <samurai/prediction_shifts.hpp>
+#include <samurai/subset/node.hpp>
+
+namespace samurai
+{
+    namespace
+    {
+        template <std::size_t dim>
+        using lca_t = LevelCellArray<dim>;
+
+        template <std::size_t dim>
+        using interval_t = typename lca_t<dim>::interval_t;
+
+        template <std::size_t dim>
+        using value_t = typename interval_t<dim>::value_t;
+
+        template <std::size_t dim>
+        using index_t = xt::xtensor_fixed<value_t<dim>, xt::xshape<dim - 1>>;
+
+        template <std::size_t dim>
+        using box_t = Box<value_t<dim>, dim>;
+
+        template <std::size_t dim>
+        using period_t = std::array<value_t<dim>, dim>;
+
+        /// One run of the decomposition, flattened for comparison.
+        template <std::size_t dim>
+        struct ShiftRun
+        {
+            value_t<dim> start;
+            value_t<dim> end;
+            std::array<int, dim> shift;
+            bool fits;
+
+            bool operator==(const ShiftRun& o) const
+            {
+                return start == o.start && end == o.end && shift == o.shift && fits == o.fits;
+            }
+        };
+
+        template <std::size_t dim>
+        std::ostream& operator<<(std::ostream& os, const ShiftRun<dim>& r)
+        {
+            os << "[" << r.start << "," << r.end << ") shift {";
+            for (std::size_t d = 0; d < dim; ++d)
+            {
+                os << (d == 0 ? "" : ",") << r.shift[d];
+            }
+            return os << "}" << (r.fits ? "" : " !fits");
+        }
+
+        template <std::size_t radius, std::size_t dim>
+        std::vector<ShiftRun<dim>>
+        runs_of(const lca_t<dim>& domain, const interval_t<dim>& i, const index_t<dim>& index, const period_t<dim>& period = {})
+        {
+            std::vector<ShiftRun<dim>> out;
+            for_each_prediction_shift_run<radius>(domain,
+                                                  period,
+                                                  i,
+                                                  index,
+                                                  [&](const auto& run, const auto& shifts)
+                                                  {
+                                                      out.push_back({run.start, run.end, shifts.shift, shifts.fits});
+                                                  });
+
+            // Property 5, checked everywhere rather than in a test of its own: the runs
+            // tile the queried interval exactly, so a consumer looping over them visits
+            // every cell once.
+            EXPECT_FALSE(out.empty());
+            EXPECT_EQ(out.front().start, i.start);
+            EXPECT_EQ(out.back().end, i.end);
+            for (std::size_t k = 0; k < out.size(); ++k)
+            {
+                EXPECT_LT(out[k].start, out[k].end) << "empty run " << out[k];
+                if (k > 0)
+                {
+                    EXPECT_EQ(out[k].start, out[k - 1].end) << "gap or overlap before " << out[k];
+                }
+            }
+            return out;
+        }
+
+        /**
+         * The same answer, worked out the slow and obvious way: ask the domain about one
+         * cell at a time. This is the definition the fast query has to agree with - it
+         * knows nothing about rows, cursors or runs, so a disagreement is a bug in the
+         * machinery rather than in both at once.
+         */
+        template <std::size_t radius, std::size_t dim>
+        PredictionShifts<dim>
+        reference_shifts(const lca_t<dim>& domain, xt::xtensor_fixed<value_t<dim>, xt::xshape<dim>> coord, const period_t<dim>& period = {})
+        {
+            const auto holds = [&](const auto& c)
+            {
+                return find(domain, c) >= 0;
+            };
+
+            if (!holds(coord))
+            {
+                return {{}, false};
+            }
+
+            PredictionShifts<dim> shifts;
+            for (std::size_t d = 0; d < dim; ++d)
+            {
+                std::array<int, 2> available = {0, 0};
+                for (std::size_t side = 0; side < 2; ++side)
+                {
+                    const auto step = (side == 0) ? -1 : 1;
+                    for (std::size_t k = 1; k <= 2 * radius; ++k)
+                    {
+                        auto neighbour = coord;
+                        neighbour[d] += static_cast<value_t<dim>>(step * static_cast<int>(k));
+                        if (!holds(neighbour))
+                        {
+                            if (period[d] == 0)
+                            {
+                                break;
+                            }
+                            // Off the end of a periodic direction the stencil reads the
+                            // cell one wrap away.
+                            neighbour[d] -= static_cast<value_t<dim>>(step) * period[d];
+                            if (!holds(neighbour))
+                            {
+                                break;
+                            }
+                        }
+                        ++available[side];
+                    }
+                }
+
+                const auto shift = prediction_shift(radius, available[0], available[1]);
+                shifts.shift[d]  = shift.shift;
+                shifts.fits      = shifts.fits && shift.fits;
+            }
+            return shifts;
+        }
+
+        /// The shift of every cell of an interval, one entry per cell.
+        template <std::size_t radius, std::size_t dim>
+        std::vector<std::array<int, dim>>
+        shift_per_cell(const lca_t<dim>& domain, const interval_t<dim>& i, const index_t<dim>& index, const period_t<dim>& period = {})
+        {
+            std::vector<std::array<int, dim>> out;
+            for (const auto& run : runs_of<radius>(domain, i, index, period))
+            {
+                for (auto x = run.start; x < run.end; ++x)
+                {
+                    out.push_back(run.shift);
+                }
+            }
+            return out;
+        }
+    }
+
+    TEST(prediction_shifts, radius1_1d_box)
+    {
+        constexpr std::size_t dim = 1;
+        const lca_t<dim> domain{
+            3,
+            box_t<dim>{{0}, {8}}
+        };
+
+        // Only the cell touching the boundary is shifted: at radius 1 the stencil is three
+        // cells wide, so one cell in is already enough to centre it.
+        const std::vector<std::array<int, 1>> expected = {{1}, {0}, {0}, {0}, {0}, {0}, {0}, {-1}};
+        EXPECT_EQ((shift_per_cell<1, dim>(domain, {0, 8}, {})), expected);
+    }
+
+    TEST(prediction_shifts, radius2_1d_box)
+    {
+        constexpr std::size_t dim = 1;
+        const lca_t<dim> domain{
+            4,
+            box_t<dim>{{0}, {16}}
+        };
+
+        // Radius 2 reads five cells, so the two cells at each end are shifted, by 2 then 1.
+        const std::vector<std::array<int, 1>> expected = {{2}, {1}, {0}, {0}, {0}, {0}, {0}, {0}, {0}, {0}, {0}, {0}, {0}, {0}, {-1}, {-2}};
+        EXPECT_EQ((shift_per_cell<2, dim>(domain, {0, 16}, {})), expected);
+    }
+
+    TEST(prediction_shifts, the_bulk_is_one_run_with_no_shift)
+    {
+        constexpr std::size_t dim = 1;
+        const lca_t<dim> domain{
+            3,
+            box_t<dim>{{0}, {8}}
+        };
+
+        // The interior comes back as a single run, so a consumer runs its current kernel
+        // over it unchanged - the mechanism by which interior values stay bit-identical.
+        const std::vector<ShiftRun<dim>> expected = {
+            {0, 1, {1},  true},
+            {1, 2, {0},  true},
+            {2, 6, {0},  true},
+            {6, 7, {0},  true},
+            {7, 8, {-1}, true}
+        };
+        EXPECT_EQ((runs_of<1, dim>(domain, {0, 8}, {})), expected);
+    }
+
+    TEST(prediction_shifts, a_domain_too_narrow_to_hold_the_stencil_does_not_fit)
+    {
+        constexpr std::size_t dim = 1;
+
+        // Three cells hold a radius-1 stencil however it is shifted; two do not.
+        const lca_t<dim> wide{
+            3,
+            box_t<dim>{{0}, {3}}
+        };
+        for (auto& run : runs_of<1, dim>(wide, {0, 3}, {}))
+        {
+            EXPECT_TRUE(run.fits) << run;
+        }
+
+        const lca_t<dim> narrow{
+            3,
+            box_t<dim>{{0}, {2}}
+        };
+        for (auto& run : runs_of<1, dim>(narrow, {0, 2}, {}))
+        {
+            EXPECT_FALSE(run.fits) << run;
+        }
+    }
+
+    TEST(prediction_shifts, cells_the_domain_does_not_hold_do_not_fit)
+    {
+        constexpr std::size_t dim = 1;
+        const lca_t<dim> domain{
+            3,
+            box_t<dim>{{0}, {8}}
+        };
+
+        // Asked about cells outside the domain, the query says so rather than inventing a
+        // shift: prediction has nothing to reach into there.
+        const std::vector<ShiftRun<dim>> expected = {
+            {-2, 0, {0}, false},
+            {0,  1, {1}, true },
+            {1,  2, {0}, true }
+        };
+        EXPECT_EQ((runs_of<1, dim>(domain, {-2, 2}, {})), expected);
+    }
+
+    TEST(prediction_shifts, radius1_2d_box_corner_shifts_in_both_directions)
+    {
+        constexpr std::size_t dim = 2;
+        const lca_t<dim> domain{
+            3,
+            box_t<dim>{{0, 0}, {8, 8}}
+        };
+
+        // A corner is "clamp in x and clamp in y", one independent shift per direction,
+        // with no notion of a diagonal or of an outward normal.
+        EXPECT_EQ((prediction_shifts_at<1, dim>(domain, {}, {0, 0})).shift, (std::array<int, 2>{1, 1}));
+        EXPECT_EQ((prediction_shifts_at<1, dim>(domain, {}, {7, 0})).shift, (std::array<int, 2>{-1, 1}));
+        EXPECT_EQ((prediction_shifts_at<1, dim>(domain, {}, {0, 7})).shift, (std::array<int, 2>{1, -1}));
+        EXPECT_EQ((prediction_shifts_at<1, dim>(domain, {}, {7, 7})).shift, (std::array<int, 2>{-1, -1}));
+
+        // An edge shifts in one direction only, the interior in none.
+        EXPECT_EQ((prediction_shifts_at<1, dim>(domain, {}, {4, 0})).shift, (std::array<int, 2>{0, 1}));
+        EXPECT_EQ((prediction_shifts_at<1, dim>(domain, {}, {0, 4})).shift, (std::array<int, 2>{1, 0}));
+        EXPECT_EQ((prediction_shifts_at<1, dim>(domain, {}, {4, 4})).shift, (std::array<int, 2>{0, 0}));
+    }
+
+    TEST(prediction_shifts, radius1_3d_box_corner_shifts_in_three_directions)
+    {
+        constexpr std::size_t dim = 3;
+        const lca_t<dim> domain{
+            2,
+            box_t<dim>{{0, 0, 0}, {4, 4, 4}}
+        };
+
+        EXPECT_EQ((prediction_shifts_at<1, dim>(domain, {}, {0, 0, 0})).shift, (std::array<int, 3>{1, 1, 1}));
+        EXPECT_EQ((prediction_shifts_at<1, dim>(domain, {}, {3, 0, 3})).shift, (std::array<int, 3>{-1, 1, -1}));
+        EXPECT_EQ((prediction_shifts_at<1, dim>(domain, {}, {1, 2, 1})).shift, (std::array<int, 3>{0, 0, 0}));
+    }
+
+    TEST(prediction_shifts, a_hole_is_a_boundary_like_any_other)
+    {
+        constexpr std::size_t dim = 2;
+        const std::size_t level   = 4;
+
+        // A box with a square hole punched out of it.
+        const lca_t<dim> full{
+            level,
+            box_t<dim>{{0, 0}, {12, 12}}
+        };
+        const lca_t<dim> hole{
+            level,
+            box_t<dim>{{4, 4}, {8, 8}}
+        };
+        const lca_t<dim> domain{difference(full, hole)};
+
+        // The row just above the hole. Over the hole's span the stencil must shift up,
+        // away from the cells the hole removed; on either side of it, it must not - and
+        // that is one interval, so the query has to split it.
+        const std::vector<ShiftRun<dim>> expected = {
+            {0,  1,  {1, 0},  true},
+            {1,  2,  {0, 0},  true},
+            {2,  4,  {0, 0},  true},
+            {4,  8,  {0, 1},  true},
+            {8,  10, {0, 0},  true},
+            {10, 11, {0, 0},  true},
+            {11, 12, {-1, 0}, true}
+        };
+        EXPECT_EQ((runs_of<1, dim>(domain, {0, 12}, {8})), expected);
+
+        // The row just below it shifts the other way, and the hole's own cells are not in
+        // the domain at all.
+        EXPECT_EQ((prediction_shifts_at<1, dim>(domain, {}, {6, 3})).shift, (std::array<int, 2>{0, -1}));
+        EXPECT_FALSE((prediction_shifts_at<1, dim>(domain, {}, {6, 6})).fits);
+
+        // A hole's side is a boundary in one direction only, exactly as the domain's own
+        // side is, and the clamp is read per direction with no notion of a normal.
+        EXPECT_EQ((prediction_shifts_at<1, dim>(domain, {}, {3, 4})).shift, (std::array<int, 2>{-1, 0}));
+        EXPECT_EQ((prediction_shifts_at<1, dim>(domain, {}, {8, 5})).shift, (std::array<int, 2>{1, 0}));
+
+        // A cell diagonally off the hole's corner sees no boundary at all: in each
+        // direction separately the cells it reads are there. A rule that looked at the
+        // hole rather than at one direction at a time would shift it, and move an interior
+        // value for nothing.
+        EXPECT_EQ((prediction_shifts_at<1, dim>(domain, {}, {3, 3})).shift, (std::array<int, 2>{0, 0}));
+        EXPECT_EQ((prediction_shifts_at<1, dim>(domain, {}, {8, 8})).shift, (std::array<int, 2>{0, 0}));
+    }
+
+    TEST(prediction_shifts, two_different_boundaries_clamp_a_cell_independently)
+    {
+        constexpr std::size_t dim = 2;
+        const std::size_t level   = 4;
+
+        // A hole biting into the left edge of the domain, so that a cell can be clamped in
+        // x by the domain's own side and in y by the hole.
+        const lca_t<dim> full{
+            level,
+            box_t<dim>{{0, 0}, {12, 12}}
+        };
+        const lca_t<dim> hole{
+            level,
+            box_t<dim>{{0, 4}, {4, 8}}
+        };
+        const lca_t<dim> domain{difference(full, hole)};
+
+        // Nothing in the query knows the two clamps come from different boundaries.
+        EXPECT_EQ((prediction_shifts_at<1, dim>(domain, {}, {0, 3})).shift, (std::array<int, 2>{1, -1}));
+        EXPECT_EQ((prediction_shifts_at<1, dim>(domain, {}, {0, 8})).shift, (std::array<int, 2>{1, 1}));
+
+        // The row the hole ends on is cut in two by it: its left part starts at the hole's
+        // edge rather than at the domain's.
+        EXPECT_EQ((prediction_shifts_at<1, dim>(domain, {}, {4, 5})).shift, (std::array<int, 2>{1, 0}));
+    }
+
+    TEST(prediction_shifts, classifying_against_one_rank_s_cells_gives_the_wrong_answer)
+    {
+        constexpr std::size_t dim = 2;
+        const std::size_t level   = 3;
+
+        const lca_t<dim> domain{
+            level,
+            box_t<dim>{{0, 0}, {8, 8}}
+        };
+        // What a rank owning the left half would see if the classifier were handed its own
+        // cells instead of the domain.
+        const lca_t<dim> one_rank{
+            level,
+            box_t<dim>{{0, 0}, {4, 8}}
+        };
+
+        // Same cell, two answers. The interior answer is the right one, and it is the one
+        // the domain gives on every rank without any communication; the subdomain invents a
+        // boundary at the partition, which is how results would start depending on the rank
+        // count.
+        EXPECT_EQ((prediction_shifts_at<1, dim>(domain, {}, {3, 4})).shift, (std::array<int, 2>{0, 0}));
+        EXPECT_EQ((prediction_shifts_at<1, dim>(one_rank, {}, {3, 4})).shift, (std::array<int, 2>{-1, 0}));
+    }
+
+    TEST(prediction_shifts, a_periodic_direction_has_no_boundary_to_clamp_against)
+    {
+        constexpr std::size_t dim = 1;
+        const lca_t<dim> domain{
+            3,
+            box_t<dim>{{0}, {8}}
+        };
+
+        // The cells a stencil would want at the ends are the ones the periodic exchange
+        // fills it from, so nothing is clamped anywhere.
+        const std::vector<std::array<int, 1>> expected = {{0}, {0}, {0}, {0}, {0}, {0}, {0}, {0}};
+        EXPECT_EQ((shift_per_cell<1, dim>(domain, {0, 8}, {}, {8})), expected);
+        EXPECT_EQ((shift_per_cell<2, dim>(domain, {0, 8}, {}, {8})), expected);
+    }
+
+    TEST(prediction_shifts, periodicity_is_per_direction)
+    {
+        constexpr std::size_t dim = 2;
+        const lca_t<dim> domain{
+            3,
+            box_t<dim>{{0, 0}, {8, 8}}
+        };
+        const period_t<dim> periodic_in_y = {0, 8};
+
+        // A corner of a domain periodic in y only is clamped in x and free in y.
+        EXPECT_EQ((prediction_shifts_at<1, dim>(domain, periodic_in_y, {0, 0})).shift, (std::array<int, 2>{1, 0}));
+        EXPECT_EQ((prediction_shifts_at<1, dim>(domain, periodic_in_y, {7, 7})).shift, (std::array<int, 2>{-1, 0}));
+        EXPECT_EQ((prediction_shifts_at<1, dim>(domain, periodic_in_y, {4, 0})).shift, (std::array<int, 2>{0, 0}));
+    }
+
+    TEST(prediction_shifts, a_hole_clamps_even_in_a_periodic_direction)
+    {
+        constexpr std::size_t dim = 2;
+        const std::size_t level   = 4;
+
+        const lca_t<dim> full{
+            level,
+            box_t<dim>{{0, 0}, {12, 12}}
+        };
+        const lca_t<dim> hole{
+            level,
+            box_t<dim>{{4, 4}, {8, 8}}
+        };
+        const lca_t<dim> domain{difference(full, hole)};
+        const period_t<dim> both = {12, 12};
+
+        // Periodicity says what happens off the end of the domain; it says nothing about a
+        // hole in the middle of it, and the cells a hole removed are not filled by anyone.
+        EXPECT_EQ((prediction_shifts_at<1, dim>(domain, both, {6, 3})).shift, (std::array<int, 2>{0, -1}));
+        EXPECT_EQ((prediction_shifts_at<1, dim>(domain, both, {3, 6})).shift, (std::array<int, 2>{-1, 0}));
+
+        // The domain's own edges, on the other hand, are not boundaries any more.
+        EXPECT_EQ((prediction_shifts_at<1, dim>(domain, both, {0, 0})).shift, (std::array<int, 2>{0, 0}));
+        EXPECT_EQ((prediction_shifts_at<1, dim>(domain, both, {11, 11})).shift, (std::array<int, 2>{0, 0}));
+    }
+
+    TEST(prediction_shifts, the_run_decomposition_agrees_cell_for_cell_when_periodic)
+    {
+        constexpr std::size_t dim = 2;
+        const std::size_t level   = 4;
+
+        const lca_t<dim> full{
+            level,
+            box_t<dim>{{0, 0}, {16, 16}}
+        };
+        const lca_t<dim> tall_hole{
+            level,
+            box_t<dim>{{3, 2}, {6, 9}}
+        };
+        const lca_t<dim> corner_hole{
+            level,
+            box_t<dim>{{14, 0}, {16, 2}}
+        };
+        const lca_t<dim> domain{difference(difference(full, tall_hole), corner_hole)};
+        const period_t<dim> both = {16, 16};
+
+        for (value_t<dim> y = 0; y < 16; ++y)
+        {
+            for (const auto& run : runs_of<1, dim>(domain, {0, 16}, {y}, both))
+            {
+                for (auto x = run.start; x < run.end; ++x)
+                {
+                    const auto expected = reference_shifts<1, dim>(domain, {x, y}, both);
+                    EXPECT_EQ(run.shift, expected.shift) << "at (" << x << "," << y << ") in run " << run;
+                    EXPECT_EQ(run.fits, expected.fits) << "at (" << x << "," << y << ") in run " << run;
+                }
+            }
+        }
+    }
+
+    TEST(prediction_shifts, the_run_decomposition_agrees_cell_for_cell_with_the_slow_answer)
+    {
+        constexpr std::size_t dim = 2;
+        const std::size_t level   = 4;
+
+        // Deliberately awkward: two holes of different shapes, one of them one cell wide
+        // (so a stencil cannot fit across it), one touching the domain's edge, plus a
+        // block hanging off the side so that rows have different lengths.
+        const lca_t<dim> full{
+            level,
+            box_t<dim>{{0, 0}, {16, 16}}
+        };
+        const lca_t<dim> tall_hole{
+            level,
+            box_t<dim>{{3, 2}, {6, 9}}
+        };
+        const lca_t<dim> thin_hole{
+            level,
+            box_t<dim>{{10, 7}, {12, 8}}
+        };
+        const lca_t<dim> edge_hole{
+            level,
+            box_t<dim>{{13, 0}, {16, 3}}
+        };
+        const lca_t<dim> wing{
+            level,
+            box_t<dim>{{16, 5}, {19, 11}}
+        };
+        const lca_t<dim> domain{union_(difference(difference(difference(full, tall_hole), thin_hole), edge_hole), wing)};
+
+        // What the comparison actually met, so that the test cannot quietly become an
+        // agreement about nothing if the domain above is ever simplified.
+        std::map<std::array<int, dim>, int> seen;
+        int outside = 0;
+        int cramped = 0;
+
+        // Queried past the domain on both sides, so cells the domain does not hold are
+        // compared too.
+        for (value_t<dim> y = -2; y < 18; ++y)
+        {
+            const auto runs = runs_of<1, dim>(domain, {-2, 21}, {y});
+            for (const auto& run : runs)
+            {
+                for (auto x = run.start; x < run.end; ++x)
+                {
+                    const auto expected = reference_shifts<1, dim>(domain, {x, y});
+                    EXPECT_EQ(run.shift, expected.shift) << "at (" << x << "," << y << ") in run " << run;
+                    EXPECT_EQ(run.fits, expected.fits) << "at (" << x << "," << y << ") in run " << run;
+
+                    ++seen[run.shift];
+                    outside += (find(domain, {x, y}) < 0) ? 1 : 0;
+                    cramped += (!run.fits && find(domain, {x, y}) >= 0) ? 1 : 0;
+                }
+            }
+        }
+
+        // Every shift a radius-1 stencil can take, in both directions and both signs.
+        for (int sx = -1; sx <= 1; ++sx)
+        {
+            for (int sy = -1; sy <= 1; ++sy)
+            {
+                const std::array<int, dim> shift = {sx, sy};
+                EXPECT_GT(seen[shift], 0) << "the domain never produced the shift {" << sx << "," << sy << "}";
+            }
+        }
+        EXPECT_GT(outside, 0) << "no cell outside the domain was compared";
+        EXPECT_GT(cramped, 0) << "the one-cell-wide hole never made a stencil not fit";
+
+        // Radius 2 reads further, so it exercises rows the radius-1 pass never consults.
+        for (value_t<dim> y = -2; y < 18; ++y)
+        {
+            for (const auto& run : runs_of<2, dim>(domain, {-2, 21}, {y}))
+            {
+                for (auto x = run.start; x < run.end; ++x)
+                {
+                    const auto expected = reference_shifts<2, dim>(domain, {x, y});
+                    EXPECT_EQ(run.shift, expected.shift) << "at (" << x << "," << y << ") in run " << run;
+                    EXPECT_EQ(run.fits, expected.fits) << "at (" << x << "," << y << ") in run " << run;
+                }
+            }
+        }
+    }
+
+    TEST(prediction_shifts, the_run_decomposition_agrees_cell_for_cell_in_3d)
+    {
+        constexpr std::size_t dim = 3;
+        const std::size_t level   = 3;
+
+        const lca_t<dim> full{
+            level,
+            box_t<dim>{{0, 0, 0}, {8, 8, 8}}
+        };
+        const lca_t<dim> hole{
+            level,
+            box_t<dim>{{2, 3, 1}, {5, 6, 4}}
+        };
+        const lca_t<dim> domain{difference(full, hole)};
+
+        for (value_t<dim> z = -1; z < 9; ++z)
+        {
+            for (value_t<dim> y = -1; y < 9; ++y)
+            {
+                for (const auto& run : runs_of<1, dim>(domain, {-1, 9}, {y, z}))
+                {
+                    for (auto x = run.start; x < run.end; ++x)
+                    {
+                        const auto expected = reference_shifts<1, dim>(domain, {x, y, z});
+                        EXPECT_EQ(run.shift, expected.shift) << "at (" << x << "," << y << "," << z << ")";
+                        EXPECT_EQ(run.fits, expected.fits) << "at (" << x << "," << y << "," << z << ")";
+                    }
+                }
+            }
+        }
+    }
+
+    TEST(prediction_shifts, radius2_needs_two_cells_of_clearance_across_a_hole)
+    {
+        constexpr std::size_t dim = 2;
+        const std::size_t level   = 4;
+
+        const lca_t<dim> full{
+            level,
+            box_t<dim>{{0, 0}, {16, 16}}
+        };
+        const lca_t<dim> hole{
+            level,
+            box_t<dim>{{6, 6}, {10, 10}}
+        };
+        const lca_t<dim> domain{difference(full, hole)};
+
+        // Radius 2 reads two cells each side, so the shift persists one cell further from
+        // the hole than radius 1 would put it.
+        EXPECT_EQ((prediction_shifts_at<2, dim>(domain, {}, {8, 10})).shift, (std::array<int, 2>{0, 2}));
+        EXPECT_EQ((prediction_shifts_at<2, dim>(domain, {}, {8, 11})).shift, (std::array<int, 2>{0, 1}));
+        EXPECT_EQ((prediction_shifts_at<2, dim>(domain, {}, {8, 12})).shift, (std::array<int, 2>{0, 0}));
+
+        // Between the hole and the domain edge there are six cells, which is more than the
+        // five a radius-2 stencil needs, so everything there still fits.
+        for (auto& run : runs_of<2, dim>(domain, {0, 6}, {8}))
+        {
+            EXPECT_TRUE(run.fits) << run;
+        }
+    }
+}

--- a/tests/test_prediction_shifts.cpp
+++ b/tests/test_prediction_shifts.cpp
@@ -25,6 +25,11 @@
 //   6. The runs tile the queried interval exactly, in order, with none empty, and no two
 //      neighbouring runs carry the same shift - they are maximal, so a consumer launches
 //      one kernel per genuine change of shift.
+//   7. The two seams the query is built on hold by themselves: the shift table and the
+//      row array index rows the same way (checked at compile time), and one row's cover
+//      reports exactly where it stops holding. That last property cannot be read off the
+//      public decomposition - a cover cut too early only fragments the sweep before the
+//      pieces are merged back together - yet the one-query-per-interval cost rests on it.
 
 #include <algorithm>
 #include <cstdlib>
@@ -301,6 +306,51 @@ namespace samurai
                     EXPECT_EQ(run.shift, expected.shift) << where.str();
                     EXPECT_EQ(run.fits, expected.fits) << where.str();
                 }
+            }
+        }
+
+        /**
+         * The row array is indexed through TransverseRows on both sides - the query when
+         * it builds the rows, the shift table when it names them - so the one contract is
+         * that index_of inverts offset. Both are constexpr: should one side's enumeration
+         * order ever change alone, this stops compiling instead of misreading rows.
+         */
+        template <std::size_t radius, std::size_t dim>
+        constexpr bool index_of_inverts_offset()
+        {
+            using rows_t = detail::TransverseRows<radius, dim>;
+            for (std::size_t k = 0; k < rows_t::count; ++k)
+            {
+                if (rows_t::index_of(rows_t::offset(k)) != k)
+                {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        static_assert(index_of_inverts_offset<1, 1>() && index_of_inverts_offset<1, 2>() && index_of_inverts_offset<1, 3>());
+        static_assert(index_of_inverts_offset<2, 1>() && index_of_inverts_offset<2, 2>() && index_of_inverts_offset<2, 3>());
+
+        /// One expected answer of DomainRow::around, for asserting a row point by point.
+        struct CoverPoint
+        {
+            value_t<1> x;
+            bool holds;
+            int low;
+            int high;
+            value_t<1> until;
+        };
+
+        void expect_cover(detail::DomainRow<interval_t<1>>& row, const std::vector<CoverPoint>& expected)
+        {
+            for (const auto& e : expected)
+            {
+                const auto cover = row.around(e.x);
+                EXPECT_EQ(cover.holds, e.holds) << "at x = " << e.x;
+                EXPECT_EQ(cover.low, e.low) << "at x = " << e.x;
+                EXPECT_EQ(cover.high, e.high) << "at x = " << e.x;
+                EXPECT_EQ(cover.until, e.until) << "at x = " << e.x;
             }
         }
     }
@@ -820,5 +870,71 @@ namespace samurai
         {
             EXPECT_TRUE(run.fits) << run;
         }
+    }
+
+    TEST(prediction_shifts, a_row_cover_reports_exactly_where_it_stops_holding)
+    {
+        // One row holding [0, 8) and [12, 20) - a hole in the middle, an end each side -
+        // read at reach 2 (radius 1) with no wrap.
+        const std::vector<interval_t<1>> cells = {
+            {0,  8 },
+            {12, 20}
+        };
+        detail::DomainRow<interval_t<1>> row{
+            detail::RowScan<interval_t<1>>{cells.data(), cells.size()},
+            0,
+            2
+        };
+
+        // What until buys: the driver asks once per breakpoint, not once per cell, so
+        // until must be exact. Too late would misclassify cells - the sweeps of test 4
+        // would see it - but too early only fragments the sweep before the merge glues
+        // the pieces back together, so that side of the contract is only visible here:
+        // in the bulk of a run the cover holds all the way to run.end - reach, and it
+        // moves cell by cell only within reach of an end or off the row.
+        expect_cover(row,
+                     {
+                         {-1, false, 0, 0, 0                                     }, // before everything: covered from 0
+                         {0,  true,  0, 2, 1                                     }, // within reach of the run's start
+                         {1,  true,  1, 2, 2                                     },
+                         {2,  true,  2, 2, 6                                     }, // the bulk: constant until end - reach
+                         {5,  true,  2, 2, 6                                     },
+                         {6,  true,  2, 1, 7                                     }, // within reach of its end
+                         {7,  true,  2, 0, 8                                     },
+                         {8,  false, 0, 0, 12                                    }, // the hole: covered again from 12
+                         {12, true,  0, 2, 13                                    },
+                         {14, true,  2, 2, 18                                    },
+                         {19, true,  2, 0, 20                                    },
+                         {20, false, 0, 0, std::numeric_limits<value_t<1>>::max()},
+        });
+    }
+
+    TEST(prediction_shifts, a_wrap_tops_the_cover_up_but_does_not_move_its_breakpoints)
+    {
+        // The same row, read with wrap 20: the row's own ends now count through the
+        // cells the periodic exchange fills them from, while the hole's edges do not -
+        // a hole cell's image one wrap away is outside the domain.
+        const std::vector<interval_t<1>> cells = {
+            {0,  8 },
+            {12, 20}
+        };
+        detail::DomainRow<interval_t<1>> row{
+            detail::RowScan<interval_t<1>>{cells.data(), cells.size()},
+            20,
+            2
+        };
+
+        // low and high are topped up, until is not: it still breaks the sweep at the
+        // geometric ends of the run. A wrap makes the end cells read the same as the
+        // bulk - the merge is what makes them one run with it, and only when the shift
+        // agrees. Cutting a run the wrap has evened out is the cheap mistake; gluing
+        // one the geometry still splits would be the wrong one.
+        expect_cover(row,
+                     {
+                         {0,  true, 2, 2, 1 }, // low reads 19, 18 through the wrap; until stays x + 1
+                         {7,  true, 2, 0, 8 }, // the hole's edge: images of 8, 9 are outside, nothing tops up
+                         {12, true, 0, 2, 13}, // same on the hole's other side
+                         {19, true, 2, 2, 20}, // the domain's end: high reads 0, 1 through the wrap
+        });
     }
 }

--- a/tests/test_prediction_shifts.cpp
+++ b/tests/test_prediction_shifts.cpp
@@ -13,21 +13,30 @@
 //   2. The bulk of an interval comes back as ONE run with every shift zero. That is the
 //      form of the interior bit-identity requirement: a consumer running its current
 //      kernel on that run cannot move an interior value.
-//   3. A holed domain is decomposed exactly, cell for cell, including an interval that
+//   3. The shift is chosen for the whole stencil BOX, not one direction at a time, so a
+//      re-entrant corner - which no single direction can see - is clamped, and a shape no
+//      shift can fit a box into reports that it does not fit.
+//   4. A holed domain is decomposed exactly, cell for cell, including an interval that
 //      passes over the edge of a hole. Classifying such an interval by its worst cell
 //      would move interior values, which is why the query returns runs at all.
-//   4. Classifying against the cells one rank holds gives a DIFFERENT answer from
+//   5. Classifying against the cells one rank holds gives a DIFFERENT answer from
 //      classifying against the whole domain. This is the executable form of the
 //      partition-independence invariant: it says what going wrong would look like.
-//   5. The runs tile the queried interval exactly, in order, with none empty.
+//   6. The runs tile the queried interval exactly, in order, with none empty, and no two
+//      neighbouring runs carry the same shift - they are maximal, so a consumer launches
+//      one kernel per genuine change of shift.
 
+#include <algorithm>
+#include <cstdlib>
 #include <map>
+#include <sstream>
 #include <vector>
 
 #include <gtest/gtest.h>
 
 #include <samurai/box.hpp>
 #include <samurai/level_cell_array.hpp>
+#include <samurai/numeric/prediction_coefficients.hpp>
 #include <samurai/prediction_shifts.hpp>
 #include <samurai/subset/node.hpp>
 
@@ -46,6 +55,9 @@ namespace samurai
 
         template <std::size_t dim>
         using index_t = xt::xtensor_fixed<value_t<dim>, xt::xshape<dim - 1>>;
+
+        template <std::size_t dim>
+        using coord_t = xt::xtensor_fixed<value_t<dim>, xt::xshape<dim>>;
 
         template <std::size_t dim>
         using box_t = Box<value_t<dim>, dim>;
@@ -88,14 +100,15 @@ namespace samurai
                                                   period,
                                                   i,
                                                   index,
-                                                  [&](const auto& run, const auto& shifts)
+                                                  [&](const auto& run, const auto& shift)
                                                   {
-                                                      out.push_back({run.start, run.end, shifts.shift, shifts.fits});
+                                                      out.push_back({run.start, run.end, shift.shift, shift.fits});
                                                   });
 
-            // Property 5, checked everywhere rather than in a test of its own: the runs
-            // tile the queried interval exactly, so a consumer looping over them visits
-            // every cell once.
+            // Property 6, checked everywhere rather than in a test of its own: the runs tile
+            // the queried interval exactly, so a consumer looping over them visits every
+            // cell once, and they are maximal, so it never launches two kernels where one
+            // would do.
             EXPECT_FALSE(out.empty());
             EXPECT_EQ(out.front().start, i.start);
             EXPECT_EQ(out.back().end, i.end);
@@ -105,65 +118,144 @@ namespace samurai
                 if (k > 0)
                 {
                     EXPECT_EQ(out[k].start, out[k - 1].end) << "gap or overlap before " << out[k];
+                    EXPECT_FALSE(out[k].shift == out[k - 1].shift && out[k].fits == out[k - 1].fits)
+                        << "run " << out[k] << " should have been merged into " << out[k - 1];
                 }
             }
             return out;
         }
 
-        /**
-         * The same answer, worked out the slow and obvious way: ask the domain about one
-         * cell at a time. This is the definition the fast query has to agree with - it
-         * knows nothing about rows, cursors or runs, so a disagreement is a bug in the
-         * machinery rather than in both at once.
-         */
+        /// The shifts a radius-@a radius stencil can take, in the order the rule prefers.
         template <std::size_t radius, std::size_t dim>
-        PredictionShifts<dim>
-        reference_shifts(const lca_t<dim>& domain, xt::xtensor_fixed<value_t<dim>, xt::xshape<dim>> coord, const period_t<dim>& period = {})
+        std::vector<std::array<int, dim>> shifts_by_preference()
         {
-            const auto holds = [&](const auto& c)
-            {
-                return find(domain, c) >= 0;
-            };
+            constexpr int r = static_cast<int>(radius);
 
-            if (!holds(coord))
-            {
-                return {{}, false};
-            }
-
-            PredictionShifts<dim> shifts;
+            std::vector<std::array<int, dim>> out;
+            std::size_t count = 1;
             for (std::size_t d = 0; d < dim; ++d)
             {
-                std::array<int, 2> available = {0, 0};
-                for (std::size_t side = 0; side < 2; ++side)
+                count *= static_cast<std::size_t>(2 * r + 1);
+            }
+            for (std::size_t n = 0; n < count; ++n)
+            {
+                std::array<int, dim> shift{};
+                auto rest = n;
+                for (std::size_t d = 0; d < dim; ++d)
                 {
-                    const auto step = (side == 0) ? -1 : 1;
-                    for (std::size_t k = 1; k <= 2 * radius; ++k)
+                    shift[d] = static_cast<int>(rest % static_cast<std::size_t>(2 * r + 1)) - r;
+                    rest /= static_cast<std::size_t>(2 * r + 1);
+                }
+                out.push_back(shift);
+            }
+
+            // Least shifted overall; then shifting x least, then y, and so on; then
+            // negative before positive. Spelled out here rather than shared with the query,
+            // so that the two say the same thing independently.
+            std::sort(out.begin(),
+                      out.end(),
+                      [](const auto& a, const auto& b)
+                      {
+                          int total_a = 0;
+                          int total_b = 0;
+                          for (std::size_t d = 0; d < dim; ++d)
+                          {
+                              total_a += std::abs(a[d]);
+                              total_b += std::abs(b[d]);
+                          }
+                          if (total_a != total_b)
+                          {
+                              return total_a < total_b;
+                          }
+                          for (std::size_t d = 0; d < dim; ++d)
+                          {
+                              if (std::abs(a[d]) != std::abs(b[d]))
+                              {
+                                  return std::abs(a[d]) < std::abs(b[d]);
+                              }
+                          }
+                          return a < b;
+                      });
+            return out;
+        }
+
+        /**
+         * The same answer, worked out the slow and obvious way: try the shifts in the order
+         * the rule prefers them and keep the first one whose whole stencil box the domain
+         * holds, asking about one cell at a time. This is the definition the fast query has
+         * to agree with - it knows nothing about rows, cursors, runs or shift tables, so a
+         * disagreement is a bug in the machinery rather than in both at once.
+         */
+        template <std::size_t radius, std::size_t dim>
+        PredictionStencilShift<dim> reference_shift(const lca_t<dim>& domain, const coord_t<dim>& coord, const period_t<dim>& period = {})
+        {
+            constexpr int r = static_cast<int>(radius);
+
+            std::size_t wraps = 1;
+            for (std::size_t d = 0; d < dim; ++d)
+            {
+                wraps *= 3;
+            }
+
+            // Does the domain hold this cell, counting the cells a periodic exchange fills
+            // it from - the same cell one wrap away, in any combination of directions?
+            const auto holds = [&](const coord_t<dim>& c)
+            {
+                for (std::size_t n = 0; n < wraps; ++n)
+                {
+                    auto probe  = c;
+                    auto rest   = n;
+                    bool usable = true;
+                    for (std::size_t d = 0; d < dim; ++d)
                     {
-                        auto neighbour = coord;
-                        neighbour[d] += static_cast<value_t<dim>>(step * static_cast<int>(k));
-                        if (!holds(neighbour))
+                        const auto choice = rest % 3;
+                        rest /= 3;
+                        if (choice == 0)
                         {
-                            if (period[d] == 0)
-                            {
-                                break;
-                            }
-                            // Off the end of a periodic direction the stencil reads the
-                            // cell one wrap away.
-                            neighbour[d] -= static_cast<value_t<dim>>(step) * period[d];
-                            if (!holds(neighbour))
-                            {
-                                break;
-                            }
+                            continue;
                         }
-                        ++available[side];
+                        if (period[d] == 0)
+                        {
+                            usable = false;
+                            break;
+                        }
+                        probe[d] += (choice == 1 ? -1 : 1) * period[d];
+                    }
+                    if (usable && find(domain, probe) >= 0)
+                    {
+                        return true;
                     }
                 }
+                return false;
+            };
 
-                const auto shift = prediction_shift(radius, available[0], available[1]);
-                shifts.shift[d]  = shift.shift;
-                shifts.fits      = shifts.fits && shift.fits;
+            std::size_t box = 1;
+            for (std::size_t d = 0; d < dim; ++d)
+            {
+                box *= static_cast<std::size_t>(2 * r + 1);
             }
-            return shifts;
+
+            for (const auto& shift : shifts_by_preference<radius, dim>())
+            {
+                bool admissible = true;
+                for (std::size_t n = 0; n < box && admissible; ++n)
+                {
+                    auto probe = coord;
+                    auto rest  = n;
+                    for (std::size_t d = 0; d < dim; ++d)
+                    {
+                        const auto offset = static_cast<int>(rest % static_cast<std::size_t>(2 * r + 1)) - r;
+                        rest /= static_cast<std::size_t>(2 * r + 1);
+                        probe[d] += static_cast<value_t<dim>>(shift[d] + offset);
+                    }
+                    admissible = holds(probe);
+                }
+                if (admissible)
+                {
+                    return {shift, true};
+                }
+            }
+            return {{}, false};
         }
 
         /// The shift of every cell of an interval, one entry per cell.
@@ -180,6 +272,36 @@ namespace samurai
                 }
             }
             return out;
+        }
+
+        /// The query against the slow answer, at every cell of a slab of the domain.
+        template <std::size_t radius, std::size_t dim>
+        void expect_agreement(const lca_t<dim>& domain, const interval_t<dim>& i, const index_t<dim>& index, const period_t<dim>& period = {})
+        {
+            for (const auto& run : runs_of<radius>(domain, i, index, period))
+            {
+                for (auto x = run.start; x < run.end; ++x)
+                {
+                    auto coord = coord_t<dim>{};
+                    coord[0]   = x;
+                    for (std::size_t d = 0; d + 1 < dim; ++d)
+                    {
+                        coord[d + 1] = index[d];
+                    }
+
+                    std::ostringstream where;
+                    where << "at (";
+                    for (std::size_t d = 0; d < dim; ++d)
+                    {
+                        where << (d == 0 ? "" : ",") << coord[d];
+                    }
+                    where << ") in run " << run;
+
+                    const auto expected = reference_shift<radius, dim>(domain, coord, period);
+                    EXPECT_EQ(run.shift, expected.shift) << where.str();
+                    EXPECT_EQ(run.fits, expected.fits) << where.str();
+                }
+            }
         }
     }
 
@@ -210,6 +332,29 @@ namespace samurai
         EXPECT_EQ((shift_per_cell<2, dim>(domain, {0, 16}, {})), expected);
     }
 
+    TEST(prediction_shifts, in_one_dimension_the_rule_is_the_shared_1d_classifier)
+    {
+        constexpr std::size_t dim = 1;
+        const lca_t<dim> domain{
+            4,
+            box_t<dim>{{0}, {16}}
+        };
+
+        // With one direction there is no box and no mixed term, so the geometric rule has to
+        // reduce to prediction_shift() applied to the two availability counts - the same
+        // classifier the coefficients are keyed on. Anything else would mean two rules.
+        for (value_t<dim> x = 0; x < 16; ++x)
+        {
+            const auto avail_low  = std::min(static_cast<int>(x), 4);
+            const auto avail_high = std::min(static_cast<int>(15 - x), 4);
+            const auto expected   = prediction_shift(2, avail_low, avail_high);
+
+            const auto got = prediction_shifts_at<2, dim>(domain, {}, {x});
+            EXPECT_EQ(got.shift[0], expected.shift) << "at x = " << x;
+            EXPECT_EQ(got.fits, expected.fits) << "at x = " << x;
+        }
+    }
+
     TEST(prediction_shifts, the_bulk_is_one_run_with_no_shift)
     {
         constexpr std::size_t dim = 1;
@@ -220,11 +365,12 @@ namespace samurai
 
         // The interior comes back as a single run, so a consumer runs its current kernel
         // over it unchanged - the mechanism by which interior values stay bit-identical.
+        // The run reaches right up to the shifted cells: the decomposition breaks the
+        // interval where the geometry changes, but neighbouring runs carrying the same
+        // shift are merged, so what comes out is one run per change of shift.
         const std::vector<ShiftRun<dim>> expected = {
             {0, 1, {1},  true},
-            {1, 2, {0},  true},
-            {2, 6, {0},  true},
-            {6, 7, {0},  true},
+            {1, 7, {0},  true},
             {7, 8, {-1}, true}
         };
         EXPECT_EQ((runs_of<1, dim>(domain, {0, 8}, {})), expected);
@@ -280,8 +426,9 @@ namespace samurai
             box_t<dim>{{0, 0}, {8, 8}}
         };
 
-        // A corner is "clamp in x and clamp in y", one independent shift per direction,
-        // with no notion of a diagonal or of an outward normal.
+        // On a box the box rule and a per-direction clamp agree at every cell, corners
+        // included: a convex corner is "clamp in x and clamp in y", and no other shift fits
+        // the stencil box in.
         EXPECT_EQ((prediction_shifts_at<1, dim>(domain, {}, {0, 0})).shift, (std::array<int, 2>{1, 1}));
         EXPECT_EQ((prediction_shifts_at<1, dim>(domain, {}, {7, 0})).shift, (std::array<int, 2>{-1, 1}));
         EXPECT_EQ((prediction_shifts_at<1, dim>(domain, {}, {0, 7})).shift, (std::array<int, 2>{1, -1}));
@@ -322,16 +469,15 @@ namespace samurai
         };
         const lca_t<dim> domain{difference(full, hole)};
 
-        // The row just above the hole. Over the hole's span the stencil must shift up,
-        // away from the cells the hole removed; on either side of it, it must not - and
-        // that is one interval, so the query has to split it.
+        // The row just above the hole. Over the hole's span the stencil must shift up, away
+        // from the cells the hole removed; away from it, it must not - and that is one
+        // interval, so the query has to split it. The shifted run reaches one cell past the
+        // hole at each end: those cells have the hole's corner in their stencil box.
         const std::vector<ShiftRun<dim>> expected = {
             {0,  1,  {1, 0},  true},
-            {1,  2,  {0, 0},  true},
-            {2,  4,  {0, 0},  true},
-            {4,  8,  {0, 1},  true},
-            {8,  10, {0, 0},  true},
-            {10, 11, {0, 0},  true},
+            {1,  3,  {0, 0},  true},
+            {3,  9,  {0, 1},  true},
+            {9,  11, {0, 0},  true},
             {11, 12, {-1, 0}, true}
         };
         EXPECT_EQ((runs_of<1, dim>(domain, {0, 12}, {8})), expected);
@@ -341,17 +487,67 @@ namespace samurai
         EXPECT_EQ((prediction_shifts_at<1, dim>(domain, {}, {6, 3})).shift, (std::array<int, 2>{0, -1}));
         EXPECT_FALSE((prediction_shifts_at<1, dim>(domain, {}, {6, 6})).fits);
 
-        // A hole's side is a boundary in one direction only, exactly as the domain's own
-        // side is, and the clamp is read per direction with no notion of a normal.
+        // A hole's side is a boundary like the domain's own side, and the shift it forces is
+        // read off the geometry with no notion of a normal.
         EXPECT_EQ((prediction_shifts_at<1, dim>(domain, {}, {3, 4})).shift, (std::array<int, 2>{-1, 0}));
         EXPECT_EQ((prediction_shifts_at<1, dim>(domain, {}, {8, 5})).shift, (std::array<int, 2>{1, 0}));
+    }
 
-        // A cell diagonally off the hole's corner sees no boundary at all: in each
-        // direction separately the cells it reads are there. A rule that looked at the
-        // hole rather than at one direction at a time would shift it, and move an interior
-        // value for nothing.
-        EXPECT_EQ((prediction_shifts_at<1, dim>(domain, {}, {3, 3})).shift, (std::array<int, 2>{0, 0}));
-        EXPECT_EQ((prediction_shifts_at<1, dim>(domain, {}, {8, 8})).shift, (std::array<int, 2>{0, 0}));
+    TEST(prediction_shifts, a_re_entrant_corner_is_clamped_though_no_direction_sees_it)
+    {
+        constexpr std::size_t dim = 2;
+        const std::size_t level   = 4;
+
+        const lca_t<dim> full{
+            level,
+            box_t<dim>{{0, 0}, {12, 12}}
+        };
+        const lca_t<dim> hole{
+            level,
+            box_t<dim>{{4, 4}, {8, 8}}
+        };
+        const lca_t<dim> domain{difference(full, hole)};
+
+        // The cell diagonally off the hole's corner. In each direction separately every cell
+        // it reads is there, so a per-direction clamp leaves it alone - and its stencil box
+        // then reads the hole's corner cell (4,4), which the domain does not hold and which
+        // nothing fills. The box rule sees it and shifts.
+        EXPECT_FALSE(find(domain, coord_t<dim>{4, 4}) >= 0);
+        const auto diagonal = prediction_shifts_at<1, dim>(domain, {}, {3, 3});
+        EXPECT_TRUE(diagonal.fits);
+        EXPECT_EQ(diagonal.shift, (std::array<int, 2>{0, -1}));
+
+        // One direction is enough to clear the corner, so it shifts by one cell and not by
+        // one cell in each direction, and it takes it transversally: a shift along x would
+        // move the reads of the innermost loop for nothing.
+        EXPECT_EQ((prediction_shifts_at<1, dim>(domain, {}, {8, 8})).shift, (std::array<int, 2>{0, 1}));
+        EXPECT_EQ((prediction_shifts_at<1, dim>(domain, {}, {3, 8})).shift, (std::array<int, 2>{0, 1}));
+        EXPECT_EQ((prediction_shifts_at<1, dim>(domain, {}, {8, 3})).shift, (std::array<int, 2>{0, -1}));
+    }
+
+    TEST(prediction_shifts, a_shape_no_box_fits_into_does_not_fit)
+    {
+        constexpr std::size_t dim = 2;
+        const std::size_t level   = 4;
+
+        // A plus: three cells wide in x through the middle row, three cells tall in y
+        // through the middle column, and nothing at the four corners.
+        const lca_t<dim> across{
+            level,
+            box_t<dim>{{0, 1}, {3, 2}}
+        };
+        const lca_t<dim> down{
+            level,
+            box_t<dim>{{1, 0}, {2, 3}}
+        };
+        const lca_t<dim> domain{union_(across, down)};
+
+        // The centre cell has one cell available either side of it in x AND in y, so every
+        // direction taken on its own says a radius-1 stencil fits. The box does not: its
+        // corners are the plus's missing corners, and no shift moves a 3x3 box inside a
+        // plus. fits is the joint condition, which is what the mesh has to guarantee.
+        EXPECT_EQ(prediction_shift(1, 1, 1).fits, true);
+        EXPECT_FALSE((prediction_shifts_at<1, dim>(domain, {}, {1, 1})).fits);
     }
 
     TEST(prediction_shifts, two_different_boundaries_clamp_a_cell_independently)
@@ -455,7 +651,9 @@ namespace samurai
         EXPECT_EQ((prediction_shifts_at<1, dim>(domain, both, {6, 3})).shift, (std::array<int, 2>{0, -1}));
         EXPECT_EQ((prediction_shifts_at<1, dim>(domain, both, {3, 6})).shift, (std::array<int, 2>{-1, 0}));
 
-        // The domain's own edges, on the other hand, are not boundaries any more.
+        // The domain's own edges, on the other hand, are not boundaries any more - and the
+        // wrap reaches diagonally too, so a corner cell of a doubly periodic domain reads
+        // the opposite corner and stays centred.
         EXPECT_EQ((prediction_shifts_at<1, dim>(domain, both, {0, 0})).shift, (std::array<int, 2>{0, 0}));
         EXPECT_EQ((prediction_shifts_at<1, dim>(domain, both, {11, 11})).shift, (std::array<int, 2>{0, 0}));
     }
@@ -482,15 +680,7 @@ namespace samurai
 
         for (value_t<dim> y = 0; y < 16; ++y)
         {
-            for (const auto& run : runs_of<1, dim>(domain, {0, 16}, {y}, both))
-            {
-                for (auto x = run.start; x < run.end; ++x)
-                {
-                    const auto expected = reference_shifts<1, dim>(domain, {x, y}, both);
-                    EXPECT_EQ(run.shift, expected.shift) << "at (" << x << "," << y << ") in run " << run;
-                    EXPECT_EQ(run.fits, expected.fits) << "at (" << x << "," << y << ") in run " << run;
-                }
-            }
+            expect_agreement<1, dim>(domain, {0, 16}, {y}, both);
         }
     }
 
@@ -534,18 +724,15 @@ namespace samurai
         // compared too.
         for (value_t<dim> y = -2; y < 18; ++y)
         {
-            const auto runs = runs_of<1, dim>(domain, {-2, 21}, {y});
-            for (const auto& run : runs)
+            expect_agreement<1, dim>(domain, {-2, 21}, {y});
+
+            for (const auto& run : runs_of<1, dim>(domain, {-2, 21}, {y}))
             {
                 for (auto x = run.start; x < run.end; ++x)
                 {
-                    const auto expected = reference_shifts<1, dim>(domain, {x, y});
-                    EXPECT_EQ(run.shift, expected.shift) << "at (" << x << "," << y << ") in run " << run;
-                    EXPECT_EQ(run.fits, expected.fits) << "at (" << x << "," << y << ") in run " << run;
-
                     ++seen[run.shift];
-                    outside += (find(domain, {x, y}) < 0) ? 1 : 0;
-                    cramped += (!run.fits && find(domain, {x, y}) >= 0) ? 1 : 0;
+                    outside += (find(domain, coord_t<dim>{x, y}) < 0) ? 1 : 0;
+                    cramped += (!run.fits && find(domain, coord_t<dim>{x, y}) >= 0) ? 1 : 0;
                 }
             }
         }
@@ -565,15 +752,7 @@ namespace samurai
         // Radius 2 reads further, so it exercises rows the radius-1 pass never consults.
         for (value_t<dim> y = -2; y < 18; ++y)
         {
-            for (const auto& run : runs_of<2, dim>(domain, {-2, 21}, {y}))
-            {
-                for (auto x = run.start; x < run.end; ++x)
-                {
-                    const auto expected = reference_shifts<2, dim>(domain, {x, y});
-                    EXPECT_EQ(run.shift, expected.shift) << "at (" << x << "," << y << ") in run " << run;
-                    EXPECT_EQ(run.fits, expected.fits) << "at (" << x << "," << y << ") in run " << run;
-                }
-            }
+            expect_agreement<2, dim>(domain, {-2, 21}, {y});
         }
     }
 
@@ -596,15 +775,20 @@ namespace samurai
         {
             for (value_t<dim> y = -1; y < 9; ++y)
             {
-                for (const auto& run : runs_of<1, dim>(domain, {-1, 9}, {y, z}))
-                {
-                    for (auto x = run.start; x < run.end; ++x)
-                    {
-                        const auto expected = reference_shifts<1, dim>(domain, {x, y, z});
-                        EXPECT_EQ(run.shift, expected.shift) << "at (" << x << "," << y << "," << z << ")";
-                        EXPECT_EQ(run.fits, expected.fits) << "at (" << x << "," << y << "," << z << ")";
-                    }
-                }
+                expect_agreement<1, dim>(domain, {-1, 9}, {y, z});
+            }
+        }
+
+        // The same domain read as periodic in all three directions. Two transverse
+        // directions then step off the end at once at an edge of the box, which no 2D sweep
+        // and no non-periodic sweep reaches: the row the stencil wants exists only after
+        // wrapping both of them.
+        const period_t<dim> all = {8, 8, 8};
+        for (value_t<dim> z = 0; z < 8; ++z)
+        {
+            for (value_t<dim> y = 0; y < 8; ++y)
+            {
+                expect_agreement<1, dim>(domain, {0, 8}, {y, z}, all);
             }
         }
     }

--- a/tests/test_prediction_shifts.cpp
+++ b/tests/test_prediction_shifts.cpp
@@ -318,7 +318,7 @@ namespace samurai
         template <std::size_t radius, std::size_t dim>
         constexpr bool index_of_inverts_offset()
         {
-            using rows_t = detail::TransverseRows<radius, dim>;
+            using rows_t = detail::TransverseRows<2 * static_cast<int>(radius), dim>;
             for (std::size_t k = 0; k < rows_t::count; ++k)
             {
                 if (rows_t::index_of(rows_t::offset(k)) != k)


### PR DESCRIPTION
- [x] I have installed [pre-commit](https://pre-commit.com/) locally and use it to validate my commits.
- [x] The PR title follows the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) convention.
- [x] This new PR is documented.
- [x] This new PR is tested.

> Stacked on #492 and #495 and contains them, so they should go in first. Its own commits are
> the last three: `fix(mr,amr): give the coarse levels the inward reach a clamped stencil needs`,
> `fix(mpi): state the prediction ghosts' real reach in neighbour discovery` and `perf(mr): fold
> the inward band into the r margin where nothing is periodic`. It needs #495:
> the wider ghost band shares more coarse cells between ranks, and the petsc cell ownership
> that #495 makes consistent is what lets `finite-volume-heat` run at 3 ranks with it.

## Description

A prediction stencil of radius `r` reads `r` cells each side, and the coarse levels carry exactly
that margin. That is enough only while the stencil stays centred. Near a boundary - the domain's
own or a hole's - it cannot: to read only cells the domain has, it shifts inward, and it then
reaches `2r` on one side. With `r` of margin it names cells the mesh does not hold.

Measured, on `tests/test_mra.cpp`'s own mesh: at level 2 the reference mesh held

```
(j=-1,[1,5)) (j=0,[1,5)) (j=1,[1,5)) (j=2,[-1,5)) (j=3,[-1,5)) (j=4,[-1,5))
```

ragged, because a level exists only where the projection chain needs it - and the detail at the
parent `(0,3)`, clamped away from the top boundary, asked for `(0,1)`, which is not there. The
centred stencil reads the row above instead, which is an outer ghost the boundary conditions
filled: exactly the read the boundary rewrite exists to remove.

`ghost_width` is not the quantity at issue - it is already `2r` at `r = 1`. **Which cells each
level holds** is.

The margin becomes **`r` outward and `2r` inward**, and the asymmetry is the content:

- **outward, `r` is all there is to read.** A centred stencil reaches `r`, and past the domain
  those cells are the outer ghosts the boundary conditions write. Adding more adds cells nobody
  writes and nobody reads - and a cell the mesh holds but nothing writes is worse than one it does
  not hold, because it is read as a value. The symmetric `2r` was tried first: it leaves NaN cells
  at `min_level - 1` and at the domain's corners, which the second test below catches;
- **across a periodic boundary the band is needed on both sides**, because there the cells exist
  and the periodic exchange fills them, and a stencil clamped in one direction reads further along
  the others. This is the one case the new tests catch unaided: without it, the cell at `x = 0`,
  level 3 names `(-1,2)` and the mesh has no such cell.

Two ways out were refused because both decide the stencil from what one rank happens to hold,
which makes results depend on the rank count: falling back to the centred stencil where the mesh
lacks the cells, and skipping those positions.

**Cost**, at the radius everything ships with: the suite goes from 32.9 s to 34.7 s (+5%), and the
reference mesh of an adapted 2D case is *unchanged* at 48896 cells, of a 3D one unchanged at
249834 - the band adds nothing where the margin was already wide enough. Widening symmetrically
instead costs **6.5x** on the suite (215 s), all of it in the roundtrip test at radius 3 in 6
dimensions, where the stencil goes from `7^6` to `13^6` points.

**Implementation note.** The band is added as a *separate contribution* with the same shape as the
existing arms rather than folded into them with `union_`. Folding it in resolves the set expression
at a different level and the intervals land in the wrong level's cell list - which showed up as
cells appearing two cells outside the domain that no expansion could account for.

### Cost, and the fused arms (last commit)

The band is a second pair of set expressions per level, on top of the r margin's. Where nothing
is periodic the two are one set - the 2r expansion of the cells, clipped to the domain expanded
by r - and the last commit builds that one instead: two operands per arm instead of one and
three, one traversal instead of two. `update_sub_mesh` on `finite-volume-advection-2d`: 0.184 s
before this PR, 0.229 s with the two arms, 0.201 s fused; on `finite-volume-advection-3d`: 1.75 s,
3.67 s, 3.06 s. Restricting the band to a shell along the boundary was tried again and rejected:
the shell itself (a contraction of the domain, per level) costs more than it saves in 3D. What
remains in 3D is the 2r expansion itself, 25 transverse shifts against 9 for r.

## Related issue

None. Part of the boundary-machinery rewrite; the prerequisite the migration plan did not have,
found by switching the consumers over and watching `test_mra` throw.

## How has this been tested?

`tests/test_prediction_inward_reach.cpp`, 6 tests, asserting both halves of the requirement in 1D,
2D, 3D, with a periodic direction, and across an adaptation loop:

- every cell a (possibly clamped) stencil names, at every position where a detail is computed, is
  one the mesh holds;
- every cell the mesh holds is written by the time the ghost update returns - the field is filled
  with NaN first, so a cell nothing writes is visible.

The periodic case fails without this change. The evidence for the rest is that `test_mra`, which
throws as soon as the consumer of these stencils is switched over, passes with the same consumer
commit stacked on top of this one: the failing meshes are intermediate ones inside `adapt`, which a
test outside `adapt` cannot reach.

Full suite: 452/452 pass (6 of them new), pre-commit clean.

## Code of Conduct

- [x] I agree to follow this project's Code of Conduct