### PR TITLE
fix(conda): declare metis in the MPI environment

### DIFF
--- a/conda/mpi-environment.yml
+++ b/conda/mpi-environment.yml
@@ -21,4 +21,5 @@ dependencies:
   - mpich
   # Optional graph partitioners (for SAMURAI_WITH_PARMETIS and SAMURAI_WITH_PTSCOTCH)
   - parmetis
+  - metis # parmetis.h includes metis.h, which the conda-forge parmetis package does not ship
   # - ptscotch # the tests are too long on the CI, so we disable it for now. It can be re-enabled when the problem will be resolved.


### PR DESCRIPTION
## Description

`-DSAMURAI_WITH_PARMETIS=ON` cannot be configured from `conda/mpi-environment.yml`:

```
Could NOT find ParMETIS (missing: METIS_LIBRARY)
```

and forcing past that step fails at compile time instead:

```
.../include/parmetis.h:18:10: fatal error: 'metis.h' file not found
```

The cause is on the conda-forge side: the `parmetis` package links METIS
statically into `libparmetis`, so it ships neither `metis.h` nor `libmetis`,
and it declares no dependency on the `metis` package either. Its metadata is
just `['mpich', 'libcxx', ...]`. Since `parmetis.h` opens with
`#include <metis.h>`, and `cmake/FindParMETIS.cmake` requires `METIS_LIBRARY`,
both the find step and the compile step need METIS to be present.

This adds `metis` to the MPI environment, which is the smallest fix and keeps
`FindParMETIS.cmake` unchanged. Making METIS optional in the find module is not
an alternative: the header dependency is real, so METIS is genuinely required,
not just a link-time extra.

Reproduced on macOS arm64 and on Linux aarch64, with `parmetis-4.0.3-*_1009`.
Worth noting that the CI passes `-DSAMURAI_WITH_PARMETIS=ON` (`.github/workflows/ci.yml`),
so the ParMETIS load-balancing strategy is currently unbuildable from the
documented environment.

## How has this been tested?

With `metis` added to the environment and `cmake/FindParMETIS.cmake` untouched:

- `cmake -DWITH_MPI=ON -DSAMURAI_WITH_PARMETIS=ON -DBUILD_TESTS=ON` configures,
  and reports `Found ParMETIS`.
- `tests/mpi/test_lb_metis.cpp` compiles and links (it is the target that
  actually calls `ParMETIS_V3_*` through
  `include/samurai/load_balancing/strategies/metis.hpp`).
- `mpiexec -n 4 tests/mpi/test_lb_metis`: 6 tests from 2 suites, all passing.

## Code of Conduct
By submitting this PR, you agree to follow our [Code of Conduct](https://github.com/hpc-maths/samurai/blob/master/docs/CODE_OF_CONDUCT.md)
- [x] I agree to follow this project's Code of Conduct
