### PR TITLE
fix(mr): avoid a size_t underflow in the harten tag-cells loop at level 0

### DIFF
--- a/include/samurai/mr/adapt.hpp
+++ b/include/samurai/mr/adapt.hpp
@@ -316,7 +316,10 @@ namespace samurai
         times::timers.stop("detail computation");
 
         times::timers.start("tag cells");
-        for (std::size_t level = min_level; level <= max_level - ite; ++level)
+        // Cells at level 0 have no coarser level to read the detail from, so they cannot be
+        // reconsidered for refinement here (level - 1 would underflow); they keep whatever tag
+        // they already carry.
+        for (std::size_t level = std::max(min_level, static_cast<std::size_t>(1)); level <= max_level - ite; ++level)
         {
             std::size_t exponent = dim * (max_level - level);
             double eps_l         = cfg.epsilon() / (1 << exponent);


### PR DESCRIPTION
## Description

The tag-cells loop in `Adapt::harten()` (`include/samurai/mr/adapt.hpp`) reads the
detail computed at `level - 1` to decide whether cells at `level` should be
refined or coarsened:

```cpp
for (std::size_t level = min_level; level <= max_level - ite; ++level)
{
    ...
    auto subset_1 = intersection(mesh[mesh_id_t::cells][level], mesh[mesh_id_t::all_cells][level - 1]).on(level - 1);
    ...
}
```

When the mesh's `min_level` is `0`, the first iteration computes `level - 1`
with `level == 0`. Since `level` is `std::size_t` (unsigned), this underflows
to `SIZE_MAX` and indexes `CellArray`'s fixed-size level array
(`std::array<LevelCellArray<dim,...>, max_level + 1>`) with a huge value,
which is undefined behaviour. On a Debug build with `SAMURAI_CHECK_NAN=ON`
this actually aborts:

```
.../include/c++/array:210: constexpr std::array<_Tp, _Nm>::value_type&
std::array<_Tp, _Nm>::operator[](size_type) [...]: Assertion '__n < this->size()' failed.
```

Level-0 cells have no coarser level to compare against, so this criterion
cannot reconsider them for refinement anyway (the analogous coarsen check a
few lines below is already internally guarded by `fine_level > min_level`,
which is false in exactly this case). The fix skips them instead of
underflowing, mirroring the intent (if not the exact bound) of the guard
already used a few lines above for the detail-computation loop.

## How has this been tested?

- Reproduced the crash on unpatched `main` (commit 4cbe7c3b) with:
  `mpiexec -n 2 ./demos/FiniteVolume/finite-volume-burgers --Tf 0.1 --nfiles 1 --max-level 8`
  (`-DWITH_MPI=ON -DCMAKE_BUILD_TYPE=Debug -DSAMURAI_CHECK_NAN=ON`), matching
  the CI job exactly. With 2 ranks, domain decomposition leaves one rank's
  local subdomain coarsened down to level 0, triggering the underflow.
- With the fix applied, the same command runs to completion (`-n 1` and
  `-n 2`), with no assertion failure.

## Code of Conduct
By submitting this PR, you agree to follow our [Code of Conduct](https://github.com/hpc-maths/samurai/blob/master/docs/CODE_OF_CONDUCT.md)
- [x] I agree to follow this project's Code of Conduct