### PR TITLE
test(graduation): give the width tests' tag ownership of its mesh

### DIFF
--- a/tests/test_graduation.cpp
+++ b/tests/test_graduation.cpp
@@ -263,6 +263,9 @@ namespace samurai
     {
         // samurai::graduation() (as opposed to make_graduation() above) reads the graduation width
         // from mesh.cfg() and dispatches it through dispatch_static<1, 9>.
+        //
+        // The tag is built on holder(mesh) so that it owns its mesh: a plain field only points to
+        // the mesh it was built on, which here is a local of this helper.
         auto make_graduation_width_test_tag(std::size_t graduation_width)
         {
             static constexpr std::size_t dim = 1;
@@ -270,7 +273,8 @@ namespace samurai
 
             auto mesh_cfg = mesh_config<dim>().min_level(1).max_level(3).graduation_width(graduation_width);
             auto mesh     = mra::make_mesh(box_t{xt::zeros<double>({dim}), xt::ones<double>({dim})}, mesh_cfg);
-            auto tag      = make_scalar_field<int>("tag", mesh);
+            auto m        = holder(mesh);
+            auto tag      = make_scalar_field<int>("tag", m);
             tag.fill(static_cast<int>(CellFlag::keep));
             return tag;
         }


### PR DESCRIPTION
## Description

`make_graduation_width_test_tag`, added in #498, built the mesh as a local variable and
returned a tag on it. A field only points to its mesh (`inner_mesh_type` stores a raw pointer),
so `graduation.width_zero_is_a_noop` and `graduation.width_above_dispatch_range_throws` run
`samurai::graduation` on a destroyed mesh.

On `main` the two tests pass by luck: the stack slot is still intact when the tag is read. On
the branches rebased on `main` today (#492, #493, #494) the full test run fails with

```
Expected: samurai::graduation(tag, stencil) doesn't throw an exception.
  Actual: it throws std::out_of_range with description
  "LevelCellArray::get_interval: interval not found at level 4098, i = [0,8[@0:2, index = ".
```

while the same test passes when run alone. AddressSanitizer confirms the cause on `main`
itself:

```
ERROR: AddressSanitizer: stack-use-after-return
    #0 samurai::graduation<...>  include/samurai/algorithm/graduation.hpp:141
    #1 graduation_width_zero_is_a_noop_Test::TestBody()  tests/test_graduation.cpp:284
Address is located in stack of thread T0 at offset ... in frame
    #0 make_graduation_width_test_tag  tests/test_graduation.cpp:267
```

The tag is now built on `holder(mesh)`: the field owns a copy of the mesh, so the helper is safe
by construction, the way `reconstruction()` already returns a field that outlives its local mesh.

Returning the mesh and building the tag in each test was considered and rejected: it keeps the
lifetime rule at every call site, and a one-liner passing a temporary mesh would recreate the bug
without any warning.

## How has this been tested?

- `tests/test_graduation.cpp`, built with `-fsanitize=address`: the report above before the
  change, clean after it, `graduation.*` all passing.
- `pre-commit run --files tests/test_graduation.cpp`.

## Code of Conduct
By submitting this PR, you agree to follow our [Code of Conduct](https://github.com/hpc-maths/samurai/blob/master/docs/CODE_OF_CONDUCT.md)
- [x] I agree to follow this project's Code of Conduct
